### PR TITLE
always atomically update justified and finalized

### DIFF
--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -186,17 +186,5 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Update finalized checkpoint
     if state.finalized_checkpoint.epoch > store.finalized_checkpoint.epoch:
         store.finalized_checkpoint = state.finalized_checkpoint
-
-        # Potentially update justified if different from store
-        if store.justified_checkpoint != state.current_justified_checkpoint:
-            # Update justified if new justified is later than store justified
-            if state.current_justified_checkpoint.epoch > store.justified_checkpoint.epoch:
-                store.justified_checkpoint = state.current_justified_checkpoint
-                return
-
-            # Update justified if store justified is not in chain with finalized checkpoint
-            finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
-            ancestor_at_finalized_slot = get_ancestor(store, store.justified_checkpoint.root, finalized_slot)
-            if ancestor_at_finalized_slot != store.finalized_checkpoint.root:
-                store.justified_checkpoint = state.current_justified_checkpoint
+        store.justified_checkpoint = state.current_justified_checkpoint
 ```

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -22,7 +22,7 @@
     - [`get_head`](#get_head)
     - [`should_update_justified_checkpoint`](#should_update_justified_checkpoint)
     - [`on_attestation` helpers](#on_attestation-helpers)
-      - [`validate_target_epoch_scope`](#validate_target_epoch_scope)
+      - [`validate_target_epoch_against_current_time`](#validate_target_epoch_against_current_time)
       - [`validate_on_attestation`](#validate_on_attestation)
       - [`store_target_checkpoint_state`](#store_target_checkpoint_state)
       - [`update_latest_messages`](#update_latest_messages)
@@ -259,10 +259,10 @@ def should_update_justified_checkpoint(store: Store, new_justified_checkpoint: C
 #### `on_attestation` helpers
 
 
-##### `validate_target_epoch_scope`
+##### `validate_target_epoch_against_current_time`
 
 ```python
-def validate_target_epoch_scope(store: Store, attestation: Attestation) -> None:
+def validate_target_epoch_against_current_time(store: Store, attestation: Attestation) -> None:
     target = attestation.data.target
 
     # Attestations must be from the current or previous epoch
