### PR TITLE
Increase gossipsub seen-ttl

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -222,7 +222,7 @@ The following gossipsub [parameters](https://github.com/libp2p/specs/blob/master
 - `fanout_ttl` (ttl for fanout maps for topics we are not subscribed to but have published to, seconds): 60
 - `mcache_len` (number of windows to retain full messages in cache for `IWANT` responses): 6
 - `mcache_gossip` (number of windows to gossip about): 3
-- `seen_ttl` (number of heartbeat intervals to retain message IDs): 550
+- `seen_ttl` (amount of time to retain message IDs): 33 slots (396 seconds, 566 heartbeats)
 
 *Note*: Gossipsub v1.1 introduces a number of
 [additional parameters](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#overview-of-new-parameters)


### PR DESCRIPTION
The gossipsub IGNORE rule for attestations is:
```
attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot
```
As `ATTESTATION_PROPAGATION_SLOT_RANGE` is `32`, this allows for clients to propagate attestations up until the start of the 33rd slot after publishing. 

Because we've set our duplicate cache to the start of the 32nd slot, I've noticed quite a few duplicates bouncing around the network. Increasing the cache time will prevent these extra duplicates being unnecessarily propagated. 