### PR TITLE
Genesis execution block handling

### DIFF
--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -44,8 +44,10 @@ Please see related Beacon Chain doc before continuing and use them as a referenc
 def get_pow_block_at_terminal_total_difficulty(pow_chain: Dict[Hash32, PowBlock]) -> Optional[PowBlock]:
     # `pow_chain` abstractly represents all blocks in the PoW chain
     for block in pow_chain:
-        parent = pow_chain[block.parent_hash]
         block_reached_ttd = block.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY
+        if block_reached_ttd and block.parent_hash == Hash32():
+            return block
+        parent = pow_chain[block.parent_hash]
         parent_reached_ttd = parent.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY
         if block_reached_ttd and not parent_reached_ttd:
             return block

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -45,6 +45,7 @@ def get_pow_block_at_terminal_total_difficulty(pow_chain: Dict[Hash32, PowBlock]
     # `pow_chain` abstractly represents all blocks in the PoW chain
     for block in pow_chain:
         block_reached_ttd = block.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY
+        # If genesis block, no parent exists so reaching TTD alone qualifies as valid terminal block
         if block_reached_ttd and block.parent_hash == Hash32():
             return block
         parent = pow_chain[block.parent_hash]


### PR DESCRIPTION
The current implementation of `get_pow_block_at_terminal_total_difficulty` will raise an exception on any chain (e.g., mainnet) if the `pow_chain` contains only the genesis block (e.g., unsynced node). This is because `genesis_block.parent_hash == Hash32()` and `Hash32()` is not in `pow_chain`.

This change also makes allowances for networks where the `TERMINAL_TOTAL_DIFFICULTY` is reached at the genesis block.

There's an alternative version of this fix which does *not* allow for a network where TTD is met at genesis: https://github.com/ethereum/consensus-specs/commit/f6ed352c8d9db604a4a4a1210f94e75e07361d97.