### PR TITLE
Bellatrix: send justified block to EL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -530,6 +530,7 @@ class NoopExecutionEngine(ExecutionEngine):
     def notify_forkchoice_updated(self: ExecutionEngine,
                                   head_block_hash: Hash32,
                                   safe_block_hash: Hash32,
+                                  justified_block_hash: Hash32,
                                   finalized_block_hash: Hash32,
                                   payload_attributes: Optional[PayloadAttributes]) -> Optional[PayloadId]:
         pass

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -61,6 +61,7 @@ Additionally, if `payload_attributes` is provided, this function sets in motion 
 def notify_forkchoice_updated(self: ExecutionEngine,
                               head_block_hash: Hash32,
                               safe_block_hash: Hash32,
+                              justified_block_hash: Hash32,
                               finalized_block_hash: Hash32,
                               payload_attributes: Optional[PayloadAttributes]) -> Optional[PayloadId]:
     ...
@@ -72,6 +73,8 @@ As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice
 *Note*: Client software MUST NOT call this function until the transition conditions are met on the PoW network, i.e. there exists a block for which `is_valid_terminal_pow_block` function returns `True`.
 
 *Note*: Client software MUST call this function to initiate the payload build process to produce the merge transition block; the `head_block_hash` parameter MUST be set to the hash of a terminal PoW block in this case.
+
+*Note*: The `justified_block_hash` value of the `notify_forkchoice_updated` function call MUST be set to the `block_hash` of the most recent justified execution payload, and MUST be stubbed with `Hash32()` if no payload is yet justified.
 
 ##### `safe_block_hash`
 

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -72,7 +72,23 @@ As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice
 
 *Note*: Client software MUST call this function to initiate the payload build process to produce the merge transition block; the `head_block_hash` parameter MUST be set to the hash of a terminal PoW block in this case.
 
