### PR TITLE
Rename coinbase to fee_recipient

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -167,7 +167,7 @@ class BeaconState(Container):
 class ExecutionPayload(Container):
     # Execution block header fields
     parent_hash: Hash32
-    coinbase: ExecutionAddress  # 'beneficiary' in the yellow paper
+    fee_recipient: ExecutionAddress  # 'beneficiary' in the yellow paper
     state_root: Bytes32
     receipt_root: Bytes32  # 'receipts root' in the yellow paper
     logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
@@ -189,7 +189,7 @@ class ExecutionPayload(Container):
 class ExecutionPayloadHeader(Container):
     # Execution block header fields
     parent_hash: Hash32
-    coinbase: ExecutionAddress
+    fee_recipient: ExecutionAddress
     state_root: Bytes32
     receipt_root: Bytes32
     logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
@@ -357,7 +357,7 @@ def process_execution_payload(state: BeaconState, payload: ExecutionPayload, exe
     # Cache execution payload header
     state.latest_execution_payload_header = ExecutionPayloadHeader(
         parent_hash=payload.parent_hash,
-        coinbase=payload.coinbase,
+        fee_recipient=payload.fee_recipient,
         state_root=payload.state_root,
         receipt_root=payload.receipt_root,
         logs_bloom=payload.logs_bloom,

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -77,7 +77,7 @@ Used to signal to initiate the payload build process via `notify_forkchoice_upda
 class PayloadAttributes(object):
     timestamp: uint64
     random: Bytes32
-    fee_recipient: ExecutionAddress
+    suggested_fee_recipient: ExecutionAddress
 ```
 
 ### `PowBlock`

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -109,18 +109,18 @@ All validator responsibilities remain unchanged other than those noted below. Na
 
 To obtain an execution payload, a block proposer building a block on top of a `state` must take the following actions:
 
-1. Set `payload_id = prepare_execution_payload(state, pow_chain, finalized_block_hash, fee_recipient, execution_engine)`, where:
+1. Set `payload_id = prepare_execution_payload(state, pow_chain, finalized_block_hash, suggested_fee_recipient, execution_engine)`, where:
     * `state` is the state object after applying `process_slots(state, slot)` transition to the resulting state of the parent block processing
     * `pow_chain` is a `Dict[Hash32, PowBlock]` dictionary that abstractly represents all blocks in the PoW chain with block hash as the dictionary key
     * `finalized_block_hash` is the hash of the latest finalized execution payload (`Hash32()` if none yet finalized)
-    * `fee_recipient` is the value suggested to be used for the `coinbase` field of the execution payload
+    * `suggested_fee_recipient` is the value suggested to be used for the `fee_recipient` field of the execution payload
 
 
 ```python
 def prepare_execution_payload(state: BeaconState,
                               pow_chain: Dict[Hash32, PowBlock],
                               finalized_block_hash: Hash32,
-                              fee_recipient: ExecutionAddress,
+                              suggested_fee_recipient: ExecutionAddress,
                               execution_engine: ExecutionEngine) -> Optional[PayloadId]:
     if not is_merge_complete(state):
         is_terminal_block_hash_set = TERMINAL_BLOCK_HASH != Hash32()
@@ -143,7 +143,7 @@ def prepare_execution_payload(state: BeaconState,
     payload_attributes = PayloadAttributes(
         timestamp=compute_timestamp_at_slot(state, state.slot),
         random=get_randao_mix(state, get_current_epoch(state)),
-        fee_recipient=fee_recipient,
+        suggested_fee_recipient=suggested_fee_recipient,
     )
     return execution_engine.notify_forkchoice_updated(parent_hash, finalized_block_hash, payload_attributes)
 ```

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -11,7 +11,7 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
 
     payload = spec.ExecutionPayload(
         parent_hash=latest.block_hash,
-        coinbase=spec.ExecutionAddress(),
+        fee_recipient=spec.ExecutionAddress(),
         state_root=latest.state_root,  # no changes to the state
         receipt_root=b"no receipts here" + b"\x00" * 16,  # TODO: root of empty MPT may be better.
         logs_bloom=spec.ByteVector[spec.BYTES_PER_LOGS_BLOOM](),  # TODO: zeroed logs bloom for empty logs ok?
@@ -34,7 +34,7 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
 def get_execution_payload_header(spec, execution_payload):
     return spec.ExecutionPayloadHeader(
         parent_hash=execution_payload.parent_hash,
-        coinbase=execution_payload.coinbase,
+        fee_recipient=execution_payload.fee_recipient,
         state_root=execution_payload.state_root,
         receipt_root=execution_payload.receipt_root,
         logs_bloom=execution_payload.logs_bloom,

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -26,7 +26,7 @@ def get_sample_genesis_execution_payload_header(spec,
         eth1_block_hash = b'\x55' * 32
     return spec.ExecutionPayloadHeader(
         parent_hash=b'\x30' * 32,
-        coinbase=b'\x42' * 20,
+        fee_recipient=b'\x42' * 20,
         state_root=b'\x20' * 32,
         receipt_root=b'\x20' * 32,
         logs_bloom=b'\x35' * spec.BYTES_PER_LOGS_BLOOM,


### PR DESCRIPTION
Relates to https://github.com/ethereum/execution-apis/pull/130

Renames:
* `coinbase` to `fee_recipient`
* `fee_recipient` to `suggested_fee_recipient`

cc @MicahZoltu 

-------------

**Note**: Due to how SSZ serialization and hashing works, this is *non-substantive* and instead only cosmetic