### PR TITLE
Fix a performance bug with the randomized block tests from #2560

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/multi_operations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/multi_operations.py
@@ -171,7 +171,7 @@ def get_random_voluntary_exits(spec, state, to_be_slashed_indices, rng):
     return prepare_signed_exits(spec, state, exit_indices)
 
 
-def get_random_sync_aggregate(spec, state, slot, fraction_participated=1.0, rng=Random(2099)):
+def get_random_sync_aggregate(spec, state, slot, block_root=None, fraction_participated=1.0, rng=Random(2099)):
     committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
     participant_count = int(len(committee_indices) * fraction_participated)
     participant_indices = rng.sample(range(len(committee_indices)), participant_count)
@@ -184,6 +184,7 @@ def get_random_sync_aggregate(spec, state, slot, fraction_participated=1.0, rng=
         state,
         slot,
         participants,
+        block_root=block_root,
     )
     return spec.SyncAggregate(
         sync_committee_bits=[index in participant_indices for index in range(len(committee_indices))],

--- a/tests/core/pyspec/eth2spec/test/utils/randomized_block_tests.py
+++ b/tests/core/pyspec/eth2spec/test/utils/randomized_block_tests.py
@@ -135,10 +135,12 @@ def random_block_altair_with_cycling_sync_committee_participation(spec,
     block_index = len(signed_blocks) % SYNC_AGGREGATE_PARTICIPATION_BUCKETS
     fraction_missed = block_index * (1 / SYNC_AGGREGATE_PARTICIPATION_BUCKETS)
     fraction_participated = 1.0 - fraction_missed
+    previous_root = block.parent_root
     block.body.sync_aggregate = get_random_sync_aggregate(
         spec,
         state,
         block.slot - 1,
+        block_root=previous_root,
         fraction_participated=fraction_participated,
     )
     return block


### PR DESCRIPTION
Running the `random` test gen after #2560 is very slow for the mainnet `altair` test suite.

Some rough profiling revealed the construction of the randomized sync aggregate to take ~30 mins (!).

Closer inspection revealed:

A low-level helper for the sync committee aggregate signature computation built an empty block in the next slot and returned the `parent_root` of that block if the helper was asked for the signature of the block root at a `slot == state.slot`.


However:

The high-level helper that produces the randomized sync aggregate already has the block so we can simply pass the right root in and shave a lot of time off the test generation.