### PR TITLE
Add new `DomainType` for application usage.

### DIFF
--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -10,6 +10,8 @@
 
 - [Introduction](#introduction)
 - [Custom types](#custom-types)
+- [Constants](#constants)
+  - [Domain types](#domain-types)
 - [Preset](#preset)
   - [Execution](#execution)
   - [Updated penalty values](#updated-penalty-values)
@@ -61,6 +63,14 @@ Additionally, this upgrade introduces the following minor changes:
 | - | - | - |
 | `Transaction` | `ByteList[MAX_BYTES_PER_TRANSACTION]` | either a [typed transaction envelope](https://eips.ethereum.org/EIPS/eip-2718#opaque-byte-array-rather-than-an-rlp-array) or a legacy transaction|
 | `ExecutionAddress` | `Bytes20` | Address of account on the execution layer |
+
+## Constants
+
+### Domain types
+
+| Name | Value |
+| - | - |
+| `DOMAIN_APPLICATION` | `DomainType('0xffffffff')` |
 
 ## Preset
 


### PR DESCRIPTION
This PR adds a new `DomainType` for use by applications adjacent to the core protocol so they can leverage the signing machinery developed here when working with consensus types.

This PR only adds a single domain and expects applications using the domain type to mix in further unique tags for domain separation; otherwise they risk signature collisions.

```python
def compute_domain_for_application(application_domain: SomeBytesType):
    protocol_domain = compute_domain(DOMAIN_APPLICATION) # adjust other args as required...
    return Domain(hash(application_domain + protocol_domain))
```

An example use case is the work-in-progress Builder API where a validator may want to outsource block construction to a network of builders external to their local execution client. See https://github.com/ethereum/execution-apis/pull/209 for details.