### PR TITLE
Remove beacon_block_root field from ShardBlob

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -270,8 +270,6 @@ class ShardBlobBody(Container):
     degree_proof: BLSCommitment
     # The actual data. Should match the commitment and degree proof.
     data: List[BLSPoint, POINTS_PER_SAMPLE * MAX_SAMPLES_PER_BLOB]
-    # Latest block root of the Beacon Chain, before shard_blob.slot
-    beacon_block_root: Root
     # fee payment fields (EIP 1559 like)
     # TODO: express in MWei instead?
     max_priority_fee_per_sample: Gwei
@@ -293,8 +291,6 @@ class ShardBlobBodySummary(Container):
     degree_proof: BLSCommitment
     # Hash-tree-root as summary of the data field
     data_root: Root
-    # Latest block root of the Beacon Chain, before shard_blob.slot
-    beacon_block_root: Root
     # fee payment fields (EIP 1559 like)
     # TODO: express in MWei instead?
     max_priority_fee_per_sample: Gwei
@@ -694,10 +690,6 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
     committee_index = (shard_count + shard - start_shard) % shard_count    
     committees_per_slot = get_committee_count_per_slot(state, header_epoch)
     assert committee_index <= committees_per_slot
-
-    # Verify that the block root matches,
-    # to ensure the header will only be included in this specific Beacon Chain sub-tree.
-    assert header.body_summary.beacon_block_root == get_block_root_at_slot(state, slot - 1)
 
     # Check that this data is still pending
     committee_work = state.shard_buffer[slot % SHARD_STATE_MEMORY_SLOTS][shard]

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -97,11 +97,6 @@ on the horizontal subnet or creating samples for it. Alias `blob = signed_blob.m
 - _[REJECT]_ The blob builder defined by `blob.builder_index` exists and has sufficient balance to back the fee payment.
 - _[REJECT]_ The blob signature, `signed_blob.signature`, is valid for the aggregate of proposer and builder --
   i.e. `bls.FastAggregateVerify([builder_pubkey, proposer_pubkey], blob_signing_root, signed_blob.signature)`.
-- _[REJECT]_ The blob is proposed by the expected `proposer_index` for the blob's `slot` and `shard`,
-  in the context of the current shuffling (defined by `blob.body.beacon_block_root`/`slot`).
-  If the `proposer_index` cannot immediately be verified against the expected shuffling,
-  the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
-  in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
 #### Global topics
 
@@ -132,11 +127,6 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
 - _[REJECT]_ The blob builder defined by `blob.builder_index` exists and has sufficient balance to back the fee payment.
 - _[REJECT]_ The header signature, `signed_blob_header.signature`, is valid for the aggregate of proposer and builder --
   i.e. `bls.FastAggregateVerify([builder_pubkey, proposer_pubkey], blob_signing_root, signed_blob_header.signature)`.
-- _[REJECT]_ The header is proposed by the expected `proposer_index` for the blob's `header.slot` and `header.shard`
-  in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`slot`).
-  If the `proposer_index` cannot immediately be verified against the expected shuffling,
-  the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
-  in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
 ##### `shard_blob_tx`
 
@@ -160,11 +150,6 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
   Propagating nodes MAY increase fee increments in case of spam.
 - _[REJECT]_ The header signature, `signed_blob_header.signature`, is valid for ONLY the builder --
   i.e. `bls.Verify(builder_pubkey, blob_signing_root, signed_blob_header.signature)`. The signature is not an aggregate with the proposer.
-- _[REJECT]_ The header is designated for proposal by the expected `proposer_index` for the blob's `header.slot` and `header.shard`
-  in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`slot`).
-  If the `proposer_index` cannot immediately be verified against the expected shuffling,
-  the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
-  in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
 ##### `shard_proposer_slashing`
 

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -97,6 +97,11 @@ on the horizontal subnet or creating samples for it. Alias `blob = signed_blob.m
 - _[REJECT]_ The blob builder defined by `blob.builder_index` exists and has sufficient balance to back the fee payment.
 - _[REJECT]_ The blob signature, `signed_blob.signature`, is valid for the aggregate of proposer and builder --
   i.e. `bls.FastAggregateVerify([builder_pubkey, proposer_pubkey], blob_signing_root, signed_blob.signature)`.
+- _[REJECT]_ The blob is proposed by the expected `proposer_index` for the blob's `slot` and `shard`,
+  in the context of the current shuffling (defined by the current node head state and `blob.slot`).
+  If the `proposer_index` cannot immediately be verified against the expected shuffling,
+  the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
+  in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
 #### Global topics
 
@@ -127,6 +132,11 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
 - _[REJECT]_ The blob builder defined by `blob.builder_index` exists and has sufficient balance to back the fee payment.
 - _[REJECT]_ The header signature, `signed_blob_header.signature`, is valid for the aggregate of proposer and builder --
   i.e. `bls.FastAggregateVerify([builder_pubkey, proposer_pubkey], blob_signing_root, signed_blob_header.signature)`.
+- _[REJECT]_ The header is proposed by the expected `proposer_index` for the blob's `header.slot` and `header.shard`
+  in the context of the current shuffling (defined by the current node head state and `header.slot`).
+  If the `proposer_index` cannot immediately be verified against the expected shuffling,
+  the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
+  in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
 ##### `shard_blob_tx`
 
@@ -150,6 +160,11 @@ The following validations MUST pass before forwarding the `signed_blob_header` o
   Propagating nodes MAY increase fee increments in case of spam.
 - _[REJECT]_ The header signature, `signed_blob_header.signature`, is valid for ONLY the builder --
   i.e. `bls.Verify(builder_pubkey, blob_signing_root, signed_blob_header.signature)`. The signature is not an aggregate with the proposer.
+- _[REJECT]_ The header is designated for proposal by the expected `proposer_index` for the blob's `header.slot` and `header.shard`
+  in the context of the current shuffling (defined by the current node head state and `header.slot`).
+  If the `proposer_index` cannot immediately be verified against the expected shuffling,
+  the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
+  in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
 ##### `shard_proposer_slashing`
 


### PR DESCRIPTION
Follow up to PR #2590

Since the order of data of an L2 getting into the shard-data layer doesn't matter it makes sense to remove `beacon_block_root` field from the `ShardBlob`

Some comments from @protolambda 

> L2s will still need some kind of anchoring, but if it's part of the L2 validation rules, and respected in fraud proof in rollup case (i.e. bad beacon block root in data is not slashable, just not a useful block), then it's not necessary in protocol layer case
And fee validation is w.r.t. the estimate block it's going to be included in, not the anchor, so it's fine there
Same applies to shard proposer index
The anchor could give a hint of which branch to look at, but ultimately it must be valid and should be included in the canonical chain