### PR TITLE
add rewards spec test with exit in current epoch

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/random.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/random.py
@@ -37,8 +37,8 @@ def exit_random_validators(spec, state, rng, fraction=None):
             continue
 
         validator = state.validators[index]
-        validator.exit_epoch = rng.choice([current_epoch - 1, current_epoch - 2, current_epoch - 3])
-        # ~1/2 are withdrawable
+        validator.exit_epoch = rng.choice([current_epoch, current_epoch - 1, current_epoch - 2, current_epoch - 3])
+        # ~1/2 are withdrawable (note, unnatural span between exit epoch and withdrawable epoch)
         if rng.choice([True, False]):
             validator.withdrawable_epoch = current_epoch
         else:


### PR DESCRIPTION
After some inspection, it seems we do not test for exits in the current epoch.

This PR adds a test for this scenario and exposes the expected rewards computation as a spec test.