### PR TITLE
Replace `assert` with custom `require` method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -339,6 +339,7 @@ from eth2spec.utils.ssz.ssz_typing import (
 from eth2spec.utils.ssz.ssz_typing import Bitvector  # noqa: F401
 from eth2spec.utils import bls
 from eth2spec.utils.hash_function import hash
+from eth2spec.test.exceptions import ValidationError
 '''
 
     @classmethod

--- a/specs/altair/bls.md
+++ b/specs/altair/bls.md
@@ -45,7 +45,7 @@ def eth2_aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
     This implementation is for demonstrative purposes only and ignores encoding/decoding concerns.
     Refer to the BLS signature draft standard for more information.
     """
-    assert len(pubkeys) > 0
+    require(len(pubkeys) > 0)
     result = copy(pubkeys[0])
     for pubkey in pubkeys[1:]:
         result += pubkey

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -161,7 +161,7 @@ def is_assigned_to_sync_committee(state: BeaconState,
     current_epoch = get_current_epoch(state)
     current_sync_committee_period = compute_sync_committee_period(current_epoch)
     next_sync_committee_period = current_sync_committee_period + 1
-    assert sync_committee_period in (current_sync_committee_period, next_sync_committee_period)
+    require(sync_committee_period in (current_sync_committee_period, next_sync_committee_period))
 
     pubkey = state.validators[validator_index].pubkey
     if sync_committee_period == current_sync_committee_period:

--- a/specs/das/das-core.md
+++ b/specs/das/das-core.md
@@ -67,7 +67,7 @@ def reverse_bit_order(n: int, order: int):
     """
     Reverse the bit order of an integer n
     """
-    assert is_power_of_two(order)
+    require(is_power_of_two(order))
     return int(('{:0' + str(order.bit_length() - 1) + 'b}').format(n)[::-1], 2)
 ```
 
@@ -76,7 +76,7 @@ def reverse_bit_order(n: int, order: int):
 ```python
 def reverse_bit_order_list(elements: Sequence[int]) -> Sequence[int]:
     order = len(elements)
-    assert is_power_of_two(order)
+    require(is_power_of_two(order))
     return [elements[reverse_bit_order(i, order)] for i in range(order)]
 ```
 
@@ -153,10 +153,10 @@ def commit_to_data(data_as_poly: Sequence[Point]) -> BLSCommitment:
 ```python
 def sample_data(slot: Slot, shard: Shard, extended_data: Sequence[Point]) -> Sequence[DASSample]:
     sample_count = len(extended_data) // POINTS_PER_SAMPLE
-    assert sample_count <= MAX_SAMPLES_PER_BLOCK
+    require(sample_count <= MAX_SAMPLES_PER_BLOCK)
     # get polynomial form of full extended data, second half will be all zeroes.
     poly = ifft(reverse_bit_order_list(extended_data))
-    assert all(v == 0 for v in poly[len(poly)//2:])
+    require(all(v == 0 for v in poly[len(poly)//2:]))
     proofs = construct_proofs(poly)
     return [
         DASSample(
@@ -179,7 +179,7 @@ def verify_sample(sample: DASSample, sample_count: uint64, commitment: BLSCommit
     sample_root_of_unity = ROOT_OF_UNITY**MAX_SAMPLES_PER_BLOCK  # change point-level to sample-level domain
     x = sample_root_of_unity**domain_pos
     ys = reverse_bit_order_list(sample.data)
-    assert check_multi_kzg_proof(commitment, sample.proof, x, ys)
+    require(check_multi_kzg_proof(commitment, sample.proof, x, ys))
 ```
 
 ```python

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -213,12 +213,11 @@ def process_execution_payload(state: BeaconState,
     Note: This function is designed to be able to be run in parallel with the other `process_block` sub-functions
     """
     if is_transition_completed(state):
-        assert execution_payload.parent_hash == state.latest_execution_payload_header.block_hash
-        assert execution_payload.number == state.latest_execution_payload_header.number + 1
+        require(execution_payload.parent_hash == state.latest_execution_payload_header.block_hash)
+        require(execution_payload.number == state.latest_execution_payload_header.number + 1)
 
-    assert execution_payload.timestamp == compute_time_at_slot(state, state.slot)
-
-    assert execution_engine.new_block(execution_payload)
+    require(execution_payload.timestamp == compute_time_at_slot(state, state.slot))
+    require(execution_engine.new_block(execution_payload))
 
     state.latest_execution_payload_header = ExecutionPayloadHeader(
         block_hash=execution_payload.block_hash,

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -114,24 +114,24 @@ def is_valid_terminal_pow_block(transition_store: TransitionStore, block: PowBlo
 def on_block(store: Store, signed_block: SignedBeaconBlock, transition_store: TransitionStore=None) -> None:
     block = signed_block.message
     # Parent block must be known
-    assert block.parent_root in store.block_states
+    require(block.parent_root in store.block_states)
     # Make a copy of the state to avoid mutability issues
     pre_state = copy(store.block_states[block.parent_root])
     # Blocks cannot be in the future. If they are, their consideration must be delayed until the are in the past.
-    assert get_current_slot(store) >= block.slot
+    require(get_current_slot(store) >= block.slot)
 
     # Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
-    assert block.slot > finalized_slot
+    require(block.slot > finalized_slot)
     # Check block is a descendant of the finalized block at the checkpoint finalized slot
-    assert get_ancestor(store, block.parent_root, finalized_slot) == store.finalized_checkpoint.root
-    
+    require(get_ancestor(store, block.parent_root, finalized_slot) == store.finalized_checkpoint.root)
+ 
     # [New in Merge]
     if (transition_store is not None) and is_transition_block(pre_state, block):
         # Delay consideration of block until PoW block is processed by the PoW node
         pow_block = get_pow_block(block.body.execution_payload.parent_hash)
-        assert pow_block.is_processed
-        assert is_valid_terminal_pow_block(transition_store, pow_block)
+        require(pow_block.is_processed)
+        require(is_valid_terminal_pow_block(transition_store, pow_block))
 
     # Check the block is valid and compute the post-state
     state = pre_state.copy()

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -595,13 +595,13 @@ class SignedBeaconBlockHeader(Container):
 #### `require`
 
 ```python
-def require(condition: bool, message: str=None) -> None:
+def require(condition: bool, message: str='') -> None:
     """
     Check if the given condition is satisfied.
     If not, raise an exception to signal that it's INVALID.
     """
     if not condition:
-        raise ValidationError(str(condition) if message is None else message)
+        raise ValidationError(message)
 ```
 
 **Note**: The `message` value is just for debugging the executable spec. The error handling details are implementation specific.

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -228,7 +228,7 @@ def get_committee_assignment(state: BeaconState,
     Return None if no assignment.
     """
     next_epoch = Epoch(get_current_epoch(state) + 1)
-    assert epoch <= next_epoch
+    require(epoch <= next_epoch)
 
     start_slot = compute_start_slot_at_epoch(epoch)
     committee_count_per_slot = get_committee_count_per_slot(state, epoch)

--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -170,8 +170,8 @@ The check can be implemented in the following way:
 ```python
 def is_within_weak_subjectivity_period(store: Store, ws_state: BeaconState, ws_checkpoint: Checkpoint) -> bool:
     # Clients may choose to validate the input state against the input Weak Subjectivity Checkpoint
-    assert ws_state.latest_block_header.state_root == ws_checkpoint.root
-    assert compute_epoch_at_slot(ws_state.slot) == ws_checkpoint.epoch
+    require(ws_state.latest_block_header.state_root == ws_checkpoint.root)
+    require(compute_epoch_at_slot(ws_state.slot) == ws_checkpoint.epoch)
 
     ws_period = compute_weak_subjectivity_period(ws_state)
     ws_state_epoch = compute_epoch_at_slot(ws_state.slot)

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -470,7 +470,7 @@ def get_start_shard(state: BeaconState, slot: Slot) -> Shard:
 ```python
 def compute_shard_from_committee_index(state: BeaconState, slot: Slot, index: CommitteeIndex) -> Shard:
     active_shards = get_active_shard_count(state, compute_epoch_at_slot(slot))
-    assert index < active_shards
+    require(index < active_shards)
     return Shard((index + get_start_shard(state, slot)) % active_shards)
 ```
 
@@ -481,7 +481,7 @@ def compute_committee_index_from_shard(state: BeaconState, slot: Slot, shard: Sh
     epoch = compute_epoch_at_slot(slot)
     active_shards = get_active_shard_count(state, epoch)
     index = CommitteeIndex((active_shards + shard - get_start_shard(state, slot)) % active_shards)
-    assert index < get_committee_count_per_slot(state, epoch)
+    require(index < get_committee_count_per_slot(state, epoch))
     return index
 ```
 

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -231,11 +231,7 @@ def expect_assertion_error(fn):
     try:
         fn()
         bad = True
-    except ValidationError:
-        pass
-    except AssertionError:
-        pass
-    except IndexError:
+    except (ValidationError, AssertionError, IndexError):
         # Index errors are special; the spec is not explicit on bound checking, an IndexError is like a failed assert.
         pass
     if bad:

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -5,7 +5,7 @@ from eth2spec.altair import mainnet as spec_altair_mainnet, minimal as spec_alta
 from eth2spec.merge import mainnet as spec_merge_mainnet, minimal as spec_merge_minimal
 from eth2spec.utils import bls
 
-from .exceptions import SkippedTest
+from .exceptions import SkippedTest, ValidationError
 from .helpers.constants import (
     SpecForkName, PresetBaseName,
     PHASE0, ALTAIR, MERGE, MINIMAL, MAINNET,
@@ -231,6 +231,8 @@ def expect_assertion_error(fn):
     try:
         fn()
         bad = True
+    except ValidationError:
+        pass
     except AssertionError:
         pass
     except IndexError:

--- a/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_chunk_challenge.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_chunk_challenge.py
@@ -27,7 +27,7 @@ def run_chunk_challenge_processing(spec, state, custody_chunk_challenge, valid=T
       - pre-state ('pre')
       - CustodyBitChallenge ('custody_chunk_challenge')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
     yield 'pre', state
     yield 'custody_chunk_challenge', custody_chunk_challenge
@@ -53,7 +53,7 @@ def run_custody_chunk_response_processing(spec, state, custody_response, valid=T
       - pre-state ('pre')
       - CustodyResponse ('custody_response')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
     yield 'pre', state
     yield 'custody_response', custody_response

--- a/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_custody_key_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_custody_key_reveal.py
@@ -14,7 +14,7 @@ def run_custody_key_reveal_processing(spec, state, custody_key_reveal, valid=Tru
       - pre-state ('pre')
       - custody_key_reveal ('custody_key_reveal')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
     yield 'pre', state
     yield 'custody_key_reveal', custody_key_reveal

--- a/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_custody_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_custody_slashing.py
@@ -28,7 +28,7 @@ def run_custody_slashing_processing(spec, state, custody_slashing, valid=True, c
       - pre-state ('pre')
       - CustodySlashing ('custody_slashing')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
     yield 'pre', state
     yield 'custody_slashing', custody_slashing

--- a/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_early_derived_secret_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_early_derived_secret_reveal.py
@@ -16,7 +16,7 @@ def run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, v
       - pre-state ('pre')
       - randao_key_reveal ('randao_key_reveal')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
     yield 'pre', state
     yield 'randao_key_reveal', randao_key_reveal

--- a/tests/core/pyspec/eth2spec/test/exceptions.py
+++ b/tests/core/pyspec/eth2spec/test/exceptions.py
@@ -1,2 +1,6 @@
 class SkippedTest(Exception):
     ...
+
+
+class ValidationError(Exception):
+    ...

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -16,7 +16,7 @@ def run_attestation_processing(spec, state, attestation, valid=True):
       - pre-state ('pre')
       - attestation ('attestation')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
     # yield pre-state
     yield 'pre', state

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -1,5 +1,7 @@
 from eth_utils import encode_hex
 
+from eth2spec.test.exceptions import ValidationError
+
 
 def get_anchor_root(spec, state):
     anchor_block_header = state.latest_block_header.copy()
@@ -77,8 +79,7 @@ def run_on_block(spec, store, signed_block, test_steps, valid=True):
     if not valid:
         try:
             spec.on_block(store, signed_block)
-
-        except AssertionError:
+        except (ValidationError, AssertionError):
             return
         else:
             assert False

--- a/tests/core/pyspec/eth2spec/test/merge/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/merge/block_processing/test_process_execution_payload.py
@@ -15,7 +15,7 @@ def run_execution_payload_processing(spec, state, execution_payload, valid=True,
       - execution payload ('execution_payload')
       - execution details, to mock EVM execution ('execution.yml', a dict with 'execution_valid' key and boolean value)
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
 
     yield 'pre', state

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
@@ -23,7 +23,7 @@ def run_attester_slashing_processing(spec, state, attester_slashing, valid=True)
       - pre-state ('pre')
       - attester_slashing ('attester_slashing')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
 
     yield 'pre', state

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_block_header.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_block_header.py
@@ -15,7 +15,7 @@ def run_block_header_processing(spec, state, block, prepare_state=True, valid=Tr
       - pre-state ('pre')
       - block ('block')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
     if prepare_state:
         prepare_state_for_header_processing(spec, state)

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_deposit.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_deposit.py
@@ -15,7 +15,7 @@ def run_deposit_processing(spec, state, deposit, validator_index, valid=True, ef
       - pre-state ('pre')
       - deposit ('deposit')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
     pre_validator_count = len(state.validators)
     pre_balance = 0

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_proposer_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_proposer_slashing.py
@@ -12,7 +12,7 @@ def run_proposer_slashing_processing(spec, state, proposer_slashing, valid=True)
       - pre-state ('pre')
       - proposer_slashing ('proposer_slashing')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
 
     pre_state = state.copy()

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_voluntary_exit.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_voluntary_exit.py
@@ -9,7 +9,7 @@ def run_voluntary_exit_processing(spec, state, signed_voluntary_exit, valid=True
       - pre-state ('pre')
       - voluntary_exit ('voluntary_exit')
       - post-state ('post').
-    If ``valid == False``, run expecting ``AssertionError``
+    If ``valid == False``, run expecting ``ValidationError``
     """
     validator_index = signed_voluntary_exit.message.validator_index
 

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import with_all_phases, spec_state_test
+from eth2spec.test.context import with_all_phases, spec_state_test, expect_assertion_error
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
 from eth2spec.test.helpers.attestations import get_valid_attestation, sign_attestation
 from eth2spec.test.helpers.constants import PHASE0, ALTAIR, MERGE
@@ -8,12 +8,8 @@ from eth2spec.test.helpers.fork_choice import get_genesis_forkchoice_store
 
 def run_on_attestation(spec, state, store, attestation, valid=True):
     if not valid:
-        try:
-            spec.on_attestation(store, attestation)
-        except AssertionError:
-            return
-        else:
-            assert False
+        expect_assertion_error(lambda: spec.on_attestation(store, attestation))
+        return
 
     indexed_attestation = spec.get_indexed_attestation(state, attestation)
     spec.on_attestation(store, attestation)

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_block.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root
 
 from eth2spec.test.context import with_all_phases, spec_state_test
+from eth2spec.test.exceptions import ValidationError
 from eth2spec.test.helpers.attestations import next_epoch_with_attestations
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot, sign_block, transition_unsigned_block, \
     build_empty_block
@@ -13,7 +14,7 @@ def run_on_block(spec, store, signed_block, valid=True):
     if not valid:
         try:
             spec.on_block(store, signed_block)
-        except AssertionError:
+        except (ValidationError, AssertionError):
             return
         else:
             assert False

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
@@ -3,6 +3,7 @@ from eth2spec.test.context import (
     always_bls, with_phases, with_all_phases,
 )
 from eth2spec.test.helpers.constants import PHASE0
+from eth2spec.test.exceptions import ValidationError
 from eth2spec.test.helpers.attestations import build_attestation_data, get_valid_attestation
 from eth2spec.test.helpers.block import build_empty_block
 from eth2spec.test.helpers.deposits import prepare_state_and_deposit
@@ -29,7 +30,7 @@ def run_get_committee_assignment(spec, state, epoch, validator_index, valid=True
         assert committee_index < spec.get_committee_count_per_slot(state, epoch)
         assert validator_index in committee
         assert valid
-    except AssertionError:
+    except (ValidationError, AssertionError):
         assert not valid
     else:
         assert valid

--- a/tests/core/pyspec/eth2spec/utils/test_merkle_minimal.py
+++ b/tests/core/pyspec/eth2spec/utils/test_merkle_minimal.py
@@ -1,4 +1,6 @@
 import pytest
+
+from eth2spec.test.exceptions import ValidationError
 from .merkle_minimal import zerohashes, merkleize_chunks, get_merkle_root
 from .hash_function import hash
 
@@ -71,7 +73,7 @@ def test_merkleize_chunks_and_get_merkle_root(count, limit, value):
         try:
             merkleize_chunks(chunks, limit=limit)
             bad = True
-        except AssertionError:
+        except (ValidationError, AssertionError):
             pass
         if bad:
             assert False, "expected merkleization to be invalid"


### PR DESCRIPTION
Replace #2045
Fix #1797

Starting with `phase0/beacon-chain.md`

### Proposed solution
- Replace `assert <condition>` with custom `require(condition: bool, message: str=None)` function to signal that the execution is INVALID. Implementers can define their custom error handling method.
- Move some comments to the `message` field.
- Note that it should be *no* substantive change.


/cc @ericsson49 