### PR TITLE
Consistently use `compute_sync_committee_period`

### DIFF
--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -157,8 +157,8 @@ def validate_light_client_update(store: LightClientStore,
     assert current_slot >= active_header.slot > store.finalized_header.slot
 
     # Verify update does not skip a sync committee period
-    finalized_period = compute_epoch_at_slot(store.finalized_header.slot) // EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-    update_period = compute_epoch_at_slot(active_header.slot) // EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+    finalized_period = compute_sync_committee_period(compute_epoch_at_slot(store.finalized_header.slot))
+    update_period = compute_sync_committee_period(compute_epoch_at_slot(active_header.slot))
     assert update_period in (finalized_period, finalized_period + 1)
 
     # Verify that the `finalized_header`, if present, actually is the finalized header saved in the
@@ -208,8 +208,8 @@ def validate_light_client_update(store: LightClientStore,
 ```python
 def apply_light_client_update(store: LightClientStore, update: LightClientUpdate) -> None:
     active_header = get_active_header(update)
-    finalized_period = compute_epoch_at_slot(store.finalized_header.slot) // EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-    update_period = compute_epoch_at_slot(active_header.slot) // EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+    finalized_period = compute_sync_committee_period(compute_epoch_at_slot(store.finalized_header.slot))
+    update_period = compute_sync_committee_period(compute_epoch_at_slot(active_header.slot))
     if update_period == finalized_period + 1:
         store.current_sync_committee = store.next_sync_committee
         store.next_sync_committee = update.next_sync_committee

--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_sync_committee_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_sync_committee_updates.py
@@ -24,7 +24,7 @@ def run_sync_committees_progress_test(spec, state):
     first_sync_committee = state.current_sync_committee.copy()
     second_sync_committee = state.next_sync_committee.copy()
 
-    current_period = spec.get_current_epoch(state) // spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+    current_period = spec.compute_sync_committee_period(spec.get_current_epoch(state))
     next_period = current_period + 1
     next_period_start_epoch = next_period * spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD
     next_period_start_slot = next_period_start_epoch * spec.SLOTS_PER_EPOCH

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
@@ -98,8 +98,8 @@ def test_process_light_client_update_timeout(spec, state):
 
     # Forward to next sync committee period
     next_slots(spec, state, spec.UPDATE_TIMEOUT)
-    snapshot_period = spec.compute_epoch_at_slot(store.optimistic_header.slot) // spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-    update_period = spec.compute_epoch_at_slot(state.slot) // spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+    snapshot_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(store.optimistic_header.slot))
+    update_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(state.slot))
     assert snapshot_period + 1 == update_period
 
     block = build_empty_block_for_next_slot(spec, state)
@@ -169,8 +169,8 @@ def test_process_light_client_update_finality_updated(spec, state):
     # Ensure that finality checkpoint has changed
     assert state.finalized_checkpoint.epoch == 3
     # Ensure that it's same period
-    snapshot_period = spec.compute_epoch_at_slot(store.optimistic_header.slot) // spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-    update_period = spec.compute_epoch_at_slot(state.slot) // spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+    snapshot_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(store.optimistic_header.slot))
+    update_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(state.slot))
     assert snapshot_period == update_period
 
     # Updated sync_committee and finality


### PR DESCRIPTION
There were a couple instances where a division was used on an epoch
to derive the corresponding sync committee period instead of calling the
`compute_sync_committee_period` function.
These instances were changed to also use the function.