### PR TITLE
Add `proposer_boost_root` field to test vector "checks" step

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -157,6 +157,7 @@ def add_block(spec,
                 'epoch': int(store.best_justified_checkpoint.epoch),
                 'root': encode_hex(store.best_justified_checkpoint.root),
             },
+            'proposer_boost_root': encode_hex(store.proposer_boost_root),
         }
     })
 

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -110,6 +110,7 @@ best_justified_checkpoint: {
     epoch: int,               -- Integer value from store.best_justified_checkpoint.epoch
     root: string,             -- Encoded 32-byte value from store.best_justified_checkpoint.root
 }
+proposer_boost_root: string   -- Encoded 32-byte value from store.proposer_boost_root
 ```
 
 For example:
@@ -120,6 +121,7 @@ For example:
     justified_checkpoint: {epoch: 3, root: '0xc25faab4acab38d3560864ca01e4d5cc4dc2cd473da053fbc03c2669143a2de4'}
     finalized_checkpoint: {epoch: 2, root: '0x40d32d6283ec11c53317a46808bc88f55657d93b95a1af920403187accf48f4f'}
     best_justified_checkpoint: {epoch: 3, root: '0xc25faab4acab38d3560864ca01e4d5cc4dc2cd473da053fbc03c2669143a2de4'}
+    proposer_boost_root: '0xdaa1d49d57594ced0c35688a6da133abb086d191a2ebdfd736fad95299325aeb'
 ```
 
 *Note*: Each `checks` step may include one or multiple items. Each item has to be checked against the current store.


### PR DESCRIPTION
### Summary
To make debugging easier, this PR adds `proposer_boost_root` field to our test vector outputs.
