### PR TITLE
Set execution params to presets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -634,6 +634,10 @@ def objects_to_spec(preset_name: str,
     ssz_dep_constants = '\n'.join(map(lambda x: '%s = %s' % (x, builder.hardcoded_ssz_dep_constants()[x]), builder.hardcoded_ssz_dep_constants()))
     ssz_dep_constants_verification = '\n'.join(map(lambda x: 'assert %s == %s' % (x, spec_object.ssz_dep_constants[x]), builder.hardcoded_ssz_dep_constants()))
     custom_type_dep_constants = '\n'.join(map(lambda x: '%s = %s' % (x, builder.hardcoded_custom_type_dep_constants()[x]), builder.hardcoded_custom_type_dep_constants()))
+    custom_type_dep_constants_verification = '\n'.join(map(
+        lambda x: 'assert %s == %s' % (x, f'{spec_object.preset_vars[x].type_name}({spec_object.preset_vars[x].value})'),
+        builder.hardcoded_custom_type_dep_constants(),
+    ))
     spec = (
             builder.imports(preset_name)
             + builder.preparations()
@@ -654,6 +658,7 @@ def objects_to_spec(preset_name: str,
             # Since some constants are hardcoded in setup.py, the following assertions verify that the hardcoded constants are
             # as same as the spec definition.
             + ('\n\n\n' + ssz_dep_constants_verification if ssz_dep_constants_verification != '' else '')
+            + ('\n\n\n' + custom_type_dep_constants_verification if custom_type_dep_constants_verification != '' else '')
             + '\n'
     )
     return spec

--- a/setup.py
+++ b/setup.py
@@ -634,10 +634,6 @@ def objects_to_spec(preset_name: str,
     ssz_dep_constants = '\n'.join(map(lambda x: '%s = %s' % (x, builder.hardcoded_ssz_dep_constants()[x]), builder.hardcoded_ssz_dep_constants()))
     ssz_dep_constants_verification = '\n'.join(map(lambda x: 'assert %s == %s' % (x, spec_object.ssz_dep_constants[x]), builder.hardcoded_ssz_dep_constants()))
     custom_type_dep_constants = '\n'.join(map(lambda x: '%s = %s' % (x, builder.hardcoded_custom_type_dep_constants()[x]), builder.hardcoded_custom_type_dep_constants()))
-    custom_type_dep_constants_verification = '\n'.join(map(
-        lambda x: 'assert %s == %s' % (x, f'{spec_object.preset_vars[x].type_name}({spec_object.preset_vars[x].value})'),
-        builder.hardcoded_custom_type_dep_constants(),
-    ))
     spec = (
             builder.imports(preset_name)
             + builder.preparations()
@@ -658,7 +654,6 @@ def objects_to_spec(preset_name: str,
             # Since some constants are hardcoded in setup.py, the following assertions verify that the hardcoded constants are
             # as same as the spec definition.
             + ('\n\n\n' + ssz_dep_constants_verification if ssz_dep_constants_verification != '' else '')
-            + ('\n\n\n' + custom_type_dep_constants_verification if custom_type_dep_constants_verification != '' else '')
             + '\n'
     )
     return spec

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -10,9 +10,8 @@
 
 - [Introduction](#introduction)
 - [Custom types](#custom-types)
-- [Constants](#constants)
-  - [Execution](#execution)
 - [Preset](#preset)
+  - [Execution](#execution)
   - [Updated penalty values](#updated-penalty-values)
 - [Configuration](#configuration)
   - [Transition settings](#transition-settings)
@@ -64,7 +63,7 @@ Additionally, this upgrade introduces the following minor changes:
 | `Transaction` | `ByteList[MAX_BYTES_PER_TRANSACTION]` | either a [typed transaction envelope](https://eips.ethereum.org/EIPS/eip-2718#opaque-byte-array-rather-than-an-rlp-array) or a legacy transaction|
 | `ExecutionAddress` | `Bytes20` | Address of account on the execution layer |
 
-## Constants
+## Preset
 
 ### Execution
 
@@ -76,8 +75,6 @@ Additionally, this upgrade introduces the following minor changes:
 | `GAS_LIMIT_DENOMINATOR` | `uint64(2**10)` (= 1,024) |
 | `MIN_GAS_LIMIT` | `uint64(5000)` (= 5,000) |
 | `MAX_EXTRA_DATA_BYTES` | `2**5` (= 32) |
-
-## Preset
 
 ### Updated penalty values
 


### PR DESCRIPTION
Spec builder fixes:

1. The execution params should have been moved to "presets" since they are defined in preset files.
2. ~~Add spec builder assertions to avoid #2701 issue happening again~~
    - ~~It will add `assert MAX_BYTES_PER_TRANSACTION == uint64(1073741824)` to the spec.~~
    - updated: reverted it