### PR TITLE
[Sharding] Forkchoice: compute DAS data dependencies starting from the finalized block

### DIFF
--- a/specs/das/fork-choice.md
+++ b/specs/das/fork-choice.md
@@ -37,7 +37,7 @@ def get_new_dependencies(state: BeaconState) -> Set[DataCommitment]:
 
 ```python
 def get_all_dependencies(store: Store, block: BeaconBlock) -> Set[DataCommitment]:
-    if compute_epoch_at_slot(block.slot) < SHARDING_FORK_EPOCH:
+    if compute_epoch_at_slot(block.slot) <= store.finalized_checkpoint.epoch:
         return set()
     else:
         latest = get_new_dependencies(store.block_states[hash_tree_root(block)])


### PR DESCRIPTION
According to the present spec a block is eligible for consideration only when _all_ previous blocks (starting from the sharding fork) pass DAS verification. 
Consider a node syncing from scratch this verification is not possible as blob samples are assumed to be cached by responsible nodes (assigned to das gossip backbone subnets) for a very limited period of time only. 

This PR proposes to treat all finalized blocks as DAS verified thus requiring sampling only for blocks starting from the earliest non-finalized.

We could potentially replace 'Finalized' with 'Justified' if it doesn't weaken security. 

The positive side effect is that a node may sync without DAS pull mechanism: when synced to head it may start sampling and DAS verify new blocks until the last unverified block becomes finalized.