### PR TITLE
pass sync committee sig consistently in tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
@@ -52,7 +52,7 @@ def test_process_light_client_update_not_updated(spec, state):
     sync_committee_signature = compute_aggregate_sync_committee_signature(
         spec,
         state,
-        block.slot,
+        block_header.slot,
         committee,
     )
     next_sync_committee_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.NEXT_SYNC_COMMITTEE_INDEX))]


### PR DESCRIPTION
There are three defined unit tests for the light client sync protocol.
They all follow a similar structure. However, there is an inconcistency
how they pass the slot to compute_aggregate_sync_committee_signature.
In one instance it is passed as `block.slot`. In the other two cases
it is passed as `block_header.slot`. As the `block_header` is created
from the `block`, they share the same value. This patch makes the way
how the slot is passed consistent across all of the test cases.