### PR TITLE
[WIP] [testgen] pre-state references

### DIFF
--- a/tests/core/gen_helpers/gen_base/gen_typing.py
+++ b/tests/core/gen_helpers/gen_base/gen_typing.py
@@ -1,9 +1,13 @@
+from pathlib import Path
 from typing import (
     Any,
     Callable,
+    Dict,
     Iterable,
+    List,
     NewType,
     Tuple,
+    Union,
 )
 from dataclasses import dataclass
 
@@ -13,7 +17,13 @@ from dataclasses import dataclass
 #  - "data" for generic
 #  - "ssz" for SSZ encoded bytes
 #  - "meta" for generic data to collect into a meta data dict.
-TestCasePart = NewType("TestCasePart", Tuple[str, str, Any])
+#  - "root" for SSZ hash tree root
+TestCasePart = NewType("TestCasePart", Tuple[str, str, Any, bytes])
+
+
+# A map to trace the overlapping SSZ object output
+# key: str -> (file_path: Path, count: int)
+SSZLookup = NewType("SSZLookup", Dict[str, List[Union[Path, int]]])
 
 
 @dataclass

--- a/tests/generators/sanity/main.py
+++ b/tests/generators/sanity/main.py
@@ -1,3 +1,4 @@
+import json
 from typing import Iterable
 
 from gen_base import gen_runner, gen_typing
@@ -8,6 +9,8 @@ from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.phase1 import spec as spec_phase1
 from eth2spec.test.context import PHASE0, PHASE1
 from eth2spec.utils import bls
+
+pre_state_path_lookup: gen_typing.SSZLookup = {}
 
 
 def create_provider(fork_name: str, handler_name: str,
@@ -43,13 +46,20 @@ if __name__ == "__main__":
 
     gen_runner.run_generator(f"sanity", [
         create_provider(PHASE0, key, mod_name, 'minimal') for key, mod_name in phase_0_mods.items()
-    ])
+    ], pre_state_path_lookup)
     gen_runner.run_generator(f"sanity", [
         create_provider(PHASE0, key, mod_name, 'mainnet') for key, mod_name in phase_0_mods.items()
-    ])
+    ], pre_state_path_lookup)
     gen_runner.run_generator(f"sanity", [
         create_provider(PHASE1, key, mod_name, 'minimal') for key, mod_name in phase_1_mods.items()
-    ])
+    ], pre_state_path_lookup)
     gen_runner.run_generator(f"sanity", [
         create_provider(PHASE1, key, mod_name, 'mainnet') for key, mod_name in phase_1_mods.items()
-    ])
+    ], pre_state_path_lookup)
+
+    # FIXME: this record dict is for debugging and computing the improvement.
+    # will remove it.
+    for key, value in pre_state_path_lookup.items():
+        value[0] = str(value[0])
+    with open('hash_count.json', 'w') as f:
+        f.write(json.dumps(pre_state_path_lookup))  # use `json.loads` to do the reverse


### PR DESCRIPTION
Based on the previous discussion with @djrtwo

### Goal: reduce the output size
### Proposal
- Use test **runner** as the base unit to create the "shared files".
- The shared files are laid under test runner (e.g., `sanity`)
- Move pre-state (`pre`) to the shared files. The file names are `pre_$PRE_HASH_TREE_ROOT.ssz` or `pre_$PRE_HASH_TREE_ROOT.yaml`
- Add meta field `pre: pre_$PRE_HASH_TREE_ROOT` to look up the corresponding file.
    - Clients need to add `.ssz` or `.yaml` to locate the file.

### Improvements

This draft PR currently only changed `sanity` testgen as a demo, so the below data is only from `sanity` tests.
Output file tree: https://gist.github.com/hwwhww/8f9b1d657ab3d6aeaba2982279aa57cf
#### 1. Compare the sizes:

| runner | version | file count | total size
| - | - | - | - 
| `sanity` | Before (a34970f8a3a1ee32e06b845bf3de6d70e69090d0) | 1,288  | 1.17 GB
| `sanity` | After    | 1,082  | 702.1 MB

#### 2. stats of duplicate files
Before this PR, some files are duplicate for >20 times. This is the stats of each `pre` file:
https://gist.github.com/hwwhww/c39eda0b582cbca40f94c6be35bbd7f7

### Pros and Cons
#### Pro:
1. Should be able to reduce the output file size vastly!
#### Cons:
1. Need to update client test suites
2. I made `eth2spec.test.utils.vector_test` to compute hash tree root of *all* SSZ output fields, so It may take more time to run testgen.

### TODOs:
- [ ] Discuss the format
- [ ] Refactor
- [ ] Update other runners
- [ ] Edit test format
- [ ] Enable other tests
- [ ] Move other fields to shared files?
