### PR TITLE
Add `CONFIG_NAME` to configs

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -3,6 +3,13 @@
 # Extends the mainnet preset
 PRESET_BASE: 'mainnet'
 
+# Free-form short name of the network that this configuration applies to - known
+# canonical network names include:
+# * 'mainnet' - there can be only one
+# * 'prater' - testnet
+# Must match the regex: [a-z0-9\-]
+CONFIG_NAME: 'mainnet'
+
 # Transition
 # ---------------------------------------------------------------
 # TBD, 2**256-2**10 is a placeholder

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -3,6 +3,13 @@
 # Extends the minimal preset
 PRESET_BASE: 'minimal'
 
+# Free-form short name of the network that this configuration applies to - known
+# canonical network names include:
+# * 'mainnet' - there can be only one
+# * 'prater' - testnet
+# Must match the regex: [a-z0-9\-]
+CONFIG_NAME: 'minimal'
+
 # Transition
 # ---------------------------------------------------------------
 # TBD, 2**256-2**10 is a placeholder

--- a/setup.py
+++ b/setup.py
@@ -752,7 +752,7 @@ def parse_config_vars(conf: Dict[str, str]) -> Dict[str, str]:
     """
     out: Dict[str, str] = dict()
     for k, v in conf.items():
-        if isinstance(v, str) and (v.startswith("0x") or k == 'PRESET_BASE'):
+        if isinstance(v, str) and (v.startswith("0x") or k == 'PRESET_BASE' or k == 'CONFIG_NAME'):
             # Represent byte data with string, to avoid misinterpretation as big-endian int.
             # Everything is either byte data or an integer, with PRESET_BASE as one exception.
             out[k] = f"'{v}'"

--- a/tests/core/pyspec/eth2spec/config/config_util.py
+++ b/tests/core/pyspec/eth2spec/config/config_util.py
@@ -14,7 +14,7 @@ def parse_config_vars(conf: Dict[str, Any]) -> Dict[str, Any]:
             out[k] = [int(item) if item.isdigit() else item for item in v]
         elif isinstance(v, str) and v.startswith("0x"):
             out[k] = bytes.fromhex(v[2:])
-        elif k != 'PRESET_BASE':
+        elif k != 'PRESET_BASE' and k != 'CONFIG_NAME':
             out[k] = int(v)
         else:
             out[k] = v


### PR DESCRIPTION
Runtime configurations apply to a certain network and the name of that
network is useful for humans such that they can talk about it.

Some of the existing configs already include a `CONFIG_NAME` toggle -
might as well add it here as well and avoid some confusion - this name
above all becomes useful in the beacon API.

By extension, the `CONFIG_NAME` config will appear in the beacon api as
a result of being defined here.