### PR TITLE
Add optimistic import for blocks for VALID ancestors

### DIFF
--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -99,7 +99,7 @@ def has_verified_ancestor(opt_store: OptimisticStore, block: BeaconBlock, finali
         # Implementations MAY choose to remove this check and iterate further
         # back in the chain.
         elif hash_tree_root(block) == finalized_root:
-            return True
+            return False
         elif block.parent_root == Hash32() or block.parent_root not in opt_store.blocks:
             return False
         else:

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -91,19 +91,19 @@ def is_optimistic_candidate_block(opt_store: OptimisticStore, current_slot: Slot
 
 ```python
 def has_verified_ancestor(opt_store: OptimisticStore, block: BeaconBlock, finalized_root: Hash32):
-	while True:
-		if not is_execution_block(block):
-			return false
-		elif hash_tree_root(block) not in opt_store.optimistic_roots:
-			return true
-		# Implementations MAY choose to remove this check and iterate further
-		# back in the chain.
-		elif hash_tree_root(block) == finalized_root:
-			return true
-		elif block.parent_root == Hash32() or block.parent_root not in opt_store.blocks:
-			return false
-		else:
-			block = opt_store.blocks[block.parent_root]
+    while True:
+        if not is_execution_block(block):
+            return false
+        elif hash_tree_root(block) not in opt_store.optimistic_roots:
+            return True
+        # Implementations MAY choose to remove this check and iterate further
+        # back in the chain.
+        elif hash_tree_root(block) == finalized_root:
+            return True
+        elif block.parent_root == Hash32() or block.parent_root not in opt_store.blocks:
+            return False
+        else:
+            block = opt_store.blocks[block.parent_root]
 ```
 
 Let only a node which returns `is_optimistic(opt_store, head) is True` be an *optimistic

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -93,7 +93,7 @@ def is_optimistic_candidate_block(opt_store: OptimisticStore, current_slot: Slot
 def has_verified_ancestor(opt_store: OptimisticStore, block: BeaconBlock, finalized_root: Hash32):
     while True:
         if not is_execution_block(block):
-            return false
+            return False
         elif hash_tree_root(block) not in opt_store.optimistic_roots:
             return True
         # Implementations MAY choose to remove this check and iterate further

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -90,7 +90,7 @@ def is_optimistic_candidate_block(opt_store: OptimisticStore, current_slot: Slot
 ```
 
 ```python
-def has_verified_ancestor(opt_store: OptimisticStore, block: BeaconBlock, finalized_root: Hash32):
+def has_verified_ancestor(opt_store: OptimisticStore, block: BeaconBlock, finalized_root: Hash32) -> bool:
     while True:
         if not is_execution_block(block):
             return False


### PR DESCRIPTION
Allow a node to optimistically import a block if it has an ancestor which:

1. Has execution enabled.
2. Has a `VALID` payload.

The `VALID` ancestor infers that the transition block was available, therefore this chain is not performing a malicious fork choice "poisoning" attack.

Implementations are permitted to stop searching at the finalized block, if they wish. This means implementations can use fork choice to store the execution status, they don't need to maintain it in the database for ancient blocks.