### PR TITLE
double eth1data params

### DIFF
--- a/configs/mainnet/phase0.yaml
+++ b/configs/mainnet/phase0.yaml
@@ -36,8 +36,8 @@ SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
 
 # Validator
 # ---------------------------------------------------------------
-# 2**10 (= 1,024)
-ETH1_FOLLOW_DISTANCE: 1024
+# 2**11 (= 2,048)
+ETH1_FOLLOW_DISTANCE: 2048
 # 2**4 (= 16)
 TARGET_AGGREGATORS_PER_COMMITTEE: 16
 # 2**0 (= 1)
@@ -90,8 +90,8 @@ SLOTS_PER_EPOCH: 32
 MIN_SEED_LOOKAHEAD: 1
 # 2**2 (= 4) epochs 25.6 minutes
 MAX_SEED_LOOKAHEAD: 4
-# 2**5 (= 32) epochs ~3.4 hours
-EPOCHS_PER_ETH1_VOTING_PERIOD: 32
+# 2**6 (= 64) epochs ~6.8 hours
+EPOCHS_PER_ETH1_VOTING_PERIOD: 64
 # 2**13 (= 8,192) slots ~13 hours
 SLOTS_PER_HISTORICAL_ROOT: 8192
 # 2**8 (= 256) epochs ~27 hours

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -183,7 +183,7 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value |
 | - | - |
-| `ETH1_FOLLOW_DISTANCE` | `uint64(2**10)` (= 1,024) |
+| `ETH1_FOLLOW_DISTANCE` | `uint64(2**11)` (= 2,048) |
 | `MAX_COMMITTEES_PER_SLOT` | `uint64(2**6)` (= 64) |
 | `TARGET_COMMITTEE_SIZE` | `uint64(2**7)` (= 128) |
 | `MAX_VALIDATORS_PER_COMMITTEE` | `uint64(2**11)` (= 2,048) |
@@ -226,7 +226,7 @@ The following values are (non-configurable) constants used throughout the specif
 | `MIN_SEED_LOOKAHEAD` | `uint64(2**0)` (= 1) | epochs | 6.4 minutes |
 | `MAX_SEED_LOOKAHEAD` | `uint64(2**2)` (= 4) | epochs | 25.6 minutes |
 | `MIN_EPOCHS_TO_INACTIVITY_PENALTY` | `uint64(2**2)` (= 4) | epochs | 25.6 minutes |
-| `EPOCHS_PER_ETH1_VOTING_PERIOD` | `uint64(2**5)` (= 32) | epochs | ~3.4 hours |
+| `EPOCHS_PER_ETH1_VOTING_PERIOD` | `uint64(2**6)` (= 64) | epochs | ~6.8 hours |
 | `SLOTS_PER_HISTORICAL_ROOT` | `uint64(2**13)` (= 8,192) | slots | ~27 hours |
 | `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `uint64(2**8)` (= 256) | epochs | ~27 hours |
 | `SHARD_COMMITTEE_PERIOD` | `uint64(2**8)` (= 256) | epochs | ~27 hours |

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -129,7 +129,7 @@ To submit a deposit:
 
 ### Process deposit
 
-Deposits cannot be processed into the beacon chain until the Eth1 block in which they were deposited or any of its descendants is added to the beacon chain `state.eth1_data`. This takes _a minimum_ of `ETH1_FOLLOW_DISTANCE` Eth1 blocks (~4 hours) plus `EPOCHS_PER_ETH1_VOTING_PERIOD` epochs (~3.4 hours). Once the requisite Eth1 data is added, the deposit will normally be added to a beacon chain block and processed into the `state.validators` within an epoch or two. The validator is then in a queue to be activated.
+Deposits cannot be processed into the beacon chain until the Eth1 block in which they were deposited or any of its descendants is added to the beacon chain `state.eth1_data`. This takes _a minimum_ of `ETH1_FOLLOW_DISTANCE` Eth1 blocks (~8 hours) plus `EPOCHS_PER_ETH1_VOTING_PERIOD` epochs (~6.8 hours). Once the requisite Eth1 data is added, the deposit will normally be added to a beacon chain block and processed into the `state.validators` within an epoch or two. The validator is then in a queue to be activated.
 
 ### Validator index
 


### PR DESCRIPTION
Ensure the cycle of eth1data voting (follow distance + voting period) is more than a sleep cycle (~8 hours) to more easily allow for intervention/recovery in the event of an issue (attacker or bug).

Rational on the UX degradation: The time it takes to go from eth1 deposit to being inducted as a validator is already perceptibly long to the user and must be due to the security requirements. Doubling this time does not alter the UX much in the grand scheme of things, but provides a much better security profile. 

Also, it is worth noting that the expected time to be inducted as a validator is still very small in comparison to the expected validation time for Phase 0 validators (1+ year).

cc: @vbuterin 