### PR TITLE
Run Pytest with specific phase(s)/fork(s) tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/conftest.py
+++ b/tests/core/pyspec/eth2spec/test/conftest.py
@@ -1,4 +1,7 @@
 from eth2spec.test import context
+from eth2spec.test.helpers.constants import (
+    ALL_PHASES,
+)
 from eth2spec.utils import bls as bls_utils
 
 # We import pytest only when it's present, i.e. when we are running tests.
@@ -30,6 +33,13 @@ def pytest_addoption(parser):
         help="preset: make the pyspec use the specified preset"
     )
     parser.addoption(
+        "--fork", action="append", type=str,
+        help=(
+            "fork: make the pyspec only run with the specified phase."
+            " To run multiple phases, e.g., --fork=phase0 --fork=altair"
+        )
+    )
+    parser.addoption(
         "--disable-bls", action="store_true", default=False,
         help="bls-default: make tests that are not dependent on BLS run without BLS"
     )
@@ -42,6 +52,16 @@ def pytest_addoption(parser):
 @fixture(autouse=True)
 def preset(request):
     context.DEFAULT_TEST_PRESET = request.config.getoption("--preset")
+
+
+@fixture(autouse=True)
+def run_phases(request):
+    phases = request.config.getoption("--fork")
+    if phases:
+        phases = [phase.lower() for phase in phases]
+        context.DEFAULT_PYTEST_FORKS = set(phases)
+    else:
+        context.DEFAULT_PYTEST_FORKS = ALL_PHASES
 
 
 @fixture(autouse=True)

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -22,6 +22,9 @@ from lru import LRU
 # Without pytest CLI arg or pyspec-test-generator 'preset' argument, this will be the config to apply.
 DEFAULT_TEST_PRESET = MINIMAL
 
+# Without pytest CLI arg or pyspec-test-generator 'run-phase' argument, this will be the config to apply.
+DEFAULT_PYTEST_FORKS = ALL_PHASES
+
 
 # TODO: currently phases are defined as python modules.
 # It would be better if they would be more well-defined interfaces for stronger typing.
@@ -351,7 +354,7 @@ def with_phases(phases, other_phases=None):
     """
     def decorator(fn):
         def wrapper(*args, **kw):
-            run_phases = phases
+            run_phases = set(phases).intersection(DEFAULT_PYTEST_FORKS)
 
             # limit phases if one explicitly specified
             if 'phase' in kw:


### PR DESCRIPTION
### Feature

Add Pytest CLI option `--fork` so that we can just run with specific phase(s)/fork(s) tests.

p.s. not strongly, but I like `--fork` rather than `--phase` here and wish to remove terminology "phases" one day. But open to discuss if anyone likes `--phase` or other names more.


### Examples
Example 1: by default, it runs all available phase(s)/fork(s):
```sh
pytest eth2spec/test/phase0/sanity/test_slots.py::test_slots_1
```

Example 2: only run `merge` tests:
```sh
pytest eth2spec/test/phase0/sanity/test_slots.py::test_slots_1 --fork=merge
```

Example 3: only run `phase0` and `altair` tests:
```sh
pytest eth2spec/test/phase0/sanity/test_slots.py::test_slots_1 --fork=phase0 --fork=altair 
```

