### PR TITLE
Optimistically import any post-merge block

### DIFF
--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -81,10 +81,17 @@ def is_execution_block(block: BeaconBlock) -> bool:
 
 ```python
 def is_optimistic_candidate_block(opt_store: OptimisticStore, current_slot: Slot, block: BeaconBlock) -> bool:
+	if is_execution_block(opt_store.blocks[block.parent_root]):
+		return True
+
     justified_root = opt_store.block_states[opt_store.head_block_root].current_justified_checkpoint.root
-    justified_is_execution_block = is_execution_block(opt_store.blocks[justified_root])
-    block_is_deep = block.slot + SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY <= current_slot
-    return justified_is_execution_block or block_is_deep
+    if is_execution_block(opt_store.blocks[justified_root]):
+		return True
+
+	if block.slot + SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY <= current_slot:
+		return True
+
+	return False
 ```
 
 Let only a node which returns `is_optimistic(opt_store, head) is True` be an *optimistic
@@ -99,13 +106,20 @@ behaviours without regard for optimistic sync.
 ### When to optimistically import blocks
 
 A block MAY be optimistically imported when
-`is_optimistic_candidate_block(opt_store, current_slot, block)` returns
-`True`. This ensures that blocks are only optimistically imported if either:
+`is_optimistic_candidate_block(opt_store, current_slot, block)` returns `True`.
+This ensures that blocks are only optimistically imported if one or more of the
+following are true:
 
+1. The parent of the block has execution enabled.
 1. The justified checkpoint has execution enabled.
 1. The current slot (as per the system clock) is at least
    `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY` ahead of the slot of the block being
    imported.
+
+In effect, there are restrictions on when a *merge block* can be optimistically
+imported. The merge block is the first block in any chain where
+`is_execution_block(block) == True`. Any descendant of a transition block may
+be imported optimistically at any time.
 
 *See [Fork Choice Poisoning](#fork-choice-poisoning) for the motivations behind
 these conditions.*


### PR DESCRIPTION
This PR implements a suggestion by @mkalinin to allow optimistic import of any post-merge block.

A post-merge block is any block where the parent block has a non-empty `ExecutionPayload`.

The fork choice poisoning attack relies upon the ability to *reliably* send *all* execution engines into a syncing state. This is only possible on the *merge block*, since that block can reference a junk `payload.parent_hash`. So, it makes sense to only apply these optimistic-import restrictions to the merge block (and not their innocent descendants).

This PR is an improvement since it avoids rejecting valid blocks in some scenarios where it is safe to (optimistically) import them.

This PR succeeds #2841 since it is a simpler and more general solution.