### PR TITLE
base_fee_per_gas to uint256

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -144,8 +144,6 @@ class BeaconState(Container):
 
 #### `ExecutionPayload`
 
-*Note*: The `base_fee_per_gas` field is serialized in little-endian.
-
 ```python
 class ExecutionPayload(Container):
     # Execution block header fields
@@ -160,7 +158,7 @@ class ExecutionPayload(Container):
     gas_used: uint64
     timestamp: uint64
     extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
-    base_fee_per_gas: Bytes32  # base fee introduced in EIP-1559, little-endian serialized
+    base_fee_per_gas: uint256
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
@@ -182,7 +180,7 @@ class ExecutionPayloadHeader(Container):
     gas_used: uint64
     timestamp: uint64
     extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
-    base_fee_per_gas: Bytes32
+    base_fee_per_gas: uint256
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
     transactions_root: Root

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -33,7 +33,7 @@ def get_sample_genesis_execution_payload_header(spec,
         random=eth1_block_hash,
         block_number=0,
         gas_limit=30000000,
-        base_fee_per_gas=spec.Bytes32('0x00ca9a3b00000000000000000000000000000000000000000000000000000000'),
+        base_fee_per_gas=1000000000,
         block_hash=eth1_block_hash,
         transactions_root=spec.Root(b'\x56' * 32),
     )


### PR DESCRIPTION
Based on some conversations on discord, we realized that the current little-endian 32-byte encoding of `base_fee_per_gas` does not make *too* much sense.

In practice, CL needs to convert this representation to an integer string for the engine API `engine_executePayload`. Thus CL clients need to at least be able to *parse/convert* uint256 values regardless of whether we create the requirement to *perform arithmetic* on such big integer values.

Note, all clients had to perform these types of conversions for the recent interop so they already can anyway. Plus this weird conversion gave some of them minor issues when getting up and running.