### PR TITLE
State that validator must consider only fully validated blocks

### DIFF
--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -122,6 +122,8 @@ def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> ExecutionPayloa
 
 All validator responsibilities remain unchanged other than those noted below. Namely, the transition block handling and the addition of `ExecutionPayload`.
 
+*Note*: A validator must not propose on or attest to a block that isn't deemed valid, i.e. hasn't yet passed the beacon chain state transition and execution validations.
+
 ### Block proposal
 
 #### Constructing the `BeaconBlockBody`

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -122,7 +122,7 @@ def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> ExecutionPayloa
 
 All validator responsibilities remain unchanged other than those noted below. Namely, the transition block handling and the addition of `ExecutionPayload`.
 
-*Note*: A validator must not propose on or attest to a block that isn't deemed valid, i.e. hasn't yet passed the beacon chain state transition and execution validations.
+*Note*: A validator must not propose on or attest to a block that isn't deemed valid, i.e. hasn't yet passed the beacon chain state transition and execution validations. In future upgrades, an "execution Proof-of-Custody" will be integrated to prevent outsourcing of execution payload validations.
 
 ### Block proposal
 


### PR DESCRIPTION
Adds the following note:
> A validator must not propose on or attest to a block that isn't deemed valid, i.e. hasn't yet passed the beacon chain state transition and execution validations.