### PR TITLE
Add extra_data field to the execution payload

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -64,6 +64,7 @@ This patch adds transaction execution to the beacon chain as part of the Merge f
 | `BYTES_PER_LOGS_BLOOM` | `uint64(2**8)` (= 256) |
 | `GAS_LIMIT_DENOMINATOR` | `uint64(2**10)` (= 1,024) |
 | `MIN_GAS_LIMIT` | `uint64(5000)` (= 5,000) |
+| `MAX_EXTRA_DATA_BYTES` | `2**5` (= 32) |
 
 ## Configuration
 
@@ -159,6 +160,7 @@ class ExecutionPayload(Container):
     gas_limit: uint64
     gas_used: uint64
     timestamp: uint64
+    extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
     base_fee_per_gas: Bytes32  # base fee introduced in EIP-1559, little-endian serialized
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
@@ -180,6 +182,7 @@ class ExecutionPayloadHeader(Container):
     gas_limit: uint64
     gas_used: uint64
     timestamp: uint64
+    extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
     base_fee_per_gas: Bytes32
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
@@ -310,6 +313,7 @@ def process_execution_payload(state: BeaconState, payload: ExecutionPayload, exe
         gas_limit=payload.gas_limit,
         gas_used=payload.gas_used,
         timestamp=payload.timestamp,
+        extra_data=payload.extra_data,
         base_fee_per_gas=payload.base_fee_per_gas,
         block_hash=payload.block_hash,
         transactions_root=hash_tree_root(payload.transactions),

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -20,6 +20,7 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
         gas_limit=latest.gas_limit,  # retain same limit
         gas_used=0,  # empty block, 0 gas
         timestamp=timestamp,
+        extra_data=spec.ByteList[spec.MAX_EXTRA_DATA_BYTES](),
         base_fee_per_gas=latest.base_fee_per_gas,  # retain same base_fee
         block_hash=spec.Hash32(),
         transactions=empty_txs,
@@ -42,6 +43,7 @@ def get_execution_payload_header(spec, execution_payload):
         gas_limit=execution_payload.gas_limit,
         gas_used=execution_payload.gas_used,
         timestamp=execution_payload.timestamp,
+        extra_data=execution_payload.extra_data,
         base_fee_per_gas=execution_payload.base_fee_per_gas,
         block_hash=execution_payload.block_hash,
         transactions_root=spec.hash_tree_root(execution_payload.transactions)


### PR DESCRIPTION
### What's done?

Adds `extra_data` field to the execution payload.

### Rationale

See the rationale section of the corresponding change to the EIP-3675 https://github.com/ethereum/EIPs/pull/3982