### PR TITLE
Increase the distance of the beacon block a blob may refer to

### DIFF
--- a/presets/mainnet/sharding.yaml
+++ b/presets/mainnet/sharding.yaml
@@ -16,6 +16,8 @@ MAX_SHARD_HEADERS_PER_SHARD: 4
 SHARD_STATE_MEMORY_SLOTS: 256
 # 2**40 (= 1,099,511,627,776)
 BLOB_BUILDER_REGISTRY_LIMIT: 1099511627776
+# 2**5 (= 32)
+MAX_BLOB_BLOCK_ROOT_DISTANCE: 32
 
 # Shard blob samples
 # ---------------------------------------------------------------

--- a/presets/mainnet/sharding.yaml
+++ b/presets/mainnet/sharding.yaml
@@ -17,7 +17,7 @@ SHARD_STATE_MEMORY_SLOTS: 256
 # 2**40 (= 1,099,511,627,776)
 BLOB_BUILDER_REGISTRY_LIMIT: 1099511627776
 # 2**5 (= 32)
-MAX_BLOB_BLOCK_ROOT_DISTANCE: 32
+MAX_BLOB_ANCHOR_DISTANCE: 32
 
 # Shard blob samples
 # ---------------------------------------------------------------

--- a/presets/minimal/sharding.yaml
+++ b/presets/minimal/sharding.yaml
@@ -18,7 +18,7 @@ SHARD_STATE_MEMORY_SLOTS: 256
 # 2**40 (= 1,099,511,627,776)
 BLOB_BUILDER_REGISTRY_LIMIT: 1099511627776
 # [customized] reduced for testing, match epoch length
-MAX_BLOB_BLOCK_ROOT_DISTANCE: 8
+MAX_BLOB_ANCHOR_DISTANCE: 8
 
 # Shard blob samples
 # ---------------------------------------------------------------

--- a/presets/minimal/sharding.yaml
+++ b/presets/minimal/sharding.yaml
@@ -17,6 +17,8 @@ MAX_SHARD_HEADERS_PER_SHARD: 4
 SHARD_STATE_MEMORY_SLOTS: 256
 # 2**40 (= 1,099,511,627,776)
 BLOB_BUILDER_REGISTRY_LIMIT: 1099511627776
