### PR TITLE
Formulation of LightClientUpdate.finality_header and finality_branch

### DIFF
--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -126,11 +126,11 @@ def validate_light_client_update(snapshot: LightClientSnapshot,
     else:
         signed_header = update.finality_header
         assert is_valid_merkle_branch(
-            leaf=hash_tree_root(update.header),
+            leaf=hash_tree_root(update.finality_header),
             branch=update.finality_branch,
             depth=floorlog2(FINALIZED_ROOT_INDEX),
             index=get_subtree_index(FINALIZED_ROOT_INDEX),
-            root=update.finality_header.state_root,
+            root=update.header.state_root,
         )
 
     # Verify update next sync committee if the update period incremented


### PR DESCRIPTION
#### Current formulation
```
is_valid_merkle_branch(
            root=update.finality_header.state_root,
            leaf=hash_tree_root(update.header),
            branch=update.finality_branch,
            index=get_subtree_index(FINALIZED_ROOT_INDEX), # FINALIZED_ROOT_INDEX=get_generalized_index(BeaconState, 'finalized_checkpoint', 'root')
            ....
        )
```
This means that the proof `update.finality_branch` is generated from a "finalized state" instead of the "header state". That is, `update.next_sync_committee_branch` is generated from the state of `update.header.state_root`, but the `update.finality_branch` is generated from the finalized state of `update.finality_header.state_root`. Note that in this formulation, "update.finality_header" refers to a block and state that happens _in the future_ of the `update.header`. `update.header` share the same root as `finalized_state.finalized_checkpoint.root`. However, `sync_committee_signature` only validates the `update.header` but has nothing to do with `update.finality_header`. In fact, For any `update.header`, `update.finality_branch` and `update.finality_header` could be generated arbitrarily. No one needs to sign off on `update.finality_header`.

In short, a fraudulent pair (`update.finality_header`, `update.finality_branch`) could be generated to validate any `update.header`.


#### Proposed alternative:
```
is_valid_merkle_branch(
            root=update.header.state_root,
            leaf=hash_tree_root(update.finality_header),
            branch=update.finality_branch,
            index=get_subtree_index(FINALIZED_ROOT_INDEX),
        )
```
The proof `update.finality_branch` is generated from the same beacon-state that `update.next_sync_committee_branch` is generated. `update.finality_header` is a simple expansion of `state.finalized_checkpoint.root` into a BeaconBlockState object. The interpretation is much simpler. The `update.finality_header` refers to a block that happens in the past relative to `update.header`, and it is validated finalized block header, signing off by the current sync committee.

