### PR TITLE
(WIP) Light client p2p interface

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -45,6 +45,7 @@
     - [Modified `process_attestation`](#modified-process_attestation)
     - [Modified `process_deposit`](#modified-process_deposit)
     - [Sync aggregate processing](#sync-aggregate-processing)
+    - [Light Client Update Processing](#light-client-update-processing)
   - [Epoch processing](#epoch-processing)
     - [Justification and finalization](#justification-and-finalization)
     - [Inactivity scores](#inactivity-scores)
@@ -52,6 +53,7 @@
     - [Slashings](#slashings)
     - [Participation flags updates](#participation-flags-updates)
     - [Sync committee updates](#sync-committee-updates)
+    - [Skip sync update](#skip-sync-update)
 - [Initialize state for pure Altair testnets and test vectors](#initialize-state-for-pure-altair-testnets-and-test-vectors)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -447,6 +449,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     process_eth1_data(state, block.body)
     process_operations(state, block.body)  # [Modified in Altair]
     process_sync_aggregate(state, block.body.sync_aggregate)  # [New in Altair]
+    process_light_update(state, block.body)  # [light-client]
 ```
 
 #### Modified `process_attestation`
@@ -564,6 +567,16 @@ def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) ->
             decrease_balance(state, participant_index, participant_reward)
 ```
 
+#### Light Client Update Processing
+
+*Note*: The function `process_light_update` is new.
+
+```python
+def process_light_update(state: BeaconState, block: BeaconBlock) -> None:
+    # TODO: Create a LightClientUpdate and save it to a queue
+```
+
+
 ### Epoch processing
 
 ```python
@@ -580,6 +593,7 @@ def process_epoch(state: BeaconState) -> None:
     process_historical_roots_update(state)
     process_participation_flag_updates(state)  # [New in Altair]
     process_sync_committee_updates(state)  # [New in Altair]
+    process_skip_sync_update(state)  # [light-client]
 ```
 
 #### Justification and finalization
@@ -676,6 +690,15 @@ def process_sync_committee_updates(state: BeaconState) -> None:
     if next_epoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0:
         state.current_sync_committee = state.next_sync_committee
         state.next_sync_committee = get_next_sync_committee(state)
+```
+
+#### Skip sync update
+
+*Note*: The function `process_skip_sync_update` is new.
+
+```python
+def process_skip_sync_update(state: BeaconState) -> None:
+    # TODO: Create SkipSyncUpdate and save it to a db keyed by hash_tree_root(state.current_sync_committee)
 ```
 
 ## Initialize state for pure Altair testnets and test vectors

--- a/specs/altair/light-client-p2p-interface.md
+++ b/specs/altair/light-client-p2p-interface.md
@@ -1,0 +1,69 @@
+# Ethereum Altair Light Client P2P Interface
+
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
+This document contains the networking specification for [minimal light client](./sync-protocol.md).
+This document should be viewed as a patch to the [Altair networking specification](./p2p-interface.md).
+
+## Table of contents
+
+<!-- TOC -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
+  - [Topics and messages](#topics-and-messages)
+- [The Req/Resp domain](#the-reqresp-domain)
+  - [Messages](#messages)
+    - [LightClientUpdate](#lightclientupdate)
+- [Server discovery](#server-discovery)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+## The gossip domain: gossipsub
+
+The `light_client_update` gossip topic is added to support a light client searching for latest block header information.
+
+### Topics and messages
+
+The new topics along with the type of the `data` field of a gossipsub message are given in this table:
+
+| Name | Message Type |
+| - | - |
+| `light_client_update` | `LightClientUpdate` |
+
+Definitions of these new types can be found in the [sync-protocol](./sync-protocol.md#LightClientUpdate).
+
+
+## The Req/Resp domain
+
+### Messages
+
+#### LightClientUpdate
+
+**Protocol ID:** `/eth2/beacon_chain/req/skip-sync/1/`
+
+Request Content:
+```
+(
+  key: bytes32
+)
+```
+
+Response Content:
+```
+(
+  LightClientUpdate
+)
+```
+
+The request key is the hash root of a SyncCommittee. This allows a light client to start with any trusted sync-committee root to skip sync to the latest sync-committee.
+
+
+## Server discovery
+
+[TODO]
+- Note that if we simply use the same set of bootnodes as the set configured in BeaconChain, the majority of the discovered peers are not likely to support the gossip topic of the req/resp protocol defined in this document.
+- If disv5 supports [topic advertisement](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md#topic-advertisement), this could be used to discover a subnet of nodes that supports the light client protocol. 
+


### PR DESCRIPTION
I created this simple PR to get the conversation going about a p2p approach. As mentioned previously in the thread in #light-client channel in discord, we could very well dismiss this approach after some discussions. Instead, we focus on building a p2p approach based on portal network, and a N-server approach. Regardless, it will be a very useful exercise to think through the input data for the light client. 


Copied from the channel's discussion. There are three approaches to the light-client networking:
1. RPC. Clients find the RPC endpoints out of band. The client could optionally use a N server approach to get data input resilience.
2. Extend beacon chain p2p interface. Light client p2p interface is part of the consensus p2p layer. **This approach is detailed in this PR.**
3. Portal network. A light client joins portal network subnetworks that are particular to beacon chain light clients.
