### PR TITLE
is_merge -> is_merge_transition

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -24,8 +24,8 @@
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
 - [Helper functions](#helper-functions)
   - [Predicates](#predicates)
-    - [`is_merge_complete`](#is_merge_complete)
-    - [`is_merge_block`](#is_merge_block)
+    - [`is_merge_transition_complete`](#is_merge_transition_complete)
+    - [`is_merge_transition_block`](#is_merge_transition_block)
     - [`is_execution_enabled`](#is_execution_enabled)
   - [Misc](#misc)
     - [`compute_timestamp_at_slot`](#compute_timestamp_at_slot)
@@ -209,25 +209,25 @@ class ExecutionPayloadHeader(Container):
 
 ### Predicates
 
-#### `is_merge_complete`
+#### `is_merge_transition_complete`
 
 ```python
-def is_merge_complete(state: BeaconState) -> bool:
+def is_merge_transition_complete(state: BeaconState) -> bool:
     return state.latest_execution_payload_header != ExecutionPayloadHeader()
 ```
 
-#### `is_merge_block`
+#### `is_merge_transition_block`
 
 ```python
-def is_merge_block(state: BeaconState, body: BeaconBlockBody) -> bool:
-    return not is_merge_complete(state) and body.execution_payload != ExecutionPayload()
+def is_merge_transition_block(state: BeaconState, body: BeaconBlockBody) -> bool:
+    return not is_merge_transition_complete(state) and body.execution_payload != ExecutionPayload()
 ```
 
 #### `is_execution_enabled`
 
 ```python
 def is_execution_enabled(state: BeaconState, body: BeaconBlockBody) -> bool:
-    return is_merge_block(state, body) or is_merge_complete(state)
+    return is_merge_transition_block(state, body) or is_merge_transition_complete(state)
 ```
 
 ### Misc
@@ -346,7 +346,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 ```python
 def process_execution_payload(state: BeaconState, payload: ExecutionPayload, execution_engine: ExecutionEngine) -> None:
     # Verify consistency of the parent hash with respect to the previous execution payload header
-    if is_merge_complete(state):
+    if is_merge_transition_complete(state):
         assert payload.parent_hash == state.latest_execution_payload_header.block_hash
     # Verify random
     assert payload.random == get_randao_mix(state, get_current_epoch(state))

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -167,7 +167,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     state_transition(state, signed_block, True)
 
     # [New in Merge]
-    if is_merge_block(pre_state, block.body):
+    if is_merge_transition_block(pre_state, block.body):
         validate_merge_block(block)
 
     # Add new block to the store

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -123,7 +123,7 @@ def prepare_execution_payload(state: BeaconState,
                               finalized_block_hash: Hash32,
                               suggested_fee_recipient: ExecutionAddress,
                               execution_engine: ExecutionEngine) -> Optional[PayloadId]:
-    if not is_merge_complete(state):
+    if not is_merge_transition_complete(state):
         is_terminal_block_hash_set = TERMINAL_BLOCK_HASH != Hash32()
         is_activation_epoch_reached = get_current_epoch(state.slot) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
         if is_terminal_block_hash_set and not is_activation_epoch_reached:

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -28,7 +28,7 @@ def tick_and_add_block(spec, store, signed_block, test_steps, valid=True,
     pre_state = store.block_states[signed_block.message.parent_root]
     block_time = pre_state.genesis_time + signed_block.message.slot * spec.config.SECONDS_PER_SLOT
     if merge_block:
-        assert spec.is_merge_block(pre_state, signed_block.message.body)
+        assert spec.is_merge_transition_block(pre_state, signed_block.message.body)
 
     if store.time < block_time:
         on_tick_and_append_step(spec, store, block_time, test_steps)

--- a/tests/core/pyspec/eth2spec/test/merge/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/merge/genesis/test_initialization.py
@@ -45,7 +45,7 @@ def test_initialize_pre_transition_no_param(spec):
     yield 'execution_payload_header', 'meta', False
     state = spec.initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)
 
-    assert not spec.is_merge_complete(state)
+    assert not spec.is_merge_transition_complete(state)
 
     yield 'state', state
 
@@ -79,7 +79,7 @@ def test_initialize_pre_transition_empty_payload(spec):
         execution_payload_header=execution_payload_header,
     )
 
-    assert not spec.is_merge_complete(state)
+    assert not spec.is_merge_transition_complete(state)
 
     yield 'execution_payload_header', execution_payload_header
 
@@ -117,6 +117,6 @@ def test_initialize_post_transition(spec):
 
     yield 'execution_payload_header', genesis_execution_payload_header
 
-    assert spec.is_merge_complete(state)
+    assert spec.is_merge_transition_complete(state)
 
     yield 'state', state

--- a/tests/core/pyspec/eth2spec/test/merge/unittests/test_transition.py
+++ b/tests/core/pyspec/eth2spec/test/merge/unittests/test_transition.py
@@ -13,17 +13,17 @@ from eth2spec.test.context import (
 @spec_state_test
 def test_fail_merge_complete(spec, state):
     state = build_state_with_incomplete_transition(spec, state)
-    assert not spec.is_merge_complete(state)
+    assert not spec.is_merge_transition_complete(state)
 
 
 @with_merge_and_later
 @spec_state_test
 def test_success_merge_complete(spec, state):
     state = build_state_with_complete_transition(spec, state)
-    assert spec.is_merge_complete(state)
+    assert spec.is_merge_transition_complete(state)
 
 
-# with_complete_transition', 'with_execution_payload', 'is_merge_block', 'is_execution_enabled'
+# with_complete_transition', 'with_execution_payload', 'is_merge_transition_block', 'is_execution_enabled'
 expected_results = [
     (True, True, False, True),
     (True, False, False, True),
@@ -39,7 +39,7 @@ def test_is_merge_block_and_is_execution_enabled(spec, state):
         (
             with_complete_transition,
             with_execution_payload,
-            is_merge_block,
+            is_merge_transition_block,
             is_execution_enabled
         ) = result
         if with_complete_transition:
@@ -51,5 +51,5 @@ def test_is_merge_block_and_is_execution_enabled(spec, state):
         if with_execution_payload:
             body.execution_payload = build_empty_execution_payload(spec, state)
 
-        assert spec.is_merge_block(state, body) == is_merge_block
+        assert spec.is_merge_transition_block(state, body) == is_merge_transition_block
         assert spec.is_execution_enabled(state, body) == is_execution_enabled


### PR DESCRIPTION
in eip 3675, the first PoS block is called the `TRANSITION_BLOCK`. We called it the `merge_block` here. 

I agree that `transition` is a bit vague for the specs as it could easily collide with a name in a subsequent upgrade, so I suggest making it explicit in these names -- `merge_transition`