### PR TITLE
Remove `difficulty` from `PowBlock`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -511,7 +511,7 @@ ExecutionState = Any
 
 
 def get_pow_block(hash: Bytes32) -> Optional[PowBlock]:
-    return PowBlock(block_hash=hash, parent_hash=Bytes32(), total_difficulty=uint256(0), difficulty=uint256(0))
+    return PowBlock(block_hash=hash, parent_hash=Bytes32(), total_difficulty=uint256(0))
 
 
 def get_execution_state(execution_state_root: Bytes32) -> ExecutionState:

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -87,7 +87,6 @@ class PowBlock(Container):
     block_hash: Hash32
     parent_hash: Hash32
     total_difficulty: uint256
-    difficulty: uint256
 ```
 
 ### `get_pow_block`

--- a/tests/core/pyspec/eth2spec/test/helpers/pow_block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/pow_block.py
@@ -21,7 +21,6 @@ def prepare_random_pow_block(spec, rng=Random(3131)):
         block_hash=spec.Hash32(spec.hash(bytearray(rng.getrandbits(8) for _ in range(32)))),
         parent_hash=spec.Hash32(spec.hash(bytearray(rng.getrandbits(8) for _ in range(32)))),
         total_difficulty=uint256(0),
-        difficulty=uint256(0)
     )
 
 


### PR DESCRIPTION
The `difficulty` field is unused in the specification and appears to be always set to `0` in fork choice tests.