### PR TITLE
No longer importing "Paragraph"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ except ImportError:
 from marko.block import Heading, FencedCode, LinkRefDef, BlankLine
 from marko.inline import CodeSpan
 from marko.ext.gfm import gfm
-from marko.ext.gfm.elements import Table, Paragraph
+from marko.ext.gfm.elements import Table
 
 
 # Definitions in context.py


### PR DESCRIPTION
removed Paragraph from being imported from marko.ext.gfm.elements as it is not being used