### PR TITLE
fix merkle proof test for mainnet

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_helpers.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_helpers.py
@@ -9,9 +9,6 @@ from eth2spec.test.helpers.merkle import build_proof
 @with_phases([ALTAIR])
 @spec_state_test
 def test_next_sync_committee_tree(spec, state):
-    state.next_sync_committee: object = spec.SyncCommittee(
-        pubkeys=[state.validators[i]for i in range(spec.SYNC_COMMITTEE_SIZE)]
-    )
     next_sync_committee_branch = build_proof(state.get_backing(), spec.NEXT_SYNC_COMMITTEE_INDEX)
     assert spec.is_valid_merkle_branch(
         leaf=state.next_sync_committee.hash_tree_root(),


### PR DESCRIPTION
The `test_next_sync_committee_tree` currently only supports the minimal
preset, as it incorrectly initializes the `next_sync_committee`. On the
mainnet preset, `SYNC_COMMITTEE_SIZE` is 512, but the default states use
only 256 validators, leading to an IndexError during the test execution.
`next_sync_committee` is already initialized correctly prior to the test
run using the spec's `get_next_sync_committee` function, which fills up
extra committee slots with duplicate validators in this scenario. This
makes it unnecessary to manually initialize the `next_sync_committee`.
Removed the incorrect initialization to allow testing on mainnet preset.