### PR TITLE
Rename `sync_committee_aggregate` > `sync_aggregate`

### DIFF
--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -69,7 +69,7 @@ class LightClientUpdate(Container):
     finalized_header: BeaconBlockHeader
     finality_branch: Vector[Bytes32, floorlog2(FINALIZED_ROOT_INDEX)]
     # Sync committee aggregate signature
-    sync_committee_aggregate: SyncAggregate
+    sync_aggregate: SyncAggregate
     # Fork version for the aggregate signature
     fork_version: Version
 ```
@@ -187,8 +187,8 @@ def validate_light_client_update(store: LightClientStore,
             index=get_subtree_index(NEXT_SYNC_COMMITTEE_INDEX),
             root=active_header.state_root,
         )
-        
-    sync_aggregate = update.sync_committee_aggregate
+
+    sync_aggregate = update.sync_aggregate
 
     # Verify sync committee has sufficient participants
     assert sum(sync_aggregate.sync_committee_bits) >= MIN_SYNC_COMMITTEE_PARTICIPANTS
@@ -225,12 +225,12 @@ def process_light_client_update(store: LightClientStore,
                                 genesis_validators_root: Root) -> None:
     validate_light_client_update(store, update, current_slot, genesis_validators_root)
 
-    sync_committee_bits = update.sync_committee_aggregate.sync_committee_bits
+    sync_committee_bits = update.sync_aggregate.sync_committee_bits
 
     # Update the best update in case we have to force-update to it if the timeout elapses
     if (
         store.best_valid_update is None
-        or sum(sync_committee_bits) > sum(store.best_valid_update.sync_committee_aggregate.sync_committee_bits)
+        or sum(sync_committee_bits) > sum(store.best_valid_update.sync_aggregate.sync_committee_bits)
     ):
         store.best_valid_update = update
 

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
@@ -58,7 +58,7 @@ def test_process_light_client_update_not_timeout(spec, state):
         block_header.slot,
         committee,
     )
-    sync_committee_aggregate = spec.SyncAggregate(
+    sync_aggregate = spec.SyncAggregate(
         sync_committee_bits=sync_committee_bits,
         sync_committee_signature=sync_committee_signature,
     )
@@ -76,7 +76,7 @@ def test_process_light_client_update_not_timeout(spec, state):
         next_sync_committee_branch=next_sync_committee_branch,
         finalized_header=finality_header,
         finality_branch=finality_branch,
-        sync_committee_aggregate=sync_committee_aggregate,
+        sync_aggregate=sync_aggregate,
         fork_version=state.fork.current_version,
     )
 
@@ -123,7 +123,7 @@ def test_process_light_client_update_timeout(spec, state):
         committee,
         block_root=spec.Root(block_header.hash_tree_root()),
     )
-    sync_committee_aggregate = spec.SyncAggregate(
+    sync_aggregate = spec.SyncAggregate(
         sync_committee_bits=sync_committee_bits,
         sync_committee_signature=sync_committee_signature,
     )
@@ -140,7 +140,7 @@ def test_process_light_client_update_timeout(spec, state):
         next_sync_committee_branch=next_sync_committee_branch,
         finalized_header=finality_header,
         finality_branch=finality_branch,
-        sync_committee_aggregate=sync_committee_aggregate,
+        sync_aggregate=sync_aggregate,
         fork_version=state.fork.current_version,
     )
 
@@ -201,7 +201,7 @@ def test_process_light_client_update_finality_updated(spec, state):
         committee,
         block_root=spec.Root(block_header.hash_tree_root()),
     )
-    sync_committee_aggregate = spec.SyncAggregate(
+    sync_aggregate = spec.SyncAggregate(
         sync_committee_bits=sync_committee_bits,
         sync_committee_signature=sync_committee_signature,
     )
@@ -212,7 +212,7 @@ def test_process_light_client_update_finality_updated(spec, state):
         next_sync_committee_branch=next_sync_committee_branch,
         finalized_header=finalized_block_header,
         finality_branch=finality_branch,
-        sync_committee_aggregate=sync_committee_aggregate,
+        sync_aggregate=sync_aggregate,
         fork_version=state.fork.current_version,
     )
 


### PR DESCRIPTION
This renames the `sync_committee_aggregate` field of `LightClientUpdate`
to `sync_aggregate` for consistency with the terminology in the rest of
the spec.