### PR TITLE
Update `ssz_generic` test format README

### DIFF
--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -180,7 +180,7 @@ class ComplexTestStruct(Container):
     A: uint16
     B: List[uint16, 128]
     C: uint8
-    D: Bytes[256]
+    D: List[uint8, 256]
     E: VarTestStruct
     F: Vector[FixedTestStruct, 4]
     G: Vector[VarTestStruct, 2]


### PR DESCRIPTION
The existing README has a reference to an alias type `Bytes[N]` that has been removed from the repo so it is not clear what it exactly refers to.

This PR updates the type to the equivalent `List[T, N]` using more recent SSZ typing syntax.