### PR TITLE
Fix param order in `prepare_execution_payload`

### DIFF
--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -110,7 +110,7 @@ All validator responsibilities remain unchanged other than those noted below. Na
 
 To obtain an execution payload, a block proposer building a block on top of a `state` must take the following actions:
 
-1. Set `payload_id = prepare_execution_payload(state, pow_chain, finalized_block_hash, safe_block_hash, suggested_fee_recipient, execution_engine)`, where:
+1. Set `payload_id = prepare_execution_payload(state, pow_chain, safe_block_hash, finalized_block_hash, suggested_fee_recipient, execution_engine)`, where:
     * `state` is the state object after applying `process_slots(state, slot)` transition to the resulting state of the parent block processing
     * `pow_chain` is a `Dict[Hash32, PowBlock]` dictionary that abstractly represents all blocks in the PoW chain with block hash as the dictionary key
     * `safe_block_hash` is the return value of the `get_safe_execution_payload_hash(store: Store)` function call

--- a/tests/core/pyspec/eth2spec/test/bellatrix/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/unittests/validator/test_validator.py
@@ -158,8 +158,8 @@ def test_prepare_execution_payload(spec, state):
         payload_id = spec.prepare_execution_payload(
             state=state,
             pow_chain=pow_chain.to_dict(),
-            finalized_block_hash=finalized_block_hash,
             safe_block_hash=safe_block_hash,
+            finalized_block_hash=finalized_block_hash,
             suggested_fee_recipient=suggested_fee_recipient,
             execution_engine=TestEngine(),
         )


### PR DESCRIPTION
Documentation on how to call `prepare_execution_payload` had the params
for `safe_block_hash` and `finalized_block` hash flipped compared to the
function definition. Also updated tests for consistency.