### PR TITLE
Eth1 block hashes have type Hash32

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -685,7 +685,7 @@ This helper function is only for initializing the state for pure Altair testnets
 *Note*: The function `initialize_beacon_state_from_eth1` is modified: (1) using `ALTAIR_FORK_VERSION` as the current fork version, (2) utilizing the Altair `BeaconBlockBody` when constructing the initial `latest_block_header`, and (3) adding initial sync committees.
 
 ```python
-def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
+def initialize_beacon_state_from_eth1(eth1_block_hash: Hash32,
                                       eth1_timestamp: uint64,
                                       deposits: Sequence[Deposit]) -> BeaconState:
     fork = Fork(

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -333,7 +333,7 @@ Modifications include:
   Else, the Merge starts from genesis and the transition is incomplete.
 
 ```python
-def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
+def initialize_beacon_state_from_eth1(eth1_block_hash: Hash32,
                                       eth1_timestamp: uint64,
                                       deposits: Sequence[Deposit],
                                       execution_payload_header: ExecutionPayloadHeader=ExecutionPayloadHeader()

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1175,7 +1175,7 @@ Before the Ethereum beacon chain genesis has been triggered, and for every Ether
 Proof-of-work blocks must only be considered once they are at least `SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE` seconds old (i.e. `eth1_timestamp + SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE <= current_unix_time`). Due to this constraint, if `GENESIS_DELAY < SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE`, then the `genesis_time` can happen before the time/state is first known. Values should be configured to avoid this case.
 
 ```python
-def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
+def initialize_beacon_state_from_eth1(eth1_block_hash: Hash32,
                                       eth1_timestamp: uint64,
                                       deposits: Sequence[Deposit]) -> BeaconState:
     fork = Fork(


### PR DESCRIPTION
[Same as #2689, see comments there. Sorry - I got in a mess with my branches and needed to redo this.]

Pernickety and largely of historical value now, but since we have added a custom `Hash32` type for Eth1 block hashes it ought to be used in the definition of `initialize_beacon_state_from_eth1()`.

Related question: why are we not migrating all the other hashes over to the `Hash32` type, only the Eth1 block hash? For example [here](https://github.com/ethereum/consensus-specs/blob/a20f6f7b5f40292c2a864337336bff74ae318354/specs/phase0/beacon-chain.md?plain=1#L633)

```
#### `hash`

`def hash(data: bytes) -> Bytes32` is SHA256.
```

Historical note: `Hash32` [used to be a thing](https://github.com/ethereum/consensus-specs/commit/0b10b0444a4e6c4f5bf548344796df76dd6d5657) back at the dawn of time, before being superseded by the generic `Bytes32`.