### PR TITLE
Fix `merge_mods` in test generators

### DIFF
--- a/tests/generators/epoch_processing/main.py
+++ b/tests/generators/epoch_processing/main.py
@@ -25,8 +25,7 @@ if __name__ == "__main__":
     }  # also run the previous phase 0 tests
 
     # No epoch-processing changes in Merge and previous testing repeats with new types, so no additional tests required.
-    # TODO: rebase onto Altair testing later.
-    merge_mods = phase_0_mods
+    merge_mods = altair_mods
 
     # TODO Custody Game testgen is disabled for now
     # custody_game_mods = {**{key: 'eth2spec.test.custody_game.epoch_processing.test_process_' + key for key in [

--- a/tests/generators/finality/main.py
+++ b/tests/generators/finality/main.py
@@ -5,7 +5,7 @@ from eth2spec.test.helpers.constants import PHASE0, ALTAIR, MERGE
 if __name__ == "__main__":
     phase_0_mods = {'finality': 'eth2spec.test.phase0.finality.test_finality'}
     altair_mods = phase_0_mods   # No additional Altair specific finality tests
-    merge_mods = phase_0_mods    # No additional Merge specific finality tests
+    merge_mods = altair_mods      # No additional Merge specific finality tests
 
     all_mods = {
         PHASE0: phase_0_mods,

--- a/tests/generators/fork_choice/main.py
+++ b/tests/generators/fork_choice/main.py
@@ -9,8 +9,8 @@ if __name__ == "__main__":
     ]}
     # No additional Altair specific finality tests, yet.
     altair_mods = phase_0_mods
-    # No specific Merge tests yet. TODO: rebase onto Altair testing later.
-    merge_mods = phase_0_mods
+    # No specific Merge tests yet.
+    merge_mods = altair_mods
 
     all_mods = {
         PHASE0: phase_0_mods,

--- a/tests/generators/operations/main.py
+++ b/tests/generators/operations/main.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         **{key: 'eth2spec.test.merge.block_processing.test_process_' + key for key in [
             'execution_payload',
         ]},
-        **phase_0_mods,  # TODO: runs phase0 tests. Rebase to include `altair_mods` testing later.
+        **altair_mods,
     }
 
     # TODO Custody Game testgen is disabled for now

--- a/tests/generators/rewards/main.py
+++ b/tests/generators/rewards/main.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     # No additional merge specific rewards tests, yet.
     # Note: Block rewards are non-epoch rewards and are tested as part of block processing tests.
     # Transaction fees are part of the execution-layer.
-    merge_mods = phase_0_mods
+    merge_mods = altair_mods
 
     all_mods = {
         PHASE0: phase_0_mods,

--- a/tests/generators/sanity/main.py
+++ b/tests/generators/sanity/main.py
@@ -9,12 +9,10 @@ if __name__ == "__main__":
     ]}
     altair_mods = {**{key: 'eth2spec.test.altair.sanity.test_' + key for key in [
         'blocks',
-    ]}, **phase_0_mods}  # also run the previous phase 0 tests
-
-    # Altair-specific test cases are ignored, but should be included after the Merge is rebased onto Altair work.
+    ]}, **phase_0_mods}
     merge_mods = {**{key: 'eth2spec.test.merge.sanity.test_' + key for key in [
         'blocks',
-    ]}, **phase_0_mods}  # TODO: Merge inherits phase0 tests for now.
+    ]}, **altair_mods}
 
     all_mods = {
         PHASE0: phase_0_mods,


### PR DESCRIPTION
Since merge spec was rebased (#2530), make `merge_mods` base on `altair_mods` instead of `phase_0_mods`.