### PR TITLE
update skipped test count when test already exists

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
@@ -112,6 +112,7 @@ def run_generator(generator_name, test_providers: Iterable[TestProvider]):
 
             if case_dir.exists():
                 if not args.force and not incomplete_tag_file.exists():
+                    skipped_test_count += 1
                     print(f'Skipping already existing test: {case_dir}')
                     continue
                 else:


### PR DESCRIPTION
#2554 should have updated this counter for existing tests, not just tests that are skipped by hand.