### PR TITLE
Fix typing problem in `merge:on_block`: `is_merge_block` expects `BeaconBlockBody`

### DIFF
--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -129,7 +129,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock, transition_store: Tr
     assert get_ancestor(store, block.parent_root, finalized_slot) == store.finalized_checkpoint.root
     
     # [New in Merge]
-    if (transition_store is not None) and is_merge_block(pre_state, block):
+    if (transition_store is not None) and is_merge_block(pre_state, block.body):
         # Delay consideration of block until PoW block is processed by the PoW node
         pow_block = get_pow_block(block.body.execution_payload.parent_hash)
         pow_parent = get_pow_block(pow_block.parent_hash)


### PR DESCRIPTION
[is_merge_block](https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/beacon-chain.md#is_merge_block) expects `BeaconBlockBody` as a second argument, however, [merge:on_block](https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/fork-choice.md#on_block) provides a `BeaconBlock` instance.