### PR TITLE
[CI] Run CI tests in parallel by forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           name: Install pyspec requirements
           command: make install_test
       - save_pyspec_cached_venv
-  test:
+  test-phase0:
     docker:
       - image: circleci/python:3.8
     working_directory: ~/specs-repo
@@ -100,7 +100,33 @@ jobs:
       - restore_pyspec_cached_venv
       - run:
           name: Run py-tests
-          command: make citest
+          command: make citest fork=phase0
+      - store_test_results:
+          path: tests/core/pyspec/test-reports
+  test-altair:
+    docker:
+      - image: circleci/python:3.8
+    working_directory: ~/specs-repo
+    steps:
+      - restore_cache:
+          key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
+      - restore_pyspec_cached_venv
+      - run:
+          name: Run py-tests
+          command: make citest fork=altair
+      - store_test_results:
+          path: tests/core/pyspec/test-reports
+  test-merge:
+    docker:
+      - image: circleci/python:3.8
+    working_directory: ~/specs-repo
+    steps:
+      - restore_cache:
+          key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
+      - restore_pyspec_cached_venv
+      - run:
+          name: Run py-tests
+          command: make citest fork=merge
       - store_test_results:
           path: tests/core/pyspec/test-reports
   table_of_contents:
@@ -208,14 +234,20 @@ workflows:
       - install_pyspec_test:
           requires:
             - checkout_specs
-      - test:
+      - test-phase0:
+          requires:
+            - install_pyspec_test
+      - test-altair:
+          requires:
+            - install_pyspec_test
+      - test-merge:
           requires:
             - install_pyspec_test
       - table_of_contents
       - codespell
       - lint:
           requires:
-            - test
+            - install_pyspec_test
       # NOTE: Since phase 0 has been launched, we disabled the deposit contract tests. 
       # - install_deposit_contract_web3_tester:
       #     requires:

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,15 @@ find_test: pyspec
 	python3 -m pytest -k=$(K) --disable-bls --cov=eth2spec.phase0.minimal --cov=eth2spec.altair.minimal --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
 
 citest: pyspec
-	mkdir -p tests/core/pyspec/test-reports/eth2spec; . venv/bin/activate; cd $(PY_SPEC_DIR); \
+	mkdir -p tests/core/pyspec/test-reports/eth2spec;
+ifdef fork
+	. venv/bin/activate; cd $(PY_SPEC_DIR); \
+	python3 -m pytest -n 4 --bls-type=milagro --fork=$(fork) --junitxml=eth2spec/test_results.xml eth2spec
+else
+	. venv/bin/activate; cd $(PY_SPEC_DIR); \
 	python3 -m pytest -n 4 --bls-type=milagro --junitxml=eth2spec/test_results.xml eth2spec
+endif
+
 
 open_cov:
 	((open "$(COV_INDEX_FILE)" || xdg-open "$(COV_INDEX_FILE)") &> /dev/null) &


### PR DESCRIPTION
Based on #2678 

This PR updates CI config so that we can divide test jobs by forks:
- `test-phase0`
- `test-altair`
- `test-merge`

## Workflows
### Before
Duration: 14m 31s 
![image](https://user-images.githubusercontent.com/9263930/137715861-18e183a7-b3e3-4968-946c-71d57563e9b2.png)

### After
Duration: 4m 3s 🚀 
![image](https://user-images.githubusercontent.com/9263930/137715912-17f32c32-07e5-482b-a664-ab1488b610b9.png)



