### PR TITLE
add some non-empty extra_data tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -214,3 +214,35 @@ def test_bad_timestamp_regular_payload(spec, state):
     execution_payload.timestamp = execution_payload.timestamp + 1
 
     yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_non_empty_extra_data_first_payload(spec, state):
+    # pre-state
+    state = build_state_with_incomplete_transition(spec, state)
+    next_slot(spec, state)
+
+    # execution payload
+    execution_payload = build_empty_execution_payload(spec, state)
+    execution_payload.extra_data = b'\x45' * 12
+
+    yield from run_execution_payload_processing(spec, state, execution_payload)
+
+    assert state.latest_execution_payload_header.extra_data == execution_payload.extra_data
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_non_empty_extra_data_regular_payload(spec, state):
+    # pre-state
+    state = build_state_with_complete_transition(spec, state)
+    next_slot(spec, state)
+
+    # execution payload
+    execution_payload = build_empty_execution_payload(spec, state)
+    execution_payload.extra_data = b'\x45' * 12
+
+    yield from run_execution_payload_processing(spec, state, execution_payload)
+
+    assert state.latest_execution_payload_header.extra_data == execution_payload.extra_data


### PR DESCRIPTION
Nimbus had a consensus split on kintsugi due to a non-empty `extra_data` field in the execution payload.
This was fixed here -- https://github.com/status-im/nimbus-eth2/pull/3228

This PR adds a couple of tests to ensure that `payload.extra_data` is copied over to `latest_payload_header.extra_data`