### PR TITLE
Name generalized index constants as _GINDEX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -475,8 +475,8 @@ def get_generalized_index(ssz_class: Any, *path: Sequence[PyUnion[int, SSZVariab
     @classmethod
     def hardcoded_ssz_dep_constants(cls) -> Dict[str, str]:
         constants = {
-            'FINALIZED_ROOT_INDEX': 'GeneralizedIndex(105)',
-            'NEXT_SYNC_COMMITTEE_INDEX': 'GeneralizedIndex(55)',
+            'FINALIZED_ROOT_GINDEX': 'GeneralizedIndex(105)',
+            'NEXT_SYNC_COMMITTEE_GINDEX': 'GeneralizedIndex(55)',
         }
         return {**super().hardcoded_ssz_dep_constants(), **constants}
 

--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -40,8 +40,8 @@ uses sync committees introduced in [this beacon chain extension](./beacon-chain.
 
 | Name | Value |
 | - | - |
-| `FINALIZED_ROOT_INDEX` | `get_generalized_index(BeaconState, 'finalized_checkpoint', 'root')` |
-| `NEXT_SYNC_COMMITTEE_INDEX` | `get_generalized_index(BeaconState, 'next_sync_committee')` |
+| `FINALIZED_ROOT_GINDEX` | `get_generalized_index(BeaconState, 'finalized_checkpoint', 'root')` |
+| `NEXT_SYNC_COMMITTEE_GINDEX` | `get_generalized_index(BeaconState, 'next_sync_committee')` |
 
 ## Preset
 
@@ -72,10 +72,10 @@ class LightClientUpdate(Container):
     header: BeaconBlockHeader
     # Next sync committee corresponding to the header
     next_sync_committee: SyncCommittee
-    next_sync_committee_branch: Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_INDEX)]
+    next_sync_committee_branch: Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX)]
     # Finality proof for the update header
     finality_header: BeaconBlockHeader
-    finality_branch: Vector[Bytes32, floorlog2(FINALIZED_ROOT_INDEX)]
+    finality_branch: Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX)]
     # Sync committee aggregate signature
     sync_committee_bits: Bitvector[SYNC_COMMITTEE_SIZE]
     sync_committee_signature: BLSSignature
@@ -122,28 +122,28 @@ def validate_light_client_update(snapshot: LightClientSnapshot,
     # Verify update header root is the finalized root of the finality header, if specified
     if update.finality_header == BeaconBlockHeader():
         signed_header = update.header
-        assert update.finality_branch == [Bytes32() for _ in range(floorlog2(FINALIZED_ROOT_INDEX))]
+        assert update.finality_branch == [Bytes32() for _ in range(floorlog2(FINALIZED_ROOT_GINDEX))]
     else:
         signed_header = update.finality_header
         assert is_valid_merkle_branch(
             leaf=hash_tree_root(update.header),
             branch=update.finality_branch,
-            depth=floorlog2(FINALIZED_ROOT_INDEX),
-            index=get_subtree_index(FINALIZED_ROOT_INDEX),
+            depth=floorlog2(FINALIZED_ROOT_GINDEX),
+            index=get_subtree_index(FINALIZED_ROOT_GINDEX),
             root=update.finality_header.state_root,
         )
 
     # Verify update next sync committee if the update period incremented
     if update_period == snapshot_period:
         sync_committee = snapshot.current_sync_committee
-        assert update.next_sync_committee_branch == [Bytes32() for _ in range(floorlog2(NEXT_SYNC_COMMITTEE_INDEX))]
+        assert update.next_sync_committee_branch == [Bytes32() for _ in range(floorlog2(NEXT_SYNC_COMMITTEE_GINDEX))]
     else:
         sync_committee = snapshot.next_sync_committee
         assert is_valid_merkle_branch(
             leaf=hash_tree_root(update.next_sync_committee),
             branch=update.next_sync_committee_branch,
-            depth=floorlog2(NEXT_SYNC_COMMITTEE_INDEX),
-            index=get_subtree_index(NEXT_SYNC_COMMITTEE_INDEX),
+            depth=floorlog2(NEXT_SYNC_COMMITTEE_GINDEX),
+            index=get_subtree_index(NEXT_SYNC_COMMITTEE_GINDEX),
             root=update.header.state_root,
         )
 

--- a/tests/core/pyspec/eth2spec/test/altair/merkle/test_single_proof.py
+++ b/tests/core/pyspec/eth2spec/test/altair/merkle/test_single_proof.py
@@ -9,17 +9,17 @@ from eth2spec.test.helpers.merkle import build_proof
 @spec_state_test
 def test_next_sync_committee_merkle_proof(spec, state):
     yield "state", state
-    next_sync_committee_branch = build_proof(state.get_backing(), spec.NEXT_SYNC_COMMITTEE_INDEX)
+    next_sync_committee_branch = build_proof(state.get_backing(), spec.NEXT_SYNC_COMMITTEE_GINDEX)
     yield "proof", {
         "leaf": "0x" + state.next_sync_committee.hash_tree_root().hex(),
-        "leaf_index": spec.NEXT_SYNC_COMMITTEE_INDEX,
+        "leaf_index": spec.NEXT_SYNC_COMMITTEE_GINDEX,
         "branch": ['0x' + root.hex() for root in next_sync_committee_branch]
     }
     assert spec.is_valid_merkle_branch(
         leaf=state.next_sync_committee.hash_tree_root(),
         branch=next_sync_committee_branch,
-        depth=spec.floorlog2(spec.NEXT_SYNC_COMMITTEE_INDEX),
-        index=spec.get_subtree_index(spec.NEXT_SYNC_COMMITTEE_INDEX),
+        depth=spec.floorlog2(spec.NEXT_SYNC_COMMITTEE_GINDEX),
+        index=spec.get_subtree_index(spec.NEXT_SYNC_COMMITTEE_GINDEX),
         root=state.hash_tree_root(),
     )
 
@@ -28,17 +28,17 @@ def test_next_sync_committee_merkle_proof(spec, state):
 @spec_state_test
 def test_finality_root_merkle_proof(spec, state):
     yield "state", state
-    finality_branch = build_proof(state.get_backing(), spec.FINALIZED_ROOT_INDEX)
+    finality_branch = build_proof(state.get_backing(), spec.FINALIZED_ROOT_GINDEX)
     yield "proof", {
         "leaf": "0x" + state.finalized_checkpoint.root.hex(),
-        "leaf_index": spec.FINALIZED_ROOT_INDEX,
+        "leaf_index": spec.FINALIZED_ROOT_GINDEX,
         "branch": ['0x' + root.hex() for root in finality_branch]
     }
 
     assert spec.is_valid_merkle_branch(
         leaf=state.finalized_checkpoint.root,
         branch=finality_branch,
-        depth=spec.floorlog2(spec.FINALIZED_ROOT_INDEX),
-        index=spec.get_subtree_index(spec.FINALIZED_ROOT_INDEX),
+        depth=spec.floorlog2(spec.FINALIZED_ROOT_GINDEX),
+        index=spec.get_subtree_index(spec.FINALIZED_ROOT_GINDEX),
         root=state.hash_tree_root(),
     )

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
@@ -52,13 +52,13 @@ def test_process_light_client_update_not_updated(spec, state):
         block_header.slot,
         committee,
     )
