### PR TITLE
Bring more clarity to notify_forkchoice_updated calls

### DIFF
--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -66,7 +66,7 @@ def notify_forkchoice_updated(self: ExecutionEngine,
 *Note*: The call of the `notify_forkchoice_updated` function maps on the `POS_FORKCHOICE_UPDATED` event defined in the [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions).
 As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice_updated` MUST be called with `finalized_block_hash = Hash32()`.
 
-*Note*: Client software MUST NOT call this function until the transition conditions are met on the PoW network, i.e. there exist a block for which `is_valid_terminal_pow_block` function returns `True`.
+*Note*: Client software MUST NOT call this function until the transition conditions are met on the PoW network, i.e. there exists a block for which `is_valid_terminal_pow_block` function returns `True`.
 
 *Note*: Client software MUST call this function to initiate the payload build process to produce the merge transition block; the `head_block_hash` parameter MUST be set to the hash of a terminal PoW block in this case.
 

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -64,9 +64,9 @@ def notify_forkchoice_updated(self: ExecutionEngine,
 ```
 
 *Note*: The call of the `notify_forkchoice_updated` function maps on the `POS_FORKCHOICE_UPDATED` event defined in the [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions).
-As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice_updated` must be called with `finalized_block_hash = Hash32()`.
+As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice_updated` MUST be called with `finalized_block_hash = Hash32()`.
 
-*Note*: Client software must not call this function as long as the paylod of the head of the chain is empty, i.e. `get_head(store).body.payload == ExecutionPayload()`.
+*Note*: Client software MUST NOT call this function until the transition conditions are met on the PoW network, i.e. there exist a block for which `is_valid_terminal_pow_block` function returns `True`.
 
 *Note*: Client software MUST call this function to initiate the payload build process to produce the merge transition block; the `head_block_hash` parameter MUST be set to the hash of a terminal PoW block in this case.
 

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -66,6 +66,10 @@ def notify_forkchoice_updated(self: ExecutionEngine,
 *Note*: The call of the `notify_forkchoice_updated` function maps on the `POS_FORKCHOICE_UPDATED` event defined in the [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions).
 As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice_updated` must be called with `finalized_block_hash = Hash32()`.
 
+*Note*: Client software must not call this function as long as the paylod of the head of the chain is empty, i.e. `get_head(store).body.payload == ExecutionPayload()`.
+
+*Note*: Client software must call this function to initiate payload build process to produce the merge transition block, in this case the `head_block_hash` parameter must be set to the hash of a terminal PoW block.
+
 ## Helpers
 
 ### `PayloadAttributes`

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -68,7 +68,7 @@ As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice
 
 *Note*: Client software must not call this function as long as the paylod of the head of the chain is empty, i.e. `get_head(store).body.payload == ExecutionPayload()`.
 
-*Note*: Client software must call this function to initiate payload build process to produce the merge transition block, in this case the `head_block_hash` parameter must be set to the hash of a terminal PoW block.
+*Note*: Client software MUST call this function to initiate the payload build process to produce the merge transition block; the `head_block_hash` parameter MUST be set to the hash of a terminal PoW block in this case.
 
 ## Helpers
 


### PR DESCRIPTION
This PR clarifies two things:
* `notify_forkchoice_updated` must not be called if a block with empty payload becomes the head of the chain
* `notify_forkchoice_updated` must be called with `head_block_hash = terminal_pow_block.block_hash` if it attempts to initiate build process of the payload for the merge transition block; this case is also specified in the `validator.md` in a form of python code hence isn't that obvious