### PR TITLE
Update per-test config to be unique per-test in `spec_configured_state_test`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -86,10 +86,9 @@ class SpecForks(TypedDict, total=False):
 
 def _prepare_state(balances_fn: Callable[[Any], Sequence[int]], threshold_fn: Callable[[Any], int],
                    spec: Spec, phases: SpecForks):
-    phase = phases[spec.fork]
-    balances = balances_fn(phase)
-    activation_threshold = threshold_fn(phase)
-    state = create_genesis_state(spec=phase, validator_balances=balances,
+    balances = balances_fn(spec)
+    activation_threshold = threshold_fn(spec)
+    state = create_genesis_state(spec=spec, validator_balances=balances,
                                  activation_threshold=activation_threshold)
     return state
 


### PR DESCRIPTION
Alternative fix for the issue addressed in #2755.

As I understand it, the issue there was that using the `spec_configured_state_test` decorator was not "thread-safe" so that any unsynchronized access could cause issues. These issues were seen  in #2752 when executing the tests with `pytest-xdist` which parallelizes tests across multiple cores.

@hwwhww found the issue and suggested a fix w/ lazy loading of the modules in the pyspec.

Rather than go around making multiple copies of various modules, this PR takes a different approach to tests using the `spec_configured_state_test` decorator: simply make a separate copy of the `Spec` object.

As long as instances of `Spec` don't get too big or resource-intensive then we should be able to easily specialize a given `Spec` for each test that uses this decorator by simply making a copy and making the necessary edits.

As far as I can tell, there is no reason to "restore" the spec after mutation as it is discarded after the result from the decorated test is obtained.