### PR TITLE
Fix sync protocol `next_sync_committee_branch` verification and remove active header

### DIFF
--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -184,7 +184,6 @@ def validate_light_client_update(store: LightClientStore,
     # Verify update next sync committee if the update period incremented
     if update_period == finalized_period:
         sync_committee = store.current_sync_committee
-        assert update.next_sync_committee_branch == [Bytes32() for _ in range(floorlog2(NEXT_SYNC_COMMITTEE_INDEX))]
     else:
         sync_committee = store.next_sync_committee
         assert is_valid_merkle_branch(


### PR DESCRIPTION
Discussed with @vbuterin today:

1. Bugfixes
     1. In the `update.next_sync_committee_branch` Merkle branch verification, it should be on `attested_header` rather than using `active_header` that may be `finalized_header`.
     2. `update_period` should be from `attested_header` rather than using `active_header`.
2. Largely simplified by removing "active header"
3. Extract `apply_light_client_update` into `update_sync_committees_from_update` and `update_new_finalized_header`.
4. For the `LightClientUpdate` builder, no need to fill empty `next_sync_committee_branch`.

---
From the perspective of a `LightClientUpdate` builder:
- Always fill `attested_header` with the recent block header
    - **Note**: if it's a finality update, the `attested_header` state should point to the `finalized_checkpoint`
- `next_sync_committee` and `next_sync_committee_branch`
    - Set the updated `next_sync_committee` and `next_sync_committee_branch` corresponding to `attested_header`
- Finality update
    - If it's a finality update
        - Fill `finalized_header != BeaconBlockHeader()`
        - Fill `finality_branch` corresponding to the state of the `attested_header`
    - Else
        -  Fill `finalized_header` with `BeaconBlockHeader()`
        -  Fill `finality_branch` with `[Bytes32() for _ in range(floorlog2(FINALIZED_ROOT_INDEX))]`
- `sync_aggregate` is always the `SyncAggregate` of `attested_header`
- `fork_version` is for `sync_aggregate`


/cc @etan-status @jinfwhuang @dapplion if you have time to review :)