### PR TITLE
Add payload id as a return value to notify_forkchoice_updated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -530,7 +530,7 @@ class NoopExecutionEngine(ExecutionEngine):
     def notify_forkchoice_updated(self: ExecutionEngine,
                                   head_block_hash: Hash32,
                                   finalized_block_hash: Hash32,
-                                  payload_attributes: Optional[PayloadAttributes]) -> None:
+                                  payload_attributes: Optional[PayloadAttributes]) -> Optional[PayloadId]:
         pass
 
     def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> ExecutionPayload:

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -8,6 +8,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
+- [Custom types](#custom-types)
 - [Protocols](#protocols)
   - [`ExecutionEngine`](#executionengine)
     - [`notify_forkchoice_updated`](#notify_forkchoice_updated)

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -29,6 +29,12 @@ This is the modification of the fork choice according to the executable beacon c
 
 *Note*: It introduces the process of transition from the last PoW block to the first PoS block.
 
+## Custom types
+
+| Name | SSZ equivalent | Description |
+| - | - | - |
+| `PayloadId` | `Bytes8` | Identifier of a payload building process |
+
 ## Protocols
 
 ### `ExecutionEngine`
@@ -46,13 +52,13 @@ This function performs two actions *atomically*:
 and corresponding state, up to and including `finalized_block_hash`.
 
 Additionally, if `payload_attributes` is provided, this function sets in motion a payload build process on top of
-`head_block_hash` with the result to be gathered by a followup call to  `get_payload`.
+`head_block_hash` and returns an identifier of initiated process.
 
 ```python
 def notify_forkchoice_updated(self: ExecutionEngine,
                               head_block_hash: Hash32,
                               finalized_block_hash: Hash32,
-                              payload_attributes: Optional[PayloadAttributes]) -> None:
+                              payload_attributes: Optional[PayloadAttributes]) -> Optional[PayloadId]:
     ...
 ```
 

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -10,11 +10,9 @@
 
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
-- [Custom types](#custom-types)
 - [Helpers](#helpers)
   - [`get_pow_block_at_terminal_total_difficulty`](#get_pow_block_at_terminal_total_difficulty)
   - [`get_terminal_pow_block`](#get_terminal_pow_block)
-  - [`get_payload_id`](#get_payload_id)
 - [Protocols](#protocols)
   - [`ExecutionEngine`](#executionengine)
     - [`get_payload`](#get_payload)

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -38,12 +38,6 @@ All behaviors and definitions defined in this document, and documents it extends
 All terminology, constants, functions, and protocol mechanics defined in the updated Beacon Chain doc of [The Merge](./beacon-chain.md) are requisite for this document and used throughout.
 Please see related Beacon Chain doc before continuing and use them as a reference throughout.
 
-## Custom types
-
-| Name | SSZ equivalent | Description |
-| - | - | - |
-| `PayloadId` | `Bytes8` | Identifier of a payload building process |
-
 ## Helpers
 
 ### `get_pow_block_at_terminal_total_difficulty`
@@ -73,24 +67,6 @@ def get_terminal_pow_block(pow_chain: Dict[Hash32, PowBlock]) -> Optional[PowBlo
             return None
 
     return get_pow_block_at_terminal_total_difficulty(pow_chain)
-```
-
-### `get_payload_id`
-
-Given the `head_block_hash` and the `payload_attributes` that were used to
-initiate the build process via `notify_forkchoice_updated`, `get_payload_id()`
-returns the `payload_id` used to retrieve the payload via `get_payload`.
-
-```python
-def get_payload_id(parent_hash: Hash32, payload_attributes: PayloadAttributes) -> PayloadId:
-    return PayloadId(
-        hash(
-            parent_hash
-            + uint_to_bytes(payload_attributes.timestamp)
-            + payload_attributes.random
-            + payload_attributes.fee_recipient
-        )[0:8]
-    )
 ```
 
 *Note*: This function does *not* use simple serialize `hash_tree_root` as to
@@ -168,8 +144,7 @@ def prepare_execution_payload(state: BeaconState,
         random=get_randao_mix(state, get_current_epoch(state)),
         fee_recipient=fee_recipient,
     )
-    execution_engine.notify_forkchoice_updated(parent_hash, finalized_block_hash, payload_attributes)
-    return get_payload_id(parent_hash, payload_attributes)
+    return execution_engine.notify_forkchoice_updated(parent_hash, finalized_block_hash, payload_attributes)
 ```
 
 2. Set `block.body.execution_payload = get_execution_payload(payload_id, execution_engine)`, where:


### PR DESCRIPTION
* Adds `Optional[PayloadId]` as a return value to the `notify_forkchoice_updated` function
* Removes redundant `get_payload_id` function

Relates to https://github.com/ethereum/execution-apis/pull/109