-*Note*: Until safe head function is implemented, `safe_block_hash` parameter MUST be stubbed with the `head_block_hash` value.
+##### `safe_block_hash`
+
+The `safe_block_hash` parameter in a call to `notify_forkchoice_updated` function
+MUST be set to the return value of the following function:
+
+```python
+def get_safe_block_hash(store: Store) -> Hash32:
+    # Use most recent justified block as a stopgap
+    safe_block_root = store.justified_checkpoint.root
+    safe_block = store.blocks[safe_block_root]
+
+    # Return Hash32() if no payload is yet justified
+    if compute_epoch_at_slot(safe_block.slot) >= BELLATRIX_FORK_EPOCH:
+        return safe_block.body.execution_payload.block_hash
+    else:
+        return Hash32()
+```
 
 ## Helpers
 

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -12,6 +12,7 @@
 - [Protocols](#protocols)
   - [`ExecutionEngine`](#executionengine)
     - [`notify_forkchoice_updated`](#notify_forkchoice_updated)
+      - [`safe_block_hash`](#safe_block_hash)
 - [Helpers](#helpers)
   - [`PayloadAttributes`](#payloadattributes)
   - [`PowBlock`](#powblock)

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -110,10 +110,11 @@ All validator responsibilities remain unchanged other than those noted below. Na
 
 To obtain an execution payload, a block proposer building a block on top of a `state` must take the following actions:
 
-1. Set `payload_id = prepare_execution_payload(state, pow_chain, finalized_block_hash, safe_block_hash, suggested_fee_recipient, execution_engine)`, where:
+1. Set `payload_id = prepare_execution_payload(state, pow_chain, finalized_block_hash, justified_block_hash, safe_block_hash, suggested_fee_recipient, execution_engine)`, where:
     * `state` is the state object after applying `process_slots(state, slot)` transition to the resulting state of the parent block processing
     * `pow_chain` is a `Dict[Hash32, PowBlock]` dictionary that abstractly represents all blocks in the PoW chain with block hash as the dictionary key
     * `finalized_block_hash` is the hash of the latest finalized execution payload (`Hash32()` if none yet finalized)
+    * `justified_block_hash` is the hash of the latest justified execution payload (`Hash32()` if none yet justified)
     * `safe_block_hash` is the return value of the `get_safe_block_hash(store: Store)` function call
     * `suggested_fee_recipient` is the value suggested to be used for the `fee_recipient` field of the execution payload
 
@@ -122,6 +123,7 @@ To obtain an execution payload, a block proposer building a block on top of a `s
 def prepare_execution_payload(state: BeaconState,
                               pow_chain: Dict[Hash32, PowBlock],
                               finalized_block_hash: Hash32,
+                              justified_block_hash: Hash32,
                               safe_block_hash: Hash32,
                               suggested_fee_recipient: ExecutionAddress,
                               execution_engine: ExecutionEngine) -> Optional[PayloadId]:
@@ -151,6 +153,7 @@ def prepare_execution_payload(state: BeaconState,
     return execution_engine.notify_forkchoice_updated(
         head_block_hash=parent_hash,
         safe_block_hash=safe_block_hash,
+        justified_block_hash=justified_block_hash,
         finalized_block_hash=finalized_block_hash,
         payload_attributes=payload_attributes,
     )

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -110,10 +110,11 @@ All validator responsibilities remain unchanged other than those noted below. Na
 
 To obtain an execution payload, a block proposer building a block on top of a `state` must take the following actions:
 
-1. Set `payload_id = prepare_execution_payload(state, pow_chain, finalized_block_hash, suggested_fee_recipient, execution_engine)`, where:
+1. Set `payload_id = prepare_execution_payload(state, pow_chain, finalized_block_hash, safe_block_hash, suggested_fee_recipient, execution_engine)`, where:
     * `state` is the state object after applying `process_slots(state, slot)` transition to the resulting state of the parent block processing
     * `pow_chain` is a `Dict[Hash32, PowBlock]` dictionary that abstractly represents all blocks in the PoW chain with block hash as the dictionary key
     * `finalized_block_hash` is the hash of the latest finalized execution payload (`Hash32()` if none yet finalized)
+    * `safe_block_hash` is the return value of the `get_safe_block_hash(store: Store)` function call
     * `suggested_fee_recipient` is the value suggested to be used for the `fee_recipient` field of the execution payload
 
 
@@ -121,6 +122,7 @@ To obtain an execution payload, a block proposer building a block on top of a `s
 def prepare_execution_payload(state: BeaconState,
                               pow_chain: Dict[Hash32, PowBlock],
                               finalized_block_hash: Hash32,
+                              safe_block_hash: Hash32,
                               suggested_fee_recipient: ExecutionAddress,
                               execution_engine: ExecutionEngine) -> Optional[PayloadId]:
     if not is_merge_transition_complete(state):
@@ -149,8 +151,7 @@ def prepare_execution_payload(state: BeaconState,
     # Set safe and head block hashes to the same value
     return execution_engine.notify_forkchoice_updated(
         head_block_hash=parent_hash,
-        # TODO: Use `parent_hash` as a stub for now.
-        safe_block_hash=parent_hash,
+        safe_block_hash=safe_block_hash,
         finalized_block_hash=finalized_block_hash,
         payload_attributes=payload_attributes,
     )

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -148,7 +148,6 @@ def prepare_execution_payload(state: BeaconState,
         prev_randao=get_randao_mix(state, get_current_epoch(state)),
         suggested_fee_recipient=suggested_fee_recipient,
     )
-    # Set safe and head block hashes to the same value
     return execution_engine.notify_forkchoice_updated(
         head_block_hash=parent_hash,
         safe_block_hash=safe_block_hash,

--- a/tests/core/pyspec/eth2spec/test/bellatrix/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/unittests/validator/test_validator.py
@@ -143,6 +143,7 @@ def test_prepare_execution_payload(spec, state):
 
         # Dummy arguments
         finalized_block_hash = b'\x56' * 32
+        justified_block_hash = b'\x57' * 32
         safe_block_hash = b'\x58' * 32
         suggested_fee_recipient = b'\x78' * 20
 
@@ -151,6 +152,7 @@ def test_prepare_execution_payload(spec, state):
             def notify_forkchoice_updated(self,
                                           head_block_hash,
                                           safe_block_hash,
+                                          justified_block_hash,
                                           finalized_block_hash,
                                           payload_attributes) -> Optional[spec.PayloadId]:
                 return SAMPLE_PAYLOAD_ID
@@ -159,6 +161,7 @@ def test_prepare_execution_payload(spec, state):
             state=state,
             pow_chain=pow_chain.to_dict(),
             finalized_block_hash=finalized_block_hash,
+            justified_block_hash=justified_block_hash,
             safe_block_hash=safe_block_hash,
             suggested_fee_recipient=suggested_fee_recipient,
             execution_engine=TestEngine(),

--- a/tests/core/pyspec/eth2spec/test/bellatrix/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/unittests/validator/test_validator.py
@@ -143,6 +143,7 @@ def test_prepare_execution_payload(spec, state):
 
         # Dummy arguments
         finalized_block_hash = b'\x56' * 32
+        safe_block_hash = b'\x58' * 32
         suggested_fee_recipient = b'\x78' * 20
 
         # Mock execution_engine
@@ -158,6 +159,7 @@ def test_prepare_execution_payload(spec, state):
             state=state,
             pow_chain=pow_chain.to_dict(),
             finalized_block_hash=finalized_block_hash,
+            safe_block_hash=safe_block_hash,
             suggested_fee_recipient=suggested_fee_recipient,
             execution_engine=TestEngine(),
         )


### PR DESCRIPTION
Adds `justified_block_hash` parameter to `notify_forkchoice_updated` function

Depends on https://github.com/ethereum/consensus-specs/pull/2858
Relates to https://github.com/ethereum/execution-apis/pull/203