-    next_sync_committee_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.NEXT_SYNC_COMMITTEE_INDEX))]
+    next_sync_committee_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.NEXT_SYNC_COMMITTEE_GINDEX))]
 
     # Ensure that finality checkpoint is genesis
     assert state.finalized_checkpoint.epoch == 0
     # Finality is unchanged
     finality_header = spec.BeaconBlockHeader()
-    finality_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.FINALIZED_ROOT_INDEX))]
+    finality_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.FINALIZED_ROOT_GINDEX))]
 
     update = spec.LightClientUpdate(
         header=block_header,
@@ -121,10 +121,10 @@ def test_process_light_client_update_timeout(spec, state):
     )
 
     # Sync committee is updated
-    next_sync_committee_branch = build_proof(state.get_backing(), spec.NEXT_SYNC_COMMITTEE_INDEX)
+    next_sync_committee_branch = build_proof(state.get_backing(), spec.NEXT_SYNC_COMMITTEE_GINDEX)
     # Finality is unchanged
     finality_header = spec.BeaconBlockHeader()
-    finality_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.FINALIZED_ROOT_INDEX))]
+    finality_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.FINALIZED_ROOT_GINDEX))]
 
     update = spec.LightClientUpdate(
         header=block_header,
@@ -172,11 +172,11 @@ def test_process_light_client_update_finality_updated(spec, state):
     assert snapshot_period == update_period
 
     # Updated sync_committee and finality
-    next_sync_committee_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.NEXT_SYNC_COMMITTEE_INDEX))]
+    next_sync_committee_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.NEXT_SYNC_COMMITTEE_GINDEX))]
     finalized_block_header = blocks[spec.SLOTS_PER_EPOCH - 1].message
     assert finalized_block_header.slot == spec.compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
     assert finalized_block_header.hash_tree_root() == state.finalized_checkpoint.root
-    finality_branch = build_proof(state.get_backing(), spec.FINALIZED_ROOT_INDEX)
+    finality_branch = build_proof(state.get_backing(), spec.FINALIZED_ROOT_GINDEX)
 
     # Build block header
     block = build_empty_block(spec, state)


### PR DESCRIPTION
Constants in `specs/altair/sync-protocol.md` that represent a generalized index are named _INDEX which may be confused with a regular array or field index. Renaming to _GINDEX clarifies this distinction. 