### PR TITLE
Require fork choice to run before proposal

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -276,9 +276,15 @@ A validator has two primary responsibilities to the beacon chain: [proposing blo
 ### Block proposal
 
 A validator is expected to propose a [`SignedBeaconBlock`](./beacon-chain.md#signedbeaconblock) at
-the beginning of any slot during which `is_proposer(state, validator_index)` returns `True`.
-To propose, the validator selects the `BeaconBlock`, `parent`,
-that in their view of the fork choice is the head of the chain during `slot - 1`.
+the beginning of any `slot` during which `is_proposer(state, validator_index)` returns `True`.
+
+To propose, the validator selects the `BeaconBlock`, `parent` which:
+
+1. In their view of fork choice is the head of the chain at the start of
+   `slot`, after applying any queued attestations from `slot - 1`.
+2. Is from a slot strictly less than the slot of the block about to be proposed,
+   i.e. `parent.slot < slot`.
+
 The validator creates, signs, and broadcasts a `block` that is a child of `parent`
 that satisfies a valid [beacon chain state transition](./beacon-chain.md#beacon-chain-state-transition-function).
 


### PR DESCRIPTION
Presently the honest validator spec states that the proposer at `slot` should build their block upon what they think the head is during `slot - 1`:

> A validator is expected to propose a `SignedBeaconBlock` at the beginning of any slot during which `is_proposer(state, validator_index)` returns `True`. **To propose, the validator selects the BeaconBlock, `parent`, that in their view of the fork choice is the head of the chain during `slot - 1`.**

The problem with this is that the attestations from `slot - 1` are queued awaiting processing until the start of `slot`, and have the potential to cause a re-org away from what the head was in `slot - 1`.

The result is that a proposer's block may get immediately re-orged out and have no hope of becoming the head. Consider the following example:

```
A <-- B <---_-----_---- E
 \--------- C <-- D

```

There is a contest between B and C as to which block should be the head during slot C. For the sake of argument let's say that block C is the head during slot C, but that the queued attestations from slot C will tip fork choice in favour of block B. When the proposer of D makes their block following the current spec they build atop C, as it was the head during slot D - 1 = C. As soon as this block is applied to the fork choice, so are the attestations from slot C, so the head re-orgs back to B (assuming no proposer boost for D, more on that in a moment).

## The role of proposer boost

If D is able to receive a proposer boost (due to being on time, and proposer boost being enabled) then it is more likely to succeed in becoming the head because its boost can counter the queued attestations. However if the weight of queued attestations exceeds the boost then the re-org will still occur immediately and D will have no hope of becoming the head.

Proposer boosting can also play a role in establishing the contest between B & C. The only way for C to be head during slot C in the scenario above is if it is receiving a proposer boost in excess of the voting weight on B (from slot B). In other words, without proposer boost there would be no reason for 0-weight C to be head, as B has strictly more weight behind it. However, it's possible that there could be a contest between two blocks over a longer timeframe: if we imagine that B and C are the heads of two longer competing chains sharing common ancestor A.

Therefore the flaw in the honest proposer logic is independent of the proposer boost feature.

## Proposed fix

I think that proposers should run fork choice at the _start_ of the slot they are due to propose in and build upon the head as it appears then.

In practical terms, this would require beacon chain clients to run `get_head` immediately before proposing a block. This likely represents <25ms of processing time at current validator counts.
