### PR TITLE
Allow spec tests author to batch tests under one handler name

### DIFF
--- a/tests/generators/operations/main.py
+++ b/tests/generators/operations/main.py
@@ -12,9 +12,9 @@ if __name__ == "__main__":
         'voluntary_exit',
     ]}
     altair_mods = {
-        **{key: 'eth2spec.test.altair.block_processing.sync_aggregate.test_process_' + key for key in [
-            'sync_aggregate',
-            'sync_aggregate_random',
+        **{'sync_aggregate': [
+            'eth2spec.test.altair.block_processing.sync_aggregate.test_process_' + key
+            for key in ['sync_aggregate', 'sync_aggregate_random']
         ]},
         **phase_0_mods,
     }  # also run the previous phase 0 tests


### PR DESCRIPTION
Request from implementation teams to batch "like-operations" when generating consensus spec tests.

The test generation infra followed the file tree of the test repo to determine the organization of the output test data.

This PR allows a test author to batch tests under one handler name, regardless of file tree layout, by providing a list of "like" test modules, rather than just a single `str` of the module name.

This PR also adds a "collect" mode to the test generation infra (like the `pytest` collection phase), used to verify we pulled the same number of tests with this change.