### PR TITLE
Clean up startswith method in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ def get_spec(file_name: Path, preset: Dict[str, str], config: Dict[str, str]) ->
 
                     if not _is_constant_id(name):
                         # Check for short type declarations
-                        if value.startswith("uint") or value.startswith("Bytes") or value.startswith("ByteList") or value.startswith("Union"):
+                        if value.startswith(("uint", "Bytes", "ByteList", "Union")):
                             custom_types[name] = value
                         continue
 


### PR DESCRIPTION
removed `or` and used a tuple.

`value.startswith(("uint", "Bytes", "ByteList", "Union"))`