### PR TITLE
Yield attestation in equivocating indices test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
@@ -20,7 +20,7 @@ from eth2spec.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
     get_formatted_head_output,
     on_tick_and_append_step,
-    run_on_attestation,
+    add_attestation,
     tick_and_run_on_attestation,
     tick_and_add_block,
 )
@@ -409,7 +409,7 @@ def test_discard_equivocations(spec, state):
 
     # Process attestation
     # The head should change to block_1
-    run_on_attestation(spec, store, attestation)
+    yield from add_attestation(spec, store, attestation, test_steps)
     assert spec.get_head(store) == spec.hash_tree_root(block_1)
 
     # Process attester_slashing


### PR DESCRIPTION
Current test processes attestation only in py test, so generated test fixtures doesn't force failure without equivocating indices feature enabled as it should. I've added attestation to the generated data