### PR TITLE
Change transition_td to terminal_td in the merge spec

### DIFF
--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -73,7 +73,7 @@ def finalize_block(self: ExecutionEngine, block_hash: Hash32) -> bool:
 ```python
 @dataclass
 class TransitionStore(object):
-    transition_total_difficulty: uint256
+    terminal_total_difficulty: uint256
 ```
 
 ### `PowBlock`
@@ -101,8 +101,8 @@ Used by fork-choice handler, `on_block`.
 
 ```python
 def is_valid_terminal_pow_block(transition_store: TransitionStore, block: PowBlock, parent: PowBlock) -> bool:
-    is_total_difficulty_reached = block.total_difficulty >= transition_store.transition_total_difficulty
-    is_parent_total_difficulty_valid = parent.total_difficulty < transition_store.transition_total_difficulty
+    is_total_difficulty_reached = block.total_difficulty >= transition_store.terminal_total_difficulty
+    is_parent_total_difficulty_valid = parent.total_difficulty < transition_store.terminal_total_difficulty
     return block.is_valid and is_total_difficulty_reached and is_parent_total_difficulty_valid
 ```
 

--- a/specs/merge/fork.md
+++ b/specs/merge/fork.md
@@ -108,7 +108,7 @@ If `state.slot % SLOTS_PER_EPOCH == 0` and `compute_epoch_at_slot(state.slot) ==
 Transition store initialization occurs after the state has been modified by corresponding `upgrade_to_merge` function.
 
 ```python
-def compute_transition_total_difficulty(anchor_pow_block: PowBlock) -> uint256:
+def compute_terminal_total_difficulty(anchor_pow_block: PowBlock) -> uint256:
     seconds_per_voting_period = EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH * SECONDS_PER_SLOT
     pow_blocks_per_voting_period = seconds_per_voting_period // SECONDS_PER_ETH1_BLOCK
     pow_blocks_to_merge = TARGET_SECONDS_TO_MERGE // SECONDS_PER_ETH1_BLOCK
@@ -119,8 +119,8 @@ def compute_transition_total_difficulty(anchor_pow_block: PowBlock) -> uint256:
 
 
 def get_transition_store(anchor_pow_block: PowBlock) -> TransitionStore:
-    transition_total_difficulty = compute_transition_total_difficulty(anchor_pow_block)
-    return TransitionStore(transition_total_difficulty=transition_total_difficulty)
+    terminal_total_difficulty = compute_terminal_total_difficulty(anchor_pow_block)
+    return TransitionStore(terminal_total_difficulty=terminal_total_difficulty)
 
 
 def initialize_transition_store(state: BeaconState) -> TransitionStore:

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -95,7 +95,7 @@ def get_execution_payload(state: BeaconState,
                           execution_engine: ExecutionEngine,
                           pow_chain: Sequence[PowBlock]) -> ExecutionPayload:
     if not is_merge_complete(state):
-        terminal_pow_block = get_pow_block_at_total_difficulty(transition_store.transition_total_difficulty, pow_chain)
+        terminal_pow_block = get_pow_block_at_total_difficulty(transition_store.terminal_total_difficulty, pow_chain)
         if terminal_pow_block is None:
             # Pre-merge, empty payload
             return ExecutionPayload()


### PR DESCRIPTION
A slight update in the Merge terminology, `transition_total_difficulty` is replaced with the newer term `terminal_total_difficulty` with the corresponding renaming all over the spec