### PR TITLE
Modify Merge Gossip Block Validation Conditions

### DIFF
--- a/specs/merge/p2p-interface.md
+++ b/specs/merge/p2p-interface.md
@@ -68,10 +68,8 @@ See the Merge [state transition document](./beacon-chain.md#beaconblockbody) for
 In addition to the gossip validations for this topic from prior specifications,
 the following validations MUST pass before forwarding the `signed_beacon_block` on the network.
 Alias `block = signed_beacon_block.message`, `execution_payload = block.body.execution_payload`.
-- If the execution is enabled for the block or the block state -- i.e. `is_execution_enabled(state, block.body)`
+- If the execution is enabled for the block -- i.e. `is_execution_enabled(state, block.body)`
   then validate the following:
-  - _[REJECT]_ The block's execution payload must be non-empty --
-    i.e. `execution_payload != ExecutionPayload()`
   - _[REJECT]_ The block's execution payload timestamp is correct with respect to the slot
     -- i.e. `execution_payload.timestamp == compute_time_at_slot(state, block.slot)`.
   - _[REJECT]_ Gas used is less than the gas limit --

--- a/specs/merge/p2p-interface.md
+++ b/specs/merge/p2p-interface.md
@@ -68,12 +68,10 @@ See the Merge [state transition document](./beacon-chain.md#beaconblockbody) for
 In addition to the gossip validations for this topic from prior specifications,
 the following validations MUST pass before forwarding the `signed_beacon_block` on the network.
 Alias `block = signed_beacon_block.message`, `execution_payload = block.body.execution_payload`.
-- If the merge is complete with respect to the head state -- i.e. `is_merge_complete(state)` --
+- If the execution is enabled for the block or the block state -- i.e. `is_execution_enabled(state, block.body)`
   then validate the following:
   - _[REJECT]_ The block's execution payload must be non-empty --
     i.e. `execution_payload != ExecutionPayload()`
-- If the execution is enabled for the block -- i.e. `is_execution_enabled(state, block.body)`
-  then validate the following:
   - _[REJECT]_ The block's execution payload timestamp is correct with respect to the slot
     -- i.e. `execution_payload.timestamp == compute_time_at_slot(state, block.slot)`.
   - _[REJECT]_ Gas used is less than the gas limit --


### PR DESCRIPTION
This PR addresses the first validation condition as it is currently written:

 - If the merge is complete with respect to the **head state** -- i.e. `is_merge_complete(state)` -- then validate the following:
    - [REJECT] The block's execution payload must be non-empty -- i.e. `execution_payload != ExecutionPayload()`

As mentioned by @paulhauner in #2618, this condition might cause problems when there are forks in the POW chain at the transition boundary, potentially causing clients to initially reject and fail to propagate blocks that might be ultimately destined to become a part of the canonical chain.

It seems likely that this condition was originally intended to apply to all descendants of the transition block. Therefore it should be validated against the `BeaconState` associated with the block being imported rather than the head state.  If that is true, the validation conditions simplify to this.