### PR TITLE
Default to "zero" Eth1Data instead of current state

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1732,8 +1732,9 @@ def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
 ```python
 def process_eth1_data(state: BeaconState, body: BeaconBlockBody) -> None:
     state.eth1_data_votes.append(body.eth1_data)
-    if state.eth1_data_votes.count(body.eth1_data) * 2 > EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH:
-        state.eth1_data = body.eth1_data
+    if body.eth1_data.block_hash != Bytes32(): 
+        if state.eth1_data_votes.count(body.eth1_data) * 2 > EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH:
+            state.eth1_data = body.eth1_data
 ```
 
 #### Operations

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -334,7 +334,7 @@ Each deposit in `block.body.deposits` must verify against `state.eth1_data.eth1_
 
 ###### `get_eth1_data`
 
-Let `Eth1Block` be an abstract object representing Eth1 blocks with the `timestamp` and depost contract data available.
+Let `Eth1Block` be an abstract object representing Eth1 blocks with the `timestamp` and deposit contract data available.
 
 Let `get_eth1_data(block: Eth1Block) -> Eth1Data` be the function that returns the Eth1 data for a given Eth1 block.
 
@@ -376,9 +376,8 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
     valid_votes = [vote for vote in state.eth1_data_votes if vote in votes_to_consider]
 
     # Default vote on latest eth1 block data in the period range unless eth1 chain is not live
-    # Non-substantive casting for linter
-    state_eth1_data: Eth1Data = state.eth1_data
-    default_vote = votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider) else state_eth1_data
+    zero_eth1_data = Eth1Data(block_hash=Bytes32(), deposit_root=Bytes32(), deposit_count=0)
+    default_vote = votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider) else zero_eth1_data
 
     return max(
         valid_votes,

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
@@ -179,9 +179,9 @@ def test_get_eth1_vote_default_vote(spec, state):
     eth1_chain = []
     eth1_data = spec.get_eth1_vote(state, eth1_chain)
     assert eth1_data == spec.Eth1Data(
-        deposit_root=Bytes32(),
+        deposit_root=spec.Bytes32(),
         deposit_count=0,
-        block_hash=Bytes32(),
+        block_hash=spec.Bytes32(),
     )
 
 
@@ -285,9 +285,9 @@ def test_get_eth1_vote_chain_in_past(spec, state):
 
     # Should be default vote
     assert eth1_data == spec.Eth1Data(
-        deposit_root=Bytes32(),
+        deposit_root=spec.Bytes32(),
         deposit_count=0,
-        block_hash=Bytes32(),
+        block_hash=spec.Bytes32(),
     )
 
 

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
@@ -178,7 +178,11 @@ def test_get_eth1_vote_default_vote(spec, state):
     state.eth1_data_votes = ()
     eth1_chain = []
     eth1_data = spec.get_eth1_vote(state, eth1_chain)
-    assert eth1_data == state.eth1_data
+    assert eth1_data == spec.Eth1Data(
+        deposit_root=Bytes32(),
+        deposit_count=0,
+        block_hash=Bytes32(),
+    )
 
 
 @with_all_phases
@@ -280,7 +284,11 @@ def test_get_eth1_vote_chain_in_past(spec, state):
     eth1_data = spec.get_eth1_vote(state, eth1_chain)
 
     # Should be default vote
-    assert eth1_data == state.eth1_data
+    assert eth1_data == spec.Eth1Data(
+        deposit_root=Bytes32(),
+        deposit_count=0,
+        block_hash=Bytes32(),
+    )
 
 
 @with_all_phases


### PR DESCRIPTION
Addresses #2227 by changing the default vote to be zeroed out - zero block hash, deposit root and zero deposits. The state transition is updated to explicitly disallow the zero vote from becoming the current `Eth1Data` in the spec.

The zero vote is automatically ignored by `get_eth1_vote` because it won't be in the set of known blocks so doesn't lead validators to following a vote which doesn't progress the chain like defaulting to the current `state.eth1_data` does.

The alternative approach would be for validators to vote for a random block hash which has the advantage of not needing to update the state transition rules as it's exceedingly unlikely 50% of validators will choose the same random data, but the downside of making it harder to identify default votes. Differentiating default votes from votes for unknown blocks is particularly useful when evaluating whether a beacon node is tracking the eth1 chain correctly.

Note: Python likely needs some tweaking but hopefully gets the idea across.