### PR TITLE
Ensure light client `optimistic_header` to be at head

### DIFF
--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -214,6 +214,8 @@ def apply_light_client_update(store: LightClientStore, update: LightClientUpdate
         store.current_sync_committee = store.next_sync_committee
         store.next_sync_committee = update.next_sync_committee
     store.finalized_header = active_header
+    if store.finalized_header.slot > store.optimistic_header.slot:
+        store.optimistic_header = store.finalized_header
 ```
 
 #### `process_light_client_update`


### PR DESCRIPTION
When a light client updates its `finalized_header` using a forced update
because of the timeout, and the new header was not signed by enough sync
committee participants to pass `get_safety_threshold(store)`, it may
occur that `store.finalized_header.slot > store.optimistic_header.slot`.
This patch ensures that the `optimistic_header` is updated to the latest
`finalized_header` if that happens, so that it always indicates the
latest known and accepted head.