### PR TITLE
Remove the trailing commas in test generators

### DIFF
--- a/tests/generators/epoch_processing/main.py
+++ b/tests/generators/epoch_processing/main.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         'inactivity_updates',
         'participation_flag_updates',
         'sync_committee_updates',
-    ]},
+    ]}
     altair_mods = combine_mods(_new_altair_mods, phase_0_mods)
 
     # No epoch-processing changes in Merge and previous testing repeats with new types, so no additional tests required.

--- a/tests/generators/fork_choice/main.py
+++ b/tests/generators/fork_choice/main.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     # PowBlock's which should be resolved by `get_pow_block(hash: Hash32) -> PowBlock` function
     _new_merge_mods = {key: 'eth2spec.test.merge.fork_choice.test_' + key for key in [
         'on_merge_block',
-    ]},
+    ]}
     merge_mods = combine_mods(_new_merge_mods, altair_mods)
 
     all_mods = {


### PR DESCRIPTION
Remove the wrong trailing commas from #2651 