### PR TITLE
[WIP] Mock Engine API req/resp in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -537,7 +537,7 @@ class NoopExecutionEngine(ExecutionEngine):
                         parent_hash: Hash32,
                         timestamp: uint64,
                         random: Bytes32,
-                        feeRecipient: ExecutionAddress) -> PayloadId:
+                        fee_recipient: ExecutionAddress) -> PayloadId:
         raise NotImplementedError("no default block production")
 
     def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> ExecutionPayload:

--- a/tests/core/pyspec/eth2spec/test/helpers/engine_apis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/engine_apis.py
@@ -1,0 +1,67 @@
+from eth_utils import encode_hex
+
+
+def to_json_rpc_request(method, params):
+    return {
+        'method': method,
+        'params': params,
+    }
+
+
+def to_json_rpc_response(result, error=False):
+    return {
+        'error': error,
+        'result': result,
+    }
+
+
+def with_mock_engine_prepare_payload(spec,
+                                     parent_hash,
+                                     timestamp,
+                                     random,
+                                     fee_recipient,
+                                     payload_id,
+                                     func,
+                                     test_steps):
+    def prepare_payload(parent_hash,
+                        timestamp,
+                        random,
+                        fee_recipient):
+        req = to_json_rpc_request(
+            method='engine_preparePayload',
+            params={
+                "parentHash": encode_hex(parent_hash),
+                "timestamp": int(timestamp),
+                "random": encode_hex(random),
+                "feeRecipient": encode_hex(fee_recipient),
+            }
+        )
+        resp = to_json_rpc_response(
+            result={
+                "payloadId": int(payload_id)
+            },
+        )
+        test_steps.append({'engine_api': {
+            'request': req,
+            'response': resp
+        }})
+        print('req', req)
+        print('resp', resp)
+        return payload_id
+
+    prepare_payload_backup = spec.EXECUTION_ENGINE.prepare_payload
+    spec.EXECUTION_ENGINE.prepare_payload = prepare_payload
+
+    class AtomicBoolean():
+        value = False
+    is_called = AtomicBoolean()
+
+    def wrap(flag: AtomicBoolean):
+        func()
+        flag.value = True
+
+    try:
+        wrap(is_called)
+    finally:
+        spec.EXECUTION_ENGINE.get_pow_block = prepare_payload_backup
+    assert is_called.value

--- a/tests/core/pyspec/eth2spec/test/merge/fork_choice/test_engine_apis.py
+++ b/tests/core/pyspec/eth2spec/test/merge/fork_choice/test_engine_apis.py
@@ -1,0 +1,80 @@
+from eth2spec.test.context import (
+    spec_state_test,
+    with_merge_and_later,
+)
+from eth2spec.test.helpers.block import (
+    build_empty_block_for_next_slot,
+)
+from eth2spec.test.helpers.engine_apis import (
+    with_mock_engine_prepare_payload,
+)
+from eth2spec.test.helpers.execution_payload import (
+    build_state_with_incomplete_transition,
+)
+from eth2spec.test.helpers.fork_choice import (
+    add_pow_block,
+    get_genesis_forkchoice_store_and_block,
+    on_tick_and_append_step,
+    prepare_empty_pow_block,
+    tick_and_add_block,
+    with_pow_block_patch,
+)
+from eth2spec.test.helpers.state import (
+    state_transition_and_sign_block,
+)
+
+
+@with_merge_and_later
+@spec_state_test
+def test_engine_execution_payload(spec, state):
+    test_steps = []
+    # Initialization
+    state = build_state_with_incomplete_transition(spec, state)
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    yield 'anchor_state', state
+    yield 'anchor_block', anchor_block
+    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
+    on_tick_and_append_step(spec, store, current_time, test_steps)
+    assert store.time == current_time
+
+    pow_block_parent = prepare_empty_pow_block(spec)
+    pow_block_parent.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - 1
+    pow_block = prepare_empty_pow_block(spec)
+    pow_block.parent_hash = pow_block_parent.block_hash
+    pow_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
+    pow_chain = [pow_block, pow_block_parent]
+    for pb in pow_chain:
+        yield from add_pow_block(spec, store, pb, test_steps)
+
+    fee_recipient = b'\x12' * 20
+    payload_id = spec.PayloadId(1)
+
+    def run_func():
+        spec.prepare_execution_payload(
+            state,
+            pow_chain,
+            fee_recipient=fee_recipient,
+            execution_engine=spec.EXECUTION_ENGINE,
+        )
+
+    with_mock_engine_prepare_payload(
+        spec,
+        parent_hash=pow_block.parent_hash,
+        timestamp=spec.compute_timestamp_at_slot(state, state.slot),
+        random=spec.get_randao_mix(state, spec.get_current_epoch(state)),
+        fee_recipient=fee_recipient,
+        payload_id=payload_id,
+        func=run_func,
+        test_steps=test_steps,
+    )
+
+    def run_func():
+        block = build_empty_block_for_next_slot(spec, state)
+        block.body.execution_payload.parent_hash = pow_block.block_hash
+        signed_block = state_transition_and_sign_block(spec, state, block)
+        yield from tick_and_add_block(spec, store, signed_block, test_steps, merge_block=True)
+        # valid
+        assert spec.get_head(store) == signed_block.message.hash_tree_root()
+
+    yield from with_pow_block_patch(spec, pow_chain, run_func)
+    yield 'steps', test_steps

