### PR TITLE
`validate_merge_block ` uses correct block hash

### DIFF
--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -116,6 +116,7 @@ def validate_merge_block(block: BeaconBlock) -> None:
         # If `TERMINAL_BLOCK_HASH` is used as an override, the activation epoch must be reached.
         assert compute_epoch_at_slot(block.slot) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
         assert block.body.execution_payload.parent_hash == TERMINAL_BLOCK_HASH
+        return
 
     pow_block = get_pow_block(block.body.execution_payload.parent_hash)
     # Check if `pow_block` is available

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -115,7 +115,7 @@ def validate_merge_block(block: BeaconBlock) -> None:
     if TERMINAL_BLOCK_HASH != Hash32():
         # If `TERMINAL_BLOCK_HASH` is used as an override, the activation epoch must be reached.
         assert compute_epoch_at_slot(block.slot) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
-        return block.body.execution_payload.parent_hash == TERMINAL_BLOCK_HASH
+        assert block.body.execution_payload.parent_hash == TERMINAL_BLOCK_HASH
 
     pow_block = get_pow_block(block.body.execution_payload.parent_hash)
     # Check if `pow_block` is available

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -115,7 +115,7 @@ def validate_merge_block(block: BeaconBlock) -> None:
     if TERMINAL_BLOCK_HASH != Hash32():
         # If `TERMINAL_BLOCK_HASH` is used as an override, the activation epoch must be reached.
         assert compute_epoch_at_slot(block.slot) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
-        return block.block_hash == TERMINAL_BLOCK_HASH
+        return block.body.execution_payload.parent_hash == TERMINAL_BLOCK_HASH
 
     pow_block = get_pow_block(block.body.execution_payload.parent_hash)
     # Check if `pow_block` is available


### PR DESCRIPTION
` block.block_hash == TERMINAL_BLOCK_HASH` still assumes `block` is `PowBlock` but was changed to `BeaconBlock`