### PR TITLE
Terminal blockhash override

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The merge is still actively in development. The exact specification has not been
   * [Merge fork](specs/merge/fork.md)
   * [Fork Choice changes](specs/merge/fork-choice.md)
   * [Validator additions](specs/merge/validator.md)
-  * [Client settings](specs/merge/client_settings.md)
+  * [Client settings](specs/merge/client-settings.md)
 
 ### Sharding
 

--- a/specs/merge/client-settings.md
+++ b/specs/merge/client-settings.md
@@ -1,21 +1,22 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [The Merge -- Client Settings](#the-merge----client-settings)
-    - [Override terminal total difficulty](#override-terminal-total-difficulty)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # The Merge -- Client Settings
 
 **Notice**: This document is a work-in-progress for researchers and implementers.
 
 This document specifies configurable settings that clients must implement for the Merge.
 
+## Table of contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [The Merge -- Client Settings](#the-merge----client-settings)
+    - [Override terminal total difficulty](#override-terminal-total-difficulty)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ### Override terminal total difficulty
 
-To coordinate manual overrides to [`terminal_total_difficulty`](fork-choice.md#transitionstore), clients
+To coordinate manual overrides to [`terminal_total_difficulty`](./fork-choice.md#transitionstore), clients
 must provide `--terminal-total-difficulty-override` as a configurable setting.
 
 If `TransitionStore` has already [been initialized](./fork.md#initializing-transition-store), this alters the previously initialized value of
@@ -23,4 +24,3 @@ If `TransitionStore` has already [been initialized](./fork.md#initializing-trans
 `terminal_total_difficulty`.
 
 Except under exceptional scenarios, this setting is expected to not be used, and `terminal_total_difficulty` will operate with [default functionality](./fork.md#initializing-transition-store). Sufficient warning to the user about this exceptional configurable setting should be provided.
-[here](fork.md#initializing-transition-store).

--- a/specs/merge/client-settings.md
+++ b/specs/merge/client-settings.md
@@ -20,7 +20,7 @@ To coordinate manual overrides to [`terminal_total_difficulty`](./fork-choice.md
 must provide `--terminal-total-difficulty-override` as a configurable setting.
 
 If `TransitionStore` has already [been initialized](./fork.md#initializing-transition-store), this alters the previously initialized value of
-`TransitionStore.terminal_total_difficulty`, otherwise this setting initializes `TransitionStore` with the specified `terminal_total_difficulty`, bypassing `compute_terminal_total_difficulty` and the use of an `anchor_pow_block`.
+`TransitionStore.terminal_total_difficulty`, otherwise this setting initializes `TransitionStore` with the specified `terminal_total_difficulty`, bypassing `compute_terminal_total_difficulty` and the use of an `anchor_pow_block`. `TransitionStore.terminal_block_hash` is initialized to `Hash32()` if this path is used.
 
 Except under exceptional scenarios, this setting is expected to not be used, and `terminal_total_difficulty` will operate with [default functionality](./fork.md#initializing-transition-store). Sufficient warning to the user about this exceptional configurable setting should be provided.
 
@@ -29,6 +29,6 @@ Except under exceptional scenarios, this setting is expected to not be used, and
 In case fork coordination around a specific PoW block hash is necessary, clients must also provide `--terminal-block-hash-override` as a configurable setting.
 
 If `TransitionStore` has already [been initialized](./fork.md#initializing-transition-store), this alters the previously initialized value of
-`TransitionStore.terminal_block_hash`, otherwise this setting initializes `TransitionStore` with the specified `terminal_block_hash`.
+`TransitionStore.terminal_block_hash`, otherwise this setting initializes `TransitionStore` with the specified `terminal_block_hash` and `terminal_total_difficulty` to `2**256 - 1`.
 
 As with `--terminal-total-difficulty-override`, this setting is not expected to be used unless under exceptional scenarios and sufficient warning to the user about this setting should be provided.

--- a/specs/merge/client-settings.md
+++ b/specs/merge/client-settings.md
@@ -9,9 +9,8 @@ This document specifies configurable settings that clients must implement for th
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [The Merge -- Client Settings](#the-merge----client-settings)
-    - [Override terminal total difficulty](#override-terminal-total-difficulty)
-    - [Override terminal block hash](#override-terminal-block-hash)
+- [Override terminal total difficulty](#override-terminal-total-difficulty)
+- [Override terminal block hash](#override-terminal-block-hash)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/specs/merge/client-settings.md
+++ b/specs/merge/client-settings.md
@@ -11,6 +11,7 @@ This document specifies configurable settings that clients must implement for th
 
 - [The Merge -- Client Settings](#the-merge----client-settings)
     - [Override terminal total difficulty](#override-terminal-total-difficulty)
+    - [Override terminal block hash](#override-terminal-block-hash)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -20,7 +21,15 @@ To coordinate manual overrides to [`terminal_total_difficulty`](./fork-choice.md
 must provide `--terminal-total-difficulty-override` as a configurable setting.
 
 If `TransitionStore` has already [been initialized](./fork.md#initializing-transition-store), this alters the previously initialized value of
-`TransitionStore.terminal_total_difficulty`, otherwise this setting initializes `TransitionStore` with the specified, bypassing `compute_terminal_total_difficulty` and the use of an `anchor_pow_block`.
-`terminal_total_difficulty`.
+`TransitionStore.terminal_total_difficulty`, otherwise this setting initializes `TransitionStore` with the specified `terminal_total_difficulty`, bypassing `compute_terminal_total_difficulty` and the use of an `anchor_pow_block`.
 
 Except under exceptional scenarios, this setting is expected to not be used, and `terminal_total_difficulty` will operate with [default functionality](./fork.md#initializing-transition-store). Sufficient warning to the user about this exceptional configurable setting should be provided.
+
+### Override terminal block hash
+
+In case fork coordination around a specific PoW block hash is necessary, clients must also provide `--terminal-block-hash-override` as a configurable setting.
+
+If `TransitionStore` has already [been initialized](./fork.md#initializing-transition-store), this alters the previously initialized value of
+`TransitionStore.terminal_block_hash`, otherwise this setting initializes `TransitionStore` with the specified `terminal_block_hash`.
+
+As with `--terminal-total-difficulty-override`, this setting is not expected to be used unless under exceptional scenarios and sufficient warning to the user about this setting should be provided.

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -102,12 +102,12 @@ Used by fork-choice handler, `on_block`.
 
 ```python
 def is_valid_terminal_pow_block(transition_store: TransitionStore, block: PowBlock, parent: PowBlock) -> bool:
-    if transition_store.terminal_block_hash is not None:
-        return block.is_valid and block.block_hash == transition_store.terminal_block_hash
-    else:
-        is_total_difficulty_reached = block.total_difficulty >= transition_store.terminal_total_difficulty
-        is_parent_total_difficulty_valid = parent.total_difficulty < transition_store.terminal_total_difficulty
-        return block.is_valid and is_total_difficulty_reached and is_parent_total_difficulty_valid
+    if block.block_hash == transition_store.terminal_block_hash:
+        return True
+
+    is_total_difficulty_reached = block.total_difficulty >= transition_store.terminal_total_difficulty
+    is_parent_total_difficulty_valid = parent.total_difficulty < transition_store.terminal_total_difficulty
+    return block.is_valid and is_total_difficulty_reached and is_parent_total_difficulty_valid
 ```
 
 ## Updated fork-choice handlers

--- a/specs/merge/fork.md
+++ b/specs/merge/fork.md
@@ -129,4 +129,4 @@ def initialize_transition_store(state: BeaconState) -> TransitionStore:
 ```
 
 *Note*: Transition store can also be initialized at client startup by [overriding terminal total
-difficulty](client_settings.md#override-terminal-total-difficulty).
+difficulty](./client-settings.md#override-terminal-total-difficulty).

--- a/specs/merge/fork.md
+++ b/specs/merge/fork.md
@@ -120,7 +120,7 @@ def compute_terminal_total_difficulty(anchor_pow_block: PowBlock) -> uint256:
 
 def get_transition_store(anchor_pow_block: PowBlock) -> TransitionStore:
     terminal_total_difficulty = compute_terminal_total_difficulty(anchor_pow_block)
-    return TransitionStore(terminal_total_difficulty=terminal_total_difficulty, terminal_block_hash=None)
+    return TransitionStore(terminal_total_difficulty=terminal_total_difficulty, terminal_block_hash=Hash32())
 
 
 def initialize_transition_store(state: BeaconState) -> TransitionStore:

--- a/specs/merge/fork.md
+++ b/specs/merge/fork.md
@@ -120,7 +120,7 @@ def compute_terminal_total_difficulty(anchor_pow_block: PowBlock) -> uint256:
 
 def get_transition_store(anchor_pow_block: PowBlock) -> TransitionStore:
     terminal_total_difficulty = compute_terminal_total_difficulty(anchor_pow_block)
-    return TransitionStore(terminal_total_difficulty=terminal_total_difficulty)
+    return TransitionStore(terminal_total_difficulty=terminal_total_difficulty, terminal_block_hash=None)
 
 
 def initialize_transition_store(state: BeaconState) -> TransitionStore:


### PR DESCRIPTION
Adds a terminal block hash override for the merge fork as originally discussed [here](https://github.com/ethereum/consensus-specs/issues/2547#issuecomment-897120430).

I'm creating this PR as a starting point for discussion while acknowledging that this might be somewhat controversial (more so than [the total difficulty override](https://github.com/ethereum/consensus-specs/pull/2587)) because coordinating on a specific blockhash might be perceived as more 'political'. 
