### PR TITLE
Add new `DomainType` for application usage with "internal" namespace

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -203,6 +203,9 @@ The following values are (non-configurable) constants used throughout the specif
 | `DOMAIN_VOLUNTARY_EXIT`      | `DomainType('0x04000000')` |
 | `DOMAIN_SELECTION_PROOF`     | `DomainType('0x05000000')` |
 | `DOMAIN_AGGREGATE_AND_PROOF` | `DomainType('0x06000000')` |
+| `DOMAIN_APPLICATION_MASK`    | `DomainType('0x00000001')` |
+
+*Note*: `DOMAIN_APPLICATION_MASK` reserves the rest of the bitspace in `DomainType` for application usage. This means for some `DomainType` `DOMAIN_SOME_APPLICATION`, `DOMAIN_SOME_APPLICATION && DOMAIN_APPLICATION_MASK` **MUST** be non-zero. This expression for any other `DomainType` in the consensus specs **MUST** be zero.
 
 ## Preset
 


### PR DESCRIPTION
Opening in lieu of #2882.

# Context

This PR adds a new DomainType for use by applications adjacent to the core protocol so they can leverage the signing machinery developed here when working with consensus types.

An example use case is the work-in-progress Builder API where a validator may want to outsource block construction to a network of builders external to their local execution client. See https://github.com/ethereum/execution-apis/pull/209 for details.

# Rationale

This PR creates a "reserved" signing namespace for applications by setting the top bit in the `DomainType`. Applications are still expected to set other bits in the remainder of the `DomainType` data to get domain separation from other applications using this scheme.

This responsibility is on the applications to self-organize who uses which concrete `DomainType`s.

Examples:

```
DOMAIN_APPLICATION_MEV_BOOST = `0x10000001`
DOMAIN_APPLICATION_ANOTHER_APP = `0x2000001`
```

This approach is chosen over the approach in #2882 as there is less machinery to get right for users of the consensus spec.