### PR TITLE
Fix `next_sync_committe` validation for light client

### DIFF
--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -185,7 +185,7 @@ def validate_light_client_update(store: LightClientStore,
             branch=update.next_sync_committee_branch,
             depth=floorlog2(NEXT_SYNC_COMMITTEE_INDEX),
             index=get_subtree_index(NEXT_SYNC_COMMITTEE_INDEX),
-            root=active_header.state_root,
+            root=update.attested_header.state_root,
         )
 
     sync_aggregate = update.sync_aggregate


### PR DESCRIPTION
PR https://github.com/ethereum/consensus-specs/pull/2746 introduced a
regression in the validation of the `next_sync_committee` where the
corresponding merkle proof is computed based on an incorrect state root.
`next_sync_committee` is always rooted in the attested header, even for
a `LightClientUpdate` that includes a `finalized_header`.