+# [customized] reduced for testing, match epoch length
+MAX_BLOB_BLOCK_ROOT_DISTANCE: 8
 
 # Shard blob samples
 # ---------------------------------------------------------------

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -441,7 +441,7 @@ def compute_previous_slot(slot: Slot) -> Slot:
 ```python
 def compute_previous_slots(slot: Slot, max_distance: int) -> [Slot]:
     from = slot - max_distance if slot > max_distance else 0
-    return range(from, slot)
+    return [Slot(s) for s in range(from, slot)]
 ```
 
 #### `compute_updated_sample_price`

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -46,6 +46,7 @@
   - [Misc](#misc-3)
     - [`next_power_of_two`](#next_power_of_two)
     - [`compute_previous_slot`](#compute_previous_slot)
+    - [`compute_previous_slots`](#compute_previous_slots)
     - [`compute_updated_sample_price`](#compute_updated_sample_price)
     - [`compute_committee_source_epoch`](#compute_committee_source_epoch)
     - [`batch_apply_participation_flag`](#batch_apply_participation_flag)
@@ -435,6 +436,14 @@ def compute_previous_slot(slot: Slot) -> Slot:
         return Slot(0)
 ```
 
+#### `compute_previous_slots`
+
+```python
+def compute_previous_slots(slot: Slot, max_distance: int) -> [Slot]:
+    from = slot - max_distance if slot > max_distance else 0
+    return range(from, slot)
+```
+
 #### `compute_updated_sample_price`
 
 ```python
@@ -698,9 +707,8 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
 
     # Verify that the block root matches,
     # to ensure the header will only be included in this specific Beacon Chain sub-tree.
-    from_slot = slot > MAX_BLOB_BLOCK_ROOT_DISTANCE ? slot - MAX_BLOB_BLOCK_ROOT_DISTANCE : 0 
     assert header.body_summary.beacon_block_root in 
-        [get_block_root_at_slot(state, s) for s in range(from_slot, slot)]
+        [get_block_root_at_slot(state, s) for s in compute_previous_slots(slot, MAX_BLOB_BLOCK_ROOT_DISTANCE)]
 
     # Check that this data is still pending
     committee_work = state.shard_buffer[slot % SHARD_STATE_MEMORY_SLOTS][shard]

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -157,6 +157,7 @@ TODO: `WEIGHT_DENOMINATOR` needs to be adjusted, but this breaks a lot of Altair
 | `MAX_SHARD_HEADERS_PER_SHARD` | `4` | |
 | `SHARD_STATE_MEMORY_SLOTS` | `uint64(2**8)` (= 256) | Number of slots for which shard commitments and confirmation status is directly available in the state |
 | `BLOB_BUILDER_REGISTRY_LIMIT` | `uint64(2**40)` (= 1,099,511,627,776) | shard blob builders |
+| `MAX_BLOB_BLOCK_ROOT_DISTANCE` | `32` | Maximum distance of the block referred by `ShardBlob.body.beacon_block_root` from the blob slot |   
 
 ### Shard blob samples
 
@@ -697,7 +698,9 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
 
     # Verify that the block root matches,
     # to ensure the header will only be included in this specific Beacon Chain sub-tree.
-    assert header.body_summary.beacon_block_root == get_block_root_at_slot(state, slot - 1)
+    from_slot = slot > MAX_BLOB_BLOCK_ROOT_DISTANCE ? slot - MAX_BLOB_BLOCK_ROOT_DISTANCE : 0 
+    assert header.body_summary.beacon_block_root in 
+        [get_block_root_at_slot(state, s) for s in range(from_slot, slot)]
 
     # Check that this data is still pending
     committee_work = state.shard_buffer[slot % SHARD_STATE_MEMORY_SLOTS][shard]

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -440,8 +440,8 @@ def compute_previous_slot(slot: Slot) -> Slot:
 
 ```python
 def compute_previous_slots(slot: Slot, max_distance: int) -> [Slot]:
-    from = slot - max_distance if slot > max_distance else 0
-    return [Slot(s) for s in range(from, slot)]
+    from_slot = slot - max_distance if slot > max_distance else 0
+    return [Slot(s) for s in range(from_slot, slot)]
 ```
 
 #### `compute_updated_sample_price`

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -157,7 +157,7 @@ TODO: `WEIGHT_DENOMINATOR` needs to be adjusted, but this breaks a lot of Altair
 | `MAX_SHARD_HEADERS_PER_SHARD` | `4` | |
 | `SHARD_STATE_MEMORY_SLOTS` | `uint64(2**8)` (= 256) | Number of slots for which shard commitments and confirmation status is directly available in the state |
 | `BLOB_BUILDER_REGISTRY_LIMIT` | `uint64(2**40)` (= 1,099,511,627,776) | shard blob builders |
-| `MAX_BLOB_BLOCK_ROOT_DISTANCE` | `32` | Maximum distance of the block, referred to by `ShardBlob.body.beacon_block_slot` from the blob slot |   
+| `MAX_BLOB_ANCHOR_DISTANCE` | `32` | Maximum distance of the block, referred to by `ShardBlob.body.beacon_block_slot` from the blob slot |   
 
 ### Shard blob samples
 
@@ -700,7 +700,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
 
     # Verify that the block root matches,
     # to ensure the header will only be included in this specific Beacon Chain sub-tree.
-    lower = max(MAX_BLOB_BLOCK_ROOT_DISTANCE, slot) - MAX_BLOB_BLOCK_ROOT_DISTANCE
+    lower = max(MAX_BLOB_ANCHOR_DISTANCE, slot) - MAX_BLOB_ANCHOR_DISTANCE
     assert lower <= header.body_summary.beacon_block_slot < slot
     assert header.body_summary.beacon_block_root == get_block_root_at_slot(state, header.body_summary.beacon_block_slot)
 

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -87,6 +87,10 @@ on the horizontal subnet or creating samples for it. Alias `blob = signed_blob.m
   i.e. validate that `compute_epoch_at_slot(blob.slot) >= get_previous_epoch(state)`
 - _[REJECT]_ The shard blob is for an active shard --
   i.e. `blob.shard < get_active_shard_count(state, compute_epoch_at_slot(blob.slot))`
+- _[REJECT]_ The header anchor slot is not out of bounds --
+  i.e. `(max(MAX_BLOB_BLOCK_ROOT_DISTANCE, header.slot) - MAX_BLOB_BLOCK_ROOT_DISTANCE) <= header.body_summary.beacon_block_slot < header.slot`
+- _[IGNORE]_ The header anchor `beacon_block_root` is canonical w.r.t. the current head --
+  i.e. `header.body_summary.beacon_block_root == get_block_root_at_slot(state, header.body_summary.beacon_block_slot)`
 - _[REJECT]_ The `blob.shard` MUST have a committee at the `blob.slot` --
   i.e. validate that `compute_committee_index_from_shard(state, blob.slot, blob.shard)` doesn't raise an error
 - _[REJECT]_ The shard blob is for the correct subnet --
@@ -97,8 +101,8 @@ on the horizontal subnet or creating samples for it. Alias `blob = signed_blob.m
 - _[REJECT]_ The blob builder defined by `blob.builder_index` exists and has sufficient balance to back the fee payment.
 - _[REJECT]_ The blob signature, `signed_blob.signature`, is valid for the aggregate of proposer and builder --
   i.e. `bls.FastAggregateVerify([builder_pubkey, proposer_pubkey], blob_signing_root, signed_blob.signature)`.
-- _[REJECT]_ The blob is proposed by the expected `proposer_index` for the blob's `slot` and `shard`,
-  in the context of the current shuffling (defined by `blob.body.beacon_block_root`/`slot`).
+- _[REJECT]_ The blob is proposed by the expected `proposer_index` for the blob's `blob.slot` and `blob.shard`,
+  in the context of the current shuffling (defined by `blob.body.beacon_block_root`/`blob.slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
   the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
   in such a case _do not_ `REJECT`, instead `IGNORE` this message.
@@ -128,12 +132,16 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
   i.e. `header.shard < get_active_shard_count(state, compute_epoch_at_slot(header.slot))`
 - _[REJECT]_ The `header.shard` MUST have a committee at the `header.slot` --
   i.e. validate that `compute_committee_index_from_shard(state, header.slot, header.shard)` doesn't raise an error.
+- _[REJECT]_ The header anchor slot is not out of bounds --
+  i.e. `(max(MAX_BLOB_BLOCK_ROOT_DISTANCE, header.slot) - MAX_BLOB_BLOCK_ROOT_DISTANCE) <= header.body_summary.beacon_block_slot < header.slot`
+- _[IGNORE]_ The header anchor `beacon_block_root` is canonical w.r.t. the current head --
+  i.e. `header.body_summary.beacon_block_root == get_block_root_at_slot(state, header.body_summary.beacon_block_slot)`
 - _[IGNORE]_ The header is the first header with valid signature received for the `(header.proposer_index, header.slot, header.shard)` combination.
 - _[REJECT]_ The blob builder defined by `blob.builder_index` exists and has sufficient balance to back the fee payment.
 - _[REJECT]_ The header signature, `signed_blob_header.signature`, is valid for the aggregate of proposer and builder --
   i.e. `bls.FastAggregateVerify([builder_pubkey, proposer_pubkey], blob_signing_root, signed_blob_header.signature)`.
 - _[REJECT]_ The header is proposed by the expected `proposer_index` for the blob's `header.slot` and `header.shard`
-  in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`slot`).
+  in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`header.slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
   the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
   in such a case _do not_ `REJECT`, instead `IGNORE` this message.
@@ -154,6 +162,10 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
 - _[REJECT]_ The `header.shard` MUST have a committee at the `header.slot` --
   i.e. validate that `compute_committee_index_from_shard(state, header.slot, header.shard)` doesn't raise an error.
 - _[IGNORE]_ The header is not stale -- i.e. the corresponding shard proposer has not already selected a header for `(header.slot, header.shard)`.
+- _[REJECT]_ The header anchor slot is not out of bounds --
+  i.e. `(max(MAX_BLOB_BLOCK_ROOT_DISTANCE, header.slot) - MAX_BLOB_BLOCK_ROOT_DISTANCE) <= header.body_summary.beacon_block_slot < header.slot`
+- _[IGNORE]_ The header anchor `beacon_block_root` is canonical w.r.t. the current head --
+  i.e. `header.body_summary.beacon_block_root == get_block_root_at_slot(state, header.body_summary.beacon_block_slot)`
 - _[IGNORE]_ The header is the first header with valid signature received for the `(header.builder_index, header.slot, header.shard)` combination.
 - _[REJECT]_ The blob builder, define by `header.builder_index`, exists and has sufficient balance to back the fee payment.
 - _[IGNORE]_ The header fee SHOULD be higher than previously seen headers for `(header.slot, header.shard)`, from any builder.
@@ -161,7 +173,7 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
 - _[REJECT]_ The header signature, `signed_blob_header.signature`, is valid for ONLY the builder --
   i.e. `bls.Verify(builder_pubkey, blob_signing_root, signed_blob_header.signature)`. The signature is not an aggregate with the proposer.
 - _[REJECT]_ The header is designated for proposal by the expected `proposer_index` for the blob's `header.slot` and `header.shard`
-  in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`slot`).
+  in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`header.slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
   the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
   in such a case _do not_ `REJECT`, instead `IGNORE` this message.

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -88,7 +88,7 @@ on the horizontal subnet or creating samples for it. Alias `blob = signed_blob.m
 - _[REJECT]_ The shard blob is for an active shard --
   i.e. `blob.shard < get_active_shard_count(state, compute_epoch_at_slot(blob.slot))`
 - _[REJECT]_ The header anchor slot is not out of bounds --
-  i.e. `(max(MAX_BLOB_BLOCK_ROOT_DISTANCE, header.slot) - MAX_BLOB_BLOCK_ROOT_DISTANCE) <= header.body_summary.beacon_block_slot < header.slot`
+  i.e. `(max(MAX_BLOB_ANCHOR_DISTANCE, header.slot) - MAX_BLOB_ANCHOR_DISTANCE) <= header.body_summary.beacon_block_slot < header.slot`
 - _[IGNORE]_ The header anchor `beacon_block_root` is canonical w.r.t. the current head --
   i.e. `header.body_summary.beacon_block_root == get_block_root_at_slot(state, header.body_summary.beacon_block_slot)`
 - _[REJECT]_ The `blob.shard` MUST have a committee at the `blob.slot` --
@@ -133,7 +133,7 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
 - _[REJECT]_ The `header.shard` MUST have a committee at the `header.slot` --
   i.e. validate that `compute_committee_index_from_shard(state, header.slot, header.shard)` doesn't raise an error.
 - _[REJECT]_ The header anchor slot is not out of bounds --
-  i.e. `(max(MAX_BLOB_BLOCK_ROOT_DISTANCE, header.slot) - MAX_BLOB_BLOCK_ROOT_DISTANCE) <= header.body_summary.beacon_block_slot < header.slot`
+  i.e. `(max(MAX_BLOB_ANCHOR_DISTANCE, header.slot) - MAX_BLOB_ANCHOR_DISTANCE) <= header.body_summary.beacon_block_slot < header.slot`
 - _[IGNORE]_ The header anchor `beacon_block_root` is canonical w.r.t. the current head --
   i.e. `header.body_summary.beacon_block_root == get_block_root_at_slot(state, header.body_summary.beacon_block_slot)`
 - _[IGNORE]_ The header is the first header with valid signature received for the `(header.proposer_index, header.slot, header.shard)` combination.
@@ -163,7 +163,7 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
   i.e. validate that `compute_committee_index_from_shard(state, header.slot, header.shard)` doesn't raise an error.
 - _[IGNORE]_ The header is not stale -- i.e. the corresponding shard proposer has not already selected a header for `(header.slot, header.shard)`.
 - _[REJECT]_ The header anchor slot is not out of bounds --
-  i.e. `(max(MAX_BLOB_BLOCK_ROOT_DISTANCE, header.slot) - MAX_BLOB_BLOCK_ROOT_DISTANCE) <= header.body_summary.beacon_block_slot < header.slot`
+  i.e. `(max(MAX_BLOB_ANCHOR_DISTANCE, header.slot) - MAX_BLOB_ANCHOR_DISTANCE) <= header.body_summary.beacon_block_slot < header.slot`
 - _[IGNORE]_ The header anchor `beacon_block_root` is canonical w.r.t. the current head --
   i.e. `header.body_summary.beacon_block_root == get_block_root_at_slot(state, header.body_summary.beacon_block_slot)`
 - _[IGNORE]_ The header is the first header with valid signature received for the `(header.builder_index, header.slot, header.shard)` combination.


### PR DESCRIPTION
Currently the `ShardBlob.body.beacon_block_root` may refer only head block at slot `ShardBlob.slot - 1`
This condition seems too hard:
- blob builder should have some freedom to choose which past beacon block he wants to 'fork' the blob from. 
For example if for some shard a blob was included to `block-100`, then no blobs were created for this shard during some slots, then it makes sense for the builder to refer the `block-100` for the blob at later slot (say `105`). If for example there are 2 forks at slot `104` the blob would be suitable for including to any of them 
- suppose blob builder/proposer when creating a blob transaction/header for slot `100` don't see the `block-99` and produces a blob referring `block-98`. Then a late `block-99` is finally published and accepted by network. The published blob header then couldn't be included 

Constant `MAX_BLOB_BLOCK_ROOT_DISTANCE = 32` was chosen kind of arbitrary. While it could be as large as `SLOTS_PER_HISTORICAL_ROOT` it probably shouldn't be too large to not burden the nodes with regenerating too old states.