### PR TITLE
[Sharding] Allow just one non-empty pending ShardHeader per shard+slot in the state

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -154,7 +154,7 @@ TODO: `WEIGHT_DENOMINATOR` needs to be adjusted, but this breaks a lot of Altair
 | `INITIAL_ACTIVE_SHARDS` | `uint64(2**6)` (= 64) | Initial shard count |
 | `SAMPLE_PRICE_ADJUSTMENT_COEFFICIENT` | `uint64(2**3)` (= 8) | Sample price may decrease/increase by at most exp(1 / this value) *per epoch* |
 | `MAX_SHARD_PROPOSER_SLASHINGS` | `2**4` (= 16) | Maximum amount of shard proposer slashing operations per block |
-| `MAX_SHARD_HEADERS_PER_SHARD` | `4` | |
+| `MAX_SHARD_HEADERS_PER_SHARD` | `2` | |
 | `SHARD_STATE_MEMORY_SLOTS` | `uint64(2**8)` (= 256) | Number of slots for which shard commitments and confirmation status is directly available in the state |
 | `BLOB_BUILDER_REGISTRY_LIMIT` | `uint64(2**40)` (= 1,099,511,627,776) | shard blob builders |
 


### PR DESCRIPTION
This PR limits the number of non-empty pending shard headers per `(shard, slot)` in the beacon state to just `1`

The list of pending shard headers would effectively contain just an empty header and [optionally] non-empty header from a proposer. 

If this PR is approved I would do the follow up effort to make the pair of `(EmptyPendingHeader, Optional<PendingHeader>)` more explicit in the spec. 

This is the follow up to offline discussion with @vbuterin: do we need to consider on the beacon chain level the situation when a blob proposer publishes more than a single header for a specific `(shard, slot)`?

If I got it right, @vbuterin point was that if proposer for some reason produces 2 headers `h1`& `h2` and attesters majority votes for `h1` but a block proposer sees only `h2` and includes it. In this case the next block proposer may still pick and include `h1`. And finally `h1` would be legitimate confirmed header despite the fact the condition is slashable for the header proposer. 
In case if we allow just one pending header then both headers `h1` and `h2` would be just lost
Please correct me if I missed anything.

My point is that this condition may appear only in one of two cases: 
- Honest validator software malfunction. I.e. no honest validator would like to do that intentionally under any conditions 
- Malicious behavior

The first situation looks quite exceptional and would be appearing in more and more rare cases (as anti-slashing protection evolves) and from my point of view could be neglected. In other words malfunction would highly unlikely add any value to the network liveness. In case when it happens the shard blob would be dismissed in the _worst_ case only.

The second case is probably still to be considered, but at the moment no viable attack vectors are come to mind.

The major drawback from my perspective of allowing `>1` non-empty pending headers is increased complexity at several points. While implementing beacon state processing, validator duties and shard builder API draft, there were some places when you need to consider that there could potentially be `>1` pending non-empty headers. I.e. one needs always consider using `List<ShardHeader>` instead of `Optional<ShardHeader>`. This could be error prone at implementation level when at some point that slashable condition would occur.