### PR TITLE
deprecate `BeaconBlocksByRange.step`

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -743,7 +743,7 @@ For example, requesting blocks starting at `start_slot=2` and `count=4` would re
 In cases where a slot is empty for a given slot number, no block is returned.
 For example, if slot 4 were empty in the previous example, the returned array would contain `[2, 3, 5]`.
 
-`step` is deprecated and must be set to 1. Clients may respond with a single block if a larger step is returned during the transition period.
+`step` is deprecated and must be set to 1. Clients may respond with a single block if a larger step is returned during the deprecation transition period.
 
 `BeaconBlocksByRange` is primarily used to sync historical blocks.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -252,7 +252,7 @@ Likewise, clients MUST NOT emit or propagate messages larger than this limit.
 The optional `from` (1), `seqno` (3), `signature` (5) and `key` (6) protobuf fields are omitted from the message,
 since messages are identified by content, anonymous, and signed where necessary in the application layer.
 Starting from Gossipsub v1.1, clients MUST enforce this by applying the `StrictNoSign`
-[signature policy](https://github.com/libp2p/specs/blob/master/pubsub/README.md#signature-policy-options). 
+[signature policy](https://github.com/libp2p/specs/blob/master/pubsub/README.md#signature-policy-options).
 
 The `message-id` of a gossipsub message MUST be the following 20 byte value computed from the message data:
 * If `message.data` has a valid snappy decompression, set `message-id` to the first 20 bytes of the `SHA256` hash of
@@ -727,7 +727,7 @@ Request Content:
 (
   start_slot: Slot
   count: uint64
-  step: uint64
+  step: uint64 # Deprecated, must be set to 1
 )
 ```
 
@@ -738,12 +738,12 @@ Response Content:
 )
 ```
 
-Requests beacon blocks in the slot range `[start_slot, start_slot + count * step)`, leading up to the current head block as selected by fork choice.
-`step` defines the slot increment between blocks.
-For example, requesting blocks starting at `start_slot` 2 with a step value of 2 would return the blocks at slots [2, 4, 6, …].
+Requests beacon blocks in the slot range `[start_slot, start_slot + count)`, leading up to the current head block as selected by fork choice.
+For example, requesting blocks starting at `start_slot=2` and `count=4` would return the blocks at slots `[2, 3, 4, 5]`.
 In cases where a slot is empty for a given slot number, no block is returned.
-For example, if slot 4 were empty in the previous example, the returned array would contain [2, 6, …].
-A request MUST NOT have a 0 slot increment, i.e. `step >= 1`.
+For example, if slot 4 were empty in the previous example, the returned array would contain `[2, 3, 5]`.
+
+`step` is deprecated and must be set to 1. Clients may respond with a single block if a larger step is returned during the transition period.
 
 `BeaconBlocksByRange` is primarily used to sync historical blocks.
 


### PR DESCRIPTION
The `step` parameter has not seen much implementation in real life
clients which instead opt to request variations on a few epochs at a
time (instead of interleaving single blocks, entire epochs are
interleaved).

At the same time, supporting `step` on the server side brings several
complications: more complex bounds checking logic, more complex loading
of blocks from linear storage (which presumably stores all blocks and
not just certain increments).

This PR suggests that we deprecate the whole idea. Backwards
compatibility is kept by simply responding with a single block when
`step > 1` - this is allowed by the spec and should thus be handled
gracefully by requesting clients already, should there exist any that
use larger step counts.

Removing `step` now allows simplifying the EL-CL protocol for serving
execution data from the EL to avoid double storage.