### PR TITLE
Revise participation tracking in light client

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
@@ -111,14 +111,12 @@ def test_process_light_client_update_timeout(spec, state):
         fork_version=state.fork.current_version,
     )
 
-    pre_store = deepcopy(store)
-
     spec.process_light_client_update(store, update, state.slot, state.genesis_validators_root)
 
-    assert store.current_max_active_participants > 0
+    assert store.previous_max_active_participants > 0
     assert store.optimistic_header == update.attested_header
-    assert store.best_valid_update == update
-    assert store.finalized_header == pre_store.finalized_header
+    assert store.finalized_header == update.attested_header
+    assert store.best_valid_update is None
 
 
 @with_altair_and_later


### PR DESCRIPTION
The current mechanism to track historic sync committee participation is
suboptimal in these aspects:
- During sync, `LightClientUpdate` are fetched across multiple sync
  committee periods. The sync participation may change drastically over
  time. If any of those synced periods had unusually high participation
  and is followed by periods of unusually low participation, this may
  prevent optimistic header updates until `current_slot` has advanced
  sufficiently (from the sync time, not from the update time).
- When the light client suspends, `process_slot_for_light_client_store`
  needs to be called for all missed slots after resuming, which is not
  practical (optimizations would be possible).

This patch changes the rollover of the tracked participation to happen
whenever the `store.finalized_header`'s sync committee period advances.
While in sync with the network, rollovers happen at the same frequency
as before, but this guarantees that participation is no longer mixed
across multiple sync committee periods, avoiding the problems above.