### PR TITLE
Apply proposer boost to ancestors correctly

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -182,13 +182,15 @@ def get_latest_attesting_balance(store: Store, root: Root) -> Gwei:
             and get_ancestor(store, store.latest_messages[i].root, store.blocks[root].slot) == root)
     ))
     proposer_score = Gwei(0)
-    if store.proposer_boost_root != Root():
-        if get_ancestor(store, store.proposer_boost_root, store.blocks[root].slot) == root:
-            num_validators = len(get_active_validator_indices(state, get_current_epoch(state)))
-            avg_balance = get_total_active_balance(state) // num_validators
-            committee_size = num_validators // SLOTS_PER_EPOCH
-            committee_weight = committee_size * avg_balance
-            proposer_score = (committee_weight * PROPOSER_SCORE_BOOST) // 100
+    if (
+        store.proposer_boost_root != Root()
+        and get_ancestor(store, store.proposer_boost_root, store.blocks[root].slot) == root
+    ):
+        num_validators = len(get_active_validator_indices(state, get_current_epoch(state)))
+        avg_balance = get_total_active_balance(state) // num_validators
+        committee_size = num_validators // SLOTS_PER_EPOCH
+        committee_weight = committee_size * avg_balance
+        proposer_score = (committee_weight * PROPOSER_SCORE_BOOST) // 100
     return attestation_score + proposer_score
 
 ```

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -184,6 +184,7 @@ def get_latest_attesting_balance(store: Store, root: Root) -> Gwei:
     if store.proposer_boost_root == Root():
         # Return only attestation score if ``proposer_boost_root`` is not set
         return attestation_score
+
     # Calculate proposer score if ``proposer_boost_root`` is set
     proposer_score = Gwei(0)
     # Boost is applied if ``root`` is an ancestor of ``proposer_boost_root``

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -181,11 +181,13 @@ def get_latest_attesting_balance(store: Store, root: Root) -> Gwei:
         if (i in store.latest_messages
             and get_ancestor(store, store.latest_messages[i].root, store.blocks[root].slot) == root)
     ))
+    if store.proposer_boost_root == Root():
+        # Return only attestation score if ``proposer_boost_root`` is not set
+        return attestation_score
+    # Calculate proposer score if ``proposer_boost_root`` is set
     proposer_score = Gwei(0)
-    if (
-        store.proposer_boost_root != Root()
-        and get_ancestor(store, store.proposer_boost_root, store.blocks[root].slot) == root
-    ):
+    # Boost is applied if ``root`` is an ancestor of ``proposer_boost_root``
+    if get_ancestor(store, store.proposer_boost_root, store.blocks[root].slot) == root:
         num_validators = len(get_active_validator_indices(state, get_current_epoch(state)))
         avg_balance = get_total_active_balance(state) // num_validators
         committee_size = num_validators // SLOTS_PER_EPOCH

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -182,12 +182,13 @@ def get_latest_attesting_balance(store: Store, root: Root) -> Gwei:
             and get_ancestor(store, store.latest_messages[i].root, store.blocks[root].slot) == root)
     ))
     proposer_score = Gwei(0)
-    if store.proposer_boost_root != Root() and root == store.proposer_boost_root:
-        num_validators = len(get_active_validator_indices(state, get_current_epoch(state)))
-        avg_balance = get_total_active_balance(state) // num_validators
-        committee_size = num_validators // SLOTS_PER_EPOCH
-        committee_weight = committee_size * avg_balance
-        proposer_score = (committee_weight * PROPOSER_SCORE_BOOST) // 100
+    if store.proposer_boost_root != Root():
+        if get_ancestor(store, store.proposer_boost_root, store.blocks[root].slot) == root:
+            num_validators = len(get_active_validator_indices(state, get_current_epoch(state)))
+            avg_balance = get_total_active_balance(state) // num_validators
+            committee_size = num_validators // SLOTS_PER_EPOCH
+            committee_weight = committee_size * avg_balance
+            proposer_score = (committee_weight * PROPOSER_SCORE_BOOST) // 100
     return attestation_score + proposer_score
 
 ```

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
@@ -166,6 +166,9 @@ def test_shorter_chain_but_heavier_weight(spec, state):
     signed_short_block = state_transition_and_sign_block(spec, short_state, short_block)
     yield from tick_and_add_block(spec, store, signed_short_block, test_steps)
 
+    # Since the long chain has higher proposer_score at slot 1, the latest long block is the head
+    assert spec.get_head(store) == spec.hash_tree_root(long_block)
+
     short_attestation = get_valid_attestation(spec, short_state, short_block.slot, signed=True)
     yield from tick_and_run_on_attestation(spec, store, short_attestation, test_steps)
 


### PR DESCRIPTION
Fixes #2757 by correctly applying proposer score boost to ancestors of the boosted block.
This removes the simplification changes from #2753.