### PR TITLE
fix issue with mutation in test generation

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/fork_transition.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_transition.py
@@ -288,7 +288,7 @@ def run_transition_with_operation(state,
 
     # after the fork
     if operation_type == OperationType.DEPOSIT:
-        _transition_until_active(post_spec, state, post_tag, blocks, selected_validator_index)
+        state = _transition_until_active(post_spec, state, post_tag, blocks, selected_validator_index)
     else:
         # avoid using the slashed validators as block proposers
         ignoring_proposers = [selected_validator_index] if is_slashing_operation else None
@@ -332,3 +332,5 @@ def _transition_until_active(post_spec, state, post_tag, blocks, validator_index
         state_transition_across_slots(post_spec, state, to_slot, block_filter=only_at(to_slot))
     ])
     assert post_spec.is_active_validator(state.validators[validator_index], post_spec.get_current_epoch(state))
+
+    return state


### PR DESCRIPTION
Mutation issues in spec generators.

`next_slots_with_attestations` creates a copy of the state, but `_transition_until_active` assumes that the original state passed in is mutated with the transition. This means that `post` is yielded incorrectly due to no affects on `state` from `_transition_until_active`.

This just returns the mutated state to be used for the yield.

Note, we have a pretty bad mismatch between some transition functions mutating and some copying and returning the new state. This PR *does not* address this fundamental issue. just fixes a discrete test generation error.