### PR TITLE
Update reserved libp2p error documentation

### DIFF
--- a/specs/das/p2p-interface.md
+++ b/specs/das/p2p-interface.md
@@ -196,11 +196,6 @@ This builds on top of the protocol identification and encoding spec which was in
 
 Note that DAS networking uses a different protocol prefix: `/eth2/das/req`
 
-The result codes are extended with:
--  3: **ResourceUnavailable** -- when the request was valid but cannot be served at this point in time.
-
-TODO: unify with phase0? Lighthoue already defined this in their response codes enum.
-
 ### Messages
 
 #### DASQuery

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -569,11 +569,11 @@ The response code can have one of the following values, encoded as a single unsi
   The response payload adheres to the `ErrorMessage` schema (described below).
 -  3: **ResourceUnavailable** -- the responder does not have requested resource.
   The response payload adheres to the `ErrorMessage` schema (described below).
-  *Note*: This response code is only valid as a response to `BlocksByRange`.
+  *Note*: This response code is only valid as a response where specified.
 
 Clients MAY use response codes above `128` to indicate alternative, erroneous request-specific responses.
 
-The range `[3, 127]` is RESERVED for future usages, and should be treated as error if not recognized expressly.
+The range `[4, 127]` is RESERVED for future usages, and should be treated as error if not recognized expressly.
 
 The `ErrorMessage` schema is:
 


### PR DESCRIPTION
The spec reserves the libp2p error code range `[3, 127]` for future use
but actually defines error code `3` as `ResourceUnavailable`. This patch
updates the reserved range to `[4, 127]`.