### PR TITLE
Fix typo in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The current features are:
 * [Honest Validator guide changes](specs/altair/validator.md)
 * [P2P Networking](specs/altair/p2p-interface.md)
 
-### Bellatrix (as known as The Merge)
+### Bellatrix (also known as The Merge)
 
 The Bellatrix protocol upgrade is still actively in development. The exact specification has not been formally accepted as final and details are still subject to change.
 


### PR DESCRIPTION
Fixes a minor typo.

I would have preferred *"the upgrade formerly known as The Merge"* but I wasn't sure I could get away with it :smile: 