### PR TITLE
use correct timestamp for empty ExecutionPayload

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -3,7 +3,7 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
     Assuming a pre-state of the same slot, build a valid ExecutionPayload without any transactions.
     """
     latest = state.latest_execution_payload_header
-    timestamp = spec.compute_time_at_slot(state, state.slot)
+    timestamp = spec.compute_timestamp_at_slot(state, state.slot)
     empty_txs = spec.List[spec.Transaction, spec.MAX_TRANSACTIONS_PER_PAYLOAD]()
 
     if randao_mix is None:


### PR DESCRIPTION
There are two similar functions to compute the timestamp for a given
beacon chain slot. `compute_time_at_slot` is used for processing Eth1
votes, and does not take into account `GENESIS_TIME`. The other one,
`compute_timestamp_at_slot`, is used everywhere else. When processing
`ExecutionPayload`, the `merge/beacon-chain.md` spec uses the latter,
`compute_timestamp_at_slot`, to verify the timestamp. However, in the
test code, `build_empty_execution_payload` uses `compute_time_at_slot`.
This patch changes the test to use the same function for creating the
timestamp that is later used to verify it. Note that `GENESIS_TIME` is 0
so there is no practical difference.