--- a/tests/core/pyspec/eth2spec/test/merge/fork_choice/test_on_merge_block.py
+++ b/tests/core/pyspec/eth2spec/test/merge/fork_choice/test_on_merge_block.py
@@ -1,48 +1,22 @@
 from eth2spec.utils.ssz.ssz_typing import uint256
-from eth2spec.test.exceptions import BlockNotFoundException
 from eth2spec.test.context import spec_state_test, with_phases, MERGE
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
 from eth2spec.test.helpers.fork_choice import (
+    add_pow_block,
     get_genesis_forkchoice_store_and_block,
     on_tick_and_append_step,
+    prepare_empty_pow_block,
     tick_and_add_block,
+    with_pow_block_patch,
 )
 from eth2spec.test.helpers.state import (
     state_transition_and_sign_block,
 )
-from eth2spec.test.helpers.fork_choice import (
-    prepare_empty_pow_block,
-    add_pow_block,
-)
 from eth2spec.test.helpers.execution_payload import (
     build_state_with_incomplete_transition,
 )
-
-
-def with_pow_block_patch(spec, blocks, func):
-    def get_pow_block(hash: spec.Bytes32) -> spec.PowBlock:
-        for block in blocks:
-            if block.block_hash == hash:
-                return block
-        raise BlockNotFoundException()
-    get_pow_block_backup = spec.get_pow_block
-    spec.get_pow_block = get_pow_block
-
-    class AtomicBoolean():
-        value = False
-    is_called = AtomicBoolean()
-
-    def wrap(flag: AtomicBoolean):
-        yield from func()
-        flag.value = True
-
-    try:
-        yield from wrap(is_called)
-    finally:
-        spec.get_pow_block = get_pow_block_backup
-    assert is_called.value
 
 
 @with_phases([MERGE])


### PR DESCRIPTION
Based on @zilm13's new merge fork-choice tests in #2598/#2630, I tried to generate the expected Engine API request & mock the response.

It would add `engine_api` event in `steps.yaml`.
A sample `steps.yaml`:
```yaml
- {tick: 0}
- {pow_block: pow_block_0x63d026870b331a9269cb121f9ad525d7d63bcaf2c29f12e6e50288b89a7b9bd7}
- {pow_block: pow_block_0x535d43dc06e80498afc0dc98fa40de8c19222d5f187705ed5de10934168bd71d}
- engine_api:
    request:
      method: engine_preparePayload
      params: {parentHash: '0x63d026870b331a9269cb121f9ad525d7d63bcaf2c29f12e6e50288b89a7b9bd7',
        timestamp: 0, random: '0xdadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadada',
        feeRecipient: '0x1212121212121212121212121212121212121212'}
    response:
      error: false
      result: {payloadId: 1}
- {tick: 12}
- {block: block_0x6358c748c76d08954fa28ee985ca6eae97f50f5ea19eb198eb97b01bd6e8e78c}
- checks:
    time: 12
    head: {slot: 1, root: '0xf81992b35f893a54c6c9848a16cd05b45a2cb483265e9e2745b71b389d162632'}
    justified_checkpoint: {epoch: 0, root: '0x8a099f1071df9b9dcd6dd5082d3e9362560d11e066ef08aac508e83a97b81022'}
    finalized_checkpoint: {epoch: 0, root: '0x8a099f1071df9b9dcd6dd5082d3e9362560d11e066ef08aac508e83a97b81022'}
    best_justified_checkpoint: {epoch: 0, root: '0x8a099f1071df9b9dcd6dd5082d3e9362560d11e066ef08aac508e83a97b81022'}
```

My idea is that the consensus client teams can:
1. Compare if the expected API requests match
2. Use the given mocking response to continue the next step
3. Test against the edge cases in CI

**Question to client teams**: Would it be helpful and worth developing?
Feedback would be appreciated. 🙏