### PR TITLE
Update 0x01 withdrawal credentials.

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -163,10 +163,7 @@ The `withdrawal_credentials` field must be such that:
 * `withdrawal_credentials[12:] == eth1_withdrawal_address`
 
 After the merge of the current Ethereum application layer into the Beacon Chain,
-withdrawals to `eth1_withdrawal_address` will be normal ETH transfers (with no payload other than the validator's ETH)
-triggered by a user transaction that will set the gas price and gas limit as well pay fees.
-As long as the account or contract with address `eth1_withdrawal_address` can receive ETH transfers,
-the future withdrawal protocol is agnostic to all other implementation details.
+withdrawals to `eth1_withdrawal_address` will simply be increases to the account's ETH balance that do **NOT** trigger any EVM execution.
 
 ### Submit deposit
 


### PR DESCRIPTION
This PR updates the language describing `0x01` withdrawal credentials to reflect latest work following the meta-spec here: https://notes.ethereum.org/@ralexstokes/Skp1mPSb9

