### PR TITLE
Run mdformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+- repo: https://github.com/executablebooks/mdformat
+  rev: 0.6.2
+  hooks:
+  - id: mdformat
+    args: [--number]
+    additional_dependencies:
+    - mdformat-gfm

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ To learn more about sharding and Ethereum 2.0 (Serenity), see the [sharding FAQ]
 
 This repository hosts the current Eth2 specifications. Discussions about design rationale and proposed changes can be brought up and discussed as issues. Solidified, agreed-upon changes to the spec can be made through pull requests.
 
-
 ## Specs
 
 [![GitHub release](https://img.shields.io/github/v/release/ethereum/eth2.0-specs)](https://github.com/ethereum/eth2.0-specs/releases/) [![PyPI version](https://badge.fury.io/py/eth2spec.svg)](https://badge.fury.io/py/eth2spec)
@@ -18,80 +17,82 @@ The current features are:
 
 ### Phase 0
 
-* [The Beacon Chain](specs/phase0/beacon-chain.md)
-* [Beacon Chain Fork Choice](specs/phase0/fork-choice.md)
-* [Deposit Contract](specs/phase0/deposit-contract.md)
-* [Honest Validator](specs/phase0/validator.md)
-* [P2P Networking](specs/phase0/p2p-interface.md)
+- [The Beacon Chain](specs/phase0/beacon-chain.md)
+- [Beacon Chain Fork Choice](specs/phase0/fork-choice.md)
+- [Deposit Contract](specs/phase0/deposit-contract.md)
+- [Honest Validator](specs/phase0/validator.md)
+- [P2P Networking](specs/phase0/p2p-interface.md)
 
 ### Altair
 
-* [Beacon chain changes](specs/altair/beacon-chain.md)
-* [Altair fork](specs/altair/fork.md)
-* [Light client sync protocol](specs/altair/sync-protocol.md)
-* [Honest Validator guide changes](specs/altair/validator.md)
+- [Beacon chain changes](specs/altair/beacon-chain.md)
+- [Altair fork](specs/altair/fork.md)
+- [Light client sync protocol](specs/altair/sync-protocol.md)
+- [Honest Validator guide changes](specs/altair/validator.md)
 
 ### Merge
 
 The merge is still actively in R&D. The specifications outline a general direction for engineering work,
 while the details are in review and may change.
 
-* Background material:
-  * An [ethresear.ch](https://ethresear.ch) post [describing the basic mechanism](https://ethresear.ch/t/the-eth1-eth2-transition/6265)
-  * [ethereum.org](https://ethereum.org) high-level description of the merge [here](https://ethereum.org/en/eth2/docking/)
-* Specifications:
-  * [Beacon Chain changes](specs/merge/beacon-chain.md)
-  * [Fork Choice changes](specs/merge/fork-choice.md)
-  * [Validator additions](specs/merge/validator.md)
+- Background material:
+  - An [ethresear.ch](https://ethresear.ch) post [describing the basic mechanism](https://ethresear.ch/t/the-eth1-eth2-transition/6265)
+  - [ethereum.org](https://ethereum.org) high-level description of the merge [here](https://ethereum.org/en/eth2/docking/)
+- Specifications:
+  - [Beacon Chain changes](specs/merge/beacon-chain.md)
+  - [Fork Choice changes](specs/merge/fork-choice.md)
+  - [Validator additions](specs/merge/validator.md)
 
 ### Sharding
 
 Sharding follows the merge, and is divided into three parts:
 
-* Sharding base functionality - In early engineering phase
-  * [Beacon Chain changes](specs/sharding/beacon-chain.md)
-  * [P2P Network changes](specs/sharding/p2p-interface.md)
-* Custody Game - Ready, dependent on sharding 
-  * [Beacon Chain changes](specs/custody_game/beacon-chain.md)
-  * [Validator custody work](specs/custody_game/validator.md)
-* Data Availability Sampling - In active R&D
-  * Technical details [here](https://hackmd.io/@HWeNw8hNRimMm2m2GH56Cw/B1YJPGkpD).
-  * [Core types and functions](specs/das/das-core.md)
-  * [P2P Networking](specs/das/p2p-interface.md)
-  * [Fork Choice](specs/das/fork-choice.md)
-  * [Sampling process](specs/das/sampling.md)
+- Sharding base functionality - In early engineering phase
+  - [Beacon Chain changes](specs/sharding/beacon-chain.md)
+  - [P2P Network changes](specs/sharding/p2p-interface.md)
+- Custody Game - Ready, dependent on sharding
+  - [Beacon Chain changes](specs/custody_game/beacon-chain.md)
+  - [Validator custody work](specs/custody_game/validator.md)
+- Data Availability Sampling - In active R&D
+  - Technical details [here](https://hackmd.io/@HWeNw8hNRimMm2m2GH56Cw/B1YJPGkpD).
+  - [Core types and functions](specs/das/das-core.md)
+  - [P2P Networking](specs/das/p2p-interface.md)
+  - [Fork Choice](specs/das/fork-choice.md)
+  - [Sampling process](specs/das/sampling.md)
 
 ### Accompanying documents can be found in [specs](specs) and include:
 
-* [SimpleSerialize (SSZ) spec](ssz/simple-serialize.md)
-* [Merkle proof formats](ssz/merkle-proofs.md)
-* [General test format](tests/formats/README.md)
+- [SimpleSerialize (SSZ) spec](ssz/simple-serialize.md)
+- [Merkle proof formats](ssz/merkle-proofs.md)
+- [General test format](tests/formats/README.md)
 
 ## Additional specifications for client implementers
 
 Additional specifications and standards outside of requisite client functionality can be found in the following repos:
 
-* [Eth2 APIs](https://github.com/ethereum/eth2.0-apis)
-* [Eth2 Metrics](https://github.com/ethereum/eth2.0-metrics/)
-* [Interop Standards in Eth2 PM](https://github.com/ethereum/eth2.0-pm/tree/master/interop)
+- [Eth2 APIs](https://github.com/ethereum/eth2.0-apis)
+- [Eth2 Metrics](https://github.com/ethereum/eth2.0-metrics/)
+- [Interop Standards in Eth2 PM](https://github.com/ethereum/eth2.0-pm/tree/master/interop)
 
 ## Design goals
 
 The following are the broad design goals for Ethereum 2.0:
-* to minimize complexity, even at the cost of some losses in efficiency
-* to remain live through major network partitions and when very large portions of nodes go offline
-* to select all components such that they are either quantum secure or can be easily swapped out for quantum secure counterparts when available
-* to utilize crypto and design techniques that allow for a large participation of validators in total and per unit time
-* to allow for a typical consumer laptop with `O(C)` resources to process/validate `O(1)` shards (including any system level validation such as the beacon chain)
+
+- to minimize complexity, even at the cost of some losses in efficiency
+- to remain live through major network partitions and when very large portions of nodes go offline
+- to select all components such that they are either quantum secure or can be easily swapped out for quantum secure counterparts when available
+- to utilize crypto and design techniques that allow for a large participation of validators in total and per unit time
+- to allow for a typical consumer laptop with `O(C)` resources to process/validate `O(1)` shards (including any system level validation such as the beacon chain)
 
 ## Useful external resources
 
-* [Design Rationale](https://notes.ethereum.org/s/rkhCgQteN#)
-* [Phase 0 Onboarding Document](https://notes.ethereum.org/s/Bkn3zpwxB)
-* [Combining GHOST and Casper paper](https://arxiv.org/abs/2003.03052)
+- [Design Rationale](https://notes.ethereum.org/s/rkhCgQteN)
+- [Phase 0 Onboarding Document](https://notes.ethereum.org/s/Bkn3zpwxB)
+- [Combining GHOST and Casper paper](https://arxiv.org/abs/2003.03052)
 
 ## For spec contributors
 
 Documentation on the different components used during spec writing can be found here:
-* [YAML Test Generators](tests/generators/README.md)
-* [Executable Python Spec, with Py-tests](tests/core/pyspec/README.md)
+
+- [YAML Test Generators](tests/generators/README.md)
+- [Executable Python Spec, with Py-tests](tests/core/pyspec/README.md)

--- a/configs/README.md
+++ b/configs/README.md
@@ -5,7 +5,6 @@ This directory contains a set of constants presets used for testing, testnets, a
 A preset file contains all the constants known for its target.
 Later-fork constants can be ignored, e.g. ignore Sharding constants as a client that only supports Phase 0 currently.
 
-
 ## Forking
 
 Configs are not replaced, but extended with forks. This is to support syncing from one state to the other over a fork boundary, without hot-swapping a config.
@@ -18,7 +17,7 @@ A previous iteration of forking made use of "timelines", but this collides with 
 Instead, the config essentially doubles as fork definition now, e.g. changing the value for `ALTAIR_FORK_SLOT` changes the fork.
 
 Another reason to prefer forking through constants is the ability to program a forking moment based on context, instead of being limited to a static slot number.
- 
+
 ## Format
 
 Each preset is a key-value mapping.
@@ -26,8 +25,9 @@ Each preset is a key-value mapping.
 **Key**: an `UPPER_SNAKE_CASE` (a.k.a. "macro case") formatted string, name of the constant.
 
 **Value** can be either:
- - an unsigned integer number, can be up to 64 bits (incl.)
- - a hexadecimal string, prefixed with `0x`
+
+- an unsigned integer number, can be up to 64 bits (incl.)
+- a hexadecimal string, prefixed with `0x`
 
 Presets may contain comments to describe the values.
 

--- a/solidity_deposit_contract/README.md
+++ b/solidity_deposit_contract/README.md
@@ -14,16 +14,17 @@ In August 2020, version `r2` was released with metadata modifications and relice
 ## Compiling solidity deposit contract
 
 In the `eth2.0-specs` directory run:
+
 ```sh
 make compile_deposit_contract
 ```
 
 The following parameters were used to generate the bytecode for the `DepositContract` available in this repository:
 
-* Contract Name: `DepositContract`
-* Compiler Version: Solidity `v0.6.11+commit.5ef660b1`
-* Optimization Enabled: `Yes` with `5000000` runs
-* Metadata Options: `--metadata-literal` (to verify metadata hash)
+- Contract Name: `DepositContract`
+- Compiler Version: Solidity `v0.6.11+commit.5ef660b1`
+- Optimization Enabled: `Yes` with `5000000` runs
+- Metadata Options: `--metadata-literal` (to verify metadata hash)
 
 ```sh
 solc --optimize --optimize-runs 5000000 --metadata-literal --bin deposit_contract.sol

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -3,7 +3,9 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -54,48 +56,49 @@
     - [Sync committee updates](#sync-committee-updates)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
 
 Altair is the first beacon chain hard fork. Its main features are:
 
-* sync committees to support light clients
-* incentive accounting reforms to reduce spec complexity
-* penalty parameter updates towards their planned maximally punitive values
+- sync committees to support light clients
+- incentive accounting reforms to reduce spec complexity
+- penalty parameter updates towards their planned maximally punitive values
 
 ## Custom types
 
-| Name | SSZ equivalent | Description |
-| - | - | - |
-| `ParticipationFlags` | `uint8` | a succinct representation of 8 boolean participation flags |
+| Name                 | SSZ equivalent | Description                                                |
+| -------------------- | -------------- | ---------------------------------------------------------- |
+| `ParticipationFlags` | `uint8`        | a succinct representation of 8 boolean participation flags |
 
 ## Constants
 
 ### Participation flag indices
 
-| Name | Value |
-| - | - |
-| `TIMELY_HEAD_FLAG_INDEX` | `0` |
-| `TIMELY_SOURCE_FLAG_INDEX` | `1` |
-| `TIMELY_TARGET_FLAG_INDEX` | `2` |
+| Name                       | Value |
+| -------------------------- | ----- |
+| `TIMELY_HEAD_FLAG_INDEX`   | `0`   |
+| `TIMELY_SOURCE_FLAG_INDEX` | `1`   |
+| `TIMELY_TARGET_FLAG_INDEX` | `2`   |
 
 ### Incentivization weights
 
-| Name | Value |
-| - | - |
-| `TIMELY_HEAD_WEIGHT` | `uint64(12)` |
+| Name                   | Value        |
+| ---------------------- | ------------ |
+| `TIMELY_HEAD_WEIGHT`   | `uint64(12)` |
 | `TIMELY_SOURCE_WEIGHT` | `uint64(12)` |
 | `TIMELY_TARGET_WEIGHT` | `uint64(24)` |
-| `SYNC_REWARD_WEIGHT` | `uint64(8)` |
-| `WEIGHT_DENOMINATOR` | `uint64(64)` |
+| `SYNC_REWARD_WEIGHT`   | `uint64(8)`  |
+| `WEIGHT_DENOMINATOR`   | `uint64(64)` |
 
 *Note*: The sum of the weight fractions (7/8) plus the proposer inclusion fraction (1/8) equals 1.
 
 ### Misc
 
-| Name | Value |
-| - | - |
+| Name                   | Value                                  |
+| ---------------------- | -------------------------------------- |
 | `G2_POINT_AT_INFINITY` | `BLSSignature(b'\xc0' + b'\x00' * 95)` |
 
 ## Configuration
@@ -106,33 +109,33 @@ This patch updates a few configuration values to move penalty parameters toward 
 
 *Note*: The spec does *not* override previous configuration values but instead creates new values and replaces usage throughout.
 
-| Name | Value |
-| - | - |
-| `INACTIVITY_PENALTY_QUOTIENT_ALTAIR` | `uint64(3 * 2**24)` (= 50,331,648) |
-| `MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR` | `uint64(2**6)` (= 64) |
-| `PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR` | `uint64(2)` |
+| Name                                      | Value                              |
+| ----------------------------------------- | ---------------------------------- |
+| `INACTIVITY_PENALTY_QUOTIENT_ALTAIR`      | `uint64(3 * 2**24)` (= 50,331,648) |
+| `MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR`    | `uint64(2**6)` (= 64)              |
+| `PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR` | `uint64(2)`                        |
 
 ### Misc
 
-| Name | Value |
-| - | - |
-| `SYNC_COMMITTEE_SIZE` | `uint64(2**10)` (= 1,024) |
-| `SYNC_PUBKEYS_PER_AGGREGATE` | `uint64(2**6)` (= 64) |
-| `INACTIVITY_SCORE_BIAS` | `uint64(4)` |
+| Name                         | Value                     |
+| ---------------------------- | ------------------------- |
+| `SYNC_COMMITTEE_SIZE`        | `uint64(2**10)` (= 1,024) |
+| `SYNC_PUBKEYS_PER_AGGREGATE` | `uint64(2**6)` (= 64)     |
+| `INACTIVITY_SCORE_BIAS`      | `uint64(4)`               |
 
 ### Time parameters
 
-| Name | Value | Unit | Duration |
-| - | - | :-: | :-: |
+| Name                               | Value                 |  Unit  | Duration  |
+| ---------------------------------- | --------------------- | :----: | :-------: |
 | `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `Epoch(2**8)` (= 256) | epochs | ~27 hours |
 
 ### Domain types
 
-| Name | Value |
-| - | - |
-| `DOMAIN_SYNC_COMMITTEE` | `DomainType('0x07000000')` |
+| Name                                    | Value                      |
+| --------------------------------------- | -------------------------- |
+| `DOMAIN_SYNC_COMMITTEE`                 | `DomainType('0x07000000')` |
 | `DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF` | `DomainType('0x08000000')` |
-| `DOMAIN_CONTRIBUTION_AND_PROOF` | `DomainType('0x09000000')` |
+| `DOMAIN_CONTRIBUTION_AND_PROOF`         | `DomainType('0x09000000')` |
 
 ## Containers
 

--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -5,6 +5,7 @@
 ## Table of contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -23,10 +24,10 @@ This document describes the process of the first upgrade of Ethereum 2.0: the Al
 
 Warning: this configuration is not definitive.
 
-| Name | Value |
-| - | - |
+| Name                  | Value                   |
+| --------------------- | ----------------------- |
 | `ALTAIR_FORK_VERSION` | `Version('0x01000000')` |
-| `ALTAIR_FORK_SLOT` | `Slot(0)` **TBD** |
+| `ALTAIR_FORK_SLOT`    | `Slot(0)` **TBD**       |
 
 ## Fork to Altair
 

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -6,14 +6,15 @@ Readers should understand the Phase 0 document and use it as a basis to understa
 
 Altair adds new messages, topics and data to the Req-Resp, Gossip and Discovery domain. Some Phase 0 features will be deprecated, but not removed immediately.
 
-
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-  - [Warning](#warning)
+- [Warning](#warning)
 - [Modifications in Altair](#modifications-in-altair)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
@@ -34,34 +35,35 @@ Altair adds new messages, topics and data to the Req-Resp, Gossip and Discovery 
   - [The discovery domain: discv5](#the-discovery-domain-discv5)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Warning
 
-This document is currently illustrative for early Altair testnets and some parts are subject to change. 
-Refer to the note in the [validator guide](./validator.md) for further details. 
+This document is currently illustrative for early Altair testnets and some parts are subject to change.
+Refer to the note in the [validator guide](./validator.md) for further details.
 
 # Modifications in Altair
 
 ## The gossip domain: gossipsub
 
-Gossip meshes are added in Altair to support the consensus activities of the sync committees. 
+Gossip meshes are added in Altair to support the consensus activities of the sync committees.
 Validators use an aggregation scheme to balance the processing and networking load across all of the relevant actors.
 
 ### Topics and messages
 
-Topics follow the same specification as in the Phase 0 document. 
+Topics follow the same specification as in the Phase 0 document.
 New topics are added in Altair to support the sync committees and the beacon block topic is updated with the modified type.
 
 The specification around the creation, validation, and dissemination of messages has not changed from the Phase 0 document.
 
 The new topics along with the type of the `data` field of a gossipsub message are given in this table:
 
-| Name | Message Type |
-| - | - |
-| `beacon_block` | `SignedBeaconBlock` (modified) |
-| `sync_committee_contribution_and_proof` | `SignedContributionAndProof` |
-| `sync_committee_{subnet_id}` | `SyncCommitteeSignature` |
+| Name                                    | Message Type                   |
+| --------------------------------------- | ------------------------------ |
+| `beacon_block`                          | `SignedBeaconBlock` (modified) |
+| `sync_committee_contribution_and_proof` | `SignedContributionAndProof`   |
+| `sync_committee_{subnet_id}`            | `SyncCommitteeSignature`       |
 
 Definitions of these new types can be found in the [Altair validator guide](./validator.md#containers).
 
@@ -74,27 +76,27 @@ Altair changes the type of the global beacon block topic and adds one global top
 ##### `beacon_block`
 
 The existing specification for this topic does not change from the Phase 0 document,
-but the type of the payload does change to the (modified) `SignedBeaconBlock`. 
+but the type of the payload does change to the (modified) `SignedBeaconBlock`.
 This type changes due to the inclusion of the inner `BeaconBlockBody` that is modified in Altair.
 
 See the [state transition document](./beacon-chain.md#beaconblockbody) for Altair for further details.
 
 ##### `sync_committee_contribution_and_proof`
- 
+
 This topic is used to propagate partially aggregated sync committee signatures to be included in future blocks.
 
 The following validations MUST pass before forwarding the `signed_contribution_and_proof` on the network; define `contribution_and_proof = signed_contribution_and_proof.message` and `contribution = contribution_and_proof.contribution` for convenience:
 
-- _[IGNORE]_ The contribution's slot is for the current slot, i.e. `contribution.slot == current_slot`.
-- _[IGNORE]_ The block being signed over (`contribution.beacon_block_root`) has been seen (via both gossip and non-gossip sources).
-- _[REJECT]_ The subcommittee index is in the allowed range, i.e. `contribution.subcommittee_index < SYNC_COMMITTEE_SUBNET_COUNT`.
-- _[IGNORE]_ The sync committee contribution is the first valid contribution received for the aggregator with index `contribution_and_proof.aggregator_index` for the slot `contribution.slot`.
-- _[REJECT]_ The aggregator's validator index is within the current sync committee --
+- _\[IGNORE\]_ The contribution's slot is for the current slot, i.e. `contribution.slot == current_slot`.
+- _\[IGNORE\]_ The block being signed over (`contribution.beacon_block_root`) has been seen (via both gossip and non-gossip sources).
+- _\[REJECT\]_ The subcommittee index is in the allowed range, i.e. `contribution.subcommittee_index < SYNC_COMMITTEE_SUBNET_COUNT`.
+- _\[IGNORE\]_ The sync committee contribution is the first valid contribution received for the aggregator with index `contribution_and_proof.aggregator_index` for the slot `contribution.slot`.
+- _\[REJECT\]_ The aggregator's validator index is within the current sync committee --
   i.e. `state.validators[aggregate_and_proof.aggregator_index].pubkey in state.current_sync_committee.pubkeys`.
-- _[REJECT]_ The `contribution_and_proof.selection_proof` is a valid signature of the `contribution.slot` by the validator with index `contribution_and_proof.aggregator_index`.
-- _[REJECT]_ `contribution_and_proof.selection_proof` selects the validator as an aggregator for the slot -- i.e. `is_sync_committee_aggregator(state, contribution.slot, contribution_and_proof.selection_proof)` returns `True`.
-- _[REJECT]_ The aggregator signature, `signed_contribution_and_proof.signature`, is valid.
-- _[REJECT]_ The aggregate signature is valid for the message `beacon_block_root` and aggregate pubkey derived from the participation info in `aggregation_bits` for the subcommittee specified by the `subcommittee_index`.
+- _\[REJECT\]_ The `contribution_and_proof.selection_proof` is a valid signature of the `contribution.slot` by the validator with index `contribution_and_proof.aggregator_index`.
+- _\[REJECT\]_ `contribution_and_proof.selection_proof` selects the validator as an aggregator for the slot -- i.e. `is_sync_committee_aggregator(state, contribution.slot, contribution_and_proof.selection_proof)` returns `True`.
+- _\[REJECT\]_ The aggregator signature, `signed_contribution_and_proof.signature`, is valid.
+- _\[REJECT\]_ The aggregate signature is valid for the message `beacon_block_root` and aggregate pubkey derived from the participation info in `aggregation_bits` for the subcommittee specified by the `subcommittee_index`.
 
 #### Sync committee subnets
 
@@ -106,19 +108,19 @@ The `sync_committee_{subnet_id}` topics are used to propagate unaggregated sync 
 
 The following validations MUST pass before forwarding the `sync_committee_signature` on the network:
 
-- _[IGNORE]_ The signature's slot is for the current slot, i.e. `sync_committee_signature.slot == current_slot`.
-- _[IGNORE]_ The block being signed over (`sync_committee_signature.beacon_block_root`) has been seen (via both gossip and non-gossip sources).
-- _[IGNORE]_ There has been no other valid sync committee signature for the declared `slot` for the validator referenced by `sync_committee_signature.validator_index`.
-- _[REJECT]_ The validator producing this `sync_committee_signature` is in the current sync committee, i.e. `state.validators[sync_committee_signature.validator_index].pubkey in state.current_sync_committee.pubkeys`.
-- _[REJECT]_ The `subnet_id` is correct, i.e. `subnet_id in compute_subnets_for_sync_committee(state, sync_committee_signature.validator_index)`.
-- _[REJECT]_ The `signature` is valid for the message `beacon_block_root` for the validator referenced by `validator_index`.
+- _\[IGNORE\]_ The signature's slot is for the current slot, i.e. `sync_committee_signature.slot == current_slot`.
+- _\[IGNORE\]_ The block being signed over (`sync_committee_signature.beacon_block_root`) has been seen (via both gossip and non-gossip sources).
+- _\[IGNORE\]_ There has been no other valid sync committee signature for the declared `slot` for the validator referenced by `sync_committee_signature.validator_index`.
+- _\[REJECT\]_ The validator producing this `sync_committee_signature` is in the current sync committee, i.e. `state.validators[sync_committee_signature.validator_index].pubkey in state.current_sync_committee.pubkeys`.
+- _\[REJECT\]_ The `subnet_id` is correct, i.e. `subnet_id in compute_subnets_for_sync_committee(state, sync_committee_signature.validator_index)`.
+- _\[REJECT\]_ The `signature` is valid for the message `beacon_block_root` for the validator referenced by `validator_index`.
 
 #### Sync committees and aggregation
 
-The aggregation scheme closely follows the design of the attestation aggregation scheme. 
-Sync committee signatures are broadcast into "subnets" defined by a topic. 
-The number of subnets is defined by `SYNC_COMMITTEE_SUBNET_COUNT` in the [Altair validator guide](./validator.md#constants). 
-Sync committee members are divided into "subcommittees" which are then assigned to a subnet for the duration of tenure in the sync committee. 
+The aggregation scheme closely follows the design of the attestation aggregation scheme.
+Sync committee signatures are broadcast into "subnets" defined by a topic.
+The number of subnets is defined by `SYNC_COMMITTEE_SUBNET_COUNT` in the [Altair validator guide](./validator.md#constants).
+Sync committee members are divided into "subcommittees" which are then assigned to a subnet for the duration of tenure in the sync committee.
 Individual validators can be duplicated in the broader sync committee such that they are included multiple times in a given subcommittee or across multiple subcommittees.
 
 Unaggregated signatures (along with metadata) are sent as `SyncCommitteeSignature`s on the `sync_committee_{subnet_id}` topics.
@@ -138,11 +140,13 @@ Topic-meshes can be grafted quickly as the nodes are already connected and excha
 Messages SHOULD NOT be re-broadcast from one fork to the other.
 A node's behavior before the fork and after the fork are as follows:
 Pre-fork:
+
 - Peers who propagate messages on the post-fork topics MAY be scored negatively proportionally to time till fork,
   to account for clock discrepancy.
 - Messages can be IGNORED on the post-fork topics, with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` margin.
 
 Post-fork:
+
 - Peers who propagate messages on the pre-fork topics MUST NOT be scored negatively. Lagging IWANT may force them to.
 - Messages on pre and post-fork variants of topics share application-level caches.
   E.g. an attestation on the both the old and new topic is ignored like any duplicate.
@@ -170,7 +174,7 @@ Starting with Altair, and in future forks, SSZ type definitions may change.
 For this common case, we define the `ForkDigest`-context:
 
 A fixed-width 4 byte `<context-bytes>`, set to the `ForkDigest` matching the chunk:
- `compute_fork_digest(fork_version, genesis_validators_root)`.
+`compute_fork_digest(fork_version, genesis_validators_root)`.
 
 ### Messages
 
@@ -203,7 +207,7 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 In advance of the fork, implementations can opt in to both run the v1 and v2 for a smooth transition.
 This is non-breaking, and is recommended as soon as the fork specification is stable.
 
-The v1 variants will be deprecated, and implementations should use v2 when available 
+The v1 variants will be deprecated, and implementations should use v2 when available
 (as negotiated with peers via LibP2P multistream-select).
 
 The v1 method MAY be unregistered at the fork boundary.
@@ -215,7 +219,7 @@ the responder MUST return the **InvalidRequest** response code.
 The `attnets` key of the ENR is used as defined in the Phase 0 document.
 
 An additional bitfield is added to the ENR under the key `syncnets` to facilitate sync committee subnet discovery.
-The length of this bitfield is `SYNC_COMMITTEE_SUBNET_COUNT` where each bit corresponds to a distinct `subnet_id` for a specific sync committee subnet. 
+The length of this bitfield is `SYNC_COMMITTEE_SUBNET_COUNT` where each bit corresponds to a distinct `subnet_id` for a specific sync committee subnet.
 The `i`th bit is set in this bitfield if the validator is currently subscribed to the `sync_committee_{i}` topic.
 
 See the [validator document](./validator.md#sync-committee-subnet-stability) for further details on how the new bits are used.

--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -5,7 +5,9 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -20,11 +22,12 @@
 - [Helper functions](#helper-functions)
   - [`get_subtree_index`](#get_subtree_index)
 - [Light client state updates](#light-client-state-updates)
-    - [`validate_light_client_update`](#validate_light_client_update)
-    - [`apply_light_client_update`](#apply_light_client_update)
-    - [`process_light_client_update`](#process_light_client_update)
+  - [`validate_light_client_update`](#validate_light_client_update)
+  - [`apply_light_client_update`](#apply_light_client_update)
+  - [`process_light_client_update`](#process_light_client_update)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
@@ -39,24 +42,24 @@ uses sync committees introduced in [this beacon chain extension](./beacon-chain.
 
 ## Constants
 
-| Name | Value |
-| - | - |
-| `FINALIZED_ROOT_INDEX` | `get_generalized_index(BeaconState, 'finalized_checkpoint', 'root')` |
-| `NEXT_SYNC_COMMITTEE_INDEX` | `get_generalized_index(BeaconState, 'next_sync_committee')` |
+| Name                        | Value                                                                |
+| --------------------------- | -------------------------------------------------------------------- |
+| `FINALIZED_ROOT_INDEX`      | `get_generalized_index(BeaconState, 'finalized_checkpoint', 'root')` |
+| `NEXT_SYNC_COMMITTEE_INDEX` | `get_generalized_index(BeaconState, 'next_sync_committee')`          |
 
 ## Configuration
 
 ### Misc
 
-| Name | Value |
-| - | - |
-| `MIN_SYNC_COMMITTEE_PARTICIPANTS` | `1` |
-| `MAX_VALID_LIGHT_CLIENT_UPDATES` | `uint64(2**64 - 1)` |
+| Name                              | Value               |
+| --------------------------------- | ------------------- |
+| `MIN_SYNC_COMMITTEE_PARTICIPANTS` | `1`                 |
+| `MAX_VALID_LIGHT_CLIENT_UPDATES`  | `uint64(2**64 - 1)` |
 
 ### Time parameters
 
-| Name | Value | Unit | Duration |
-| - | - | :-: | :-: |
+| Name                          | Value         | Unit  | Duration  |
+| ----------------------------- | ------------- | :---: | :-------: |
 | `LIGHT_CLIENT_UPDATE_TIMEOUT` | `Slot(2**13)` | slots | ~27 hours |
 
 ## Containers

--- a/specs/custody_game/beacon-chain.md
+++ b/specs/custody_game/beacon-chain.md
@@ -5,7 +5,9 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -52,8 +54,8 @@
   - [Final updates](#final-updates)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-<!-- /TOC -->
 
+<!-- /TOC -->
 
 ## Introduction
 
@@ -64,50 +66,49 @@ building upon the [Sharding](../sharding/beacon-chain.md) specification.
 
 ### Misc
 
-| Name | Value | Unit |
-| - | - | - |
-| `CUSTODY_PRIME` | `int(2 ** 256 - 189)` | - |
-| `CUSTODY_SECRETS` | `uint64(3)` | - |
-| `BYTES_PER_CUSTODY_ATOM` | `uint64(32)` | bytes |
-| `CUSTODY_PROBABILITY_EXPONENT` | `uint64(10)` | - |
+| Name                           | Value                 | Unit  |
+| ------------------------------ | --------------------- | ----- |
+| `CUSTODY_PRIME`                | `int(2 ** 256 - 189)` | -     |
+| `CUSTODY_SECRETS`              | `uint64(3)`           | -     |
+| `BYTES_PER_CUSTODY_ATOM`       | `uint64(32)`          | bytes |
+| `CUSTODY_PROBABILITY_EXPONENT` | `uint64(10)`          | -     |
 
 ## Configuration
 
 ### Time parameters
 
-| Name | Value | Unit | Duration |
-| - | - | :-: | :-: |
-| `RANDAO_PENALTY_EPOCHS` | `uint64(2**1)` (= 2) | epochs | 12.8 minutes |
-| `EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS` | `uint64(2**15)` (= 32,768) | epochs | ~146 days |
-| `EPOCHS_PER_CUSTODY_PERIOD` | `uint64(2**14)` (= 16,384) | epochs | ~73 days |
-| `CUSTODY_PERIOD_TO_RANDAO_PADDING` | `uint64(2**11)` (= 2,048) | epochs | ~9 days |
-| `MAX_CHUNK_CHALLENGE_DELAY` | `uint64(2**15)` (= 32,768) | epochs | ~146 days |
+| Name                                             | Value                      |  Unit  |   Duration   |
+| ------------------------------------------------ | -------------------------- | :----: | :----------: |
+| `RANDAO_PENALTY_EPOCHS`                          | `uint64(2**1)` (= 2)       | epochs | 12.8 minutes |
+| `EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS` | `uint64(2**15)` (= 32,768) | epochs |  ~146 days   |
+| `EPOCHS_PER_CUSTODY_PERIOD`                      | `uint64(2**14)` (= 16,384) | epochs |   ~73 days   |
+| `CUSTODY_PERIOD_TO_RANDAO_PADDING`               | `uint64(2**11)` (= 2,048)  | epochs |   ~9 days    |
+| `MAX_CHUNK_CHALLENGE_DELAY`                      | `uint64(2**15)` (= 32,768) | epochs |  ~146 days   |
 
 ### Max operations per block
 
-| Name | Value |
-| - | - |
-| `MAX_CUSTODY_CHUNK_CHALLENGE_RECORDS` | `uint64(2**20)` (= 1,048,576) |
-| `MAX_CUSTODY_KEY_REVEALS` | `uint64(2**8)` (= 256) |
-| `MAX_EARLY_DERIVED_SECRET_REVEALS` | `uint64(2**0)` (= 1) |
-| `MAX_CUSTODY_CHUNK_CHALLENGES` | `uint64(2**2)` (= 4) |
-| `MAX_CUSTODY_CHUNK_CHALLENGE_RESPONSES` | `uint64(2**4)` (= 16) |
-| `MAX_CUSTODY_SLASHINGS` | `uint64(2**0)` (= 1) |
-
+| Name                                    | Value                         |
+| --------------------------------------- | ----------------------------- |
+| `MAX_CUSTODY_CHUNK_CHALLENGE_RECORDS`   | `uint64(2**20)` (= 1,048,576) |
+| `MAX_CUSTODY_KEY_REVEALS`               | `uint64(2**8)` (= 256)        |
+| `MAX_EARLY_DERIVED_SECRET_REVEALS`      | `uint64(2**0)` (= 1)          |
+| `MAX_CUSTODY_CHUNK_CHALLENGES`          | `uint64(2**2)` (= 4)          |
+| `MAX_CUSTODY_CHUNK_CHALLENGE_RESPONSES` | `uint64(2**4)` (= 16)         |
+| `MAX_CUSTODY_SLASHINGS`                 | `uint64(2**0)` (= 1)          |
 
 ### Size parameters
 
-| Name | Value | Unit |
-| - | - | - |
-| `BYTES_PER_CUSTODY_CHUNK` | `uint64(2**12)` (= 4,096) | bytes |
-| `CUSTODY_RESPONSE_DEPTH` | `ceillog2(MAX_SHARD_BLOCK_SIZE // BYTES_PER_CUSTODY_CHUNK)` | - |
+| Name                      | Value                                                       | Unit  |
+| ------------------------- | ----------------------------------------------------------- | ----- |
+| `BYTES_PER_CUSTODY_CHUNK` | `uint64(2**12)` (= 4,096)                                   | bytes |
+| `CUSTODY_RESPONSE_DEPTH`  | `ceillog2(MAX_SHARD_BLOCK_SIZE // BYTES_PER_CUSTODY_CHUNK)` | -     |
 
 ### Reward and penalty quotients
 
-| Name | Value |
-| - | - |
-| `EARLY_DERIVED_SECRET_REVEAL_SLOT_REWARD_MULTIPLE` | `uint64(2**1)` (= 2) |
-| `MINOR_REWARD_QUOTIENT` | `uint64(2**8)` (= 256) |
+| Name                                               | Value                  |
+| -------------------------------------------------- | ---------------------- |
+| `EARLY_DERIVED_SECRET_REVEAL_SLOT_REWARD_MULTIPLE` | `uint64(2**1)` (= 2)   |
+| `MINOR_REWARD_QUOTIENT`                            | `uint64(2**8)` (= 256) |
 
 ## Data structures
 
@@ -347,7 +348,6 @@ def get_custody_period_for_validator(validator_index: ValidatorIndex, epoch: Epo
     '''
     return (epoch + validator_index % EPOCHS_PER_CUSTODY_PERIOD) // EPOCHS_PER_CUSTODY_PERIOD
 ```
-
 
 ## Per-block processing
 

--- a/specs/custody_game/validator.md
+++ b/specs/custody_game/validator.md
@@ -7,23 +7,25 @@ participating in the Ethereum 2.0 Custody Game.
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
 - [Becoming a validator](#becoming-a-validator)
 - [Beacon chain validator assignments](#beacon-chain-validator-assignments)
-      - [Custody slashings](#custody-slashings)
-      - [Custody key reveals](#custody-key-reveals)
-      - [Early derived secret reveals](#early-derived-secret-reveals)
-    - [Construct attestation](#construct-attestation)
+  \- [Custody slashings](#custody-slashings)
+  \- [Custody key reveals](#custody-key-reveals)
+  \- [Early derived secret reveals](#early-derived-secret-reveals)
+  - [Construct attestation](#construct-attestation)
 - [How to avoid slashing](#how-to-avoid-slashing)
   - [Custody slashing](#custody-slashing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-<!-- /TOC -->
 
+<!-- /TOC -->
 
 ## Introduction
 
@@ -56,8 +58,7 @@ Up to `MAX_EARLY_DERIVED_SECRET_REVEALS`, [`EarlyDerivedSecretReveal`](./beacon-
 
 #### Construct attestation
 
-`attestation.data`, `attestation.aggregation_bits`, and `attestation.signature` are unchanged from Phase 0. But safety/validity in signing the message is premised upon calculation of the "custody bit" [TODO].
-
+`attestation.data`, `attestation.aggregation_bits`, and `attestation.signature` are unchanged from Phase 0. But safety/validity in signing the message is premised upon calculation of the "custody bit" \[TODO\].
 
 ## How to avoid slashing
 

--- a/specs/das/das-core.md
+++ b/specs/das/das-core.md
@@ -5,7 +5,9 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Custom types](#custom-types)
@@ -22,26 +24,24 @@
 - [DAS functions](#das-functions)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-<!-- /TOC -->
 
+<!-- /TOC -->
 
 ## Custom types
 
 We define the following Python custom types for type hinting and readability:
 
-| Name | SSZ equivalent | Description |
-| - | - | - |
-| `SampleIndex` | `uint64` | A sample index, corresponding to chunk of extended data |
-
+| Name          | SSZ equivalent | Description                                             |
+| ------------- | -------------- | ------------------------------------------------------- |
+| `SampleIndex` | `uint64`       | A sample index, corresponding to chunk of extended data |
 
 ## Configuration
 
 ### Misc
 
-| Name | Value | Notes |
-| - | - | - |
+| Name                | Value           | Notes                                                             |
+| ------------------- | --------------- | ----------------------------------------------------------------- |
 | `MAX_RESAMPLE_TIME` | `TODO` (= TODO) | Time window to sample a shard blob and put it on vertical subnets |
-
 
 ## New containers
 
@@ -83,6 +83,7 @@ def reverse_bit_order_list(elements: Sequence[int]) -> Sequence[int]:
 ### Data extension
 
 Implementations:
+
 - [Python](https://github.com/protolambda/partial_fft/blob/master/das_fft.py)
 - [Go](https://github.com/protolambda/go-kate/blob/master/das_extension.go)
 
@@ -98,8 +99,9 @@ def das_fft_extension(data: Sequence[Point]) -> Sequence[Point]:
 
 ### Data recovery
 
-See [Reed-Solomon erasure code recovery in n*log^2(n) time with FFTs](https://ethresear.ch/t/reed-solomon-erasure-code-recovery-in-n-log-2-n-time-with-ffts/3039) for theory.
+See [Reed-Solomon erasure code recovery in n\*log^2(n) time with FFTs](https://ethresear.ch/t/reed-solomon-erasure-code-recovery-in-n-log-2-n-time-with-ffts/3039) for theory.
 Implementations:
+
 - [Original Python](https://github.com/ethereum/research/blob/master/mimc_stark/recovery.py)
 - [New optimized approach in python](https://github.com/ethereum/research/tree/master/polynomial_reconstruction)
 - [Old approach in Go](https://github.com/protolambda/go-kate/blob/master/recovery.go)

--- a/specs/das/fork-choice.md
+++ b/specs/das/fork-choice.md
@@ -5,15 +5,17 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
 - [Dependency calculation](#dependency-calculation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-<!-- /TOC -->
 
+<!-- /TOC -->
 
 ## Introduction
 

--- a/specs/das/sampling.md
+++ b/specs/das/sampling.md
@@ -5,7 +5,9 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Data Availability Sampling](#data-availability-sampling)
@@ -20,8 +22,8 @@
     - [Stage 2: Pulling missing data from validators with custody.](#stage-2-pulling-missing-data-from-validators-with-custody)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-<!-- /TOC -->
 
+<!-- /TOC -->
 
 ## Data Availability Sampling
 
@@ -45,7 +47,6 @@ TODO
 
 TODO
 
-
 ### DAS during network instability
 
 The GossipSub based retrieval of samples may not always work.
@@ -56,6 +57,7 @@ In such event, a node can move through below stages until it recovers data avail
 Wait for the sample to re-broadcast. Someone may be slow with publishing, or someone else is able to do the work.
 
 Any node can do the following work to keep the network healthy:
+
 - Common: Listen on a horizontal subnet, chunkify the block data in samples, and propagate the samples to vertical subnets.
 - Extreme: Listen on enough vertical subnets, reconstruct the missing samples by recovery, and propagate the recovered samples.
 
@@ -70,6 +72,7 @@ without explicitly asking for the data.
 However, *network identities* are still used to build a backbone for each vertical subnet.
 These nodes should have received the samples, and can serve a buffer of them on demand.
 Although serving these is not directly incentivised, it is little work:
+
 1. Buffer any message you see on the backbone vertical subnets, for a buffer of up to two weeks.
 2. Serve the samples on request. An individual sample is just expected to be `~ 0.5 KB`, and does not require any pre-processing to serve.
 
@@ -81,4 +84,3 @@ TODO: detailed failure-mode spec. Stop after trying e.g. 3 peers for any sample 
 
 Pulling samples directly from nodes with validators that have a custody responsibility,
 without revealing their identity to the network, is an open problem.
-

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -7,7 +7,9 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -32,36 +34,37 @@
       - [`process_application_payload`](#process_application_payload)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
 
-This is a patch implementing the executable beacon chain proposal. 
+This is a patch implementing the executable beacon chain proposal.
 It enshrines application-layer execution and validity as a first class citizen at the core of the beacon chain.
 
 ## Custom types
 
 We define the following Python custom types for type hinting and readability:
 
-| Name | SSZ equivalent | Description |
-| - | - | - |
+| Name                | SSZ equivalent                               | Description                                                                                                                                                                                              |
+| ------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `OpaqueTransaction` | `ByteList[MAX_BYTES_PER_OPAQUE_TRANSACTION]` | a byte-list containing a single [typed transaction envelope](https://eips.ethereum.org/EIPS/eip-2718#opaque-byte-array-rather-than-an-rlp-array) structured as `TransactionType \|\| TransactionPayload` |
 
 ## Constants
 
 ### Transition
 
-| Name | Value |
-| - | - |
+| Name                          | Value   |
+| ----------------------------- | ------- |
 | `TRANSITION_TOTAL_DIFFICULTY` | **TBD** |
 
 ### Execution
 
-| Name | Value |
-| - | - |
+| Name                               | Value                         |
+| ---------------------------------- | ----------------------------- |
 | `MAX_BYTES_PER_OPAQUE_TRANSACTION` | `uint64(2**20)` (= 1,048,576) |
-| `MAX_APPLICATION_TRANSACTIONS` | `uint64(2**14)` (= 16,384) |
-| `BYTES_PER_LOGS_BLOOM` | `uint64(2**8)` (= 256) |
+| `MAX_APPLICATION_TRANSACTIONS`     | `uint64(2**14)` (= 16,384)    |
+| `BYTES_PER_LOGS_BLOOM`             | `uint64(2**8)` (= 256)        |
 
 ## Containers
 
@@ -143,12 +146,12 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 *Note*: `ApplicationState` class is an abstract class representing ethereum application state.
 
-Let `get_application_state(application_state_root: Bytes32) -> ApplicationState`  be the function that given the root hash returns a copy of ethereum application state. 
+Let `get_application_state(application_state_root: Bytes32) -> ApplicationState`  be the function that given the root hash returns a copy of ethereum application state.
 The body of the function is implementation dependent.
 
 ##### `application_state_transition`
 
-Let `application_state_transition(application_state: ApplicationState, application_payload: ApplicationPayload) -> None` be the transition function of ethereum application state. 
+Let `application_state_transition(application_state: ApplicationState, application_payload: ApplicationPayload) -> None` be the transition function of ethereum application state.
 The body of the function is implementation dependent.
 
 *Note*: `application_state_transition` must throw `AssertionError` if either the transition itself or one of the post-transition verifications has failed.

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -3,8 +3,11 @@
 **Notice**: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
+
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -16,6 +19,7 @@
     - [`on_block`](#on_block)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
@@ -113,4 +117,3 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
             if ancestor_at_finalized_slot != store.finalized_checkpoint.root:
                 store.justified_checkpoint = state.current_justified_checkpoint
 ```
-

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -7,7 +7,9 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -20,6 +22,7 @@
         - [`produce_application_payload`](#produce_application_payload)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
@@ -51,7 +54,7 @@ Let `get_pow_chain_head() -> PowBlock` be the function that returns the head of 
 Let `produce_application_payload(parent_hash: Bytes32) -> ApplicationPayload` be the function that produces new instance of application payload.
 The body of this function is implementation dependent.
 
-* Set `block.body.application_payload = get_application_payload(state)` where:
+- Set `block.body.application_payload = get_application_payload(state)` where:
 
 ```python
 def get_application_payload(state: BeaconState) -> ApplicationPayload:

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1,8 +1,11 @@
 # Ethereum 2.0 Phase 0 -- The Beacon Chain
 
 ## Table of contents
+
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -132,6 +135,7 @@
       - [Voluntary exits](#voluntary-exits)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
@@ -149,34 +153,34 @@ Code snippets appearing in `this style` are to be interpreted as Python 3 code.
 
 We define the following Python custom types for type hinting and readability:
 
-| Name | SSZ equivalent | Description |
-| - | - | - |
-| `Slot` | `uint64` | a slot number |
-| `Epoch` | `uint64` | an epoch number |
-| `CommitteeIndex` | `uint64` | a committee index at a slot |
-| `ValidatorIndex` | `uint64` | a validator registry index |
-| `Gwei` | `uint64` | an amount in Gwei |
-| `Root` | `Bytes32` | a Merkle root |
-| `Version` | `Bytes4` | a fork version number |
-| `DomainType` | `Bytes4` | a domain type |
-| `ForkDigest` | `Bytes4` | a digest of the current fork data |
-| `Domain` | `Bytes32` | a signature domain |
-| `BLSPubkey` | `Bytes48` | a BLS12-381 public key |
-| `BLSSignature` | `Bytes96` | a BLS12-381 signature |
+| Name             | SSZ equivalent | Description                       |
+| ---------------- | -------------- | --------------------------------- |
+| `Slot`           | `uint64`       | a slot number                     |
+| `Epoch`          | `uint64`       | an epoch number                   |
+| `CommitteeIndex` | `uint64`       | a committee index at a slot       |
+| `ValidatorIndex` | `uint64`       | a validator registry index        |
+| `Gwei`           | `uint64`       | an amount in Gwei                 |
+| `Root`           | `Bytes32`      | a Merkle root                     |
+| `Version`        | `Bytes4`       | a fork version number             |
+| `DomainType`     | `Bytes4`       | a domain type                     |
+| `ForkDigest`     | `Bytes4`       | a digest of the current fork data |
+| `Domain`         | `Bytes32`      | a signature domain                |
+| `BLSPubkey`      | `Bytes48`      | a BLS12-381 public key            |
+| `BLSSignature`   | `Bytes96`      | a BLS12-381 signature             |
 
 ## Constants
 
 The following values are (non-configurable) constants used throughout the specification.
 
-| Name | Value |
-| - | - |
-| `GENESIS_SLOT` | `Slot(0)` |
-| `GENESIS_EPOCH` | `Epoch(0)` |
-| `FAR_FUTURE_EPOCH` | `Epoch(2**64 - 1)` |
-| `BASE_REWARDS_PER_EPOCH` | `uint64(4)` |
+| Name                          | Value                 |
+| ----------------------------- | --------------------- |
+| `GENESIS_SLOT`                | `Slot(0)`             |
+| `GENESIS_EPOCH`               | `Epoch(0)`            |
+| `FAR_FUTURE_EPOCH`            | `Epoch(2**64 - 1)`    |
+| `BASE_REWARDS_PER_EPOCH`      | `uint64(4)`           |
 | `DEPOSIT_CONTRACT_TREE_DEPTH` | `uint64(2**5)` (= 32) |
-| `JUSTIFICATION_BITS_LENGTH` | `uint64(4)` |
-| `ENDIANNESS` | `'little'` |
+| `JUSTIFICATION_BITS_LENGTH`   | `uint64(4)`           |
+| `ENDIANNESS`                  | `'little'`            |
 
 ## Configuration
 
@@ -184,81 +188,81 @@ The following values are (non-configurable) constants used throughout the specif
 
 ### Misc
 
-| Name | Value |
-| - | - |
-| `ETH1_FOLLOW_DISTANCE` | `uint64(2**11)` (= 2,048) |
-| `MAX_COMMITTEES_PER_SLOT` | `uint64(2**6)` (= 64) |
-| `TARGET_COMMITTEE_SIZE` | `uint64(2**7)` (= 128) |
-| `MAX_VALIDATORS_PER_COMMITTEE` | `uint64(2**11)` (= 2,048) |
-| `MIN_PER_EPOCH_CHURN_LIMIT` | `uint64(2**2)` (= 4) |
-| `CHURN_LIMIT_QUOTIENT` | `uint64(2**16)` (= 65,536) |
-| `SHUFFLE_ROUND_COUNT` | `uint64(90)` |
-| `MIN_GENESIS_ACTIVE_VALIDATOR_COUNT` | `uint64(2**14)` (= 16,384) |
-| `MIN_GENESIS_TIME` | `uint64(1606824000)` (Dec 1, 2020, 12pm UTC) |
-| `HYSTERESIS_QUOTIENT` | `uint64(4)` |
-| `HYSTERESIS_DOWNWARD_MULTIPLIER` | `uint64(1)` |
-| `HYSTERESIS_UPWARD_MULTIPLIER` | `uint64(5)` |
+| Name                                 | Value                                        |
+| ------------------------------------ | -------------------------------------------- |
+| `ETH1_FOLLOW_DISTANCE`               | `uint64(2**11)` (= 2,048)                    |
+| `MAX_COMMITTEES_PER_SLOT`            | `uint64(2**6)` (= 64)                        |
+| `TARGET_COMMITTEE_SIZE`              | `uint64(2**7)` (= 128)                       |
+| `MAX_VALIDATORS_PER_COMMITTEE`       | `uint64(2**11)` (= 2,048)                    |
+| `MIN_PER_EPOCH_CHURN_LIMIT`          | `uint64(2**2)` (= 4)                         |
+| `CHURN_LIMIT_QUOTIENT`               | `uint64(2**16)` (= 65,536)                   |
+| `SHUFFLE_ROUND_COUNT`                | `uint64(90)`                                 |
+| `MIN_GENESIS_ACTIVE_VALIDATOR_COUNT` | `uint64(2**14)` (= 16,384)                   |
+| `MIN_GENESIS_TIME`                   | `uint64(1606824000)` (Dec 1, 2020, 12pm UTC) |
+| `HYSTERESIS_QUOTIENT`                | `uint64(4)`                                  |
+| `HYSTERESIS_DOWNWARD_MULTIPLIER`     | `uint64(1)`                                  |
+| `HYSTERESIS_UPWARD_MULTIPLIER`       | `uint64(5)`                                  |
 
 - For the safety of committees, `TARGET_COMMITTEE_SIZE` exceeds [the recommended minimum committee size of 111](http://web.archive.org/web/20190504131341/https://vitalik.ca/files/Ithaca201807_Sharding.pdf); with sufficient active validators (at least `SLOTS_PER_EPOCH * TARGET_COMMITTEE_SIZE`), the shuffling algorithm ensures committee sizes of at least `TARGET_COMMITTEE_SIZE`. (Unbiasable randomness with a Verifiable Delay Function (VDF) will improve committee robustness and lower the safe minimum committee size.)
 
 ### Gwei values
 
-| Name | Value |
-| - | - |
-| `MIN_DEPOSIT_AMOUNT` | `Gwei(2**0 * 10**9)` (= 1,000,000,000) |
-| `MAX_EFFECTIVE_BALANCE` | `Gwei(2**5 * 10**9)` (= 32,000,000,000) |
-| `EJECTION_BALANCE` | `Gwei(2**4 * 10**9)` (= 16,000,000,000) |
-| `EFFECTIVE_BALANCE_INCREMENT` | `Gwei(2**0 * 10**9)` (= 1,000,000,000) |
+| Name                          | Value                                   |
+| ----------------------------- | --------------------------------------- |
+| `MIN_DEPOSIT_AMOUNT`          | `Gwei(2**0 * 10**9)` (= 1,000,000,000)  |
+| `MAX_EFFECTIVE_BALANCE`       | `Gwei(2**5 * 10**9)` (= 32,000,000,000) |
+| `EJECTION_BALANCE`            | `Gwei(2**4 * 10**9)` (= 16,000,000,000) |
+| `EFFECTIVE_BALANCE_INCREMENT` | `Gwei(2**0 * 10**9)` (= 1,000,000,000)  |
 
 ### Initial values
 
-| Name | Value |
-| - | - |
+| Name                   | Value                   |
+| ---------------------- | ----------------------- |
 | `GENESIS_FORK_VERSION` | `Version('0x00000000')` |
 
 ### Withdrawal prefixes
 
-| Name | Value |
-| - | - |
-| `BLS_WITHDRAWAL_PREFIX` | `Bytes1('0x00')` |
+| Name                             | Value            |
+| -------------------------------- | ---------------- |
+| `BLS_WITHDRAWAL_PREFIX`          | `Bytes1('0x00')` |
 | `ETH1_ADDRESS_WITHDRAWAL_PREFIX` | `Bytes1('0x01')` |
 
 ### Time parameters
 
-| Name | Value | Unit | Duration |
-| - | - | :-: | :-: |
-| `GENESIS_DELAY` | `uint64(604800)` | seconds | 7 days |
-| `SECONDS_PER_SLOT` | `uint64(12)` | seconds | 12 seconds |
-| `SECONDS_PER_ETH1_BLOCK` | `uint64(14)` | seconds | 14 seconds |
-| `MIN_ATTESTATION_INCLUSION_DELAY` | `uint64(2**0)` (= 1) | slots | 12 seconds |
-| `SLOTS_PER_EPOCH` | `uint64(2**5)` (= 32) | slots | 6.4 minutes |
-| `MIN_SEED_LOOKAHEAD` | `uint64(2**0)` (= 1) | epochs | 6.4 minutes |
-| `MAX_SEED_LOOKAHEAD` | `uint64(2**2)` (= 4) | epochs | 25.6 minutes |
-| `MIN_EPOCHS_TO_INACTIVITY_PENALTY` | `uint64(2**2)` (= 4) | epochs | 25.6 minutes |
-| `EPOCHS_PER_ETH1_VOTING_PERIOD` | `uint64(2**6)` (= 64) | epochs | ~6.8 hours |
-| `SLOTS_PER_HISTORICAL_ROOT` | `uint64(2**13)` (= 8,192) | slots | ~27 hours |
-| `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `uint64(2**8)` (= 256) | epochs | ~27 hours |
-| `SHARD_COMMITTEE_PERIOD` | `uint64(2**8)` (= 256) | epochs | ~27 hours |
+| Name                                  | Value                     |  Unit   |   Duration   |
+| ------------------------------------- | ------------------------- | :-----: | :----------: |
+| `GENESIS_DELAY`                       | `uint64(604800)`          | seconds |    7 days    |
+| `SECONDS_PER_SLOT`                    | `uint64(12)`              | seconds |  12 seconds  |
+| `SECONDS_PER_ETH1_BLOCK`              | `uint64(14)`              | seconds |  14 seconds  |
+| `MIN_ATTESTATION_INCLUSION_DELAY`     | `uint64(2**0)` (= 1)      |  slots  |  12 seconds  |
+| `SLOTS_PER_EPOCH`                     | `uint64(2**5)` (= 32)     |  slots  | 6.4 minutes  |
+| `MIN_SEED_LOOKAHEAD`                  | `uint64(2**0)` (= 1)      | epochs  | 6.4 minutes  |
+| `MAX_SEED_LOOKAHEAD`                  | `uint64(2**2)` (= 4)      | epochs  | 25.6 minutes |
+| `MIN_EPOCHS_TO_INACTIVITY_PENALTY`    | `uint64(2**2)` (= 4)      | epochs  | 25.6 minutes |
+| `EPOCHS_PER_ETH1_VOTING_PERIOD`       | `uint64(2**6)` (= 64)     | epochs  |  ~6.8 hours  |
+| `SLOTS_PER_HISTORICAL_ROOT`           | `uint64(2**13)` (= 8,192) |  slots  |  ~27 hours   |
+| `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `uint64(2**8)` (= 256)    | epochs  |  ~27 hours   |
+| `SHARD_COMMITTEE_PERIOD`              | `uint64(2**8)` (= 256)    | epochs  |  ~27 hours   |
 
 ### State list lengths
 
-| Name | Value | Unit | Duration |
-| - | - | :-: | :-: |
-| `EPOCHS_PER_HISTORICAL_VECTOR` | `uint64(2**16)` (= 65,536) | epochs | ~0.8 years |
-| `EPOCHS_PER_SLASHINGS_VECTOR` | `uint64(2**13)` (= 8,192) | epochs | ~36 days |
-| `HISTORICAL_ROOTS_LIMIT` | `uint64(2**24)` (= 16,777,216) | historical roots | ~52,262 years |
-| `VALIDATOR_REGISTRY_LIMIT` | `uint64(2**40)` (= 1,099,511,627,776) | validators |
+| Name                           | Value                                 |       Unit       |   Duration    |
+| ------------------------------ | ------------------------------------- | :--------------: | :-----------: |
+| `EPOCHS_PER_HISTORICAL_VECTOR` | `uint64(2**16)` (= 65,536)            |      epochs      |  ~0.8 years   |
+| `EPOCHS_PER_SLASHINGS_VECTOR`  | `uint64(2**13)` (= 8,192)             |      epochs      |   ~36 days    |
+| `HISTORICAL_ROOTS_LIMIT`       | `uint64(2**24)` (= 16,777,216)        | historical roots | ~52,262 years |
+| `VALIDATOR_REGISTRY_LIMIT`     | `uint64(2**40)` (= 1,099,511,627,776) |    validators    |               |
 
 ### Rewards and penalties
 
-| Name | Value |
-| - | - |
-| `BASE_REWARD_FACTOR` | `uint64(2**6)` (= 64) |
-| `WHISTLEBLOWER_REWARD_QUOTIENT` | `uint64(2**9)` (= 512) |
-| `PROPOSER_REWARD_QUOTIENT` | `uint64(2**3)` (= 8) |
-| `INACTIVITY_PENALTY_QUOTIENT` | `uint64(2**26)` (= 67,108,864) |
-| `MIN_SLASHING_PENALTY_QUOTIENT` | `uint64(2**7)` (= 128) |
-| `PROPORTIONAL_SLASHING_MULTIPLIER` | `uint64(1)` |
+| Name                               | Value                          |
+| ---------------------------------- | ------------------------------ |
+| `BASE_REWARD_FACTOR`               | `uint64(2**6)` (= 64)          |
+| `WHISTLEBLOWER_REWARD_QUOTIENT`    | `uint64(2**9)` (= 512)         |
+| `PROPOSER_REWARD_QUOTIENT`         | `uint64(2**3)` (= 8)           |
+| `INACTIVITY_PENALTY_QUOTIENT`      | `uint64(2**26)` (= 67,108,864) |
+| `MIN_SLASHING_PENALTY_QUOTIENT`    | `uint64(2**7)` (= 128)         |
+| `PROPORTIONAL_SLASHING_MULTIPLIER` | `uint64(1)`                    |
 
 - The `INACTIVITY_PENALTY_QUOTIENT` equals `INVERSE_SQRT_E_DROP_TIME**2` where `INVERSE_SQRT_E_DROP_TIME := 2**13` epochs (about 36 days) is the time it takes the inactivity penalty to reduce the balance of non-participating validators to about `1/sqrt(e) ~= 60.6%`. Indeed, the balance retained by offline validators after `n` epochs is about `(1 - 1/INACTIVITY_PENALTY_QUOTIENT)**(n**2/2)`; so after `INVERSE_SQRT_E_DROP_TIME` epochs, it is roughly `(1 - 1/INACTIVITY_PENALTY_QUOTIENT)**(INACTIVITY_PENALTY_QUOTIENT/2) ~= 1/sqrt(e)`. Note this value will be upgraded to `2**24` after Phase 0 mainnet stabilizes to provide a faster recovery in the event of an inactivity leak.
 
@@ -266,18 +270,18 @@ The following values are (non-configurable) constants used throughout the specif
 
 ### Max operations per block
 
-| Name | Value |
-| - | - |
-| `MAX_PROPOSER_SLASHINGS` | `2**4` (= 16) |
-| `MAX_ATTESTER_SLASHINGS` | `2**1` (= 2) |
-| `MAX_ATTESTATIONS` | `2**7` (= 128) |
-| `MAX_DEPOSITS` | `2**4` (= 16) |
-| `MAX_VOLUNTARY_EXITS` | `2**4` (= 16) |
+| Name                     | Value          |
+| ------------------------ | -------------- |
+| `MAX_PROPOSER_SLASHINGS` | `2**4` (= 16)  |
+| `MAX_ATTESTER_SLASHINGS` | `2**1` (= 2)   |
+| `MAX_ATTESTATIONS`       | `2**7` (= 128) |
+| `MAX_DEPOSITS`           | `2**4` (= 16)  |
+| `MAX_VOLUNTARY_EXITS`    | `2**4` (= 16)  |
 
 ### Domain types
 
-| Name | Value |
-| - | - |
+| Name                         | Value                      |
+| ---------------------------- | -------------------------- |
 | `DOMAIN_BEACON_PROPOSER`     | `DomainType('0x00000000')` |
 | `DOMAIN_BEACON_ATTESTER`     | `DomainType('0x01000000')` |
 | `DOMAIN_RANDAO`              | `DomainType('0x02000000')` |
@@ -590,7 +594,7 @@ def xor(bytes_1: Bytes32, bytes_2: Bytes32) -> Bytes32:
 
 #### `uint_to_bytes`
 
-`def uint_to_bytes(n: uint) -> bytes` is a function for serializing the `uint` type object to bytes in ``ENDIANNESS``-endian. The expected length of the output is the byte-length of the `uint` type.
+`def uint_to_bytes(n: uint) -> bytes` is a function for serializing the `uint` type object to bytes in `ENDIANNESS`-endian. The expected length of the output is the byte-length of the `uint` type.
 
 #### `bytes_to_uint64`
 
@@ -1378,24 +1382,20 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
     return Gwei(effective_balance * BASE_REWARD_FACTOR // integer_squareroot(total_balance) // BASE_REWARDS_PER_EPOCH)
 ```
 
-
 ```python
 def get_proposer_reward(state: BeaconState, attesting_index: ValidatorIndex) -> Gwei:
     return Gwei(get_base_reward(state, attesting_index) // PROPOSER_REWARD_QUOTIENT)
 ```
-
 
 ```python
 def get_finality_delay(state: BeaconState) -> uint64:
     return get_previous_epoch(state) - state.finalized_checkpoint.epoch
 ```
 
-
 ```python
 def is_in_inactivity_leak(state: BeaconState) -> bool:
     return get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
 ```
-
 
 ```python
 def get_eligible_validator_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
@@ -1585,6 +1585,7 @@ def process_slashings(state: BeaconState) -> None:
 ```
 
 #### Eth1 data votes updates
+
 ```python
 def process_eth1_data_reset(state: BeaconState) -> None:
     next_epoch = Epoch(get_current_epoch(state) + 1)
@@ -1630,6 +1631,7 @@ def process_randao_mixes_reset(state: BeaconState) -> None:
 ```
 
 #### Historical roots updates
+
 ```python
 def process_historical_roots_update(state: BeaconState) -> None:
     # Set historical root accumulator

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -1,8 +1,11 @@
 # Ethereum 2.0 Phase 0 -- Deposit Contract
 
 ## Table of contents
+
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -16,6 +19,7 @@
 - [Solidity code](#solidity-code)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
@@ -26,8 +30,8 @@ This document represents the specification for the beacon chain deposit contract
 
 The following values are (non-configurable) constants used throughout the specification.
 
-| Name | Value |
-| - | - |
+| Name                          | Value         |
+| ----------------------------- | ------------- |
 | `DEPOSIT_CONTRACT_TREE_DEPTH` | `2**5` (= 32) |
 
 ## Configuration
@@ -36,10 +40,10 @@ The following values are (non-configurable) constants used throughout the specif
 The different configurations for mainnet, testnets, and YAML-based testing can be found in the [`configs/constant_presets`](../../configs) directory.
 These configurations are updated for releases and may be out of sync during `dev` changes.
 
-| Name | Value |
-| - | - |
-| `DEPOSIT_CHAIN_ID` | `1` |
-| `DEPOSIT_NETWORK_ID` | `1` |
+| Name                       | Value                                        |
+| -------------------------- | -------------------------------------------- |
+| `DEPOSIT_CHAIN_ID`         | `1`                                          |
+| `DEPOSIT_NETWORK_ID`       | `1`                                          |
 | `DEPOSIT_CONTRACT_ADDRESS` | `0x00000000219ab540356cBB839Cbe05303d7705Fa` |
 
 ## Ethereum 1.0 deposit contract

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -1,8 +1,11 @@
 # Ethereum 2.0 Phase 0 -- Beacon Chain Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -31,6 +34,7 @@
     - [`on_attestation`](#on_attestation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
@@ -49,16 +53,16 @@ Any of the above handlers that trigger an unhandled exception (e.g. a failed ass
 
 *Notes*:
 
-1) **Leap seconds**: Slots will last `SECONDS_PER_SLOT + 1` or `SECONDS_PER_SLOT - 1` seconds around leap seconds. This is automatically handled by [UNIX time](https://en.wikipedia.org/wiki/Unix_time).
-2) **Honest clocks**: Honest nodes are assumed to have clocks synchronized within `SECONDS_PER_SLOT` seconds of each other.
-3) **Eth1 data**: The large `ETH1_FOLLOW_DISTANCE` specified in the [honest validator document](./validator.md) should ensure that `state.latest_eth1_data` of the canonical Ethereum 2.0 chain remains consistent with the canonical Ethereum 1.0 chain. If not, emergency manual intervention will be required.
-4) **Manual forks**: Manual forks may arbitrarily change the fork choice rule but are expected to be enacted at epoch transitions, with the fork details reflected in `state.fork`.
-5) **Implementation**: The implementation found in this specification is constructed for ease of understanding rather than for optimization in computation, space, or any other resource. A number of optimized alternatives can be found [here](https://github.com/protolambda/lmd-ghost).
+1. **Leap seconds**: Slots will last `SECONDS_PER_SLOT + 1` or `SECONDS_PER_SLOT - 1` seconds around leap seconds. This is automatically handled by [UNIX time](https://en.wikipedia.org/wiki/Unix_time).
+2. **Honest clocks**: Honest nodes are assumed to have clocks synchronized within `SECONDS_PER_SLOT` seconds of each other.
+3. **Eth1 data**: The large `ETH1_FOLLOW_DISTANCE` specified in the [honest validator document](./validator.md) should ensure that `state.latest_eth1_data` of the canonical Ethereum 2.0 chain remains consistent with the canonical Ethereum 1.0 chain. If not, emergency manual intervention will be required.
+4. **Manual forks**: Manual forks may arbitrarily change the fork choice rule but are expected to be enacted at epoch transitions, with the fork details reflected in `state.fork`.
+5. **Implementation**: The implementation found in this specification is constructed for ease of understanding rather than for optimization in computation, space, or any other resource. A number of optimized alternatives can be found [here](https://github.com/protolambda/lmd-ghost).
 
 ### Configuration
 
-| Name | Value | Unit | Duration |
-| - | - | :-: | :-: |
+| Name                             | Value        | Unit  |  Duration  |
+| -------------------------------- | ------------ | :---: | :--------: |
 | `SAFE_SLOTS_TO_UPDATE_JUSTIFIED` | `2**3` (= 8) | slots | 96 seconds |
 
 ### Helpers
@@ -310,7 +314,6 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
         if i not in store.latest_messages or target.epoch > store.latest_messages[i].epoch:
             store.latest_messages[i] = LatestMessage(epoch=target.epoch, root=beacon_block_root)
 ```
-
 
 ### Handlers
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -10,8 +10,11 @@ It consists of four main sections:
 4. An analysis of the maturity/state of the libp2p features required by this spec across the languages in which Eth2 clients are being developed.
 
 ## Table of contents
+
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Network fundamentals](#network-fundamentals)
@@ -107,6 +110,7 @@ It consists of four main sections:
 - [libp2p implementations matrix](#libp2p-implementations-matrix)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 # Network fundamentals
@@ -167,18 +171,17 @@ See the [Rationale](#design-decision-rationale) section below for tradeoffs.
 
 This section outlines constants that are used in this spec.
 
-| Name | Value | Description |
-|---|---|---|
-| `GOSSIP_MAX_SIZE` | `2**20` (= 1048576, 1 MiB) | The maximum allowed size of uncompressed gossip messages. |
-| `MAX_REQUEST_BLOCKS` | `2**10` (= 1024) | Maximum number of blocks in a single request |
-| `MAX_CHUNK_SIZE` | `2**20` (1048576, 1 MiB) | The maximum allowed size of uncompressed req/resp chunked responses. |
-| `TTFB_TIMEOUT` | `5s` | The maximum time to wait for first byte of request response (time-to-first-byte). |
-| `RESP_TIMEOUT` | `10s` | The maximum time for complete response transfer. |
-| `ATTESTATION_PROPAGATION_SLOT_RANGE` | `32` | The maximum number of slots during which an attestation can be propagated. |
-| `MAXIMUM_GOSSIP_CLOCK_DISPARITY` | `500ms` | The maximum milliseconds of clock disparity assumed between honest nodes. |
-| `MESSAGE_DOMAIN_INVALID_SNAPPY` | `0x00000000` | 4-byte domain for gossip message-id isolation of *invalid* snappy messages |
-| `MESSAGE_DOMAIN_VALID_SNAPPY`  | `0x01000000` | 4-byte domain for gossip message-id isolation of *valid* snappy messages |
-
+| Name                                 | Value                      | Description                                                                       |
+| ------------------------------------ | -------------------------- | --------------------------------------------------------------------------------- |
+| `GOSSIP_MAX_SIZE`                    | `2**20` (= 1048576, 1 MiB) | The maximum allowed size of uncompressed gossip messages.                         |
+| `MAX_REQUEST_BLOCKS`                 | `2**10` (= 1024)           | Maximum number of blocks in a single request                                      |
+| `MAX_CHUNK_SIZE`                     | `2**20` (1048576, 1 MiB)   | The maximum allowed size of uncompressed req/resp chunked responses.              |
+| `TTFB_TIMEOUT`                       | `5s`                       | The maximum time to wait for first byte of request response (time-to-first-byte). |
+| `RESP_TIMEOUT`                       | `10s`                      | The maximum time for complete response transfer.                                  |
+| `ATTESTATION_PROPAGATION_SLOT_RANGE` | `32`                       | The maximum number of slots during which an attestation can be propagated.        |
+| `MAXIMUM_GOSSIP_CLOCK_DISPARITY`     | `500ms`                    | The maximum milliseconds of clock disparity assumed between honest nodes.         |
+| `MESSAGE_DOMAIN_INVALID_SNAPPY`      | `0x00000000`               | 4-byte domain for gossip message-id isolation of *invalid* snappy messages        |
+| `MESSAGE_DOMAIN_VALID_SNAPPY`        | `0x01000000`               | 4-byte domain for gossip message-id isolation of *valid* snappy messages          |
 
 ## MetaData
 
@@ -234,8 +237,8 @@ Topic strings have form: `/eth2/ForkDigestValue/Name/Encoding`.
 This defines both the type of data being sent on the topic and how the data field of the message is encoded.
 
 - `ForkDigestValue` - the lowercase hex-encoded (no "0x" prefix) bytes of `compute_fork_digest(current_fork_version, genesis_validators_root)` where
-    - `current_fork_version` is the fork version of the epoch of the message to be sent on the topic
-    - `genesis_validators_root` is the static `Root` found in `state.genesis_validators_root`
+  - `current_fork_version` is the fork version of the epoch of the message to be sent on the topic
+  - `genesis_validators_root` is the static `Root` found in `state.genesis_validators_root`
 - `Name` - see table below
 - `Encoding` - the encoding strategy describes a specific representation of bytes that will be transmitted over the wire.
   See the [Encodings](#Encodings) section for further details.
@@ -250,13 +253,14 @@ Likewise, clients MUST NOT emit or propagate messages larger than this limit.
 The optional `from` (1), `seqno` (3), `signature` (5) and `key` (6) protobuf fields are omitted from the message,
 since messages are identified by content, anonymous, and signed where necessary in the application layer.
 Starting from Gossipsub v1.1, clients MUST enforce this by applying the `StrictNoSign`
-[signature policy](https://github.com/libp2p/specs/blob/master/pubsub/README.md#signature-policy-options). 
+[signature policy](https://github.com/libp2p/specs/blob/master/pubsub/README.md#signature-policy-options).
 
 The `message-id` of a gossipsub message MUST be the following 20 byte value computed from the message data:
-* If `message.data` has a valid snappy decompression, set `message-id` to the first 20 bytes of the `SHA256` hash of
+
+- If `message.data` has a valid snappy decompression, set `message-id` to the first 20 bytes of the `SHA256` hash of
   the concatenation of `MESSAGE_DOMAIN_VALID_SNAPPY` with the snappy decompressed message data,
   i.e. `SHA256(MESSAGE_DOMAIN_VALID_SNAPPY + snappy_decompress(message.data))[:20]`.
-* Otherwise, set `message-id` to the first 20 bytes of the `SHA256` hash of
+- Otherwise, set `message-id` to the first 20 bytes of the `SHA256` hash of
   the concatenation of `MESSAGE_DOMAIN_INVALID_SNAPPY` with the raw message data,
   i.e. `SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + message.data)[:20]`.
 
@@ -267,7 +271,7 @@ and (2) some message `data` can fail to snappy decompress altogether.
 The payload is carried in the `data` field of a gossipsub message, and varies depending on the topic:
 
 | Name                             | Message Type              |
-|----------------------------------|---------------------------|
+| -------------------------------- | ------------------------- |
 | `beacon_block`                   | `SignedBeaconBlock`       |
 | `beacon_aggregate_and_proof`     | `SignedAggregateAndProof` |
 | `beacon_attestation_{subnet_id}` | `Attestation`             |
@@ -301,23 +305,23 @@ The `beacon_block` topic is used solely for propagating new signed beacon blocks
 Signed blocks are sent in their entirety.
 
 The following validations MUST pass before forwarding the `signed_beacon_block` on the network.
-- _[IGNORE]_ The block is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
+
+- _\[IGNORE\]_ The block is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. validate that `signed_beacon_block.message.slot <= current_slot`
   (a client MAY queue future blocks for processing at the appropriate slot).
-- _[IGNORE]_ The block is from a slot greater than the latest finalized slot --
+- _\[IGNORE\]_ The block is from a slot greater than the latest finalized slot --
   i.e. validate that `signed_beacon_block.message.slot > compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)`
   (a client MAY choose to validate and store such blocks for additional purposes -- e.g. slashing detection, archive nodes, etc).
-- _[IGNORE]_ The block is the first block with valid signature received for the proposer for the slot, `signed_beacon_block.message.slot`.
-- _[REJECT]_ The proposer signature, `signed_beacon_block.signature`, is valid with respect to the `proposer_index` pubkey.
-- _[IGNORE]_ The block's parent (defined by `block.parent_root`) has been seen
+- _\[IGNORE\]_ The block is the first block with valid signature received for the proposer for the slot, `signed_beacon_block.message.slot`.
+- _\[REJECT\]_ The proposer signature, `signed_beacon_block.signature`, is valid with respect to the `proposer_index` pubkey.
+- _\[IGNORE\]_ The block's parent (defined by `block.parent_root`) has been seen
   (via both gossip and non-gossip sources)
   (a client MAY queue blocks for processing once the parent block is retrieved).
-- _[REJECT]_ The block's parent (defined by `block.parent_root`) passes validation.
-- _[REJECT]_ The block is from a higher slot than its parent.
-- _[REJECT]_ The current `finalized_checkpoint` is an ancestor of `block` -- i.e.
-  `get_ancestor(store, block.parent_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch))
-  == store.finalized_checkpoint.root`
-- _[REJECT]_ The block is proposed by the expected `proposer_index` for the block's slot
+- _\[REJECT\]_ The block's parent (defined by `block.parent_root`) passes validation.
+- _\[REJECT\]_ The block is from a higher slot than its parent.
+- _\[REJECT\]_ The current `finalized_checkpoint` is an ancestor of `block` -- i.e.
+  `get_ancestor(store, block.parent_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root`
+- _\[REJECT\]_ The block is proposed by the expected `proposer_index` for the block's slot
   in the context of the current shuffling (defined by `parent_root`/`slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
   the block MAY be queued for later processing while proposers for the block's branch are calculated --
@@ -330,31 +334,29 @@ to subscribing nodes (typically validators) to be included in future blocks.
 
 The following validations MUST pass before forwarding the `signed_aggregate_and_proof` on the network.
 (We define the following for convenience -- `aggregate_and_proof = signed_aggregate_and_proof.message` and `aggregate = aggregate_and_proof.aggregate`)
-- _[IGNORE]_ `aggregate.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
+
+- _\[IGNORE\]_ `aggregate.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate.data.slot`
   (a client MAY queue future aggregates for processing at the appropriate slot).
-- _[REJECT]_ The aggregate attestation's epoch matches its target -- i.e. `aggregate.data.target.epoch ==
-  compute_epoch_at_slot(aggregate.data.slot)`
-- _[IGNORE]_ The `aggregate` is the first valid aggregate received for the aggregator
+- _\[REJECT\]_ The aggregate attestation's epoch matches its target -- i.e. `aggregate.data.target.epoch == compute_epoch_at_slot(aggregate.data.slot)`
+- _\[IGNORE\]_ The `aggregate` is the first valid aggregate received for the aggregator
   with index `aggregate_and_proof.aggregator_index` for the epoch `aggregate.data.target.epoch`.
-- _[REJECT]_ The attestation has participants --
+- _\[REJECT\]_ The attestation has participants --
   that is, `len(get_attesting_indices(state, aggregate.data, aggregate.aggregation_bits)) >= 1`.
-- _[REJECT]_ `aggregate_and_proof.selection_proof` selects the validator as an aggregator for the slot --
+- _\[REJECT\]_ `aggregate_and_proof.selection_proof` selects the validator as an aggregator for the slot --
   i.e. `is_aggregator(state, aggregate.data.slot, aggregate.data.index, aggregate_and_proof.selection_proof)` returns `True`.
-- _[REJECT]_ The aggregator's validator index is within the committee --
+- _\[REJECT\]_ The aggregator's validator index is within the committee --
   i.e. `aggregate_and_proof.aggregator_index in get_beacon_committee(state, aggregate.data.slot, aggregate.data.index)`.
-- _[REJECT]_ The `aggregate_and_proof.selection_proof` is a valid signature
+- _\[REJECT\]_ The `aggregate_and_proof.selection_proof` is a valid signature
   of the `aggregate.data.slot` by the validator with index `aggregate_and_proof.aggregator_index`.
-- _[REJECT]_ The aggregator signature, `signed_aggregate_and_proof.signature`, is valid.
-- _[REJECT]_ The signature of `aggregate` is valid.
-- _[IGNORE]_ The block being voted for (`aggregate.data.beacon_block_root`) has been seen
+- _\[REJECT\]_ The aggregator signature, `signed_aggregate_and_proof.signature`, is valid.
+- _\[REJECT\]_ The signature of `aggregate` is valid.
+- _\[IGNORE\]_ The block being voted for (`aggregate.data.beacon_block_root`) has been seen
   (via both gossip and non-gossip sources)
   (a client MAY queue aggregates for processing once block is retrieved).
-- _[REJECT]_ The block being voted for (`aggregate.data.beacon_block_root`) passes validation.
-- _[REJECT]_ The current `finalized_checkpoint` is an ancestor of the `block` defined by `aggregate.data.beacon_block_root` -- i.e.
-  `get_ancestor(store, aggregate.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch))
-  == store.finalized_checkpoint.root`
-
+- _\[REJECT\]_ The block being voted for (`aggregate.data.beacon_block_root`) passes validation.
+- _\[REJECT\]_ The current `finalized_checkpoint` is an ancestor of the `block` defined by `aggregate.data.beacon_block_root` -- i.e.
+  `get_ancestor(store, aggregate.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root`
 
 ##### `voluntary_exit`
 
@@ -362,9 +364,10 @@ The `voluntary_exit` topic is used solely for propagating signed voluntary valid
 Signed voluntary exits are sent in their entirety.
 
 The following validations MUST pass before forwarding the `signed_voluntary_exit` on to the network.
-- _[IGNORE]_ The voluntary exit is the first valid voluntary exit received
+
+- _\[IGNORE\]_ The voluntary exit is the first valid voluntary exit received
   for the validator with index `signed_voluntary_exit.message.validator_index`.
-- _[REJECT]_ All of the conditions within `process_voluntary_exit` pass validation.
+- _\[REJECT\]_ All of the conditions within `process_voluntary_exit` pass validation.
 
 ##### `proposer_slashing`
 
@@ -372,9 +375,10 @@ The `proposer_slashing` topic is used solely for propagating proposer slashings 
 Proposer slashings are sent in their entirety.
 
 The following validations MUST pass before forwarding the `proposer_slashing` on to the network.
-- _[IGNORE]_ The proposer slashing is the first valid proposer slashing received
+
+- _\[IGNORE\]_ The proposer slashing is the first valid proposer slashing received
   for the proposer with index `proposer_slashing.signed_header_1.message.proposer_index`.
-- _[REJECT]_ All of the conditions within `process_proposer_slashing` pass validation.
+- _\[REJECT\]_ All of the conditions within `process_proposer_slashing` pass validation.
 
 ##### `attester_slashing`
 
@@ -382,11 +386,12 @@ The `attester_slashing` topic is used solely for propagating attester slashings 
 Attester slashings are sent in their entirety.
 
 Clients who receive an attester slashing on this topic MUST validate the conditions within `process_attester_slashing` before forwarding it across the network.
-- _[IGNORE]_ At least one index in the intersection of the attesting indices of each attestation
+
+- _\[IGNORE\]_ At least one index in the intersection of the attesting indices of each attestation
   has not yet been seen in any prior `attester_slashing`
   (i.e. `attester_slashed_indices = set(attestation_1.attesting_indices).intersection(attestation_2.attesting_indices)`,
   verify if `any(attester_slashed_indices.difference(prior_seen_attester_slashed_indices))`).
-- _[REJECT]_ All of the conditions within `process_attester_slashing` pass validation.
+- _\[REJECT\]_ All of the conditions within `process_attester_slashing` pass validation.
 
 #### Attestation subnets
 
@@ -398,35 +403,32 @@ The `beacon_attestation_{subnet_id}` topics are used to propagate unaggregated a
 to the subnet `subnet_id` (typically beacon and persistent committees) to be aggregated before being gossiped to `beacon_aggregate_and_proof`.
 
 The following validations MUST pass before forwarding the `attestation` on the subnet.
-- _[REJECT]_ The committee index is within the expected range -- i.e. `data.index < get_committee_count_per_slot(state, data.target.epoch)`.
-- _[REJECT]_ The attestation is for the correct subnet --
+
+- _\[REJECT\]_ The committee index is within the expected range -- i.e. `data.index < get_committee_count_per_slot(state, data.target.epoch)`.
+- _\[REJECT\]_ The attestation is for the correct subnet --
   i.e. `compute_subnet_for_attestation(committees_per_slot, attestation.data.slot, attestation.data.index) == subnet_id`,
   where `committees_per_slot = get_committee_count_per_slot(state, attestation.data.target.epoch)`,
   which may be pre-computed along with the committee information for the signature check.
-- _[IGNORE]_ `attestation.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots
+- _\[IGNORE\]_ `attestation.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots
   (within a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot`
   (a client MAY queue future attestations for processing at the appropriate slot).
-- _[REJECT]_ The attestation's epoch matches its target -- i.e. `attestation.data.target.epoch ==
-  compute_epoch_at_slot(attestation.data.slot)`
-- _[REJECT]_ The attestation is unaggregated --
+- _\[REJECT\]_ The attestation's epoch matches its target -- i.e. `attestation.data.target.epoch == compute_epoch_at_slot(attestation.data.slot)`
+- _\[REJECT\]_ The attestation is unaggregated --
   that is, it has exactly one participating validator (`len([bit for bit in attestation.aggregation_bits if bit]) == 1`, i.e. exactly 1 bit is set).
-- _[REJECT]_ The number of aggregation bits matches the committee size -- i.e.
+- _\[REJECT\]_ The number of aggregation bits matches the committee size -- i.e.
   `len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot, data.index))`.
-- _[IGNORE]_ There has been no other valid attestation seen on an attestation subnet
+- _\[IGNORE\]_ There has been no other valid attestation seen on an attestation subnet
   that has an identical `attestation.data.target.epoch` and participating validator index.
-- _[REJECT]_ The signature of `attestation` is valid.
-- _[IGNORE]_ The block being voted for (`attestation.data.beacon_block_root`) has been seen
+- _\[REJECT\]_ The signature of `attestation` is valid.
+- _\[IGNORE\]_ The block being voted for (`attestation.data.beacon_block_root`) has been seen
   (via both gossip and non-gossip sources)
   (a client MAY queue attestations for processing once block is retrieved).
-- _[REJECT]_ The block being voted for (`attestation.data.beacon_block_root`) passes validation.
-- _[REJECT]_ The attestation's target block is an ancestor of the block named in the LMD vote -- i.e.
+- _\[REJECT\]_ The block being voted for (`attestation.data.beacon_block_root`) passes validation.
+- _\[REJECT\]_ The attestation's target block is an ancestor of the block named in the LMD vote -- i.e.
   `get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(attestation.data.target.epoch)) == attestation.data.target.root`
-- _[REJECT]_ The current `finalized_checkpoint` is an ancestor of the `block` defined by `attestation.data.beacon_block_root` -- i.e.
-  `get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch))
-  == store.finalized_checkpoint.root`
-
-
+- _\[REJECT\]_ The current `finalized_checkpoint` is an ancestor of the `block` defined by `attestation.data.beacon_block_root` -- i.e.
+  `get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root`
 
 #### Attestations and Aggregation
 
@@ -525,6 +527,7 @@ On that happening, the requester allows a further `RESP_TIMEOUT` for each subseq
 If any of these timeouts fire, the requester SHOULD reset the stream and deem the req/resp operation to have failed.
 
 A requester SHOULD read from the stream until either:
+
 1. An error result is received in one of the chunks (the error payload MAY be read before stopping).
 2. The responder closes the stream.
 3. Any part of the `response_chunk` fails validation.
@@ -543,7 +546,7 @@ The responder MUST:
 
 1. Use the encoding strategy to read the optional header.
 2. If there are any length assertions for length `N`, it should read exactly `N` bytes from the stream, at which point an EOF should arise (no more bytes).
-  Should this not be the case, it should be treated as a failure.
+   Should this not be the case, it should be treated as a failure.
 3. Deserialize the expected type, and process the request.
 4. Write the response which may consist of zero or more `response_chunk`s (result, optional header, payload).
 5. Close their write side of the stream. At this point, the stream will be fully closed.
@@ -560,10 +563,10 @@ For multiple chunks, only the last chunk is allowed to have a non-zero error cod
 
 The response code can have one of the following values, encoded as a single unsigned byte:
 
--  0: **Success** -- a normal response follows, with contents matching the expected message schema and encoding specified in the request.
--  1: **InvalidRequest** -- the contents of the request are semantically invalid, or the payload is malformed, or could not be understood.
+- 0: **Success** -- a normal response follows, with contents matching the expected message schema and encoding specified in the request.
+- 1: **InvalidRequest** -- the contents of the request are semantically invalid, or the payload is malformed, or could not be understood.
   The response payload adheres to the `ErrorMessage` schema (described below).
--  2: **ServerError** -- the responder encountered an error while processing the request.
+- 2: **ServerError** -- the responder encountered an error while processing the request.
   The response payload adheres to the `ErrorMessage` schema (described below).
 
 Clients MAY use response codes above `128` to indicate alternative, erroneous request-specific responses.
@@ -586,7 +589,7 @@ Clients MUST treat as valid any byte sequences.
 The token of the negotiated protocol ID specifies the type of encoding to be used for the req/resp interaction.
 Only one value is possible at this time:
 
--  `ssz_snappy`: The contents are first [SSZ-encoded](../../ssz/simple-serialize.md)
+- `ssz_snappy`: The contents are first [SSZ-encoded](../../ssz/simple-serialize.md)
   and then compressed with [Snappy](https://github.com/google/snappy) frames compression.
   For objects containing a single field, only the field is SSZ-encoded not a container with a single field.
   For example, the `BeaconBlocksByRoot` request is an SSZ-encoded list of `Root`'s.
@@ -615,20 +618,24 @@ When Snappy is applied, it can be passed through a buffered Snappy writer to com
 When snappy is applied, it can be passed through a buffered Snappy reader to decompress frame by frame.
 
 Before reading the payload, the header MUST be validated:
+
 - The unsigned protobuf varint used for the length-prefix MUST not be longer than 10 bytes, which is sufficient for any `uint64`.
 - The length-prefix is within the expected [size bounds derived from the payload SSZ type](#what-are-ssz-type-size-bounds).
 
 After reading a valid header, the payload MAY be read, while maintaining the size constraints from the header.
 
 A reader SHOULD NOT read more than `max_encoded_len(n)` bytes after reading the SSZ length-prefix `n` from the header.
+
 - For `ssz_snappy` this is: `32 + n + n // 6`.
   This is considered the [worst-case compression result](https://github.com/google/snappy/blob/537f4ad6240e586970fe554614542e9717df7902/snappy.cc#L98) by Snappy.
 
 A reader SHOULD consider the following cases as invalid input:
+
 - Any remaining bytes, after having read the `n` SSZ bytes. An EOF is expected if more bytes are read than required.
 - An early EOF, before fully reading the declared length-prefix worth of SSZ bytes.
 
 In case of an invalid input (header or payload), a reader MUST:
+
 - From requests: send back an error message, response code `InvalidRequest`. The request itself is ignored.
 - From responses: ignore the response, the response MUST be considered bad server behavior.
 
@@ -643,9 +650,10 @@ Each _successful_ `response_chunk` contains a single `SignedBeaconBlock` payload
 
 #### Status
 
-**Protocol ID:** ``/eth2/beacon_chain/req/status/1/``
+**Protocol ID:** `/eth2/beacon_chain/req/status/1/`
 
 Request, Response Content:
+
 ```
 (
   fork_digest: ForkDigest
@@ -655,12 +663,13 @@ Request, Response Content:
   head_slot: Slot
 )
 ```
+
 The fields are, as seen by the client at the time of sending the message:
 
 - `fork_digest`: The node's `ForkDigest` (`compute_fork_digest(current_fork_version, genesis_validators_root)`) where
-    - `current_fork_version` is the fork version at the node's current epoch defined by the wall-clock time
-      (not necessarily the epoch to which the node is sync)
-    - `genesis_validators_root` is the static `Root` found in `state.genesis_validators_root`
+  - `current_fork_version` is the fork version at the node's current epoch defined by the wall-clock time
+    (not necessarily the epoch to which the node is sync)
+  - `genesis_validators_root` is the static `Root` found in `state.genesis_validators_root`
 - `finalized_root`: `state.finalized_checkpoint.root` for the state corresponding to the head block
   (Note this defaults to `Root(b'\x00' * 32)` for the genesis finalized checkpoint).
 - `finalized_epoch`: `state.finalized_checkpoint.epoch` for the state corresponding to the head block.
@@ -677,8 +686,8 @@ Clients SHOULD immediately disconnect from one another following the handshake a
 
 1. If `fork_digest` does not match the node's local `fork_digest`, since the client’s chain is on another fork.
 2. If the (`finalized_root`, `finalized_epoch`) shared by the peer is not in the client's chain at the expected epoch.
-  For example, if Peer 1 sends (root, epoch) of (A, 5) and Peer 2 sends (B, 3) but Peer 1 has root C at epoch 3,
-  then Peer 1 would disconnect because it knows that their chains are irreparably disjoint.
+   For example, if Peer 1 sends (root, epoch) of (A, 5) and Peer 2 sends (B, 3) but Peer 1 has root C at epoch 3,
+   then Peer 1 would disconnect because it knows that their chains are irreparably disjoint.
 
 Once the handshake completes, the client with the lower `finalized_epoch` or `head_slot` (if the clients have equal `finalized_epoch`s)
 SHOULD request beacon blocks from its counterparty via the `BeaconBlocksByRange` request.
@@ -689,14 +698,16 @@ Implementers are free to implement such behavior in their own way.
 
 #### Goodbye
 
-**Protocol ID:** ``/eth2/beacon_chain/req/goodbye/1/``
+**Protocol ID:** `/eth2/beacon_chain/req/goodbye/1/`
 
 Request, Response Content:
+
 ```
 (
   uint64
 )
 ```
+
 Client MAY send goodbye messages upon disconnection. The reason field MAY be one of the following values:
 
 - 1: Client shut down.
@@ -716,6 +727,7 @@ The response MUST consist of a single `response_chunk`.
 **Protocol ID:** `/eth2/beacon_chain/req/beacon_blocks_by_range/1/`
 
 Request Content:
+
 ```
 (
   start_slot: Slot
@@ -725,6 +737,7 @@ Request Content:
 ```
 
 Response Content:
+
 ```
 (
   List[SignedBeaconBlock, MAX_REQUEST_BLOCKS]
@@ -733,9 +746,9 @@ Response Content:
 
 Requests beacon blocks in the slot range `[start_slot, start_slot + count * step)`, leading up to the current head block as selected by fork choice.
 `step` defines the slot increment between blocks.
-For example, requesting blocks starting at `start_slot` 2 with a step value of 2 would return the blocks at slots [2, 4, 6, …].
+For example, requesting blocks starting at `start_slot` 2 with a step value of 2 would return the blocks at slots \[2, 4, 6, …\].
 In cases where a slot is empty for a given slot number, no block is returned.
-For example, if slot 4 were empty in the previous example, the returned array would contain [2, 6, …].
+For example, if slot 4 were empty in the previous example, the returned array would contain \[2, 6, …\].
 A request MUST NOT have a 0 slot increment, i.e. `step >= 1`.
 
 `BeaconBlocksByRange` is primarily used to sync historical blocks.
@@ -883,13 +896,13 @@ This integration enables the libp2p stack to subsequently form connections and s
 The Ethereum Node Record (ENR) for an Ethereum 2.0 client MUST contain the following entries
 (exclusive of the sequence number and signature, which MUST be present in an ENR):
 
--  The compressed secp256k1 publickey, 33 bytes (`secp256k1` field).
+- The compressed secp256k1 publickey, 33 bytes (`secp256k1` field).
 
 The ENR MAY contain the following entries:
 
--  An IPv4 address (`ip` field) and/or IPv6 address (`ip6` field).
--  A TCP port (`tcp` field) representing the local libp2p listening port.
--  A UDP port (`udp` field) representing the local discv5 listening port.
+- An IPv4 address (`ip` field) and/or IPv6 address (`ip6` field).
+- A TCP port (`tcp` field) representing the local libp2p listening port.
+- A UDP port (`udp` field) representing the local discv5 listening port.
 
 Specifications of these parameters can be found in the [ENR Specification](http://eips.ethereum.org/EIPS/eip-778).
 
@@ -898,9 +911,9 @@ Specifications of these parameters can be found in the [ENR Specification](http:
 The ENR `attnets` entry signifies the attestation subnet bitfield with the following form
 to more easily discover peers participating in particular attestation gossip subnets.
 
-| Key          | Value                                            |
-|:-------------|:-------------------------------------------------|
-| `attnets`    | SSZ `Bitvector[ATTESTATION_SUBNET_COUNT]`        |
+| Key       | Value                                     |
+| :-------- | :---------------------------------------- |
+| `attnets` | SSZ `Bitvector[ATTESTATION_SUBNET_COUNT]` |
 
 If a node's `MetaData.attnets` has any non-zero bit, the ENR MUST include the `attnets` entry with the same value as `MetaData.attnets`.
 
@@ -911,9 +924,9 @@ If a node's `MetaData.attnets` is composed of all zeros, the ENR MAY optionally 
 ENRs MUST carry a generic `eth2` key with an 16-byte value of the node's current fork digest, next fork version,
 and next fork epoch to ensure connections are made with peers on the intended eth2 network.
 
-| Key          | Value               |
-|:-------------|:--------------------|
-| `eth2`       | SSZ `ENRForkID`        |
+| Key    | Value           |
+| :----- | :-------------- |
+| `eth2` | SSZ `ENRForkID` |
 
 Specifically, the value of the `eth2` key MUST be the following SSZ encoded object (`ENRForkID`)
 
@@ -927,13 +940,13 @@ Specifically, the value of the `eth2` key MUST be the following SSZ encoded obje
 
 where the fields of `ENRForkID` are defined as
 
-* `fork_digest` is `compute_fork_digest(current_fork_version, genesis_validators_root)` where
-    * `current_fork_version` is the fork version at the node's current epoch defined by the wall-clock time
-      (not necessarily the epoch to which the node is sync)
-    * `genesis_validators_root` is the static `Root` found in `state.genesis_validators_root`
-* `next_fork_version` is the fork version corresponding to the next planned hard fork at a future epoch.
+- `fork_digest` is `compute_fork_digest(current_fork_version, genesis_validators_root)` where
+  - `current_fork_version` is the fork version at the node's current epoch defined by the wall-clock time
+    (not necessarily the epoch to which the node is sync)
+  - `genesis_validators_root` is the static `Root` found in `state.genesis_validators_root`
+- `next_fork_version` is the fork version corresponding to the next planned hard fork at a future epoch.
   If no future fork is planned, set `next_fork_version = current_fork_version` to signal this fact
-* `next_fork_epoch` is the epoch at which the next fork is planned and the `current_fork_version` will be updated.
+- `next_fork_epoch` is the epoch at which the next fork is planned and the `current_fork_version` will be updated.
   If no future fork is planned, set `next_fork_epoch = FAR_FUTURE_EPOCH` to signal this fact
 
 *Note*: `fork_digest` is composed of values that are not known until the genesis block/state are available.
@@ -967,8 +980,8 @@ However, it is useful to define a minimum baseline for interoperability purposes
 Clients may support other transports such as libp2p QUIC, WebSockets, and WebRTC transports, if available in the language of choice.
 While interoperability shall not be harmed by lack of such support, the advantages are desirable:
 
--  Better latency, performance, and other QoS characteristics (QUIC).
--  Paving the way for interfacing with future light clients (WebSockets, WebRTC).
+- Better latency, performance, and other QoS characteristics (QUIC).
+- Paving the way for interfacing with future light clients (WebSockets, WebRTC).
 
 The libp2p QUIC transport inherently relies on TLS 1.3 per requirement in section 7
 of the [QUIC protocol specification](https://tools.ietf.org/html/draft-ietf-quic-transport-22#section-7)
@@ -1089,7 +1102,7 @@ SecIO is not considered secure for the purposes of this spec.
 Copied from the Noise Protocol Framework [website](http://www.noiseprotocol.org):
 
 > Noise is a framework for building crypto protocols.
-Noise protocols support mutual and optional authentication, identity hiding, forward secrecy, zero round-trip encryption, and other advanced features.
+> Noise protocols support mutual and optional authentication, identity hiding, forward secrecy, zero round-trip encryption, and other advanced features.
 
 Noise in itself does not specify a single handshake procedure,
 but provides a framework to build secure handshakes based on Diffie-Hellman key agreement with a variety of tradeoffs and guarantees.
@@ -1168,6 +1181,7 @@ so hashing topics would bloat messages unnecessarily.
 ### Why are we using the `StrictNoSign` signature policy?
 
 The policy omits the `from` (1), `seqno` (3), `signature` (5) and `key` (6) fields. These fields would:
+
 - Expose origin of sender (`from`), type of sender (based on `seqno`)
 - Add extra unused data to the gossip, since message IDs are based on `data`, not on the `from` and `seqno`.
 - Introduce more message validation than necessary, e.g. no `signature`.
@@ -1179,10 +1193,10 @@ By overriding the default `message-id` to use content-addressing we can filter u
 
 Some examples of where messages could be duplicated:
 
-* A validator client connected to multiple beacon nodes publishing duplicate gossip messages
-* Attestation aggregation strategies where clients partially aggregate attestations and propagate them.
+- A validator client connected to multiple beacon nodes publishing duplicate gossip messages
+- Attestation aggregation strategies where clients partially aggregate attestations and propagate them.
   Partial aggregates could be duplicated
-* Clients re-publishing seen messages
+- Clients re-publishing seen messages
 
 ### Why are these specific gossip parameters chosen?
 
@@ -1201,7 +1215,6 @@ Some examples of where messages could be duplicated:
   does not provide enough responsiveness during adverse conditions.
 - `seen_ttl`: `SLOTS_PER_EPOCH * SECONDS_PER_SLOT / heartbeat_interval = approx. 550`.
   Attestation gossip validity is bounded by an epoch, so this is the safe max bound.
-
 
 ### Why is there `MAXIMUM_GOSSIP_CLOCK_DISPARITY` when validating slot ranges of messages in gossip subnets?
 
@@ -1285,26 +1298,26 @@ This allows for handling sync and processing messages starting from past forks/e
 Requests are segregated by protocol ID to:
 
 1. Leverage protocol routing in libp2p, such that the libp2p stack will route the incoming stream to the appropriate handler.
-  This allows the handler function for each request type to be self-contained.
-  For an analogy, think about how you attach HTTP handlers to a REST API server.
+   This allows the handler function for each request type to be self-contained.
+   For an analogy, think about how you attach HTTP handlers to a REST API server.
 2. Version requests independently.
-  In a coarser-grained umbrella protocol, the entire protocol would have to be versioned even if just one field in a single message changed.
+   In a coarser-grained umbrella protocol, the entire protocol would have to be versioned even if just one field in a single message changed.
 3. Enable clients to select the individual requests/versions they support.
-  It would no longer be a strict requirement to support all requests,
-  and clients, in principle, could support a subset of requests and variety of versions.
+   It would no longer be a strict requirement to support all requests,
+   and clients, in principle, could support a subset of requests and variety of versions.
 4. Enable flexibility and agility for clients adopting spec changes that impact the request, by signalling to peers exactly which subset of new/old requests they support.
 5. Enable clients to explicitly choose backwards compatibility at the request granularity.
-  Without this, clients would be forced to support entire versions of the coarser request protocol.
+   Without this, clients would be forced to support entire versions of the coarser request protocol.
 6. Parallelise RFCs (or Eth2 EIPs).
-  By decoupling requests from one another, each RFC that affects the request protocol can be deployed/tested/debated independently
-  without relying on a synchronization point to version the general top-level protocol.
+   By decoupling requests from one another, each RFC that affects the request protocol can be deployed/tested/debated independently
+   without relying on a synchronization point to version the general top-level protocol.
    1. This has the benefit that clients can explicitly choose which RFCs to deploy
       without buying into all other RFCs that may be included in that top-level version.
    2. Affording this level of granularity with a top-level protocol would imply creating as many variants
       (e.g. /protocol/43-{a,b,c,d,...}) as the cartesian product of RFCs inflight, O(n^2).
 7. Allow us to simplify the payload of requests.
-  Request-id’s and method-ids no longer need to be sent.
-  The encoding/request type and version can all be handled by the framework.
+   Request-id’s and method-ids no longer need to be sent.
+   The encoding/request type and version can all be handled by the framework.
 
 **Caveat**: The protocol negotiation component in the current version of libp2p is called multistream-select 1.0.
 It is somewhat naïve and introduces overhead on every request when negotiating streams,
@@ -1321,10 +1334,11 @@ libp2p streams are full-duplex, and each party is responsible for closing their 
 We can therefore use stream closure to mark the end of the request and response independently.
 
 Nevertheless, in the case of `ssz_snappy`, messages are still length-prefixed with the length of the underlying data:
-* A basic reader can prepare a correctly sized buffer before reading the message
-* A more advanced reader can stream-decode SSZ given the length of the SSZ data.
-* Alignment with protocols like gRPC over HTTP/2 that prefix with length
-* Sanity checking of message length, and enabling much stricter message length limiting based on SSZ type information,
+
+- A basic reader can prepare a correctly sized buffer before reading the message
+- A more advanced reader can stream-decode SSZ given the length of the SSZ data.
+- Alignment with protocols like gRPC over HTTP/2 that prefix with length
+- Sanity checking of message length, and enabling much stricter message length limiting based on SSZ type information,
   to provide even more DOS protection than the global message length already does.
   E.g. a small `Status` message does not nearly require `MAX_CHUNK_SIZE` bytes.
 
@@ -1362,9 +1376,9 @@ When requesting blocks by range or root, it may happen that there are no blocks 
 
 Thus, it may happen that we need to transmit an empty list - there are several ways to encode this:
 
-0) Close the stream without sending any data
-1) Add a `null` option to the `success` response, for example by introducing an additional byte
-2) Respond with an error result, using a specific error code for "No data"
+0. Close the stream without sending any data
+1. Add a `null` option to the `success` response, for example by introducing an additional byte
+2. Respond with an error result, using a specific error code for "No data"
 
 Semantically, it is not an error that a block is missing during a slot making option 2 unnatural.
 
@@ -1399,7 +1413,7 @@ When syncing one can only tell that a slot has been skipped on a particular bran
 by examining subsequent blocks and analyzing the graph formed by the parent root.
 Because the server side may choose to omit blocks in the response for any reason, clients must validate the graph and be prepared to fill in gaps.
 
-For example, if a peer responds with blocks [2, 3] when asked for [2, 3, 4], clients may not assume that block 4 doesn't exist
+For example, if a peer responds with blocks \[2, 3\] when asked for \[2, 3, 4\], clients may not assume that block 4 doesn't exist
 -- it merely means that the responding peer did not send it (they may not have it yet or may maliciously be trying to hide it)
 and successive blocks will be needed to determine if there exists a block at slot 4 in this particular branch.
 
@@ -1439,7 +1453,7 @@ discv5 uses ENRs and we will presumably need to:
 
 1. Add `multiaddr` to the dictionary, so that nodes can advertise their multiaddr under a reserved namespace in ENRs. – and/or –
 2. Define a bi-directional conversion function between multiaddrs and the corresponding denormalized fields in an ENR
-  (ip, ip6, tcp, tcp6, etc.), for compatibility with nodes that do not support multiaddr natively (e.g. Eth 1.0 nodes).
+   (ip, ip6, tcp, tcp6, etc.), for compatibility with nodes that do not support multiaddr natively (e.g. Eth 1.0 nodes).
 
 ### Why do we not form ENRs and find peers until genesis block/state is known?
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -5,7 +5,9 @@ This is an accompanying document to [Ethereum 2.0 Phase 0 -- The Beacon Chain](.
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -70,6 +72,7 @@ This is an accompanying document to [Ethereum 2.0 Phase 0 -- The Beacon Chain](.
 - [Protection best practices](#protection-best-practices)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
@@ -86,12 +89,12 @@ All terminology, constants, functions, and protocol mechanics defined in the [Ph
 
 ### Misc
 
-| Name | Value | Unit | Duration |
-| - | - | :-: | :-: |
-| `TARGET_AGGREGATORS_PER_COMMITTEE` | `2**4` (= 16) | validators | |
-| `RANDOM_SUBNETS_PER_VALIDATOR` | `2**0` (= 1) | subnets | |
-| `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` | `2**8` (= 256) | epochs | ~27 hours |
-| `ATTESTATION_SUBNET_COUNT` | `64` | The number of attestation subnets used in the gossipsub protocol. |
+| Name                                    | Value          |                               Unit                                | Duration  |
+| --------------------------------------- | -------------- | :---------------------------------------------------------------: | :-------: |
+| `TARGET_AGGREGATORS_PER_COMMITTEE`      | `2**4` (= 16)  |                            validators                             |           |
+| `RANDOM_SUBNETS_PER_VALIDATOR`          | `2**0` (= 1)   |                              subnets                              |           |
+| `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` | `2**8` (= 256) |                              epochs                               | ~27 hours |
+| `ATTESTATION_SUBNET_COUNT`              | `64`           | The number of attestation subnets used in the gossipsub protocol. |           |
 
 ## Containers
 
@@ -145,8 +148,8 @@ Withdrawal credentials with the BLS withdrawal prefix allow a BLS key pair
 `(bls_withdrawal_privkey, bls_withdrawal_pubkey)` to trigger withdrawals.
 The `withdrawal_credentials` field must be such that:
 
-* `withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX`
-* `withdrawal_credentials[1:] == hash(bls_withdrawal_pubkey)[1:]`
+- `withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX`
+- `withdrawal_credentials[1:] == hash(bls_withdrawal_pubkey)[1:]`
 
 *Note*: The `bls_withdrawal_privkey` is not required for validating and can be kept in cold storage.
 
@@ -158,9 +161,9 @@ The `eth1_withdrawal_address` can be the address of either an externally owned a
 
 The `withdrawal_credentials` field must be such that:
 
-* `withdrawal_credentials[:1] == ETH1_ADDRESS_WITHDRAWAL_PREFIX`
-* `withdrawal_credentials[1:12] == b'\x00' * 11`
-* `withdrawal_credentials[12:] == eth1_withdrawal_address`
+- `withdrawal_credentials[:1] == ETH1_ADDRESS_WITHDRAWAL_PREFIX`
+- `withdrawal_credentials[1:12] == b'\x00' * 11`
+- `withdrawal_credentials[12:] == eth1_withdrawal_address`
 
 After the merge of the current Ethereum application layer (Eth1) into the Beacon Chain (Eth2),
 withdrawals to `eth1_withdrawal_address` will be normal ETH transfers (with no payload other than the validator's ETH)
@@ -263,12 +266,13 @@ A validator should plan for future assignments by noting their assigned attestat
 slot and joining the committee index attestation subnet related to their committee assignment.
 
 Specifically a validator should:
-* Call `get_committee_assignment(state, next_epoch, validator_index)` when checking for next epoch assignments.
-* Calculate the committees per slot for the next epoch: `committees_per_slot = get_committee_count_per_slot(state, next_epoch)`
-* Calculate the subnet index: `subnet_id = compute_subnet_for_attestation(committees_per_slot, slot, committee_index)`
-* Find peers of the pubsub topic `beacon_attestation_{subnet_id}`.
-    * If an _insufficient_ number of current peers are subscribed to the topic, the validator must discover new peers on this topic. Via the discovery protocol, find peers with an ENR containing the `attnets` entry such that `ENR["attnets"][subnet_id] == True`. Then validate that the peers are still persisted on the desired topic by requesting `GetMetaData` and checking the resulting `attnets` field.
-    * If the validator is assigned to be an aggregator for the slot (see `is_aggregator()`), then subscribe to the topic.
+
+- Call `get_committee_assignment(state, next_epoch, validator_index)` when checking for next epoch assignments.
+- Calculate the committees per slot for the next epoch: `committees_per_slot = get_committee_count_per_slot(state, next_epoch)`
+- Calculate the subnet index: `subnet_id = compute_subnet_for_attestation(committees_per_slot, slot, committee_index)`
+- Find peers of the pubsub topic `beacon_attestation_{subnet_id}`.
+  - If an _insufficient_ number of current peers are subscribed to the topic, the validator must discover new peers on this topic. Via the discovery protocol, find peers with an ENR containing the `attnets` entry such that `ENR["attnets"][subnet_id] == True`. Then validate that the peers are still persisted on the desired topic by requesting `GetMetaData` and checking the resulting `attnets` field.
+  - If the validator is assigned to be an aggregator for the slot (see `is_aggregator()`), then subscribe to the topic.
 
 *Note*: If the validator is _not_ assigned to be an aggregator, the validator only needs sufficient number of peers on the topic to be able to publish messages. The validator does not need to _subscribe_ and listen to all messages on the topic.
 
@@ -459,8 +463,8 @@ First, the validator should construct `attestation_data`, an [`AttestationData`]
 
 ##### General
 
-* Set `attestation_data.slot = slot` where `slot` is the assigned slot.
-* Set `attestation_data.index = index` where `index` is the index associated with the validator's committee.
+- Set `attestation_data.slot = slot` where `slot` is the assigned slot.
+- Set `attestation_data.index = index` where `index` is the index associated with the validator's committee.
 
 ##### LMD GHOST vote
 
@@ -506,6 +510,7 @@ def get_attestation_signature(state: BeaconState, attestation_data: AttestationD
 Finally, the validator broadcasts `attestation` to the associated attestation subnet, the `beacon_attestation_{subnet_id}` pubsub topic.
 
 The `subnet_id` for the `attestation` is calculated with:
+
 - Let `committees_per_slot = get_committee_count_per_slot(state, attestation.data.target.epoch)`.
 - Let `subnet_id = compute_subnet_for_attestation(committees_per_slot, attestation.data.slot, attestation.data.committee_index)`.
 
@@ -605,9 +610,9 @@ def get_aggregate_and_proof_signature(state: BeaconState,
 
 Because Phase 0 does not have shards and thus does not have Shard Committees, there is no stable backbone to the attestation subnets (`beacon_attestation_{subnet_id}`). To provide this stability, each validator must:
 
-* Randomly select and remain subscribed to `RANDOM_SUBNETS_PER_VALIDATOR` attestation subnets
-* Maintain advertisement of the randomly selected subnets in their node's ENR `attnets` entry by setting the randomly selected `subnet_id` bits to `True` (e.g. `ENR["attnets"][subnet_id] = True`) for all persistent attestation subnets
-* Set the lifetime of each random subscription to a random number of epochs between `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` and `2 * EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION]`. At the end of life for a subscription, select a new random subnet, update subnet subscriptions, and publish an updated ENR
+- Randomly select and remain subscribed to `RANDOM_SUBNETS_PER_VALIDATOR` attestation subnets
+- Maintain advertisement of the randomly selected subnets in their node's ENR `attnets` entry by setting the randomly selected `subnet_id` bits to `True` (e.g. `ENR["attnets"][subnet_id] = True`) for all persistent attestation subnets
+- Set the lifetime of each random subscription to a random number of epochs between `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` and `2 * EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION]`. At the end of life for a subscription, select a new random subnet, update subnet subscriptions, and publish an updated ENR
 
 *Note*: Short lived beacon committee assignments should not be added in into the ENR `attnets` entry.
 
@@ -647,8 +652,8 @@ If the software crashes at some point within this routine, then when the validat
 
 A validator client should be considered standalone and should consider the beacon node as untrusted. This means that the validator client should protect:
 
-1) Private keys -- private keys should be protected from being exported accidentally or by an attacker.
-2) Slashing -- before a validator client signs a message it should validate the data, check it against a local slashing database (do not sign a slashable attestation or block) and update its internal slashing database with the newly signed object.
-3) Recovered validator -- Recovering a validator from a private key will result in an empty local slashing db. Best practice is to import (from a trusted source) that validator's attestation history. See [EIP 3076](https://github.com/ethereum/EIPs/pull/3076/files) for a standard slashing interchange format.
-4) Far future signing requests -- A validator client can be requested to sign a far into the future attestation, resulting in a valid non-slashable request. If the validator client signs this message, it will result in it blocking itself from attesting any other attestation until the beacon-chain reaches that far into the future epoch. This will result in an inactivity penalty and potential ejection due to low balance.
-A validator client should prevent itself from signing such requests by: a) keeping a local time clock if possible and following best practices to stop time server attacks and b) refusing to sign, by default, any message that has a large (>6h) gap from the current slashing protection database indicated a time "jump" or a long offline event. The administrator can manually override this protection to restart the validator after a genuine long offline event.
+1. Private keys -- private keys should be protected from being exported accidentally or by an attacker.
+2. Slashing -- before a validator client signs a message it should validate the data, check it against a local slashing database (do not sign a slashable attestation or block) and update its internal slashing database with the newly signed object.
+3. Recovered validator -- Recovering a validator from a private key will result in an empty local slashing db. Best practice is to import (from a trusted source) that validator's attestation history. See [EIP 3076](https://github.com/ethereum/EIPs/pull/3076/files) for a standard slashing interchange format.
+4. Far future signing requests -- A validator client can be requested to sign a far into the future attestation, resulting in a valid non-slashable request. If the validator client signs this message, it will result in it blocking itself from attesting any other attestation until the beacon-chain reaches that far into the future epoch. This will result in an inactivity penalty and potential ejection due to low balance.
+   A validator client should prevent itself from signing such requests by: a) keeping a local time clock if possible and following best practices to stop time server attacks and b) refusing to sign, by default, any message that has a large (>6h) gap from the current slashing protection database indicated a time "jump" or a long offline event. The administrator can manually override this protection to restart the validator after a genuine long offline event.

--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -3,7 +3,9 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -22,6 +24,7 @@
 - [Distributing Weak Subjectivity Checkpoints](#distributing-weak-subjectivity-checkpoints)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Introduction
@@ -40,20 +43,20 @@ This document uses data structures, constants, functions, and terminology from
 
 ## Custom Types
 
-| Name | SSZ Equivalent | Description |
-|---|---|---|
-| `Ether` | `uint64` | an amount in Ether |
+| Name    | SSZ Equivalent | Description        |
+| ------- | -------------- | ------------------ |
+| `Ether` | `uint64`       | an amount in Ether |
 
 ## Constants
 
-| Name | Value |
-|---|---|
+| Name          | Value           |
+| ------------- | --------------- |
 | `ETH_TO_GWEI` | `uint64(10**9)` |
 
 ## Configuration
 
-| Name | Value |
-|---|---|
+| Name           | Value        |
+| -------------- | ------------ |
 | `SAFETY_DECAY` | `uint64(10)` |
 
 ## Weak Subjectivity Checkpoint
@@ -120,19 +123,19 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
 A brief reference for what these values look like in practice ([reference script](https://gist.github.com/adiasg/3aceab409b36aa9a9d9156c1baa3c248)):
 
 | Safety Decay | Avg. Val. Balance (ETH) | Val. Count | Weak Sub. Period (Epochs) |
-| ---- | ---- | ---- | ---- |
-| 10 | 28 | 32768 | 504 |
-| 10 | 28 | 65536 | 752 |
-| 10 | 28 | 131072 | 1248 |
-| 10 | 28 | 262144 | 2241 |
-| 10 | 28 | 524288 | 2241 |
-| 10 | 28 | 1048576 | 2241 |
-| 10 | 32 | 32768 | 665 |
-| 10 | 32 | 65536 | 1075 |
-| 10 | 32 | 131072 | 1894 |
-| 10 | 32 | 262144 | 3532 |
-| 10 | 32 | 524288 | 3532 |
-| 10 | 32 | 1048576 | 3532 |
+| ------------ | ----------------------- | ---------- | ------------------------- |
+| 10           | 28                      | 32768      | 504                       |
+| 10           | 28                      | 65536      | 752                       |
+| 10           | 28                      | 131072     | 1248                      |
+| 10           | 28                      | 262144     | 2241                      |
+| 10           | 28                      | 524288     | 2241                      |
+| 10           | 28                      | 1048576    | 2241                      |
+| 10           | 32                      | 32768      | 665                       |
+| 10           | 32                      | 65536      | 1075                      |
+| 10           | 32                      | 131072     | 1894                      |
+| 10           | 32                      | 262144     | 3532                      |
+| 10           | 32                      | 524288     | 3532                      |
+| 10           | 32                      | 1048576    | 3532                      |
 
 ## Weak Subjectivity Sync
 
@@ -149,12 +152,13 @@ Clients should allow users to input a Weak Subjectivity Checkpoint at startup, a
    ```
 
 2. Check the weak subjectivity requirements:
-    - *IF* `epoch_number > store.finalized_checkpoint.epoch`,
-          then *ASSERT* during block sync that block with root `block_root` is in the sync path at epoch `epoch_number`.
-          Emit descriptive critical error if this assert fails, then exit client process.
-    - *IF* `epoch_number <= store.finalized_checkpoint.epoch`,
-          then *ASSERT* that the block in the canonical chain at epoch `epoch_number` has root `block_root`.
-          Emit descriptive critical error if this assert fails, then exit client process.
+
+   - *IF* `epoch_number > store.finalized_checkpoint.epoch`,
+     then *ASSERT* during block sync that block with root `block_root` is in the sync path at epoch `epoch_number`.
+     Emit descriptive critical error if this assert fails, then exit client process.
+   - *IF* `epoch_number <= store.finalized_checkpoint.epoch`,
+     then *ASSERT* that the block in the canonical chain at epoch `epoch_number` has root `block_root`.
+     Emit descriptive critical error if this assert fails, then exit client process.
 
 ### Checking for Stale Weak Subjectivity Checkpoint
 

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -5,7 +5,9 @@
 ## Table of contents
 
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
@@ -18,13 +20,13 @@
     - [Shard header: `shard_header`](#shard-header-shard_header)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-<!-- /TOC -->
 
+<!-- /TOC -->
 
 ## Introduction
 
 The specification of these changes continues in the same format as the [Phase0](../phase0/p2p-interface.md) and
-[Altair](../altair/p2p-interface.md) network specifications, and assumes them as pre-requisite. 
+[Altair](../altair/p2p-interface.md) network specifications, and assumes them as pre-requisite.
 The adjustments and additions for Shards are outlined in this document.
 
 ## New containers
@@ -62,10 +64,10 @@ class SignedShardBlob(Container):
 
 Following the same scheme as the [Phase0 gossip topics](../phase0/p2p-interface.md#topics-and-messages), names and payload types are:
 
-| Name                             | Message Type              |
-|----------------------------------|---------------------------|
-| `shard_blob_{shard}`             | `SignedShardBlob`         |
-| `shard_header`                   | `SignedShardHeader`       |
+| Name                 | Message Type        |
+| -------------------- | ------------------- |
+| `shard_blob_{shard}` | `SignedShardBlob`   |
+| `shard_header`       | `SignedShardHeader` |
 
 The [DAS network specification](./das-p2p.md) defines additional topics.
 
@@ -74,15 +76,16 @@ The [DAS network specification](./das-p2p.md) defines additional topics.
 Shard block data, in the form of a `SignedShardBlob` is published to the `shard_blob_{shard}` subnets.
 
 The following validations MUST pass before forwarding the `signed_blob` (with inner `blob`) on the horizontal subnet or creating samples for it.
-- _[REJECT]_ `blob.shard` MUST match the topic `{shard}` parameter. (And thus within valid shard index range)
-- _[IGNORE]_ The `blob` is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
+
+- _\[REJECT\]_ `blob.shard` MUST match the topic `{shard}` parameter. (And thus within valid shard index range)
+- _\[IGNORE\]_ The `blob` is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. validate that `blob.slot <= current_slot`
   (a client MAY queue future blobs for processing at the appropriate slot).
-- _[IGNORE]_ The blob is the first blob with valid signature received for the proposer for the `(slot, shard)` combination.
-- _[REJECT]_ As already limited by the SSZ list-limit, it is important the blob is well-formatted and not too large.
-- _[REJECT]_ The `blob.data` MUST NOT contain any point `p >= MODULUS`. Although it is a `uint256`, not the full 256 bit range is valid.
-- _[REJECT]_ The proposer signature, `signed_blob.signature`, is valid with respect to the `proposer_index` pubkey, signed over the SSZ output of `commit_to_data(blob.data)`.
-- _[REJECT]_ The blob is proposed by the expected `proposer_index` for the blob's slot.
+- _\[IGNORE\]_ The blob is the first blob with valid signature received for the proposer for the `(slot, shard)` combination.
+- _\[REJECT\]_ As already limited by the SSZ list-limit, it is important the blob is well-formatted and not too large.
+- _\[REJECT\]_ The `blob.data` MUST NOT contain any point `p >= MODULUS`. Although it is a `uint256`, not the full 256 bit range is valid.
+- _\[REJECT\]_ The proposer signature, `signed_blob.signature`, is valid with respect to the `proposer_index` pubkey, signed over the SSZ output of `commit_to_data(blob.data)`.
+- _\[REJECT\]_ The blob is proposed by the expected `proposer_index` for the blob's slot.
 
 TODO: make double blob proposals slashable?
 
@@ -91,4 +94,3 @@ TODO: make double blob proposals slashable?
 Shard header data, in the form of a `SignedShardHeader` is published to the global `shard_header` subnet.
 
 TODO: validation conditions.
-

--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -3,8 +3,11 @@
 **Notice**: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
+
 <!-- TOC -->
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Helper functions](#helper-functions)
@@ -20,6 +23,7 @@
 - [Merkle multiproofs](#merkle-multiproofs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- /TOC -->
 
 ## Helper functions

--- a/tests/core/pyspec/README.md
+++ b/tests/core/pyspec/README.md
@@ -1,24 +1,25 @@
 # Eth2 Executable Python Spec (PySpec)
 
-The executable Python spec is built from the Eth2 specification, 
- complemented with the necessary helper functions for hashing, BLS, and more.
+The executable Python spec is built from the Eth2 specification,
+complemented with the necessary helper functions for hashing, BLS, and more.
 
 With this executable spec,
- test-generators can easily create test-vectors for client implementations,
- and the spec itself can be verified to be consistent and coherent through sanity tests implemented with pytest.
+test-generators can easily create test-vectors for client implementations,
+and the spec itself can be verified to be consistent and coherent through sanity tests implemented with pytest.
 
 ## Building
 
 To build the pyspec: `python setup.py build`
- (or `pip install .`, but beware that ignored files will still be copied over to a temporary dir, due to pip issue 2195).
-This outputs the build files to the `./build/lib/eth2spec/...` dir, and can't be used for local test running. Instead, use the dev-install as described below. 
+(or `pip install .`, but beware that ignored files will still be copied over to a temporary dir, due to pip issue 2195).
+This outputs the build files to the `./build/lib/eth2spec/...` dir, and can't be used for local test running. Instead, use the dev-install as described below.
 
 ## Dev Install
 
 All the dynamic parts of the spec are automatically built with `python setup.py pyspecdev`.
 Unlike the regular install, this outputs spec files to their original source location, instead of build output only.
 
-Alternatively, you can build a sub-set of the pyspec with the distutil command: 
+Alternatively, you can build a sub-set of the pyspec with the distutil command:
+
 ```bash
 python setup.py pyspec --spec-fork=phase0 --md-doc-paths="specs/phase0/beacon-chain.md specs/phase0/fork-choice.md" --out-dir=my_spec_dir
 ```
@@ -44,6 +45,7 @@ Run `make test` from the root of the specs repository (after running `make insta
 From the repository root:
 
 Install venv and install:
+
 ```bash
 python3 -m venv venv
 . venv/bin/activate
@@ -51,11 +53,13 @@ python setup.py pyspecdev
 ```
 
 Run the test command from the `tests/core/pyspec` directory:
+
 ```
 pytest --config=minimal eth2spec
 ```
 
 Options:
+
 - `--config`, to change the config. Defaults to `minimal`, can be set to `mainnet`, or other configs from the configs directory.
 - `--disable-bls`, to disable BLS (only for tests that can run without)
 - `--bls-type`, `milagro` or `py_ecc` (default)
@@ -64,12 +68,10 @@ Options:
 
 Run `make open_cov` from the root of the specs repository after running `make test` to open the html code coverage report.
 
-
 ## Contributing
 
 Contributions are welcome, but consider implementing your idea as part of the spec itself first.
 The pyspec is not a replacement.
-
 
 ## License
 

--- a/tests/core/pyspec/eth2spec/gen_helpers/README.md
+++ b/tests/core/pyspec/eth2spec/gen_helpers/README.md
@@ -43,12 +43,13 @@ The yielding pattern is:
 3 value style: `yield <key name> <kind name> <value>`.
 
 Test part output kinds:
+
 - `ssz`: value is expected to be a `bytes`, and the raw data is written to a `<key name>.ssz_snappy` file.
 - `data`: value is expected to be any Python object that can be dumped as YAML. Output is written to `<key name>.yaml`
-- `meta`: these key-value pairs are collected into a dict, and then collectively written to a metadata 
-          file named `meta.yaml`, if anything is yielded with `meta` empty.
+- `meta`: these key-value pairs are collected into a dict, and then collectively written to a metadata
+  file named `meta.yaml`, if anything is yielded with `meta` empty.
 
 The `vector_test()` decorator can detect pyspec SSZ types, and output them both as `data` and `ssz`, for the test consumer to choose.
 
-Note that the yielded outputs are processed before the test continues. It is safe to yield information that later mutates, 
- as the output will already be encoded to yaml or ssz bytes. This avoids the need to deep-copy the whole object.
+Note that the yielded outputs are processed before the test continues. It is safe to yield information that later mutates,
+as the output will already be encoded to yaml or ssz bytes. This avoids the need to deep-copy the whole object.

--- a/tests/formats/README.md
+++ b/tests/formats/README.md
@@ -3,27 +3,28 @@
 This document defines the YAML format and structure used for Eth2 testing.
 
 ## Table of contents
+
 <!-- TOC -->
 
-* [About](#about)
-  + [Test-case formats](#test-case-formats)
-* [Glossary](#glossary)
-* [Test format philosophy](#test-format-philosophy)
-  + [Config design](#config-design)
-  + [Test completeness](#test-completeness)
-* [Test structure](#test-structure)
-  + [`<config name>/`](#--config-name---)
-  + [`<fork or phase name>/`](#--fork-or-phase-name---)
-  + [`<test runner name>/`](#--test-runner-name---)
-  + [`<test handler name>/`](#--test-handler-name---)
-  + [`<test suite name>/`](#--test-suite-name---)
-  + [`<test case>/`](#--test-case---)
-  + [`<output part>`](#--output-part--)
+- [About](#about)
+  - [Test-case formats](#test-case-formats)
+- [Glossary](#glossary)
+- [Test format philosophy](#test-format-philosophy)
+  - [Config design](#config-design)
+  - [Test completeness](#test-completeness)
+- [Test structure](#test-structure)
+  - [`<config name>/`](#--config-name---)
+  - [`<fork or phase name>/`](#--fork-or-phase-name---)
+  - [`<test runner name>/`](#--test-runner-name---)
+  - [`<test handler name>/`](#--test-handler-name---)
+  - [`<test suite name>/`](#--test-suite-name---)
+  - [`<test case>/`](#--test-case---)
+  - [`<output part>`](#--output-part--)
     - [Special output parts](#special-output-parts)
-      * [`meta.yaml`](#-metayaml-)
-* [Config](#config)
-* [Config sourcing](#config-sourcing)
-* [Note for implementers](#note-for-implementers)
+      - [`meta.yaml`](#-metayaml-)
+- [Config](#config)
+- [Config sourcing](#config-sourcing)
+- [Note for implementers](#note-for-implementers)
 
 <!-- /TOC -->
 
@@ -36,6 +37,7 @@ Ethereum 2.0 uses YAML as the format for all cross client tests. This document d
 The particular formats of specific types of tests (test suites) are defined in separate documents.
 
 Test formats:
+
 - [`bls`](./bls/README.md)
 - [`epoch_processing`](./epoch_processing/README.md)
 - [`genesis`](./genesis/README.md)
@@ -46,11 +48,10 @@ Test formats:
 - [`ssz_static`](./ssz_static/README.md)
 - More formats are planned, see tracking issues for CI/testing
 
-
 ## Glossary
 
 - `generator`: a program that outputs one or more test-cases, each organized into a `config > runner > handler > suite` hierarchy.
-- `config`: tests are grouped by configuration used for spec presets. In addition to the standard configurations, 
+- `config`: tests are grouped by configuration used for spec presets. In addition to the standard configurations,
   `general` may be used as a catch-all for tests not restricted to one configuration. (E.g. BLS).
 - `type`: the specialization of one single `generator`. E.g. epoch processing.
 - `runner`: where a generator is a *"producer"*, this is the *"consumer"*.
@@ -59,29 +60,30 @@ Test formats:
   To facilitate this, you specify a `handler`: the runner can deal with the format by using the specified handler.
 - `suite`: a directory containing test cases that are coherent. Each `suite` under the same `handler` shares the same format.
   This is an organizational/cosmetic hierarchy layer.
-- `case`: a test case, a directory in a `suite`. A case can be anything in general, 
+- `case`: a test case, a directory in a `suite`. A case can be anything in general,
   but its format should be well-defined in the documentation corresponding to the `type` (and `handler`).
 - `case part`: a test case consists of different files, possibly in different formats, to facilitate the specific test case format better.
-  Optionally, a `meta.yaml` is included to declare meta-data for the test, e.g. BLS requirements. 
+  Optionally, a `meta.yaml` is included to declare meta-data for the test, e.g. BLS requirements.
 
 ## Test format philosophy
 
 ### Config design
 
 The configuration constant types are:
+
 - Never changing: genesis data.
-- Changing, but reliant on old value: e.g. an epoch time may change, but if you want to do the conversion 
+- Changing, but reliant on old value: e.g. an epoch time may change, but if you want to do the conversion
   `(genesis data, timestamp) -> epoch number`, you end up needing both constants.
 - Changing, but kept around during fork transition: finalization may take a while,
   e.g. an executable has to deal with new deposits and old deposits at the same time. Another example may be economic constants.
 - Additional, backwards compatible: new constants are introduced for later phases.
-- Changing: there is a very small chance some constant may really be *replaced*. 
+- Changing: there is a very small chance some constant may really be *replaced*.
   In this off-chance, it is likely better to include it as an additional variable,
   and some clients may simply stop supporting the old one if they do not want to sync from genesis.
   The change of functionality goes through a phase of deprecation of the old constant, and eventually only the new constant is kept around in the config (when old state is not supported anymore).
 
 Based on these types of changes, we model the config as a list of key value pairs,
- that only grows with every fork (they may change in development versions of forks, however; git manages this).
+that only grows with every fork (they may change in development versions of forks, however; git manages this).
 With this approach, configurations are backwards compatible (older clients ignore unknown variables) and easy to maintain.
 
 ### Test completeness
@@ -92,7 +94,6 @@ The aim is to provide clients with a well-defined scope of work to run a particu
 - Clients that are complete are expected to contribute to testing, seeking for better resources to get conformance with the spec, and other clients.
 - Clients that are not complete in functionality can choose to ignore suites that use certain test-runners, or specific handlers of these test-runners.
 - Clients that are on older versions can test their work based on older releases of the generated tests, and catch up with newer releases when possible.
-
 
 ## Test structure
 
@@ -114,7 +115,6 @@ some tests of earlier forks repeat with updated state data.
 ### `<test runner name>/`
 
 The well known bls/shuffling/ssz_static/operations/epoch_processing/etc. Handlers can change the format, but there is a general target to test.
-
 
 ### `<test handler name>/`
 
@@ -151,12 +151,11 @@ Between all types of tests, a few formats are common:
 - **`.ssz_snappy`**: Like `.ssz`, but compressed with Snappy block compression.
   Snappy block compression is already applied to SSZ in Eth2 gossip, available in client implementations, and thus chosen as compression method.
 
-
 #### Special output parts
 
 ##### `meta.yaml`
 
-If present (it is optional), the test is enhanced with extra data to describe usage. Specialized data is described in the documentation of the specific test format. 
+If present (it is optional), the test is enhanced with extra data to describe usage. Specialized data is described in the documentation of the specific test format.
 
 Common data is documented here:
 
@@ -174,11 +173,11 @@ reveal_deadlines_setting:   -- optional, can have 2 different values:
                             1: `process_reveal_deadlines` is OFF.
 ```
 
-
 ## Config
 
 A configuration is a separate YAML file.
 Separation of configuration and tests aims to:
+
 - Prevent duplication of configuration
 - Make all tests easy to upgrade (e.g. when a new config constant is introduced)
 - Clearly define which constants to use
@@ -189,7 +188,6 @@ Separation of configuration and tests aims to:
 - Include constants to coordinate forking with
 
 The format is described in [`/configs`](../../configs/README.md#format).
-
 
 ## Config sourcing
 
@@ -207,14 +205,13 @@ And copied by CI for testing purposes to:
 
 The first `<config name>` is a directory, which contains exactly all tests that make use of the given config.
 
-
 ## Note for implementers
 
 The basic pattern for test-suite loading and running is:
 
 1. For a specific config, load it first (and only need to do so once),
-    then continue with the tests defined in the config folder.
-2. Select a fork. Repeat for each fork if running tests for multiple forks.  
+   then continue with the tests defined in the config folder.
+2. Select a fork. Repeat for each fork if running tests for multiple forks.
 3. Select the category and specialization of interest (e.g. `operations > deposits`). Again, repeat for each if running all.
 4. Select a test suite. Or repeat for each.
 5. Select a test case. Or repeat for each.
@@ -222,4 +219,4 @@ The basic pattern for test-suite loading and running is:
 7. Run the test, as defined by the test format.
 
 Step 1 may be a step with compile time selection of a configuration, if desired for optimization.
-The base requirement is just to use the same set of constants, independent of the loading process. 
+The base requirement is just to use the same set of constants, independent of the loading process.

--- a/tests/formats/epoch_processing/README.md
+++ b/tests/formats/epoch_processing/README.md
@@ -25,8 +25,8 @@ An SSZ-snappy encoded `BeaconState`, the state after applying the epoch sub-tran
 
 ## Condition
 
-A handler of the `epoch_processing` test-runner should process these cases, 
- calling the corresponding processing implementation (same name, prefixed with `process_`).
+A handler of the `epoch_processing` test-runner should process these cases,
+calling the corresponding processing implementation (same name, prefixed with `process_`).
 This excludes the other parts of the epoch-transition.
 The provided pre-state is already transitioned to just before the specific sub-transition of focus of the handler.
 

--- a/tests/formats/finality/README.md
+++ b/tests/formats/finality/README.md
@@ -20,11 +20,10 @@ An SSZ-snappy encoded `BeaconState`, the state before running the block transiti
 
 Also available as `pre.ssz_snappy`.
 
-
 ### `blocks_<index>.yaml`
 
 A series of files, with `<index>` in range `[0, blocks_count)`. Blocks need to be processed in order,
- following the main transition function (i.e. process slot and epoch transitions in between blocks as normal)
+following the main transition function (i.e. process slot and epoch transitions in between blocks as normal)
 
 Each file is a YAML-encoded `SignedBeaconBlock`.
 
@@ -34,8 +33,7 @@ Each block is also available as `blocks_<index>.ssz_snappy`
 
 An SSZ-snappy encoded `BeaconState`, the state after applying the block transitions.
 
-
 ## Condition
 
 The resulting state should match the expected `post` state, or if the `post` state is left blank,
- the handler should reject the series of blocks as invalid.
+the handler should reject the series of blocks as invalid.

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -40,6 +40,7 @@ The parameter that is required for executing `on_attestation(store, attestation)
 ```yaml
 { attestation: string }  -- the name of the `attestation_<32-byte-root>.ssz_snappy` file. To execute `on_attestation(store, attestation)` with the given attestation.
 ```
+
 The file is located in the same folder (see below).
 
 After this step, the `store` object may have been updated.
@@ -51,6 +52,7 @@ The parameter that is required for executing `on_block(store, block)`.
 ```yaml
 { block: string }  -- the name of the `block_<32-byte-root>.ssz_snappy` file. To execute `on_block(store, block)` with the given attestation.
 ```
+
 The file is located in the same folder (see below).
 
 After this step, the `store` object may have been updated.
@@ -78,6 +80,7 @@ best_justified_checkpoint_root: string      -- Encoded 32-byte value from store.
 ```
 
 For example:
+
 ```yaml
 - checks:
     time: 144
@@ -106,6 +109,6 @@ Each file is an SSZ-snappy encoded `SignedBeaconBlock`.
 
 1. Deserialize `anchor_state.ssz_snappy` and `anchor_block.ssz_snappy` to initialize the local store object by with `get_forkchoice_store(anchor_state, anchor_block)` helper.
 2. Iterate sequentially through `steps.yaml`
-    - For each execution, look up the corresponding ssz_snappy file. Execute the corresponding helper function on the current store.
-        - For the `on_block` execution step: if `len(block.message.body.attestations) > 0`, execute each attestation with `on_attestation(store, attestation)` after executing `on_block(store, block)`.
-    - For each `checks` step, the assertions on the current store must be satisfied.
+   - For each execution, look up the corresponding ssz_snappy file. Execute the corresponding helper function on the current store.
+     - For the `on_block` execution step: if `len(block.message.body.attestations) > 0`, execute each attestation with `on_attestation(store, attestation)` after executing `on_block(store, block)`.
+   - For each `checks` step, the assertions on the current store must be satisfied.

--- a/tests/formats/forks/README.md
+++ b/tests/formats/forks/README.md
@@ -1,10 +1,10 @@
 # Forks
 
 The aim of the fork tests is to ensure that a pre-fork state can be transformed
- into a valid post-fork state, utilizing the `upgrade` function found in the relevant `fork.md` spec.
+into a valid post-fork state, utilizing the `upgrade` function found in the relevant `fork.md` spec.
 
 There is only one handler: `fork`. Each fork (after genesis) is handled with the same format,
- and the particular fork boundary being tested is noted in `meta.yaml`.
+and the particular fork boundary being tested is noted in `meta.yaml`.
 
 ## Test case format
 
@@ -20,9 +20,9 @@ fork: str    -- Fork being transitioned to
 
 Key of valid `fork` strings that might be found in `meta.yaml`
 
-| String ID | Pre-fork | Post-fork | Function |
-| - | - | - | - |
-| `altair` | Phase 0 | Altair | `upgrade_to_altair` |
+| String ID | Pre-fork | Post-fork | Function            |
+| --------- | -------- | --------- | ------------------- |
+| `altair`  | Phase 0  | Altair    | `upgrade_to_altair` |
 
 ### `pre.ssz_snappy`
 

--- a/tests/formats/genesis/README.md
+++ b/tests/formats/genesis/README.md
@@ -1,8 +1,9 @@
 # Genesis tests
 
 The aim of the genesis tests is to provide a baseline to test genesis-state initialization and test
- if the proposed genesis-validity conditions are working.
+if the proposed genesis-validity conditions are working.
 
 There are two handlers, documented individually:
+
 - [`validity`](./validity.md): Tests if a genesis state is valid, i.e. if it counts as trigger to launch.
 - [`initialization`](./initialization.md): Tests the initialization of a genesis state based on Eth1 data.

--- a/tests/formats/genesis/initialization.md
+++ b/tests/formats/genesis/initialization.md
@@ -11,7 +11,6 @@ eth1_block_hash: Bytes32  -- A `Bytes32` hex encoded, with prefix 0x. The root o
 eth1_timestamp: int       -- An integer. The timestamp of the block, in seconds.
 ```
 
-
 ### `meta.yaml`
 
 A yaml file to help read the deposit count:
@@ -26,16 +25,15 @@ deposits_count: int    -- Amount of deposits.
 A series of files, with `<index>` in range `[0, deposits_count)`. Deposits need to be processed in order.
 Each file is a SSZ-snappy encoded `Deposit` object.
 
-###  `state.ssz_snappy`
+### `state.ssz_snappy`
 
 The expected genesis state. An SSZ-snappy encoded `BeaconState` object.
-
 
 ## Processing
 
 To process this test, build a genesis state with the provided `eth1_block_hash`, `eth1_timestamp` and `deposits`:
 `initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)`,
- as described in the Beacon Chain specification.
+as described in the Beacon Chain specification.
 
 ## Condition
 

--- a/tests/formats/genesis/validity.md
+++ b/tests/formats/genesis/validity.md
@@ -16,16 +16,13 @@ description: string    -- Optional. Description of test case, purely for debuggi
 
 An SSZ-snappy encoded `BeaconState`, the state to validate as genesis candidate.
 
-
 ### `is_valid.yaml`
 
 A boolean, true if the genesis state is deemed valid as to launch with, false otherwise.
 
-
 ## Processing
 
 To process the data, call `is_valid_genesis_state(genesis)`.
-
 
 ## Condition
 

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -24,26 +24,25 @@ An SSZ-snappy encoded operation object, e.g. a `ProposerSlashing`, or `Deposit`.
 
 An SSZ-snappy encoded `BeaconState`, the state after applying the operation. No value if operation processing is aborted.
 
-
 ## Condition
 
 A handler of the `operations` test-runner should process these cases,
- calling the corresponding processing implementation.
+calling the corresponding processing implementation.
 This excludes the other parts of the block-transition.
 
 Operations:
 
-| *`operation-name`*      | *`operation-object`*  | *`input name`*       | *`processing call`*                                             |
-|-------------------------|-----------------------|----------------------|-----------------------------------------------------------------|
-| `attestation`           | `Attestation`         | `attestation`        | `process_attestation(state, attestation)`                       |
-| `attester_slashing`     | `AttesterSlashing`    | `attester_slashing`  | `process_attester_slashing(state, attester_slashing)`           |
-| `block_header`          | `BeaconBlock`         | **`block`**          | `process_block_header(state, block)`                            |
-| `deposit`               | `Deposit`             | `deposit`            | `process_deposit(state, deposit)`                               |
-| `proposer_slashing`     | `ProposerSlashing`    | `proposer_slashing`  | `process_proposer_slashing(state, proposer_slashing)`           |
-| `voluntary_exit`        | `SignedVoluntaryExit` | `voluntary_exit`     | `process_voluntary_exit(state, voluntary_exit)`                 |
-| `sync_aggregate`        | `SyncAggregate`       | `sync_aggregate`     | `process_sync_committee(state, sync_aggregate)` (new in Altair) |
+| *`operation-name`*  | *`operation-object`*  | *`input name`*      | *`processing call`*                                             |
+| ------------------- | --------------------- | ------------------- | --------------------------------------------------------------- |
+| `attestation`       | `Attestation`         | `attestation`       | `process_attestation(state, attestation)`                       |
+| `attester_slashing` | `AttesterSlashing`    | `attester_slashing` | `process_attester_slashing(state, attester_slashing)`           |
+| `block_header`      | `BeaconBlock`         | **`block`**         | `process_block_header(state, block)`                            |
+| `deposit`           | `Deposit`             | `deposit`           | `process_deposit(state, deposit)`                               |
+| `proposer_slashing` | `ProposerSlashing`    | `proposer_slashing` | `process_proposer_slashing(state, proposer_slashing)`           |
+| `voluntary_exit`    | `SignedVoluntaryExit` | `voluntary_exit`    | `process_voluntary_exit(state, voluntary_exit)`                 |
+| `sync_aggregate`    | `SyncAggregate`       | `sync_aggregate`    | `process_sync_committee(state, sync_aggregate)` (new in Altair) |
 
 Note that `block_header` is not strictly an operation (and is a full `Block`), but processed in the same manner, and hence included here.
 
 The resulting state should match the expected `post` state, or if the `post` state is left blank,
- the handler should reject the input operation as invalid.
+the handler should reject the input operation as invalid.

--- a/tests/formats/rewards/README.md
+++ b/tests/formats/rewards/README.md
@@ -5,6 +5,7 @@ There is no "change" factor, the rewards/penalties outputs are pure functions wi
 (See test condition documentation on how to run the tests.)
 
 `Deltas` is defined as:
+
 ```python
 class Deltas(Container):
     rewards: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
@@ -21,7 +22,7 @@ description: string    -- Optional description of test case, purely for debuggin
 ```
 
 _Note_: No signature verification happens within rewards sub-functions. These
- tests can safely be run with or without BLS enabled.
+tests can safely be run with or without BLS enabled.
 
 ### `pre.ssz_snappy`
 
@@ -49,13 +50,13 @@ An SSZ-snappy encoded `Deltas` representing the rewards and penalties returned b
 
 ## Condition
 
-A handler of the `rewards` test-runner should process these cases, 
- calling the corresponding rewards deltas function for each set of deltas.
+A handler of the `rewards` test-runner should process these cases,
+calling the corresponding rewards deltas function for each set of deltas.
 
 The provided pre-state is ready to be input into each rewards deltas function.
 
 The provided `deltas` should match the return values of the
- deltas function. Specifically the following must hold true for each set of deltas:
+deltas function. Specifically the following must hold true for each set of deltas:
 
 ```python
     deltas.rewards == deltas_function(state)[0]

--- a/tests/formats/sanity/README.md
+++ b/tests/formats/sanity/README.md
@@ -3,5 +3,6 @@
 The aim of the sanity tests is to set a base-line on what really needs to pass, i.e. the essentials.
 
 There are two handlers, documented individually:
+
 - [`slots`](./slots.md): transitions of one or more slots (and epoch transitions within)
 - [`blocks`](./blocks.md): transitions triggered by one or more blocks

--- a/tests/formats/sanity/blocks.md
+++ b/tests/formats/sanity/blocks.md
@@ -13,16 +13,14 @@ reveal_deadlines_setting: int  -- see general test-format spec.
 blocks_count: int              -- the number of blocks processed in this test.
 ```
 
-
 ### `pre.ssz_snappy`
 
 An SSZ-snappy encoded `BeaconState`, the state before running the block transitions.
 
-
 ### `blocks_<index>.ssz_snappy`
 
 A series of files, with `<index>` in range `[0, blocks_count)`. Blocks need to be processed in order,
- following the main transition function (i.e. process slot and epoch transitions in between blocks as normal)
+following the main transition function (i.e. process slot and epoch transitions in between blocks as normal)
 
 Each file is a SSZ-snappy encoded `SignedBeaconBlock`.
 
@@ -30,8 +28,7 @@ Each file is a SSZ-snappy encoded `SignedBeaconBlock`.
 
 An SSZ-snappy encoded `BeaconState`, the state after applying the block transitions.
 
-
 ## Condition
 
 The resulting state should match the expected `post` state, or if the `post` state is left blank,
- the handler should reject the series of blocks as invalid.
+the handler should reject the series of blocks as invalid.

--- a/tests/formats/sanity/slots.md
+++ b/tests/formats/sanity/slots.md
@@ -11,13 +11,11 @@ description: string    -- Optional. Description of test case, purely for debuggi
 bls_setting: int       -- see general test-format spec.
 ```
 
-
 ### `pre.ssz_snappy`
 
 An SSZ-snappy `BeaconState`, the state before running the transitions.
 
 Also available as `pre.ssz_snappy`.
-
 
 ### `slots.yaml`
 
@@ -28,7 +26,6 @@ An integer. The amount of slots to process (i.e. the difference in slots between
 An SSZ-snappy `BeaconState`, the state after applying the transitions.
 
 Also available as `post.ssz_snappy`.
-
 
 ### Processing
 

--- a/tests/formats/shuffling/README.md
+++ b/tests/formats/shuffling/README.md
@@ -4,13 +4,14 @@ The runner of the Shuffling test type has only one handler: `core`.
 
 However, this does not mean that testing is limited.
 Clients may take different approaches to shuffling, for optimizing,
- and supporting advanced lookup behavior back in older history.
+and supporting advanced lookup behavior back in older history.
 
 For implementers, possible test runners implementing testing can include:
-1) Just test permute-index, run it for each index `i` in `range(count)`, and check against expected `mapping[i]` (default spec implementation).
-2) Test un-permute-index (the reverse lookup; implemented by running the shuffling rounds in reverse, from `round_count-1` to `0`).
-3) Test the optimized complete shuffle, where all indices are shuffled at once; test output in one go.
-4) Test complete shuffle in reverse (reverse rounds, same as #2).
+
+1. Just test permute-index, run it for each index `i` in `range(count)`, and check against expected `mapping[i]` (default spec implementation).
+2. Test un-permute-index (the reverse lookup; implemented by running the shuffling rounds in reverse, from `round_count-1` to `0`).
+3. Test the optimized complete shuffle, where all indices are shuffled at once; test output in one go.
+4. Test complete shuffle in reverse (reverse rounds, same as #2).
 
 ## Test case format
 
@@ -35,4 +36,4 @@ I.e. `mapping[i]` is the shuffled location of `i`.
 ## Condition
 
 The resulting list should match the expected output after shuffling the implied input, using the given `seed`.
-The output is checked using the `mapping`, based on the shuffling test type (e.g. can be backwards shuffling). 
+The output is checked using the `mapping`, based on the shuffling test type (e.g. can be backwards shuffling).

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -1,7 +1,7 @@
 # SSZ, generic tests
 
 This set of test-suites provides general testing for SSZ:
- to decode any container/list/vector/other type from binary data, encode it back, and compute the hash-tree-root.
+to decode any container/list/vector/other type from binary data, encode it back, and compute the hash-tree-root.
 
 This test collection for general-purpose SSZ is experimental.
 The `ssz_static` suite is the required minimal support for SSZ, and should be prioritized.
@@ -9,20 +9,19 @@ The `ssz_static` suite is the required minimal support for SSZ, and should be pr
 The `ssz_generic` tests are split up into different handler, each specialized into a SSZ type:
 
 - Vectors
-    - `basic_vector`
-    - `complex_vector` *not supported yet*
+  - `basic_vector`
+  - `complex_vector` *not supported yet*
 - List
-    - `basic_list` *not supported yet*
-    - `complex_list` *not supported yet*
+  - `basic_list` *not supported yet*
+  - `complex_list` *not supported yet*
 - Bitfields
-    - `bitvector`
-    - `bitlist`
+  - `bitvector`
+  - `bitlist`
 - Basic types
-    - `boolean`
-    - `uints`
+  - `boolean`
+  - `uints`
 - Containers
-    - `containers`
-
+  - `containers`
 
 ## Format
 
@@ -59,7 +58,7 @@ The object, encoded as a YAML structure. Using the same familiar encoding as YAM
 The conditions are the same for each type:
 
 - Encoding: After encoding the given `value` object, the output should match `serialized`.
-- Decoding: After decoding the given `serialized` bytes, it should match the `value` object. 
+- Decoding: After decoding the given `serialized` bytes, it should match the `value` object.
 - Hash-tree-root: the root should match the root declared in the metadata.
 
 ## `invalid`
@@ -74,14 +73,13 @@ The `serialized` data should simply not be decoded without raising an error.
 Note that for some type declarations in the invalid suite, the type itself may technically be invalid.
 This is a valid way of detecting `invalid` data too. E.g. a 0-length basic vector.
 
-
 ## Type declarations
 
 Most types are not as static, and can reasonably be constructed during test runtime from the test case name.
 Formats are listed below.
 
 For each test case, an additional `_{extra...}` may be appended to the name,
- where `{extra...}` contains a human readable indication of the test case contents for debugging purposes.
+where `{extra...}` contains a human readable indication of the test case contents for debugging purposes.
 
 ### `basic_vector`
 
@@ -97,7 +95,6 @@ Data:
 {length}: an unsigned integer
 ```
 
-
 ### `bitlist`
 
 ```
@@ -109,7 +106,6 @@ Data:
 
 {limit}: the list limit, in bits, of the bitlist. Does not include the length-delimiting bit in the serialized form.
 ```
-
 
 ### `bitvector`
 

--- a/tests/formats/ssz_static/README.md
+++ b/tests/formats/ssz_static/README.md
@@ -1,7 +1,7 @@
 # SSZ, static tests
 
 This set of test-suites provides static testing for SSZ:
- to instantiate just the known Eth2 SSZ types from binary data.
+to instantiate just the known Eth2 SSZ types from binary data.
 
 This series of tests is based on the spec-maintained `eth2spec/utils/ssz/ssz_impl.py`, i.e. fully consistent with the SSZ spec.
 

--- a/tests/formats/ssz_static/core.md
+++ b/tests/formats/ssz_static/core.md
@@ -8,7 +8,7 @@ do not support (or have alternatives for) generic SSZ encoding/decoding.
 This test-format ensures these direct serializations are covered.
 
 Note that this test suite does not cover the invalid-encoding case:
- SSZ implementations should be hardened against invalid inputs with the other SSZ tests as guide, along with fuzzing.
+SSZ implementations should be hardened against invalid inputs with the other SSZ tests as guide, along with fuzzing.
 
 ## Test case format
 
@@ -34,18 +34,17 @@ The SSZ-snappy encoded bytes.
 
 The same value as `serialized.ssz_snappy`, represented as YAML.
 
-
 ## Condition
 
 A test-runner can implement the following assertions:
-- If YAML decoding of SSZ objects is supported by the implementation:
-    - Serialization: After parsing the `value`, SSZ-serialize it: the output should match `serialized`
-    - Deserialization: SSZ-deserialize the `serialized` value, and see if it matches the parsed `value`
-- If YAML decoding of SSZ objects is not supported by the implementation:
-    - Serialization in 2 steps: deserialize `serialized`, then serialize the result, 
-       and verify if the bytes match the original `serialized`.
-- Hash-tree-root: After parsing the `value` (or deserializing `serialized`), Hash-tree-root it: the output should match `root`
 
+- If YAML decoding of SSZ objects is supported by the implementation:
+  - Serialization: After parsing the `value`, SSZ-serialize it: the output should match `serialized`
+  - Deserialization: SSZ-deserialize the `serialized` value, and see if it matches the parsed `value`
+- If YAML decoding of SSZ objects is not supported by the implementation:
+  - Serialization in 2 steps: deserialize `serialized`, then serialize the result,
+    and verify if the bytes match the original `serialized`.
+- Hash-tree-root: After parsing the `value` (or deserializing `serialized`), Hash-tree-root it: the output should match `root`
 
 ## References
 

--- a/tests/generators/README.md
+++ b/tests/generators/README.md
@@ -3,17 +3,17 @@
 This directory contains all the generators for tests, consumed by Eth2 client implementations.
 
 Any issues with the generators and/or generated tests should be filed in the repository that hosts the generator outputs,
- here: [ethereum/eth2.0-spec-tests](https://github.com/ethereum/eth2.0-spec-tests).
+here: [ethereum/eth2.0-spec-tests](https://github.com/ethereum/eth2.0-spec-tests).
 
 On releases, test generators are run by the release manager. Test-generation of mainnet tests can take a significant amount of time, and is better left out of a CI setup.
 
-An automated nightly tests release system, with a config filter applied, is being considered as implementation needs mature.  
+An automated nightly tests release system, with a config filter applied, is being considered as implementation needs mature.
 
 ## Table of contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [How to run generators](#how-to-run-generators)
   - [Cleaning](#cleaning)
@@ -25,11 +25,10 @@ An automated nightly tests release system, with a config filter applied, is bein
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-
-
 ## How to run generators
 
 Prerequisites:
+
 - Python 3 installed
 - PIP 3
 - GNU Make
@@ -52,10 +51,9 @@ make -j 4 generate_tests
 
 The `-j N` flag makes the generators run in parallel, with `N` being the amount of cores.
 
-
 ### Running a single generator
 
-The makefile auto-detects generators in the `tests/generators` directory and provides a tests-gen target (gen_<generator_name>) for each generator. See example:
+The makefile auto-detects generators in the `tests/generators` directory and provides a tests-gen target (gen\_\<generator_name>) for each generator. See example:
 
 ```bash
 make gen_ssz_static
@@ -77,6 +75,7 @@ Now that you have a virtual environment, write your generator.
 It's recommended to extend the base-generator.
 
 Create a `requirements.txt` in the root of your generator directory:
+
 ```
 pytest>=4.4
 ../../../[generator]
@@ -88,12 +87,13 @@ Applying configurations to the spec is simple and enables you to create test sui
 *Note*: Make sure to run `make pyspec` from the root of the specs repository in order to build the pyspec requirement.
 
 Install all the necessary requirements (re-run when you add more):
+
 ```bash
 pip3 install -r requirements.txt
 ```
 
 Note that you may need `PYTHONPATH` to include the pyspec directory, as with running normal tests,
- to run test generators manually. The makefile handles this for you already.
+to run test generators manually. The makefile handles this for you already.
 
 And write your initial test generator, extending the base generator:
 
@@ -152,6 +152,7 @@ if __name__ == "__main__":
 ```
 
 This generator:
+
 - builds off of `gen_runner.run_generator` to handle configuration / filter / output logic.
 - parametrized the creation of a test-provider to support multiple configs.
 - Iterates through tests cases.
@@ -192,12 +193,13 @@ if __name__ == "__main__":
 Here multiple phases load the configuration, and the stream of test cases is derived from a pytest file using the `eth2spec.gen_helpers.gen_from_tests.gen.run_state_test_generators` utility. Note that this helper generates all available tests of `TESTGEN_FORKS` forks of `ALL_CONFIGS` configs of the given runner.
 
 Recommendations:
+
 - You can have more than just one test provider.
 - Your test provider is free to output any configuration and combination of runner/handler/fork/case name.
 - You can split your test case generators into different Python files/packages; this is good for code organization.
-- Use config `minimal` for performance and simplicity, but also implement a suite with the `mainnet` config where necessary. 
+- Use config `minimal` for performance and simplicity, but also implement a suite with the `mainnet` config where necessary.
 - You may be able to write your test case provider in a way where it does not make assumptions on constants.
-  If so, you can generate test cases with different configurations for the same scenario (see example). 
+  If so, you can generate test cases with different configurations for the same scenario (see example).
 - See [`tests/core/gen_helpers/README.md`](../core/pyspec/eth2spec/gen_helpers/README.md) for command line options for generators.
 
 ## How to add a new test generator
@@ -205,21 +207,20 @@ Recommendations:
 To add a new test generator that builds `New Tests`:
 
 1. Create a new directory `new_tests` within the `tests/generators` directory.
- Note that `new_tests` is also the name of the directory in which the tests will appear in the tests repository later.
+   Note that `new_tests` is also the name of the directory in which the tests will appear in the tests repository later.
 2. Your generator is assumed to have a `requirements.txt` file,
- with any dependencies it may need. Leave it empty if your generator has none.
+   with any dependencies it may need. Leave it empty if your generator has none.
 3. Your generator is assumed to have a `main.py` file in its root.
- By adding the base generator to your requirements, you can make a generator really easily. See docs below.
+   By adding the base generator to your requirements, you can make a generator really easily. See docs below.
 4. Your generator is called with `-o some/file/path/for_testing/can/be_anything -c some/other/path/to_configs/`.
- The base generator helps you handle this; you only have to define test case providers.
+   The base generator helps you handle this; you only have to define test case providers.
 5. Finally, add any linting or testing commands to the
- [circleci config file](../../.circleci/config.yml) if desired to increase code quality.
- Or add it to the [`Makefile`](../../Makefile), if it can be run locally.
+   [circleci config file](../../.circleci/config.yml) if desired to increase code quality.
+   Or add it to the [`Makefile`](../../Makefile), if it can be run locally.
 
 *Note*: You do not have to change the makefile.
 However, if necessary (e.g. not using Python, or mixing in other languages), submit an issue, and it can be a special case.
 Do note that generators should be easy to maintain, lean, and based on the spec.
-
 
 ## How to remove a test generator
 

--- a/tests/generators/epoch_processing/README.md
+++ b/tests/generators/epoch_processing/README.md
@@ -3,9 +3,6 @@
 Epoch processing covers the sub-transitions during an epoch change.
 
 An epoch-processing test-runner can consume these sub-transition test-suites,
- and handle different kinds of epoch sub-transitions by processing the cases using the specified test handler.
+and handle different kinds of epoch sub-transitions by processing the cases using the specified test handler.
 
 Information on the format of the tests can be found in the [epoch-processing test formats documentation](../../formats/epoch_processing/README.md).
-
- 
-

--- a/tests/generators/genesis/README.md
+++ b/tests/generators/genesis/README.md
@@ -3,4 +3,3 @@
 Genesis tests cover the initialization and validity-based launch trigger for the Beacon Chain genesis state.
 
 Information on the format of the tests can be found in the [genesis test formats documentation](../../formats/genesis/README.md).
-

--- a/tests/generators/operations/README.md
+++ b/tests/generators/operations/README.md
@@ -1,12 +1,9 @@
 # Operations
 
 Operations (or "transactions" in previous spec iterations),
- are atomic changes to the state, introduced by embedding in blocks.
+are atomic changes to the state, introduced by embedding in blocks.
 
 An operation test-runner can consume these operation test-suites,
- and handle different kinds of operations by processing the cases using the specified test handler.
+and handle different kinds of operations by processing the cases using the specified test handler.
 
 Information on the format of the tests can be found in the [operations test formats documentation](../../formats/operations/README.md).
-
- 
-

--- a/tests/generators/rewards/README.md
+++ b/tests/generators/rewards/README.md
@@ -3,6 +3,6 @@
 Rewards covers the sub-functions of `process_rewards_and_penalties` for granular testing of components of the rewards function.
 
 A rewards test-runner can consume these sub-transition test-suites,
- and handle different kinds of epoch sub-transitions by processing the cases using the specified test handler.
+and handle different kinds of epoch sub-transitions by processing the cases using the specified test handler.
 
 Information on the format of the tests can be found in the [rewards test formats documentation](../../formats/rewards/README.md).

--- a/tests/generators/sanity/README.md
+++ b/tests/generators/sanity/README.md
@@ -3,6 +3,3 @@
 Sanity tests cover regular state-transitions in a common block-list format, to ensure the basics work.
 
 Information on the format of the tests can be found in the [sanity test formats documentation](../../formats/sanity/README.md).
-
- 
-

--- a/tests/generators/shuffling/README.md
+++ b/tests/generators/shuffling/README.md
@@ -3,6 +3,7 @@
 Tests for the swap-or-not shuffling in Eth2.
 
 Tips for initial shuffling write:
+
 - run with `round_count = 1` first, do the same with pyspec.
 - start with permute index
 - optimized shuffling implementations:

--- a/tests/generators/ssz_static/README.md
+++ b/tests/generators/ssz_static/README.md
@@ -1,6 +1,6 @@
 # SSZ-static
 
 The purpose of this test-generator is to provide test-vectors for the most important applications of SSZ:
- the serialization and hashing of Eth2 data types.
+the serialization and hashing of Eth2 data types.
 
 Test-format documentation can be found [here](../../formats/ssz_static/README.md).


### PR DESCRIPTION
This PR is continuation on the discussion in https://github.com/ethereum/eth2.0-specs/pull/2248, adding a [Markdown formatter](https://github.com/executablebooks/mdformat) configuration to the repository and formatting all Markdown with it.

If this is considered to be merged, there's some configuration that should be tweaked according to this repo's preferences, for more detail read the downmost comments in https://github.com/ethereum/eth2.0-specs/pull/2248 (i.e. https://github.com/ethereum/eth2.0-specs/pull/2248#issuecomment-810268080 and https://github.com/ethereum/eth2.0-specs/pull/2248#issuecomment-810284765)

This PR currently includes a `.pre-commit-config.yaml` file which makes it as simple as `pip install pre-commit && pre-commit install` for a contributor to set up a git pre commit hook to automatically format before committing. It also acts as a configuration file for https://pre-commit.ci/ which is a CI that can be set up to automatically commit formatting fixes to PRs.