### PR TITLE
Mock Engine API req/resp in tests - take 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -537,7 +537,7 @@ class NoopExecutionEngine(ExecutionEngine):
                         parent_hash: Hash32,
                         timestamp: uint64,
                         random: Bytes32,
-                        feeRecipient: ExecutionAddress) -> PayloadId:
+                        fee_recipient: ExecutionAddress) -> PayloadId:
         raise NotImplementedError("no default block production")
 
     def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> ExecutionPayload:

--- a/setup.py
+++ b/setup.py
@@ -510,8 +510,8 @@ from eth2spec.utils.ssz.ssz_typing import Bytes20, ByteList, ByteVector, uint256
 ExecutionState = Any
 
 
-def get_pow_block(hash: Bytes32) -> PowBlock:
-    return PowBlock(block_hash=hash, parent_hash=Bytes32(), total_difficulty=uint256(0), difficulty=uint256(0))
+def get_pow_block(block_hash: Bytes32) -> PowBlock:
+    return PowBlock(block_hash=block_hash, parent_hash=Bytes32(), total_difficulty=uint256(0), difficulty=uint256(0))
 
 
 def get_execution_state(execution_state_root: Bytes32) -> ExecutionState:

--- a/tests/core/pyspec/eth2spec/test/helpers/engine_apis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/engine_apis.py
@@ -163,7 +163,7 @@ def with_pow_blocks_and_execute_payload(
                     '_to_next_on_block': {
                         'get_pow_block': {
                             'input': {
-                                'pow_chain': [get_pow_block_file_name(pow_block) for pow_block in pow_chain]
+                                'block_hash': encode_hex(block_hash)
                             },
                             'output': {
                                 'result': get_pow_block_file_name(block),

--- a/tests/core/pyspec/eth2spec/test/helpers/engine_apis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/engine_apis.py
@@ -1,0 +1,221 @@
+from enum import Enum
+from eth_utils import encode_hex
+
+from eth2spec.test.exceptions import BlockNotFoundException
+from eth2spec.test.helpers.execution_payload import (
+    build_execution_payload,
+)
+from eth2spec.test.helpers.fork_choice import (
+    get_pow_block_file_name,
+)
+
+
+class StatusCode(Enum):
+    VALID = "VALID"
+    INVALID = "INVALID"
+    SYNCING = "SYNCING"
+
+
+def to_json_rpc_request(method, params):
+    return {
+        'method': method,
+        'params': params,
+    }
+
+
+def to_json_rpc_response(result, error=False):
+    return {
+        'error': error,
+        'result': result,
+    }
+
+
+def execution_payload_to_json(execution_payload):
+    return {
+        "parentHash": encode_hex(execution_payload.parent_hash),
+        "coinbase": encode_hex(execution_payload.coinbase),
+        "stateRoot": encode_hex(execution_payload.state_root),
+        "receiptRoot": encode_hex(execution_payload.receipt_root),
+        "logsBloom": encode_hex(execution_payload.logs_bloom),
+        "random": encode_hex(execution_payload.random),
+        "blockNumber": int(execution_payload.block_number),
+        "gasLimit": int(execution_payload.gas_limit),
+        "gasUsed": int(execution_payload.gas_used),
+        "timestamp": int(execution_payload.timestamp),
+        "extraData": encode_hex(execution_payload.extra_data),
+        "baseFeePerGas": int.from_bytes(execution_payload.base_fee_per_gas, byteorder='little'),
+        "blockHash": encode_hex(execution_payload.block_hash),
+        "transactions": [encode_hex(tx) for tx in execution_payload.transactions],
+    }
+
+
+def run_prepare_execution_payload_with_mock_engine_prepare_payload(
+        spec,
+        state,
+        pow_chain,
+        parent_hash,
+        timestamp,
+        random,
+        fee_recipient,
+        payload_id,
+        test_steps,
+        dump_rpc=False):
+    class TestEngine(spec.NoopExecutionEngine):
+        def prepare_payload(self,
+                            parent_hash,
+                            timestamp,
+                            random,
+                            fee_recipient):
+            if dump_rpc:
+                req = to_json_rpc_request(
+                    method='engine_preparePayload',
+                    params={
+                        "parentHash": encode_hex(parent_hash),
+                        "timestamp": int(timestamp),
+                        "random": encode_hex(random),
+                        "feeRecipient": encode_hex(fee_recipient),
+                    }
+                )
+                resp = to_json_rpc_response(
+                    result={
+                        "payloadId": int(payload_id)
+                    },
+                )
+                test_steps.append({
+                    '_block_production': {
+                        'prepare_execution_payload': {
+                            'engine_api': {
+                                'request': req,
+                                'response': resp
+                            }
+                        }
+                    }
+                })
+            return payload_id
+
+    return spec.prepare_execution_payload(
+        state=state,
+        pow_chain=pow_chain,
+        fee_recipient=fee_recipient,
+        execution_engine=TestEngine(),
+    )
+
+
+def run_get_execution_payload_with_mock_engine_get_payload(
+        spec,
+        state,
+        payload_id,
+        parent_hash,
+        fee_recipient,
+        test_steps,
+        dump_rpc=False):
+    timestamp = spec.compute_timestamp_at_slot(state, state.slot + 1)
+    random = spec.get_randao_mix(state, spec.get_current_epoch(state))
+
+    class TestEngine(spec.NoopExecutionEngine):
+        def get_payload(self, payload_id):
+            execution_payload = build_execution_payload(
+                spec,
+                state,
+                parent_hash=parent_hash,
+                timestamp=timestamp,
+                random=random,
+                coinbase=fee_recipient,
+            )
+            if dump_rpc:
+                req = to_json_rpc_request(
+                    method='engine_getPayload',
+                    params={
+                        "payloadId": int(payload_id)
+                    },
+                )
+                resp = to_json_rpc_response(
+                    result={
+                        "executionPayload": execution_payload_to_json(execution_payload),
+                    },
+                )
+                test_steps.append({
+                    '_block_production': {
+                        'get_execution_payload': {
+                            'engine_api': {
+                                'request': req,
+                                'response': resp
+                            }
+                        }
+                    }
+                })
+            return execution_payload
+
+    return spec.get_execution_payload(payload_id, TestEngine())
+
+
+def with_pow_blocks_and_execute_payload(
+    spec,
+    pow_chain,
+    status,
+    func,
+    test_steps
+):
+    def get_pow_block(block_hash):
+        for block in pow_chain:  # type: ignore
+            if block.block_hash == block_hash:
+                test_steps.append({
+                    '_to_next_on_block': {
+                        'get_pow_block': {
+                            'input': {
+                                'pow_chain': [get_pow_block_file_name(pow_block) for pow_block in pow_chain]
+                            },
+                            'output': {
+                                'result': get_pow_block_file_name(block),
+                            },
+                        }
+                    }
+                })
+                return block
+        raise BlockNotFoundException()
+
+    class TestEngine(spec.NoopExecutionEngine):
+        def execute_payload(self, execution_payload):
+            req = to_json_rpc_request(
+                method='engine_executePayload',
+                params=execution_payload_to_json(execution_payload),
+            )
+            resp = to_json_rpc_response(
+                result={
+                    "status": status.value
+                },
+            )
+            test_steps.append({
+                '_to_next_on_block': {
+                    'process_execution_payload': {
+                        'engine_api': {
+                            'request': req,
+                            'response': resp
+                        }
+                    }
+                }
+            })
+            return status == StatusCode.VALID
+
+    # Spec stub replacement
+    get_pow_block_backup = spec.get_pow_block
+    spec.get_pow_block = get_pow_block
+
+    execute_engine_backup = spec.EXECUTION_ENGINE
+    spec.EXECUTION_ENGINE = TestEngine()
+
+    class AtomicBoolean():
+        value = False
+    is_called = AtomicBoolean()
+
+    def wrap(flag: AtomicBoolean):
+        yield from func()
+        flag.value = True
+
+    try:
+        yield from wrap(is_called)
+    finally:
+        # Revert replacement
+        spec.get_pow_block = get_pow_block_backup
+        spec.EXECUTION_ENGINE = execute_engine_backup
+    assert is_called.value

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -1,32 +1,75 @@
-def build_empty_execution_payload(spec, state, randao_mix=None):
+def build_empty_execution_payload(spec, state):
     """
     Assuming a pre-state of the same slot, build a valid ExecutionPayload without any transactions.
     """
-    latest = state.latest_execution_payload_header
-    timestamp = spec.compute_timestamp_at_slot(state, state.slot)
-    empty_txs = spec.List[spec.Transaction, spec.MAX_TRANSACTIONS_PER_PAYLOAD]()
+    return build_execution_payload(spec, state)
 
-    if randao_mix is None:
-        randao_mix = spec.get_randao_mix(state, spec.get_current_epoch(state))
+
+def build_execution_payload(spec,
+                            state,
+                            *,
+                            parent_hash=None,
+                            coinbase=None,
+                            state_root=None,
+                            receipt_root=None,
+                            logs_bloom=None,
+                            block_number=None,
+                            random=None,
+                            gas_limit=None,
+                            gas_used=0,
+                            timestamp=None,
+                            extra_data=None,
+                            base_fee_per_gas=None,
+                            block_hash=None,
+                            transactions=None):
+    latest = state.latest_execution_payload_header
+    # By default, assuming a pre-state of the same slot, build a valid ExecutionPayload without any transactions.
+    if parent_hash is None:
+        parent_hash = latest.block_hash
+    if coinbase is None:
+        coinbase = spec.ExecutionAddress()
+    if state_root is None:
+        state_root = latest.state_root
+    if receipt_root is None:
+        receipt_root = b"no receipts here" + b"\x00" * 16  # TODO: root of empty MPT may be better.
+    if logs_bloom is None:
+        logs_bloom = spec.ByteVector[spec.BYTES_PER_LOGS_BLOOM]()  # TODO: zeroed logs bloom for empty logs ok?
+    if block_number is None:
+        block_number = latest.block_number + 1
+    if random is None:
+        random = spec.get_randao_mix(state, spec.get_current_epoch(state))
+    if gas_limit is None:
+        gas_limit = latest.gas_limit  # retain same limit
+    if timestamp is None:
+        timestamp = spec.compute_timestamp_at_slot(state, state.slot)
+    if extra_data is None:
+        extra_data = spec.ByteList[spec.MAX_EXTRA_DATA_BYTES]()
+    if base_fee_per_gas is None:
+        base_fee_per_gas = latest.base_fee_per_gas  # retain same base_fee
+    if transactions is None:
+        transactions = spec.List[spec.Transaction, spec.MAX_TRANSACTIONS_PER_PAYLOAD]()
 
     payload = spec.ExecutionPayload(
-        parent_hash=latest.block_hash,
-        coinbase=spec.ExecutionAddress(),
-        state_root=latest.state_root,  # no changes to the state
-        receipt_root=b"no receipts here" + b"\x00" * 16,  # TODO: root of empty MPT may be better.
-        logs_bloom=spec.ByteVector[spec.BYTES_PER_LOGS_BLOOM](),  # TODO: zeroed logs bloom for empty logs ok?
-        block_number=latest.block_number + 1,
-        random=randao_mix,
-        gas_limit=latest.gas_limit,  # retain same limit
-        gas_used=0,  # empty block, 0 gas
+        parent_hash=parent_hash,
+        coinbase=coinbase,
+        state_root=state_root,
+        receipt_root=receipt_root,
+        logs_bloom=logs_bloom,
+        block_number=block_number,
+        random=random,
+        gas_limit=gas_limit,
+        gas_used=gas_used,
         timestamp=timestamp,
-        extra_data=spec.ByteList[spec.MAX_EXTRA_DATA_BYTES](),
-        base_fee_per_gas=latest.base_fee_per_gas,  # retain same base_fee
-        block_hash=spec.Hash32(),
-        transactions=empty_txs,
+        extra_data=extra_data,
+        base_fee_per_gas=base_fee_per_gas,
+        transactions=transactions,
     )
+
     # TODO: real RLP + block hash logic would be nice, requires RLP and keccak256 dependency however.
-    payload.block_hash = spec.Hash32(spec.hash(payload.hash_tree_root() + b"FAKE RLP HASH"))
+    payload.block_hash = (
+        block_hash if block_hash is not None
+        else spec.Hash32(spec.hash(parent_hash + b"FAKE RLP HASH"))
+    )
 
     return payload
 

--- a/tests/core/pyspec/eth2spec/test/merge/fork_choice/test_on_merge_block.py
+++ b/tests/core/pyspec/eth2spec/test/merge/fork_choice/test_on_merge_block.py
@@ -1,48 +1,26 @@
 from eth2spec.utils.ssz.ssz_typing import uint256
-from eth2spec.test.exceptions import BlockNotFoundException
 from eth2spec.test.context import spec_state_test, with_phases, MERGE
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
+from eth2spec.test.helpers.engine_apis import (
+    StatusCode,
+    run_get_execution_payload_with_mock_engine_get_payload,
+    with_pow_blocks_and_execute_payload,
+)
 from eth2spec.test.helpers.fork_choice import (
+    add_pow_block,
     get_genesis_forkchoice_store_and_block,
     on_tick_and_append_step,
+    prepare_random_hash_pow_block,
     tick_and_add_block,
 )
 from eth2spec.test.helpers.state import (
     state_transition_and_sign_block,
 )
-from eth2spec.test.helpers.fork_choice import (
-    prepare_empty_pow_block,
-    add_pow_block,
-)
 from eth2spec.test.helpers.execution_payload import (
     build_state_with_incomplete_transition,
 )
-
-
-def with_pow_block_patch(spec, blocks, func):
-    def get_pow_block(hash: spec.Bytes32) -> spec.PowBlock:
-        for block in blocks:
-            if block.block_hash == hash:
-                return block
-        raise BlockNotFoundException()
-    get_pow_block_backup = spec.get_pow_block
-    spec.get_pow_block = get_pow_block
-
-    class AtomicBoolean():
-        value = False
-    is_called = AtomicBoolean()
-
-    def wrap(flag: AtomicBoolean):
-        yield from func()
-        flag.value = True
-
-    try:
-        yield from wrap(is_called)
-    finally:
-        spec.get_pow_block = get_pow_block_backup
-    assert is_called.value
 
 
 @with_phases([MERGE])
@@ -58,24 +36,46 @@ def test_all_valid(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    pow_block_parent = prepare_empty_pow_block(spec)
-    pow_block_parent.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
-    pow_block = prepare_empty_pow_block(spec)
+    # Block production
+    # Required PoW blocks at the merge boundary
+    pow_block_parent = prepare_random_hash_pow_block(spec)
+    pow_block_parent.parent_hash = spec.Hash32()
+    pow_block_parent.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - 1
+    pow_block = prepare_random_hash_pow_block(spec)
     pow_block.parent_hash = pow_block_parent.block_hash
     pow_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
-    pow_blocks = [pow_block, pow_block_parent]
-    for pb in pow_blocks:
-        yield from add_pow_block(spec, store, pb, test_steps)
+    pow_chain = [pow_block_parent, pow_block]
+    for pb in pow_chain:
+        yield from add_pow_block(pb)
 
-    def run_func():
-        block = build_empty_block_for_next_slot(spec, state)
-        block.body.execution_payload.parent_hash = pow_block.block_hash
-        signed_block = state_transition_and_sign_block(spec, state, block)
+    # Validator guide - get_execution_payload
+    fee_recipient = spec.ExecutionAddress(b'\x12' * 20)
+    payload_id = spec.PayloadId(1)
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.execution_payload = run_get_execution_payload_with_mock_engine_get_payload(
+        spec,
+        state,
+        payload_id=payload_id,
+        parent_hash=pow_block.block_hash,
+        fee_recipient=fee_recipient,
+        test_steps=test_steps,
+    )
+    signed_block = state_transition_and_sign_block(spec, state, block)
+
+    # For on_block
+    def run_tick_and_add_block():
         yield from tick_and_add_block(spec, store, signed_block, test_steps, merge_block=True)
         # valid
         assert spec.get_head(store) == signed_block.message.hash_tree_root()
 
-    yield from with_pow_block_patch(spec, pow_blocks, run_func)
+    yield from with_pow_blocks_and_execute_payload(
+        spec,
+        pow_chain=pow_chain,
+        status=StatusCode.VALID,
+        func=run_tick_and_add_block,
+        test_steps=test_steps,
+    )
+
     yield 'steps', test_steps
 
 
@@ -92,20 +92,37 @@ def test_block_lookup_failed(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    pow_block = prepare_empty_pow_block(spec)
+    pow_block = prepare_random_hash_pow_block(spec)
     pow_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
-    pow_blocks = [pow_block]
-    for pb in pow_blocks:
-        yield from add_pow_block(spec, store, pb, test_steps)
+    pow_chain = [pow_block]
+    for pb in pow_chain:
+        yield from add_pow_block(pb)
 
-    def run_func():
-        block = build_empty_block_for_next_slot(spec, state)
-        block.body.execution_payload.parent_hash = pow_block.block_hash
-        signed_block = state_transition_and_sign_block(spec, state, block)
+    # Validator guide - get_execution_payload
+    fee_recipient = spec.ExecutionAddress(b'\x12' * 20)
+    payload_id = spec.PayloadId(1)
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.execution_payload = run_get_execution_payload_with_mock_engine_get_payload(
+        spec,
+        state,
+        payload_id=payload_id,
+        parent_hash=pow_block.block_hash,
+        fee_recipient=fee_recipient,
+        test_steps=test_steps,
+    )
+    signed_block = state_transition_and_sign_block(spec, state, block)
+
+    def run_tick_and_add_block():
         yield from tick_and_add_block(spec, store, signed_block, test_steps, valid=False, merge_block=True,
                                       block_not_found=True)
 
-    yield from with_pow_block_patch(spec, pow_blocks, run_func)
+    yield from with_pow_blocks_and_execute_payload(
+        spec,
+        pow_chain=pow_chain,
+        status=StatusCode.VALID,
+        func=run_tick_and_add_block,
+        test_steps=test_steps,
+    )
     yield 'steps', test_steps
 
 
@@ -122,22 +139,39 @@ def test_too_early_for_merge(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    pow_block_parent = prepare_empty_pow_block(spec)
+    pow_block_parent = prepare_random_hash_pow_block(spec)
     pow_block_parent.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(2)
-    pow_block = prepare_empty_pow_block(spec)
+    pow_block = prepare_random_hash_pow_block(spec)
     pow_block.parent_hash = pow_block_parent.block_hash
     pow_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
-    pow_blocks = [pow_block, pow_block_parent]
-    for pb in pow_blocks:
-        yield from add_pow_block(spec, store, pb, test_steps)
+    pow_chain = [pow_block, pow_block_parent]
+    for pb in pow_chain:
+        yield from add_pow_block(pb)
 
-    def run_func():
-        block = build_empty_block_for_next_slot(spec, state)
-        block.body.execution_payload.parent_hash = pow_block.block_hash
-        signed_block = state_transition_and_sign_block(spec, state, block)
+    # Validator guide - get_execution_payload
+    fee_recipient = spec.ExecutionAddress(b'\x12' * 20)
+    payload_id = spec.PayloadId(1)
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.execution_payload = run_get_execution_payload_with_mock_engine_get_payload(
+        spec,
+        state,
+        payload_id=payload_id,
+        parent_hash=pow_block.block_hash,
+        fee_recipient=fee_recipient,
+        test_steps=test_steps,
+    )
+    signed_block = state_transition_and_sign_block(spec, state, block)
+
+    def run_tick_and_add_block():
         yield from tick_and_add_block(spec, store, signed_block, test_steps, valid=False, merge_block=True)
 
-    yield from with_pow_block_patch(spec, pow_blocks, run_func)
+    yield from with_pow_blocks_and_execute_payload(
+        spec,
+        pow_chain=pow_chain,
+        status=StatusCode.VALID,
+        func=run_tick_and_add_block,
+        test_steps=test_steps,
+    )
     yield 'steps', test_steps
 
 
@@ -154,20 +188,40 @@ def test_too_late_for_merge(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    pow_block_parent = prepare_empty_pow_block(spec)
+    pow_block_parent = prepare_random_hash_pow_block(spec)
     pow_block_parent.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
-    pow_block = prepare_empty_pow_block(spec)
+    pow_block = prepare_random_hash_pow_block(spec)
     pow_block.parent_hash = pow_block_parent.block_hash
     pow_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY + uint256(1)
-    pow_blocks = [pow_block, pow_block_parent]
-    for pb in pow_blocks:
-        yield from add_pow_block(spec, store, pb, test_steps)
+    pow_chain = [pow_block, pow_block_parent]
+    for pb in pow_chain:
+        yield from add_pow_block(pb)
 
-    def run_func():
+    # Validator guide - get_execution_payload
+    fee_recipient = spec.ExecutionAddress(b'\x12' * 20)
+    payload_id = spec.PayloadId(1)
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.execution_payload = run_get_execution_payload_with_mock_engine_get_payload(
+        spec,
+        state,
+        payload_id=payload_id,
+        parent_hash=pow_block.block_hash,
+        fee_recipient=fee_recipient,
+        test_steps=test_steps,
+    )
+
+    def run_tick_and_add_block():
         block = build_empty_block_for_next_slot(spec, state)
         block.body.execution_payload.parent_hash = pow_block.block_hash
         signed_block = state_transition_and_sign_block(spec, state, block)
         yield from tick_and_add_block(spec, store, signed_block, test_steps, valid=False, merge_block=True)
 
-    yield from with_pow_block_patch(spec, pow_blocks, run_func)
+    yield from with_pow_blocks_and_execute_payload(
+        spec,
+        pow_chain=pow_chain,
+        status=StatusCode.VALID,
+        func=run_tick_and_add_block,
+        test_steps=test_steps,
+    )
+
     yield 'steps', test_steps

--- a/tests/core/pyspec/eth2spec/test/merge/unittests/test_terminal_validity.py
+++ b/tests/core/pyspec/eth2spec/test/merge/unittests/test_terminal_validity.py
@@ -1,7 +1,7 @@
 from eth2spec.test.exceptions import BlockNotFoundException
 from eth2spec.utils.ssz.ssz_typing import uint256
 from eth2spec.test.helpers.fork_choice import (
-    prepare_empty_pow_block,
+    prepare_random_hash_pow_block,
 )
 from eth2spec.test.context import spec_state_test, with_merge_and_later
 
@@ -58,9 +58,9 @@ def run_validate_transition_execution_payload(spec, block, parent_block, payload
 @with_merge_and_later
 @spec_state_test
 def test_valid_terminal_pow_block_success_valid(spec, state):
-    parent_block = prepare_empty_pow_block(spec)
+    parent_block = prepare_random_hash_pow_block(spec)
     parent_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
-    block = prepare_empty_pow_block(spec)
+    block = prepare_random_hash_pow_block(spec)
     block.parent_hash = parent_block.block_hash
     block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
 
@@ -70,9 +70,9 @@ def test_valid_terminal_pow_block_success_valid(spec, state):
 @with_merge_and_later
 @spec_state_test
 def test_valid_terminal_pow_block_fail_before_terminal(spec, state):
-    parent_block = prepare_empty_pow_block(spec)
+    parent_block = prepare_random_hash_pow_block(spec)
     parent_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(2)
-    block = prepare_empty_pow_block(spec)
+    block = prepare_random_hash_pow_block(spec)
     block.parent_hash = parent_block.block_hash
     block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
 
@@ -82,9 +82,9 @@ def test_valid_terminal_pow_block_fail_before_terminal(spec, state):
 @with_merge_and_later
 @spec_state_test
 def test_valid_terminal_pow_block_fail_just_after_terminal(spec, state):
-    parent_block = prepare_empty_pow_block(spec)
+    parent_block = prepare_random_hash_pow_block(spec)
     parent_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
-    block = prepare_empty_pow_block(spec)
+    block = prepare_random_hash_pow_block(spec)
     block.parent_hash = parent_block.block_hash
     block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY + uint256(1)
 
@@ -94,9 +94,9 @@ def test_valid_terminal_pow_block_fail_just_after_terminal(spec, state):
 @with_merge_and_later
 @spec_state_test
 def test_validate_transition_execution_payload_success(spec, state):
-    parent_block = prepare_empty_pow_block(spec)
+    parent_block = prepare_random_hash_pow_block(spec)
     parent_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
-    block = prepare_empty_pow_block(spec)
+    block = prepare_random_hash_pow_block(spec)
     block.parent_hash = parent_block.block_hash
     block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
     payload = spec.ExecutionPayload()
@@ -107,9 +107,9 @@ def test_validate_transition_execution_payload_success(spec, state):
 @with_merge_and_later
 @spec_state_test
 def test_validate_transition_execution_payload_fail_block_lookup(spec, state):
-    parent_block = prepare_empty_pow_block(spec)
+    parent_block = prepare_random_hash_pow_block(spec)
     parent_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
-    block = prepare_empty_pow_block(spec)
+    block = prepare_random_hash_pow_block(spec)
     block.parent_hash = parent_block.block_hash
     block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
     payload = spec.ExecutionPayload()
@@ -120,9 +120,9 @@ def test_validate_transition_execution_payload_fail_block_lookup(spec, state):
 @with_merge_and_later
 @spec_state_test
 def test_validate_transition_execution_payload_fail_parent_block_lookup(spec, state):
-    parent_block = prepare_empty_pow_block(spec)
+    parent_block = prepare_random_hash_pow_block(spec)
     parent_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
-    block = prepare_empty_pow_block(spec)
+    block = prepare_random_hash_pow_block(spec)
     block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
     payload = spec.ExecutionPayload()
     payload.parent_hash = block.block_hash
@@ -133,9 +133,9 @@ def test_validate_transition_execution_payload_fail_parent_block_lookup(spec, st
 @with_merge_and_later
 @spec_state_test
 def test_validate_transition_execution_payload_fail_after_terminal(spec, state):
-    parent_block = prepare_empty_pow_block(spec)
+    parent_block = prepare_random_hash_pow_block(spec)
     parent_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
-    block = prepare_empty_pow_block(spec)
+    block = prepare_random_hash_pow_block(spec)
     block.parent_hash = parent_block.block_hash
     block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY + 1
     payload = spec.ExecutionPayload()

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -55,7 +55,7 @@ After this step, the `store` object may have been updated.
 
 #### `on_block` execution step
 
-The parameter that is required for executing `on_block(store, block)`.
+The parameters that are required for executing `on_block(store, block)`.
 
 ```yaml
 {
@@ -63,23 +63,42 @@ The parameter that is required for executing `on_block(store, block)`.
                       To execute `on_block(store, block)` with the given attestation.
     valid: bool    -- optional, default to `true`.
                       If it's `false`, this execution step is expected to be invalid.
+    get_pow_block: -- this item only exists if `get_pow_block` is called with `on_block` call
+      input: {
+          pow_chain: List[strings]   -- map to the name of the `pow_block_<32-byte-root>.ssz_snappy` file
+      }
+      output: {
+          result: string             -- map to the name of the `pow_block_<32-byte-root>.ssz_snappy` file
+      }
+    process_execution_payload:  -- this item only exists if `process_execution_payload` is called with `on_block` call
+      engine_api:
+        request:
+          method: engine_executePayload
+          params:               -- the parameters of engine_executePayload API call
+            parentHash: string
+            coinbase: string
+            stateRoot: string
+            receiptRoot: string
+            logsBloom: string
+            random: string
+            blockNumber: int
+            gasLimit: int
+            gasUsed: int
+            timestamp: int
+            extraData: string
+            baseFeePerGas: int
+            blockHash: string
+            transactions: List[string]
+        response:
+          error: bool           -- if error is True, the result would be the error code
+          result: {
+              status: string    -- VALID | INVALID | SYNCING
+          } 
 }  
 ```
 The file is located in the same folder (see below).
 
 After this step, the `store` object may have been updated.
-
-#### `on_merge_block` execution
-
-Adds `PowBlock` data which is required for executing `on_block(store, block)`.
-```yaml
-{
-    pow_block: string  -- the name of the `pow_block_<32-byte-root>.ssz_snappy` file.
-                          To be used in `get_pow_block` lookup
-}  
-```
-The file is located in the same folder (see below).
-PowBlocks should be used as return values for `get_pow_block(hash: Hash32) -> PowBlock` function if hashes match.
 
 #### Checks step
 

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -65,10 +65,10 @@ The parameters that are required for executing `on_block(store, block)`.
                       If it's `false`, this execution step is expected to be invalid.
     get_pow_block: -- this item only exists if `get_pow_block` is called with `on_block` call
       input: {
-          pow_chain: List[strings]   -- map to the name of the `pow_block_<32-byte-root>.ssz_snappy` file
+          block_hash: string         -- 32-byte-hash string of the PoW block
       }
       output: {
-          result: string             -- map to the name of the `pow_block_<32-byte-root>.ssz_snappy` file
+          result: string             -- map to the name of the `pow_block_<32-byte-hash>.ssz_snappy` file
       }
     process_execution_payload:  -- this item only exists if `process_execution_payload` is called with `on_block` call
       engine_api:


### PR DESCRIPTION
Replace #2637
It may be better to start with small changes rather than writing overcomplicated scripts.

### 1. Use validator guide helpers to generate the execution payload for `on_merge_block` tests
See `run_get_execution_payload_with_mock_engine_get_payload`.

- Comparing to #2637, this PR doesn't output the block production API calls logs.
- Using validator guide `get_execution_payload` would improve our test coverage a bit. 🙂 We can also create validator guide unit tests later in other PRs.

### 2. Fork choice rule test format updates
This PR changes the existing fork choice tests output:
1.  Add one more layer to the execution steps.
    - e.g., previous `{'attestation': attestation_0x<attestation_root>}` is now `{'on_attestation': {'attestation': 'attestation_0x<attestation_root>'}}`
    - it allows us to add more description to the `on_block` step.
2. Change the `pow_block` output
    - make it only shows when `get_pow_block` helper is called.
    - e.g.,
      ```yaml
      - on_block:
          ...
          block: block_0x6f0e0d6d65481fc1142bde4234b8537a502facc3b26168046cfcecd95e6bdc8a
          get_pow_block:
            input: {block_hash: 0x922ef34b6ca455c5d13de0ac5db0f6d7c1c26adfa026141a2e086fb155deb6b4}
            output: {result: pow_block_0x006a9edb9f8316403009d1cf96c21907ddfafe86c5701c49cd0d57abab2a8a7b}
      ```
3. Output mocking `engine_executePayload` request and response with `on_block`
    - e.g., if an `on_block` step triggers `process_execution_payload` and `engine_executePayload`: 
      ```yaml
      - on_block:
          ...
          process_execution_payload:
            engine_api:
              request:
                method: engine_executePayload
                params:
                  parentHash: '0x006a9edb9f8316403009d1cf96c21907ddfafe86c5701c49cd0d57abab2a8a7b'
                  coinbase: '0x1212121212121212121212121212121212121212'
                  stateRoot: '0x0000000000000000000000000000000000000000000000000000000000000000'
                  receiptRoot: '0x6e6f207265636569707473206865726500000000000000000000000000000000'
                  logsBloom: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
                  random: '0xdadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadada'
                  blockNumber: 1
                  gasLimit: 0
                  gasUsed: 0
                  timestamp: 12
                  extraData: 0x
                  baseFeePerGas: 0
                  blockHash: '0x15c1774a93c7a216ca89fb27245b0dec9c6a8a8ebab162ffcbe80861de87e4fc'
                  transactions: []
              response:
                error: false
                result: {status: VALID}
      ```
    - Client team can use the `request` fields to verify if the request is as expected.
    - Client team can use the `response` fields as the return value of the given APIs.

### Minor fixes
- Fix default `prepare_payload` parameters in setup.py
- Refactor `build_empty_execution_payload`