### PR TITLE
sharding eip-1559-like behavior, with rolling-window adjustments

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -752,8 +752,9 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
 
     # Initialize the pending header
     index = compute_committee_index_from_shard(state, slot, shard)
-    committee_length = len(get_beacon_committee(state, slot, index))
-    initial_votes = Bitlist[MAX_VALIDATORS_PER_COMMITTEE]([0] * committee_length)
+    full_committee = get_beacon_committee(state, slot, index)
+    initial_votes = Bitlist[MAX_VALIDATORS_PER_COMMITTEE]([0] * len(full_committee))
+    max_weight = sum(state.validators[index].effective_balance for index in full_committee)
     pending_header = PendingShardHeader(
         attested=AttestedDataCommitment(
             commitment=body_summary.commitment,
@@ -762,6 +763,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
         ),
         votes=initial_votes,
         weight=0,
+        max_weight=max_weight,
         update_slot=state.slot,
     )
 

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -156,7 +156,8 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
 - _[IGNORE]_ The header is not stale -- i.e. the corresponding shard proposer has not already selected a header for `(header.slot, header.shard)`.
 - _[IGNORE]_ The header is the first header with valid signature received for the `(header.builder_index, header.slot, header.shard)` combination.
 - _[REJECT]_ The blob builder, define by `header.builder_index`, exists and has sufficient balance to back the fee payment.
-- _[IGNORE]_ The header fee SHOULD be higher than previously seen headers for `(header.slot, header.shard)`, from any builder.
+- _[REJECT]_ The max fee MUST be higher or equal to the max priority fee -- i.e. validate `header.body_summary.max_priority_fee <= header.body_summary.max_fee`
+- _[IGNORE]_ The `header.body_summary.max_priority_fee` SHOULD be higher than previously seen headers for `(header.slot, header.shard)`, from any builder.
   Propagating nodes MAY increase fee increments in case of spam.
 - _[REJECT]_ The header signature, `signed_blob_header.signature`, is valid for ONLY the builder --
   i.e. `bls.Verify(builder_pubkey, blob_signing_root, signed_blob_header.signature)`. The signature is not an aggregate with the proposer.


### PR DESCRIPTION
Changes:
- Fee fields are for fixed-length shard data anyway (unlike dynamic gas count in eth1), account for it as total instead of per sample.
- The above enables `Gwei` usage for these fields, without losing as much accuracy for low-fee transactions.
- Base fees are tracked per shard, to avoid 1 fat shard and 63 slim shards from balancing out. Also increases predictability.
- Rolling window base-fee updates. A single base fee update is still very similar, but instead of processing once and moving to the next slot, we process with a lower maximum change, and repeat it for a few slots.
  - When there is a beacon gap slot, fees are stable, as the processing func is not called
  - When there is a shard gap slot, it accounts as 0, until it becomes non-zero with e.g. late inclusion. The effect of inclusion latency is minimized by spreading the adjustments, yet the base-fee keeps adjusting per slot, to not have to wait e.g. a whole epoch for adjustments.
  - When a beacon slot gap results in a late shard header, it is just one less adjustment step. Making the shard header fees less volatile, yet accounted for.
  - The exact quotient computation needs some work, just a rough guess how it could be like, the old one was outdated (per epoch, global fee instead of per-shard), corrections welcome. Might chart it out later, it's a starting point.
- Small bonus shard update: store the committee weight along with the voters weight, so we do not have to compute/cache committees and balances when checking confirmation progress. Especially useful for faster API service of shard data confs.

