### PR TITLE
Add a test to cover the case of `is_execution_enabled` result is false

### DIFF
--- a/tests/core/pyspec/eth2spec/test/merge/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/merge/sanity/test_blocks.py
@@ -23,3 +23,22 @@ def test_empty_block_transition_no_tx(spec, state):
     yield 'post', state
 
 # TODO: tests with EVM, mock or replacement?
+
+
+@with_merge_and_later
+@spec_state_test
+def test_is_execution_enabled_false(spec, state):
+    # Set `latest_execution_payload_header` to empty
+    state.latest_execution_payload_header = spec.ExecutionPayloadHeader()
+    yield 'pre', state
+
+    block = build_empty_block_for_next_slot(spec, state)
+
+    # Set `execution_payload` to empty
+    block.body.execution_payload = spec.ExecutionPayload()
+    assert len(block.body.execution_payload.transactions) == 0
+
+    signed_block = state_transition_and_sign_block(spec, state, block)
+
+    yield 'blocks', [signed_block]
+    yield 'post', state


### PR DESCRIPTION
### Issue
To address #2722, this new test case simply covers the case of `is_execution_enabled` result is false in `process_block`.