### PR TITLE
on_block: `pre_state` can't be before `BELLATRIX_FORK_EPOCH`

### DIFF
--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -213,6 +213,8 @@ class ExecutionPayloadHeader(Container):
 
 ```python
 def is_merge_transition_complete(state: BeaconState) -> bool:
+    if compute_epoch_at_slot(state.slot) < BELLATRIX_FORK_EPOCH:
+        return False
     return state.latest_execution_payload_header != ExecutionPayloadHeader()
 ```
 

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -171,7 +171,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     state_transition(state, signed_block, True)
 
     # [New in Bellatrix]
-    if is_merge_transition_block(pre_state, block.body):
+    if compute_epoch_at_slot(pre_state.slot) >= BELLATRIX_FORK_EPOCH and is_merge_transition_block(pre_state, block.body):
         validate_merge_block(block)
 
     # Add new block to the store

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -171,7 +171,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     state_transition(state, signed_block, True)
 
     # [New in Bellatrix]
-    if compute_epoch_at_slot(pre_state.slot) >= BELLATRIX_FORK_EPOCH and is_merge_transition_block(pre_state, block.body):
+    if is_merge_transition_block(pre_state, block.body):
         validate_merge_block(block)
 
     # Add new block to the store


### PR DESCRIPTION
The `pre_state` in `on_block`  can be version Altair if the parent block is version Altair. `is_merge_transition_block` will no longer be viable because `pre_state` doesn't have `latest_execution_payload_header` field.  I'm not entirely sure what's the best approach to this. I think other clients are probably silently handling it? In Prysm, we are skipping the `is_merge_transition_block` if the `pre_state` is not the `Bellatrix` version. Checking the epoch is equally sufficient. Looking forward to hearing more feedback about this