### PR TITLE
`--fork` cli option: fix the case of using `pytest -k` without setting directory path

### DIFF
--- a/tests/core/pyspec/eth2spec/test/conftest.py
+++ b/tests/core/pyspec/eth2spec/test/conftest.py
@@ -67,7 +67,7 @@ def preset(request):
 def run_phases(request):
     forks = request.config.getoption("--fork", default=None)
     if forks:
-        forks = [phase.lower() for phase in forks]
+        forks = [fork.lower() for fork in forks]
         _validate_fork_name(forks)
         context.DEFAULT_PYTEST_FORKS = set(forks)
     else:


### PR DESCRIPTION
### Issue

1. `--fork` is `action="append"` option without a single default value.
    - `request.config.getoption("--fork")` returns `None` if directory path is set.
    - `request.config.getoption("--fork")` raises `ValueError` if directory path is unset. (Some `AttributeError` in pytest internally)
2. If anyone wants to run with `-k` AND without setting file or path, it raises error:
```sh
pytest -k test_slots_1
```

```sh
request = <SubRequest 'run_phases' for <Function test_slots_1>>

    @fixture(autouse=True)
    def run_phases(request):
>       phases = request.config.getoption("--fork")
E       ValueError: no option named 'fork'
```

p.s. Thank Ori and Danny for reporting it!


### How did I fix it

This PR fixes this special case so that it will run tests against `ALL_FORKS` even if the directory path is unset.

Also, this PR adds `_validate_fork_name` to verify if the given fork name is valid.


Note: if anyone uses custom options *without* target file or directory path, it will raise errors. e.g., `pytest -k test_slots_1 --bls-type milagro` is invalid.
```
✦9 ➜ pytest -k test_slots_1 --bls-type milagro
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --bls-type
  inifile: None
  rootdir: /Users/hwwang/ethereum/consensus-specs
```

