### PR TITLE
Fix random validation

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -291,12 +291,14 @@ def is_valid_gas_limit(payload: ExecutionPayload, parent: ExecutionPayloadHeader
 
 ```python
 def process_execution_payload(state: BeaconState, payload: ExecutionPayload, execution_engine: ExecutionEngine) -> None:
-    # Verify consistency of the parent hash, block number, random, base fee per gas and gas limit
+    # Verify consistency of the parent hash, block number, base fee per gas and gas limit
+    # with respect to the previous execution payload header
     if is_merge_complete(state):
         assert payload.parent_hash == state.latest_execution_payload_header.block_hash
         assert payload.block_number == state.latest_execution_payload_header.block_number + uint64(1)
-        assert payload.random == get_randao_mix(state, get_current_epoch(state))
         assert is_valid_gas_limit(payload, state.latest_execution_payload_header)
+    # Verify random
+    assert payload.random == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
     assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
     # Verify the execution payload is valid

--- a/tests/core/pyspec/eth2spec/test/merge/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/merge/block_processing/test_process_execution_payload.py
@@ -146,6 +146,34 @@ def test_bad_parent_hash_regular_payload(spec, state):
 
 @with_merge_and_later
 @spec_state_test
+def test_bad_random_first_payload(spec, state):
+    # pre-state
+    state = build_state_with_incomplete_transition(spec, state)
+    next_slot(spec, state)
+
+    # execution payload
+    execution_payload = build_empty_execution_payload(spec, state)
+    execution_payload.random = b'\x42' * 32
+
+    yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
+
+
+@with_merge_and_later
+@spec_state_test
+def test_bad_random_regular_payload(spec, state):
+    # pre-state
+    state = build_state_with_complete_transition(spec, state)
+    next_slot(spec, state)
+
+    # execution payload
+    execution_payload = build_empty_execution_payload(spec, state)
+    execution_payload.random = b'\x04' * 32
+
+    yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
+
+
+@with_merge_and_later
+@spec_state_test
 def test_bad_number_regular_payload(spec, state):
     # pre-state
     state = build_state_with_complete_transition(spec, state)


### PR DESCRIPTION
`execution_payload.random` was incorrectly only being evaluated once the transition had happened and there was a non-empty `latest_execution_payload` in the state.

This field can and should be evaluated even at the transition block because it is not a function of the `latest_execution_payload` but instead is a function of just the beacon state.  Without this fix, arbitrary data could be inserted for `random` at the transition block.

Ensured that `test_bad_random_first_payload` before change to beacon transition function. And passes with the change

