### PR TITLE
Remove Union from ExecutionPayload transaction type

### DIFF
--- a/presets/mainnet/merge.yaml
+++ b/presets/mainnet/merge.yaml
@@ -1,3 +1,16 @@
 # Mainnet preset - The Merge
 
-# No presets here.
+# Execution
+# ---------------------------------------------------------------
+# 2**20 (= 1,048,576)
+MAX_BYTES_PER_TRANSACTION: 1048576
+# 2**14 (= 16,384)
+MAX_TRANSACTIONS_PER_PAYLOAD: 16384
+# 2**8 (= 256)
+BYTES_PER_LOGS_BLOOM: 256
+# 2**10 (= 1,024)
+GAS_LIMIT_DENOMINATOR: 1024
+# 5,000
+MIN_GAS_LIMIT: 5000
+# 2**5 (= 32)
+MAX_EXTRA_DATA_BYTES: 32

--- a/presets/minimal/merge.yaml
+++ b/presets/minimal/merge.yaml
@@ -1,3 +1,16 @@
 # Minimal preset - The Merge
 
-# No presets here.
+# Execution
+# ---------------------------------------------------------------
+# 2**20 (= 1,048,576)
+MAX_BYTES_PER_TRANSACTION: 1048576
+# 2**14 (= 16,384)
+MAX_TRANSACTIONS_PER_PAYLOAD: 16384
+# 2**8 (= 256)
+BYTES_PER_LOGS_BLOOM: 256
+# 2**10 (= 1,024)
+GAS_LIMIT_DENOMINATOR: 1024
+# 5,000
+MIN_GAS_LIMIT: 5000
+# 2**5 (= 32)
+MAX_EXTRA_DATA_BYTES: 32

--- a/setup.py
+++ b/setup.py
@@ -497,7 +497,7 @@ class MergeSpecBuilder(AltairSpecBuilder):
         return super().imports(preset_name) + f'''
 from typing import Protocol
 from eth2spec.altair import {preset_name} as altair
-from eth2spec.utils.ssz.ssz_typing import Bytes8, Bytes20, ByteList, ByteVector, uint256, Union
+from eth2spec.utils.ssz.ssz_typing import Bytes8, Bytes20, ByteList, ByteVector, uint256
 '''
 
     @classmethod
@@ -543,7 +543,7 @@ EXECUTION_ENGINE = NoopExecutionEngine()"""
     @classmethod
     def hardcoded_custom_type_dep_constants(cls) -> str:
         constants = {
-            'MAX_BYTES_PER_OPAQUE_TRANSACTION': 'uint64(2**20)',
+            'MAX_BYTES_PER_TRANSACTION': 'uint64(2**20)',
         }
         return {**super().hardcoded_custom_type_dep_constants(), **constants}
 

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -50,8 +50,7 @@ This patch adds transaction execution to the beacon chain as part of the Merge f
 
 | Name | SSZ equivalent | Description |
 | - | - | - |
-| `OpaqueTransaction` | `ByteList[MAX_BYTES_PER_OPAQUE_TRANSACTION]` | a [typed transaction envelope](https://eips.ethereum.org/EIPS/eip-2718#opaque-byte-array-rather-than-an-rlp-array) structured as `TransactionType \|\| TransactionPayload` |
-| `Transaction` | `Union[OpaqueTransaction]` | a transaction |
+| `Transaction` | `ByteList[MAX_BYTES_PER_TRANSACTION]` | either a [typed transaction envelope](https://eips.ethereum.org/EIPS/eip-2718#opaque-byte-array-rather-than-an-rlp-array) or a legacy transaction|
 | `ExecutionAddress` | `Bytes20` | Address of account on the execution layer |
 
 ## Constants
@@ -60,7 +59,7 @@ This patch adds transaction execution to the beacon chain as part of the Merge f
 
 | Name | Value |
 | - | - |
-| `MAX_BYTES_PER_OPAQUE_TRANSACTION` | `uint64(2**20)` (= 1,048,576) |
+| `MAX_BYTES_PER_TRANSACTION` | `uint64(2**20)` (= 1,048,576) |
 | `MAX_TRANSACTIONS_PER_PAYLOAD` | `uint64(2**14)` (= 16,384) |
 | `BYTES_PER_LOGS_BLOOM` | `uint64(2**8)` (= 256) |
 | `GAS_LIMIT_DENOMINATOR` | `uint64(2**10)` (= 1,024) |


### PR DESCRIPTION
It seems that we are at an impasse as to how to properly use a Union-type for Transactions that maps well to the execution layer native typing. (based on convo here -- https://github.com/ethereum/consensus-specs/issues/2608)

This PR removes the `Union` type completely, making the execution layer transactions just opaque bytes. This is nice because we don't tightly couple Consensus Layer changes if/when any new Execution Layer txs are added/modified.

This keeps a cleaner separation of concerns and allows the layers to be specified (and even upgraded) relatively independently. I'm personally pro keeping this divide clean where possible. The fact that we can't agree on a proper Union selector typing is because of decisions that need to be made in EL (or that CL would imply a decision needs to be made in a certain way eventually). This goes to show us that crossing these layers in specs is complication inducing and imo should be avoided when possible.

------------

additionally, I added the Execution presets to the associated yaml files