### PR TITLE
Fix typos in `sharding/beacon-chain.md`

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -503,14 +503,14 @@ def get_active_shard_count(state: BeaconState, epoch: Epoch) -> uint64:
 #### `get_shard_proposer_index`
 
 ```python
-def get_shard_proposer_index(beacon_state: BeaconState, slot: Slot, shard: Shard) -> ValidatorIndex:
+def get_shard_proposer_index(state: BeaconState, slot: Slot, shard: Shard) -> ValidatorIndex:
     """
     Return the proposer's index of shard block at ``slot``.
     """
     epoch = compute_epoch_at_slot(slot)
-    seed = hash(get_seed(beacon_state, epoch, DOMAIN_SHARD_BLOB) + uint_to_bytes(slot) + uint_to_bytes(shard))
+    seed = hash(get_seed(state, epoch, DOMAIN_SHARD_BLOB) + uint_to_bytes(slot) + uint_to_bytes(shard))
     indices = get_active_validator_indices(state, epoch)
-    return compute_proposer_index(beacon_state, indices, seed)
+    return compute_proposer_index(state, indices, seed)
 ```
 
 #### `get_start_shard`

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -520,7 +520,7 @@ def get_start_shard(state: BeaconState, slot: Slot) -> Shard:
     """
     Return the start shard at ``slot``.
     """
-    epoch = compute_epoch_at_slot(Slot(_slot))
+    epoch = compute_epoch_at_slot(Slot(slot))
     committee_count = get_committee_count_per_slot(state, epoch)
     active_shard_count = get_active_shard_count(state, epoch)
     return committee_count * slot % active_shard_count 


### PR DESCRIPTION
Minor typos fixes:
- `get_shard_proposer_index`: variable `state` is used to reffer to `beacon_state` parameter. Renamed all uses to `state` to be consistent with the rest of the specs.
- `get_start_shard` refers to `_slot` instead of `slot`