### PR TITLE
Add networking req/resp request rate limiting rule

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -179,6 +179,7 @@ This section outlines constants that are used in this spec.
 | `RESP_TIMEOUT` | `10s` | The maximum time for complete response transfer. |
 | `ATTESTATION_PROPAGATION_SLOT_RANGE` | `32` | The maximum number of slots during which an attestation can be propagated. |
 | `MAXIMUM_GOSSIP_CLOCK_DISPARITY` | `500ms` | The maximum milliseconds of clock disparity assumed between honest nodes. |
+| `MAXIMUM_CONCURRENT_REQUESTS` | `2` | The maximum number of parallel requests waiting for response per message type |
 | `MESSAGE_DOMAIN_INVALID_SNAPPY` | `0x00000000` | 4-byte domain for gossip message-id isolation of *invalid* snappy messages |
 | `MESSAGE_DOMAIN_VALID_SNAPPY`  | `0x01000000` | 4-byte domain for gossip message-id isolation of *valid* snappy messages |
 
@@ -534,6 +535,12 @@ A requester SHOULD read from the stream until either:
 
 For requests consisting of a single valid `response_chunk`,
 the requester SHOULD read the chunk fully, as defined by the `encoding-dependent-header`, before closing the stream.
+
+The requesting side should bind its request rate by limiting the number of concurrent requests to 
+`MAXIMUM_CONCURRENT_REQUESTS` on per request type basis. 
+I.e. a requester MUST NOT send another request if it still awaits responses for previous 
+`MAXIMUM_CONCURRENT_REQUESTS` requests of the same type. Else it is subject to be disconnected and downscored 
+by the remote party.
 
 #### Responding side
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -179,7 +179,7 @@ This section outlines constants that are used in this spec.
 | `RESP_TIMEOUT` | `10s` | The maximum time for complete response transfer. |
 | `ATTESTATION_PROPAGATION_SLOT_RANGE` | `32` | The maximum number of slots during which an attestation can be propagated. |
 | `MAXIMUM_GOSSIP_CLOCK_DISPARITY` | `500ms` | The maximum milliseconds of clock disparity assumed between honest nodes. |
-| `MAXIMUM_CONCURRENT_REQUESTS` | `2` | The maximum number of parallel requests waiting for response per message type |
+| `MAXIMUM_CONCURRENT_REQUESTS` | `32` | The maximum number of parallel requests waiting for response per message type |
 | `MESSAGE_DOMAIN_INVALID_SNAPPY` | `0x00000000` | 4-byte domain for gossip message-id isolation of *invalid* snappy messages |
 | `MESSAGE_DOMAIN_VALID_SNAPPY`  | `0x01000000` | 4-byte domain for gossip message-id isolation of *valid* snappy messages |
 


### PR DESCRIPTION
The networking spec is still missing any request rate limit rules. That leads to the situation when different clients make their own assumptions on 'reasonable' rate limits and could disconnect and downscore other clients with different assumptions. 

This PR introduces rate limiting similar to RLPx, where requester must not send another request until previous one is responded. However it would be good to relax this rule and allow sending maximum `2` concurrent requests to compensate network roundtrip latency.

**UPD**: changed the maximum from 2 to 32 to give a space for fast nodes to serve many requests in parallel
**UPD**: RLPx actually supports parallel requests (though without req/resp ids), then not sure how rate limiting actually works there

Below there is a bit more background from Discord channel conversation: 

> [17:35] Nashatyrev: On merge event we hit the issue when Teku was regularly disconnecting Lodestar due to exceeding block request rate limit. 
In chat with @dapplion we found out that there are no any limits settled in the spec and each client limits inbound/outbound requests (or does not limit at all) according to its internal options.
From my perspective it makes sense adding ReqResp rate limiting rules to the networking spec.
[17:41] Nashatyrev: However instead of hardcoding rate limits I would suggest to add a ReqResp error code RateLimitExceeded which would allow more flexible traffic limiting. I.e. a serving node could dynamically limit the traffic according to it's current load while a requesting node may dynamically adopt its request rate without a risk of being disconnected and downscored
[17:44] Nashatyrev: That approach could also be helpful for small networks when a number of peers low, but they could serve requests at higher rates. E.g. due to Teku conservative rate limits a test net with just 2 nodes syncs very slowly
[17:56] Nashatyrev: There are possible options of how RateLimitExceeded could work:
> - either per ReqResp message type or globally across all types. I would prefer the first option here since e.g. ping/metadata messages are expected to be less frequent than e.g. block requests
> - error message may contain a cool down time period after which messages could be sent again (I've seen a couple of stock exchange trading protocols which utilize this option)
> - If RateLimitExceeded errors are ignored by the requesting side (e.g. > N errors were sent during some time frame) then the peer could be disconnected and downscored

> [18:05] Nashatyrev: A different possible option for rate limiting is the maximum number of concurrent requests. 
E.g. if this number is 1  then requester must not send a new request until receives response to the previous one (I believe this is how RLPx works)
[10:13] arnetheduck: the simple solution here is that the server withholds the response until the client is within the quota - this avoids the need for complex error handling, decreases chatter, avoids roundtrip timing issues and is trivial to implement - the rate limiting happens "naturally" at the pace that the server is willing to serve and the client can judge how good a server is by the only metric that mattters: how many valid blocks is this server giving me, per second
[13:02] Nashatyrev: Right, this looks like the latter option I suggested (with parallelism of max 1). And it looks more simple and natural to me as well.
However that may work weird for ping/metadata requests. I.e. if a node assumes max rate for ping as 1 request per 10 seconds, what should it do when receiving an extra ping request? From the other side should we rate limit ping/metadata requests at all?
[13:58] arnetheduck: well, one thing to keep in mind is that ping requests are pretty useless from a utility point of view - they basically announce that you have nothing important to say - re parallelism, there's a case to allow multiple parallel requests up to some limit, but again, this "naturally" solves itself if you limit processing to one at a time per node - this allows clients to pipeline requests and avoid roundtrip latency, but by serving them one by one according to a budget, if they send too many, some will simply time out - and if you have too many requests timing out, you eventually disconnect (regardless if they're pings or block requests) 
[14:00] arnetheduck: from a performance point of view, you might make 1-2 block requests in parallel - one in-flight and one queued - beyond that, you don't have much to gain as a client - if you're doing more, you're likely buggy or spammy
[14:01] arnetheduck: the beauty of this solution is that you don't need to add anything to the spec, and you don't have to worry about compatibility over time with different versions of clients 
[14:10] Nashatyrev: Totally agree except I believe it should still be added to the spec for all clients to be in line with this rate limiting scheme. 
Currently spec doesn't prevent you from sending as many parallel requests as you like. 
I'm also tending to limit max parallel requests (to 2) on per message type basis. 

CCing @dapplion @arnetheduck 