@@ -281,7 +281,7 @@ def validate_on_attestation(store: Store, attestation: Attestation, is_from_bloc
 
     # If the given attestation is not from a beacon block message, we have to check the target epoch scope.
     if not is_from_block:
-        validate_target_epoch_scope(store, attestation)
+        validate_target_epoch_against_current_time(store, attestation)
 
     # Check that the epoch number and slot number are matching
     assert target.epoch == compute_epoch_at_slot(attestation.data.slot)
@@ -386,6 +386,9 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
 
     # Update finalized checkpoint
     if state.finalized_checkpoint.epoch > store.finalized_checkpoint.epoch:
+        print("made it")
+        print(state.finalized_checkpoint)
+        print(state.current_justified_checkpoint)
         store.finalized_checkpoint = state.finalized_checkpoint
         store.justified_checkpoint = state.current_justified_checkpoint
 ```

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -276,8 +276,12 @@ def validate_target_epoch_scope(store: Store, attestation: Attestation) -> None:
 ##### `validate_on_attestation`
 
 ```python
-def validate_on_attestation(store: Store, attestation: Attestation) -> None:
+def validate_on_attestation(store: Store, attestation: Attestation, is_from_block: bool) -> None:
     target = attestation.data.target
+
+    # If the given attestation is not from a beacon block message, we have to check the target epoch scope.
+    if not is_from_block:
+        validate_target_epoch_scope(store, attestation)
 
     # Check that the epoch number and slot number are matching
     assert target.epoch == compute_epoch_at_slot(attestation.data.slot)
@@ -396,10 +400,7 @@ def on_attestation(store: Store, attestation: Attestation, is_from_block: bool=F
     An ``attestation`` that is asserted as invalid may be valid at a later time,
     consider scheduling it for later processing in such case.
     """
-    validate_on_attestation(store, attestation)
-    if not is_from_block:
-        # If the given attestation is not from a beacon block message, we have to check the target epoch scope.
-        validate_target_epoch_scope(store, attestation)
+    validate_on_attestation(store, attestation, is_from_block)
 
     store_target_checkpoint_state(store, attestation.data.target)
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -372,19 +372,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Update finalized checkpoint
     if state.finalized_checkpoint.epoch > store.finalized_checkpoint.epoch:
         store.finalized_checkpoint = state.finalized_checkpoint
-
-        # Potentially update justified if different from store
-        if store.justified_checkpoint != state.current_justified_checkpoint:
-            # Update justified if new justified is later than store justified
-            if state.current_justified_checkpoint.epoch > store.justified_checkpoint.epoch:
-                store.justified_checkpoint = state.current_justified_checkpoint
-                return
-
-            # Update justified if store justified is not in chain with finalized checkpoint
-            finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
-            ancestor_at_finalized_slot = get_ancestor(store, store.justified_checkpoint.root, finalized_slot)
-            if ancestor_at_finalized_slot != store.finalized_checkpoint.root:
-                store.justified_checkpoint = state.current_justified_checkpoint
+        store.justified_checkpoint = state.current_justified_checkpoint
 ```
 
 #### `on_attestation`

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -386,9 +386,6 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
 
     # Update finalized checkpoint
     if state.finalized_checkpoint.epoch > store.finalized_checkpoint.epoch:
-        print("made it")
-        print(state.finalized_checkpoint)
-        print(state.current_justified_checkpoint)
         store.finalized_checkpoint = state.finalized_checkpoint
         store.justified_checkpoint = state.current_justified_checkpoint
 ```

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -23,7 +23,7 @@ def add_block_to_store(spec, store, signed_block):
     spec.on_block(store, signed_block)
 
 
-def tick_and_add_block(spec, store, signed_block, test_steps, valid=True, allow_invalid_attestations=False,
+def tick_and_add_block(spec, store, signed_block, test_steps, valid=True,
                        merge_block=False, block_not_found=False):
     pre_state = store.block_states[signed_block.message.parent_root]
     block_time = pre_state.genesis_time + signed_block.message.slot * spec.config.SECONDS_PER_SLOT
@@ -36,14 +36,13 @@ def tick_and_add_block(spec, store, signed_block, test_steps, valid=True, allow_
     post_state = yield from add_block(
         spec, store, signed_block, test_steps,
         valid=valid,
-        allow_invalid_attestations=allow_invalid_attestations,
         block_not_found=block_not_found,
     )
 
     return post_state
 
 
-def tick_and_run_on_attestation(spec, store, attestation, test_steps):
+def tick_and_run_on_attestation(spec, store, attestation, test_steps, is_from_block=False):
     parent_block = store.blocks[attestation.data.beacon_block_root]
     pre_state = store.block_states[spec.hash_tree_root(parent_block)]
     block_time = pre_state.genesis_time + parent_block.slot * spec.config.SECONDS_PER_SLOT
@@ -53,40 +52,21 @@ def tick_and_run_on_attestation(spec, store, attestation, test_steps):
         spec.on_tick(store, next_epoch_time)
         test_steps.append({'tick': int(next_epoch_time)})
 
-    spec.on_attestation(store, attestation)
+    spec.on_attestation(store, attestation, is_from_block=is_from_block)
     yield get_attestation_file_name(attestation), attestation
     test_steps.append({'attestation': get_attestation_file_name(attestation)})
 
 
-def add_attestation(spec, store, attestation, test_steps, valid=True):
-    yield get_attestation_file_name(attestation), attestation
-
+def run_on_attestation(spec, store, attestation, is_from_block=False, valid=True):
     if not valid:
         try:
-            run_on_attestation(spec, store, attestation, valid=True)
-        except AssertionError:
-            test_steps.append({
-                'attestation': get_attestation_file_name(attestation),
-                'valid': False,
-            })
-            return
-        else:
-            assert False
-
-    run_on_attestation(spec, store, attestation, valid=True)
-    test_steps.append({'attestation': get_attestation_file_name(attestation)})
-
-
-def run_on_attestation(spec, store, attestation, valid=True):
-    if not valid:
-        try:
-            spec.on_attestation(store, attestation)
+            spec.on_attestation(store, attestation, is_from_block)
         except AssertionError:
             return
         else:
             assert False
 
-    spec.on_attestation(store, attestation)
+    spec.on_attestation(store, attestation, is_from_block)
 
 
 def get_genesis_forkchoice_store(spec, genesis_state):
@@ -131,7 +111,6 @@ def add_block(spec,
               signed_block,
               test_steps,
               valid=True,
-              allow_invalid_attestations=False,
               block_not_found=False):
     """
     Run on_block and on_attestation
@@ -156,14 +135,8 @@ def add_block(spec,
     test_steps.append({'block': get_block_file_name(signed_block)})
 
     # An on_block step implies receiving block's attestations
-    try:
-        for attestation in signed_block.message.body.attestations:
-            run_on_attestation(spec, store, attestation, valid=True)
-    except AssertionError:
-        if allow_invalid_attestations:
-            pass
-        else:
-            raise
+    for attestation in signed_block.message.body.attestations:
+        run_on_attestation(spec, store, attestation, is_from_block=True, valid=True)
 
     block_root = signed_block.message.hash_tree_root()
     print(encode_hex(block_root))

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -60,13 +60,13 @@ def tick_and_run_on_attestation(spec, store, attestation, test_steps, is_from_bl
 def run_on_attestation(spec, store, attestation, is_from_block=False, valid=True):
     if not valid:
         try:
-            spec.on_attestation(store, attestation, is_from_block)
+            spec.on_attestation(store, attestation, is_from_block=is_from_block)
         except AssertionError:
             return
         else:
             assert False
 
-    spec.on_attestation(store, attestation, is_from_block)
+    spec.on_attestation(store, attestation, is_from_block=is_from_block)
 
 
 def get_genesis_forkchoice_store(spec, genesis_state):
@@ -139,7 +139,6 @@ def add_block(spec,
         run_on_attestation(spec, store, attestation, is_from_block=True, valid=True)
 
     block_root = signed_block.message.hash_tree_root()
-    print(encode_hex(block_root))
     assert store.blocks[block_root] == signed_block.message
     assert store.block_states[block_root].hash_tree_root() == signed_block.message.state_root
     test_steps.append({
@@ -160,7 +159,6 @@ def add_block(spec,
             },
         }
     })
-    print(test_steps[-1])
 
     return store.block_states[signed_block.message.hash_tree_root()]
 

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -166,6 +166,7 @@ def add_block(spec,
             raise
 
     block_root = signed_block.message.hash_tree_root()
+    print(encode_hex(block_root))
     assert store.blocks[block_root] == signed_block.message
     assert store.block_states[block_root].hash_tree_root() == signed_block.message.state_root
     test_steps.append({
@@ -186,6 +187,7 @@ def add_block(spec,
             },
         }
     })
+    print(test_steps[-1])
 
     return store.block_states[signed_block.message.hash_tree_root()]
 

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
@@ -694,21 +694,13 @@ def test_new_finalized_slot_is_justified_checkpoint_ancestor(spec, state):
 
     pre_store_justified_checkpoint_root = store.justified_checkpoint.root
     for block in all_blocks:
-        # FIXME: Once `on_block` and `on_attestation` logic is fixed,
-        # fix test case and remove allow_invalid_attestations flag
         yield from tick_and_add_block(spec, store, block, test_steps)
 
     finalized_slot = spec.compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     ancestor_at_finalized_slot = spec.get_ancestor(store, pre_store_justified_checkpoint_root, finalized_slot)
     assert ancestor_at_finalized_slot == store.finalized_checkpoint.root
 
-    print(store.finalized_checkpoint)
-    print(store.justified_checkpoint)
-    print(another_state.current_justified_checkpoint)
-    print('spec.get_head(store)', spec.get_head(store))
-
     assert store.finalized_checkpoint == another_state.finalized_checkpoint
-    # Thus should fail with the fix. Once show fail, swap to ==
     assert store.justified_checkpoint == another_state.current_justified_checkpoint
 
     yield 'steps', test_steps

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
@@ -618,20 +618,19 @@ def test_new_finalized_slot_is_not_justified_checkpoint_ancestor(spec, state):
     assert state.finalized_checkpoint != another_state.finalized_checkpoint
     assert state.current_justified_checkpoint != another_state.current_justified_checkpoint
 
-    # pre_store_justified_checkpoint_root = store.justified_checkpoint.root
+    pre_store_justified_checkpoint_root = store.justified_checkpoint.root
 
-    # FIXME: pending on the `on_block`, `on_attestation` fix
-    # # Apply blocks of `another_state` to `store`
-    # for block in all_blocks:
-    #     # NOTE: Do not call `on_tick` here
-    #     yield from add_block(spec, store, block, test_steps)
+    # Apply blocks of `another_state` to `store`
+    for block in all_blocks:
+        # NOTE: Do not call `on_tick` here
+        yield from add_block(spec, store, block, test_steps)
 
-    # finalized_slot = spec.compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
-    # ancestor_at_finalized_slot = spec.get_ancestor(store, pre_store_justified_checkpoint_root, finalized_slot)
-    # assert ancestor_at_finalized_slot != store.finalized_checkpoint.root
+    finalized_slot = spec.compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+    ancestor_at_finalized_slot = spec.get_ancestor(store, pre_store_justified_checkpoint_root, finalized_slot)
+    assert ancestor_at_finalized_slot != store.finalized_checkpoint.root
 
-    # assert store.finalized_checkpoint == another_state.finalized_checkpoint
-    # assert store.justified_checkpoint == another_state.current_justified_checkpoint
+    assert store.finalized_checkpoint == another_state.finalized_checkpoint
+    assert store.justified_checkpoint == another_state.current_justified_checkpoint
 
     yield 'steps', test_steps
 

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
@@ -658,6 +658,7 @@ def test_new_finalized_slot_is_justified_checkpoint_ancestor(spec, state):
     """
     test_steps = []
     # Initialization
+    print("INIT")
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield 'anchor_state', state
     yield 'anchor_block', anchor_block
@@ -679,12 +680,14 @@ def test_new_finalized_slot_is_justified_checkpoint_ancestor(spec, state):
         state, store, _ = yield from apply_next_epoch_with_attestations(
             spec, state, store, False, True, test_steps=test_steps)
 
+    print("INIT FIN")
     assert state.finalized_checkpoint.epoch == store.finalized_checkpoint.epoch == 2
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 4
     assert store.justified_checkpoint == state.current_justified_checkpoint
 
     # Create another chain
     # Forking from epoch 3
+    print("FORK")
     all_blocks = []
     slot = spec.compute_start_slot_at_epoch(3)
     block_root = spec.get_block_root_at_slot(state, slot)
@@ -696,6 +699,7 @@ def test_new_finalized_slot_is_justified_checkpoint_ancestor(spec, state):
     assert another_state.finalized_checkpoint.epoch == 3
     assert another_state.current_justified_checkpoint.epoch == 4
 
+    print("APPLY FORK TO FORK CHOICE")
     pre_store_justified_checkpoint_root = store.justified_checkpoint.root
     for block in all_blocks:
         # FIXME: Once `on_block` and `on_attestation` logic is fixed,
@@ -707,6 +711,9 @@ def test_new_finalized_slot_is_justified_checkpoint_ancestor(spec, state):
     assert ancestor_at_finalized_slot == store.finalized_checkpoint.root
 
     assert store.finalized_checkpoint == another_state.finalized_checkpoint
+    # Thus should fail with the fix. Once show fail, swap to ==
     assert store.justified_checkpoint != another_state.current_justified_checkpoint
+    print(store.finalized_checkpoint)
+    print(store.justified_checkpoint)
 
     yield 'steps', test_steps


### PR DESCRIPTION
When finalized is updated, the fork choice should *always* update to the justification that finalized the new checkpoint atomically with the finality update.

This document goes into the problem unearthed and the solution -- https://notes.ethereum.org/YfStc2i6Rgenk_gzhEojfQ?view

Note that this bug can only be triggered on mainnet with >1/3 slashing, and if you are willing to do that, there are plenty of much more interesting attacks you'd probably pull off. This patch is a *must* prior to the Merge (along with proposer boosting!)

Thank you @realbigsean and @paulhauner for bringing the issue to our attention!

---------

@adiasg's comment copied from [below](https://github.com/ethereum/consensus-specs/pull/2727#pullrequestreview-812756853):

This PR makes 2 changes:
1. Only make atomic updates to store (as discussed above)
2. Allow old attestations from blocks to be processed

Fix for atomic updates to store looks good.
Also good to move ahead with processing old attestations from blocks for now - that's the only way to make atomic updates to the store work in our current testing setup. If that changes in the future, this logic should go through security analysis (esp. for flip-flop attacks).

