### PR TITLE
Bellatrix: Rename execute_payload to notify_new_payload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -524,7 +524,7 @@ def get_pow_chain_head() -> PowBlock:
 
 class NoopExecutionEngine(ExecutionEngine):
 
-    def execute_payload(self: ExecutionEngine, execution_payload: ExecutionPayload) -> bool:
+    def notify_new_payload(self: ExecutionEngine, execution_payload: ExecutionPayload) -> bool:
         return True
 
     def notify_forkchoice_updated(self: ExecutionEngine,

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -35,7 +35,7 @@
     - [Modified `slash_validator`](#modified-slash_validator)
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
   - [Execution engine](#execution-engine)
-    - [`execute_payload`](#execute_payload)
+    - [`notify_new_payload`](#notify_new_payload)
   - [Block processing](#block-processing)
     - [Execution payload](#execution-payload)
       - [`process_execution_payload`](#process_execution_payload)
@@ -307,17 +307,17 @@ def slash_validator(state: BeaconState,
 The implementation-dependent `ExecutionEngine` protocol encapsulates the execution sub-system logic via:
 
 * a state object `self.execution_state` of type `ExecutionState`
-* a state transition function `self.execute_payload` which applies changes to the `self.execution_state`
+* a notification function `self.notify_new_payload` which may apply changes to the `self.execution_state`
 
-*Note*: `execute_payload` is a function accessed through the `EXECUTION_ENGINE` module which instantiates the `ExecutionEngine` protocol.
+*Note*: `notify_new_payload` is a function accessed through the `EXECUTION_ENGINE` module which instantiates the `ExecutionEngine` protocol.
 
 The body of this function is implementation dependent.
 The Engine API may be used to implement this and similarly defined functions via an external execution engine.
 
-#### `execute_payload`
+#### `notify_new_payload`
 
 ```python
-def execute_payload(self: ExecutionEngine, execution_payload: ExecutionPayload) -> bool:
+def notify_new_payload(self: ExecutionEngine, execution_payload: ExecutionPayload) -> bool:
     """
     Return ``True`` if and only if ``execution_payload`` is valid with respect to ``self.execution_state``.
     """
@@ -353,7 +353,7 @@ def process_execution_payload(state: BeaconState, payload: ExecutionPayload, exe
     # Verify timestamp
     assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
     # Verify the execution payload is valid
-    assert execution_engine.execute_payload(payload)
+    assert execution_engine.notify_new_payload(payload)
     # Cache execution payload header
     state.latest_execution_payload_header = ExecutionPayloadHeader(
         parent_hash=payload.parent_hash,

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -106,8 +106,8 @@ these conditions.*
 
 To optimistically import a block:
 
-- The [`execute_payload`](../specs/bellatrix/beacon-chain.md#execute_payload) function MUST return `True` if the execution
-  engine returns `SYNCING` or `VALID`. An `INVALID` response MUST return `False`.
+- The [`notify_new_payload`](../specs/bellatrix/beacon-chain.md#notify_new_payload) function MUST return `True` if the execution
+  engine returns `SYNCING`, `VALID`, or `ACCEPTED`. An `INVALID` or `INVALID_BLOCK_HASH` response MUST return `False`.
 - The [`validate_merge_block`](../specs/bellatrix/fork-choice.md#validate_merge_block)
  function MUST NOT raise an assertion if both the
 `pow_block` and `pow_parent` are unknown to the execution engine.
@@ -119,7 +119,7 @@ In addition to this change in validation, the consensus engine MUST track which
 blocks returned `SYNCING` and which returned `VALID` for subsequent processing.
 
 Optimistically imported blocks MUST pass all verifications included in
-`process_block` (withstanding the modifications to `execute_payload`).
+`process_block` (withstanding the modifications to `notify_new_payload`).
 
 A consensus engine MUST be able to retrospectively (i.e., after import) modify
 the status of `SYNCING` blocks to be either `VALID` or `INVALID` based upon responses

--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -25,7 +25,7 @@ def run_execution_payload_processing(spec, state, execution_payload, valid=True,
     called_new_block = False
 
     class TestEngine(spec.NoopExecutionEngine):
-        def execute_payload(self, payload) -> bool:
+        def notify_new_payload(self, payload) -> bool:
             nonlocal called_new_block, execution_valid
             called_new_block = True
             assert payload == execution_payload


### PR DESCRIPTION
Related to https://github.com/ethereum/execution-apis/pull/165

This update touches `sync/optimistic.md` in places where it's necessary by the renaming, but general adjustments to the opti-sync spec related to the recent semantics change of Engine API methods are supposed to be submitted in a separate PR