### PR TITLE
Update `unpack_compact_validator` in sync protocol

### DIFF
--- a/specs/light_client/sync_protocol.md
+++ b/specs/light_client/sync_protocol.md
@@ -86,7 +86,7 @@ def unpack_compact_validator(compact_validator: CompactValidator) -> Tuple[Valid
     """
     return (
         ValidatorIndex(compact_validator >> 16),
-        (compact_validator >> 15) % 2 == 0,
+        bool((compact_validator >> 15) % 2),
         uint64(compact_validator & (2**15 - 1)),
     )
 ```


### PR DESCRIPTION
`unpack_compact_validator` returns slashed status as `bool`, it looks like we missed the comparison `==0` there