### PR TITLE
import `Spec` objects for each test case

### DIFF
--- a/tests/core/pyspec/eth2spec/test/merge/fork_choice/test_on_merge_block.py
+++ b/tests/core/pyspec/eth2spec/test/merge/fork_choice/test_on_merge_block.py
@@ -1,9 +1,10 @@
 from eth2spec.utils.ssz.ssz_typing import uint256
 from eth2spec.test.exceptions import BlockNotFoundException
-from eth2spec.test.context import spec_state_test, with_phases, MERGE
+from eth2spec.test.context import spec_state_test, with_phases
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
+from eth2spec.test.helpers.constants import MERGE
 from eth2spec.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
     on_tick_and_append_step,

--- a/tests/core/pyspec/eth2spec/test/merge/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/merge/genesis/test_initialization.py
@@ -1,12 +1,14 @@
 from eth2spec.test.context import (
-    MERGE,
     single_phase,
     spec_test,
     with_presets,
     with_phases,
     with_merge_and_later,
 )
-from eth2spec.test.helpers.constants import MINIMAL
+from eth2spec.test.helpers.constants import (
+    MERGE,
+    MINIMAL,
+)
 from eth2spec.test.helpers.deposits import (
     prepare_full_genesis_deposits,
 )

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_ex_ante.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_ex_ante.py
@@ -1,5 +1,4 @@
 from eth2spec.test.context import (
-    MAINNET,
     spec_configured_state_test,
     spec_state_test,
     with_all_phases,
@@ -12,6 +11,7 @@ from eth2spec.test.helpers.attestations import (
 from eth2spec.test.helpers.block import (
     build_empty_block,
 )
+from eth2spec.test.helpers.constants import MAINNET
 from eth2spec.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
     on_tick_and_append_step,


### PR DESCRIPTION
### Issue

1. `spec_configured_state_test` is not thread-safe:
    - The given `spec: Spec` object was initialized with global `spec_targets` in `context.py`.
    -  `spec_configured_state_test` overrides `spec.config`, execute the test case, and then change it back to the unchanged config.
    - In multi-processing or multi-thread context, if a config field is overridden when running one test case, the `spec.config` object in other concurrent tasks might be changed too.
2. pytest-xdist implemented parallelization with subprocess.
3. We want to make the test generator parallelable!

Due to 1+2, #2752 failed because some of the ex-ante tests override `spec.config.PROPOSER_SCORE_BOOST` temporarily, and then concurrently, `test_proposer_boost_correct_head` failed because it wrongly used the overridden value.

### How did I fix it

To better isolate the test cases, it would be better to reduce the risk of these side effects. This PR tries to import `Spec` objects for *each* test case. The solution was found from [here](https://stackoverflow.com/a/11285504) and [here](https://docs.python.org/3/library/importlib.html#implementing-lazy-imports).
