### PR TITLE
0x02 Credential Prefix

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -192,6 +192,7 @@ The following values are (non-configurable) constants used throughout the specif
 | - | - |
 | `BLS_WITHDRAWAL_PREFIX` | `Bytes1('0x00')` |
 | `ETH1_ADDRESS_WITHDRAWAL_PREFIX` | `Bytes1('0x01')` |
+| `ETH1_ADDRESS_WITHDRAWAL_AND_COINBASE_PREFIX` | `Bytes1('0x02')` |
 
 ### Domain types
 

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -60,7 +60,7 @@ The amount of ETH (rounded down to the closest Gwei) sent to the deposit contrac
 
 One of the `DepositData` fields is `withdrawal_credentials` which constrains validator withdrawals.
 The first byte of this 32-byte field is a withdrawal prefix which defines the semantics of the remaining 31 bytes.
-The withdrawal prefixes currently supported are `BLS_WITHDRAWAL_PREFIX` and `ETH1_ADDRESS_WITHDRAWAL_PREFIX`.
+The withdrawal prefixes currently supported are `BLS_WITHDRAWAL_PREFIX`, `ETH1_ADDRESS_WITHDRAWAL_PREFIX`, and `ETH1_ADDRESS_WITHDRAWAL_AND_COINBASE_PREFIX`.
 Read more in the [validator guide](./validator.md#withdrawal-credentials).
 
 *Note*: The deposit contract does not validate the `withdrawal_credentials` field.

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -182,7 +182,7 @@ The `withdrawal_credentials` field must be such that:
 * `withdrawal_credentials[1:12] == b'\x00' * 11`
 * `withdrawal_credentials[12:] == eth1_withdrawal_address`
 
-After the merge of the current Ethereum application layer (Eth1) into the Beacon Chain (Eth2),
+After the merge of the current Ethereum execution layer (Eth1) into the Beacon Chain (Eth2),
 withdrawals to `eth1_withdrawal_address` will be normal ETH transfers (with no payload other than the validator's ETH)
 triggered by a user transaction that will set the gas price and gas limit as well pay fees.
 As long as the account or contract with address `eth1_withdrawal_address` can receive ETH transfers,

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -22,6 +22,7 @@ This is an accompanying document to [Ethereum 2.0 Phase 0 -- The Beacon Chain](.
     - [Withdrawal credentials](#withdrawal-credentials)
       - [`BLS_WITHDRAWAL_PREFIX`](#bls_withdrawal_prefix)
       - [`ETH1_ADDRESS_WITHDRAWAL_PREFIX`](#eth1_address_withdrawal_prefix)
+      - [`ETH1_ADDRESS_WITHDRAWAL_AND_COINBASE_PREFIX`](#eth1_address_withdrawal_and_coinbase_prefix)
   - [Submit deposit](#submit-deposit)
   - [Process deposit](#process-deposit)
   - [Validator index](#validator-index)

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -168,6 +168,26 @@ triggered by a user transaction that will set the gas price and gas limit as wel
 As long as the account or contract with address `eth1_withdrawal_address` can receive ETH transfers,
 the future withdrawal protocol is agnostic to all other implementation details.
 
+##### `ETH1_ADDRESS_WITHDRAWAL_AND_COINBASE_PREFIX`
+
+This is an extension of `ETH1_ADDRESS_WITHDRAWAL_PREFIX`.
+As with that prefix, this specifies a 20-byte Eth1 address `eth1_withdrawal_address`, which can be the address of either an externally owned account or of a contract.
+This address will be the recipient for all withdrawals.
+Additionally, blocks proposed by validators using this prefix **will be invalid** if the `coinbase` for those blocks is not equal to `eth1_withdrawal_address`.
+
+The `withdrawal_credentials` field must be such that:
+
+* `withdrawal_credentials[:1] == ETH1_ADDRESS_WITHDRAWAL_AND_COINBASE_PREFIX`
+* `withdrawal_credentials[1:12] == b'\x00' * 11`
+* `withdrawal_credentials[12:] == eth1_withdrawal_address`
+
+After the merge of the current Ethereum application layer (Eth1) into the Beacon Chain (Eth2),
+withdrawals to `eth1_withdrawal_address` will be normal ETH transfers (with no payload other than the validator's ETH)
+triggered by a user transaction that will set the gas price and gas limit as well pay fees.
+As long as the account or contract with address `eth1_withdrawal_address` can receive ETH transfers,
+the future withdrawal protocol is agnostic to all other implementation details.
+
+
 ### Submit deposit
 
 In Phase 0, all incoming validator deposits originate from the Ethereum 1.0 chain defined by `DEPOSIT_CHAIN_ID` and `DEPOSIT_NETWORK_ID`. Deposits are made to the [deposit contract](./deposit-contract.md) located at `DEPOSIT_CONTRACT_ADDRESS`.

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_deposit.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_deposit.py
@@ -118,12 +118,34 @@ def test_new_deposit_eth1_withdrawal_credentials(spec, state):
 
 @with_all_phases
 @spec_state_test
+def test_new_deposit_eth1_withdrawal_and_coinbase_credentials(spec, state):
+    # fresh deposit = next validator index = validator appended to registry
+    validator_index = len(state.validators)
+    withdrawal_credentials = (
+        spec.ETH1_ADDRESS_WITHDRAWAL_AND_COINBASE_PREFIX
+        + b'\x00' * 11  # specified 0s
+        + b'\x59' * 20  # a 20-byte eth1 address
+    )
+    amount = spec.MAX_EFFECTIVE_BALANCE
+    deposit = prepare_state_and_deposit(
+        spec, state,
+        validator_index,
+        amount,
+        withdrawal_credentials=withdrawal_credentials,
+        signed=True,
+    )
+
+    yield from run_deposit_processing(spec, state, deposit, validator_index)
+
+
+@with_all_phases
+@spec_state_test
 def test_new_deposit_non_versioned_withdrawal_credentials(spec, state):
     # fresh deposit = next validator index = validator appended to registry
     validator_index = len(state.validators)
     withdrawal_credentials = (
         b'\xFF'  # Non specified withdrawal credentials version
-        + b'\x02' * 31  # Garabage bytes
+        + b'\x02' * 31  # Garbage bytes
     )
     amount = spec.MAX_EFFECTIVE_BALANCE
     deposit = prepare_state_and_deposit(


### PR DESCRIPTION
# Summary

This PR adds a new withdrawal credential prefix, `0x02`, to the eth2 specification.
It was decided upon after [a lengthy brainstorming session in the ETH R&D Discord](https://discord.com/channels/595666850260713488/692062809701482577/847367811096903680).

The new prefix is an extension of `0x01` ([PR here](https://github.com/ethereum/eth2.0-specs/pull/2149)) and follows the same formatting and behavior rules:

- Its contents will be a 20-byte eth1 address
- Withdrawals must be sent to that address

In addition, `0x02` includes a new constraint related to the current merge design that will be unique to validators with this prefix:

- Blocks proposed by validators using this prefix **will be invalid** if the `coinbase` for those blocks is not equal to `eth1_withdrawal_address`.

In other words, 0x02 comes with the constraint that when these validators propose a block, the priority fees *must be sent to the withdrawal address* for the blocks to be considered valid. As the withdrawal address is an eth1 address, the new prefix should not introduce any fundamental synchronization issues between the execution and consensus layers.


# Rationale

The current merge design assumes that a validator owns all of the ETH deposited to the Beacon Chain, and is thus entitled to all of the rewards that come from attestations, block proposals, and priority fees. These rewards are distributed by sending attestation and block proposal rewards to the validator address on the Beacon Chain, and priority fees to the `coinbase` address specified in an argument provided to the execution client on startup (which is an eth1 address).

This assumption is not valid in certain contexts.

In the case of decentralized staking pools, where a node operator only owns *some* of the 32 ETH deposit that created the validator, it is desirable for the node operator to only be entitled to a *proportion* of the total rewards from each block, including the priority fees; however, in the current design, the node operator will be able to pocket all of the priority fees by setting `coinbase` to an address that they personally control.

Since the `coinbase` is just an argument in the execution client, it is trivial to change it and exploit this behavior. Doing so decouples those fees from the staking pool entirely, thus robbing the pool from some of the reward that it should be entitled to.

This problem encourages node operators to act selfishly, thereby reducing the rewards accumulated by decentralized staking pools and ultimately encouraging centralized staking pools.

This is not a desirable outcome.

One mitigation strategy would be to employ a watching system that detects when the node "cheats" in this way, and punish them by removing their ability to withdraw their initial deposit. Unfortunately, this strategy does not scale - the maximum punishment would equal their portion of the initial 32 ETH deposit (say, for example, 16 of their own ETH). It is entirely possible for the node operator to accumulate more than 16 ETH from priority fees by cheating, and thus defeat the punishment. Furthermore, this encourages a centralized "manager" aspect that decentralized staking platforms may have fundamental conflicts with.

Ultimately, solving this problem requires a solution that:

- Allows for the fair distribution of priority fees
- Can scale to arbitrary balances
- Does not interfere with other validators that use the existing 0x00 or 0x01 prefixes
- Does not add extra burden on (and thus, delay) the merge

`0x02` is our proposal to satisfy these criteria.


# Possible Implementation

One reasonable implementation would be for the validator client to send the withdrawal address to the execution client upon block proposal, and for the execution client to then check for the `0x02` prefix.

If the prefix is absent, it would send priority fees to the address provided in the `coinbase` argument as it does today.

If the `0x02` prefix is present, it would then send them to the `withdrawal_address` instead.

The address presented by the validator client would take precedence over the `coinbase` argument for `0x02`-based validators.


# Timing

One drawback to this proposal is added complexity, the implementation of which may delay the merge. If this ends up being true upon further investigation, there is a possible workaround in some circumstances:

- Accept the proposal now, so that services can create validators with `0x02` credentials today
- Proceed with the merge as planned, deferring `0x02`'s implementation to a later date (call it `X`)
- Validators can "cheat" between now and `X`
- After `X`, they are forced to use the `withdrawal_address`

In this situation, the watcher-based tracking strategy above could be employed to observe how much ETH was "stolen" by the malicious node operator.
As long as `X` occurs before they've had time to accumulate a "stolen" balance greater than their initial proportion of the deposit, they could be penalized accordingly without any damage to the staking pool.

Even if `X` is long enough that they *do* manage to steal some ETH overall, we submit that this solution is better than doing nothing and letting them steal the priority fees in perpetuity.


# A Note on MEV

`0x02` is targeted as a solution to `coinbase`-based balance problems. It is not intended to solve MEV-based problems; however, it could do so in certain situations. For example, the current Flashbot system generally distributes rewards to the `coinbase` address of the execution client. In this case, `0x02` would enforce the fair distribution of these MEV rewards.

In situations where node operators set up their own MEV system locally or create an agreement where they are paid for their work via side channels, this proposal will not solve the "stolen balance" problem, nor is it an attempt to do so. That is a larger problem that will need to be solved via some other means, and staking pool providers will need to alert users to this issue accordingly.

That being said, the priority fee distribution problem lives in parallel with side-channel problems; it does not go away with the existence of MEV. One could argue that unfair distribution of priority fee rewards will be more common than MEV-based issues in the context of decentralized pools: a typical at-home node operator may not be familiar with MEV, know how to run a compatible client, or know how to subscribe to such a service. However, switching the `coinbase` argument out for an address that they control is well within the grasp of any node operator.

Because of this, we submit that `0x02` provides an important improvement to the eth2 spec, even in a world where MEV-based side-channel payment problems exist.


# Proponents

- Rocket Pool is a major proponent of this proposal. The problem it solves is one of the protocol's largest challenges to competition with centralized staking pools.
- Blox Staking [would be able to leverage this proposal](https://discord.com/channels/595666850260713488/692062809701482577/847367811096903680). They have expressed a desire to have priority fees paid to custom addresses that their customers provide, rather than having to manage and map them internally. This proposal would provide a path towards that goal.


# Open Questions

### How are withdrawal address changes handled? If someone creates a `0x02` address, are they bound to it permanently?

Rocket Pool actually considers this "address locking" to be a requirement for `0x02` to work as intended. It guarantees that the priority fee distribution is fair (because the withdrawal address is a smart contract that handles rewards delegation). Furthermore, it **improves the security of legitimate node operators**. This would stop an attacker from gaining access to a legitimate node and changing the `coinbase` to their own address. For Rocket Pool's use case, the ability for the user to modify the withdrawal address after validator creation would invalidate this proposal entirely. 

That being said, for Blox's use case, it may be desirable for users to be able to modify their addresses. One possible middle-ground is to allow the withdrawal address to be changed by a signed transaction *from the withdrawal address itself*. This would support the use cases of both parties.


### Can `0x00` validators "upgrade" to `0x02`, in the same way that they can upgrade to `0x01` currently?

We don't see why not, though the conditions associated with `0x02` will need to be made very clear to a user who does this.