### PR TITLE
run tests against future forks by default

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/merkle/test_single_proof.py
+++ b/tests/core/pyspec/eth2spec/test/altair/merkle/test_single_proof.py
@@ -1,12 +1,11 @@
 from eth2spec.test.context import (
     spec_state_test,
-    with_phases,
+    with_altair_and_later,
 )
-from eth2spec.test.helpers.constants import ALTAIR
 from eth2spec.test.helpers.merkle import build_proof
 
 
-@with_phases([ALTAIR])
+@with_altair_and_later
 @spec_state_test
 def test_next_sync_committee_merkle_proof(spec, state):
     yield "state", state
@@ -25,7 +24,7 @@ def test_next_sync_committee_merkle_proof(spec, state):
     )
 
 
-@with_phases([ALTAIR])
+@with_altair_and_later
 @spec_state_test
 def test_finality_root_merkle_proof(spec, state):
     yield "state", state

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/networking/test_networking.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/networking/test_networking.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
-    with_altair_and_later,
     spec_state_test,
+    with_altair_and_later,
 )
 from eth2spec.test.helpers.state import (
     transition_to,

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_config_invariants.py
@@ -1,11 +1,10 @@
 from eth2spec.test.context import (
     spec_state_test,
-    with_phases,
+    with_altair_and_later,
 )
-from eth2spec.test.helpers.constants import ALTAIR
 
 
-@with_phases([ALTAIR])
+@with_altair_and_later
 @spec_state_test
 def test_weight_denominator(spec, state):
     assert (
@@ -17,7 +16,7 @@ def test_weight_denominator(spec, state):
     ) == spec.WEIGHT_DENOMINATOR
 
 
-@with_phases([ALTAIR])
+@with_altair_and_later
 @spec_state_test
 def test_inactivity_score(spec, state):
     assert spec.config.INACTIVITY_SCORE_BIAS <= spec.config.INACTIVITY_SCORE_RECOVERY_RATE

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
@@ -1,17 +1,14 @@
 from eth2spec.test.context import (
     spec_state_test,
     with_presets,
-    with_phases,
+    with_altair_and_later,
 )
 from eth2spec.test.helpers.attestations import next_epoch_with_attestations
 from eth2spec.test.helpers.block import (
     build_empty_block,
     build_empty_block_for_next_slot,
 )
-from eth2spec.test.helpers.constants import (
-    ALTAIR,
-    MINIMAL,
-)
+from eth2spec.test.helpers.constants import MINIMAL
 from eth2spec.test.helpers.state import (
     next_slots,
     state_transition_and_sign_block,
@@ -22,7 +19,7 @@ from eth2spec.test.helpers.sync_committee import (
 from eth2spec.test.helpers.merkle import build_proof
 
 
-@with_phases([ALTAIR])
+@with_altair_and_later
 @spec_state_test
 def test_process_light_client_update_not_updated(spec, state):
     pre_snapshot = spec.LightClientSnapshot(
@@ -81,7 +78,7 @@ def test_process_light_client_update_not_updated(spec, state):
     assert store.snapshot == pre_snapshot
 
 
-@with_phases([ALTAIR])
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_timeout(spec, state):
@@ -147,7 +144,7 @@ def test_process_light_client_update_timeout(spec, state):
     assert store.snapshot.header == update.header
 
 
-@with_phases([ALTAIR])
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_finality_updated(spec, state):

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -463,8 +463,8 @@ def is_post_merge(spec):
     return spec.fork not in FORKS_BEFORE_MERGE
 
 
-with_altair_and_later = with_phases([ALTAIR, MERGE])
-with_merge_and_later = with_phases([MERGE])  # TODO: include sharding when spec stabilizes.
+with_altair_and_later = with_all_phases_except([PHASE0])
+with_merge_and_later = with_all_phases_except([PHASE0, ALTAIR])
 
 
 def only_generator(reason):

--- a/tests/generators/merkle/main.py
+++ b/tests/generators/merkle/main.py
@@ -1,4 +1,4 @@
-from eth2spec.test.helpers.constants import ALTAIR
+from eth2spec.test.helpers.constants import ALTAIR, MERGE
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
 
 
@@ -6,9 +6,11 @@ if __name__ == "__main__":
     altair_mods = {key: 'eth2spec.test.altair.merkle.test_' + key for key in [
         'single_proof',
     ]}
+    merge_mods = altair_mods
 
     all_mods = {
-        ALTAIR: altair_mods
+        ALTAIR: altair_mods,
+        MERGE: merge_mods,
     }
 
     run_state_test_generators(runner_name="merkle", all_mods=all_mods)


### PR DESCRIPTION
Some tests are currently restricted to a single phase using @with_phases
even though they could likely run unchanged in later phases. This patch
changes the default for such tests to also run in later phases. If the
beacon chain changes enough in later phases to break these tests, this
highlights that the tests need to be adjusted or extended accordingly.