### PR TITLE
remove notify_consensus_validated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -527,9 +527,6 @@ class NoopExecutionEngine(ExecutionEngine):
     def execute_payload(self: ExecutionEngine, execution_payload: ExecutionPayload) -> bool:
         return True
 
-    def notify_consensus_validated(self: ExecutionEngine, block_hash: Hash32, valid: bool) -> None:
-        pass
-
     def notify_forkchoice_updated(self: ExecutionEngine, head_block_hash: Hash32, finalized_block_hash: Hash32) -> None:
         pass
 

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -31,7 +31,6 @@
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
   - [Execution engine](#execution-engine)
     - [`execute_payload`](#execute_payload)
-    - [`notify_consensus_validated`](#notify_consensus_validated)
   - [Block processing](#block-processing)
   - [Execution payload processing](#execution-payload-processing)
     - [`is_valid_gas_limit`](#is_valid_gas_limit)
@@ -234,13 +233,11 @@ The implementation-dependent `ExecutionEngine` protocol encapsulates the executi
 
 * a state object `self.execution_state` of type `ExecutionState`
 * a state transition function `self.execute_payload` which applies changes to the `self.execution_state`
-* a function `self.notify_consensus_validated` which signals that the beacon block containing the execution payload
-is valid with respect to the consensus rule set
 
-*Note*: `execute_payload` and `notify_consensus_validated` are functions accessed through the `EXECUTION_ENGINE` module which instantiates the `ExecutionEngine` protocol.
+*Note*: `execute_payload` is a function accessed through the `EXECUTION_ENGINE` module which instantiates the `ExecutionEngine` protocol.
 
-The body of each of these functions is implementation dependent.
-The Engine API may be used to implement them with an external execution engine.
+The body of this function is implementation dependent.
+The Engine API may be used to implement this and similarly defined functions via an external execution engine.
 
 #### `execute_payload`
 
@@ -251,20 +248,6 @@ def execute_payload(self: ExecutionEngine, execution_payload: ExecutionPayload) 
     """
     ...
 ```
-
-#### `notify_consensus_validated`
-
-```python
-def notify_consensus_validated(self: ExecutionEngine, block_hash: Hash32, valid: bool) -> None:
-    ...
-```
-
-The inputs to this function depend on the result of the state transition. A call to `notify_consensus_validated` must be made after the [`state_transition`](../phase0/beacon-chain.md#beacon-chain-state-transition-function) function finishes. The value of the `valid` parameter must be set as follows:
-
-* `True` if `state_transition` function call succeeds
-* `False` if `state_transition` function call fails
-
-*Note*: The call of the `notify_consensus_validated` function with `valid = True` maps on the `POS_CONSENSUS_VALIDATED` event defined in the [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions).
 
 ### Block processing
 


### PR DESCRIPTION
`POS_CONSENSUS_VALIDATED` was removed from EIP 3675. See relevant issue for discussion: https://github.com/ethereum/EIPs/pull/4357

Remove `notify_consensus_validated` from CL specs in accordance with the change in EIP 3675