### PR TITLE
Convert sets to sorted lists prior to sampling

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py
+++ b/tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py
@@ -281,7 +281,7 @@ def test_transition_with_random_three_quarters_participation(state, fork_epoch, 
         assert committee_len >= 4
         filter_len = committee_len // 4
         participant_count = committee_len - filter_len
-        return rng.sample(indices, participant_count)
+        return rng.sample(sorted(indices), participant_count)
 
     yield from _run_transition_test_with_attestations(
         state,
@@ -304,7 +304,7 @@ def test_transition_with_random_half_participation(state, fork_epoch, spec, post
         assert committee_len >= 2
         filter_len = committee_len // 2
         participant_count = committee_len - filter_len
-        return rng.sample(indices, participant_count)
+        return rng.sample(sorted(indices), participant_count)
 
     yield from _run_transition_test_with_attestations(
         state,

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py
@@ -59,7 +59,7 @@ def test_is_assigned_to_sync_committee(spec, state):
     if disqualified_pubkeys:
         sample_size = 3
         assert validator_count >= sample_size
-        some_pubkeys = rng.sample(disqualified_pubkeys, sample_size)
+        some_pubkeys = rng.sample(sorted(disqualified_pubkeys), sample_size)
         for pubkey in some_pubkeys:
             validator_index = active_pubkeys.index(pubkey)
             is_current = spec.is_assigned_to_sync_committee(

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
@@ -215,7 +215,8 @@ def test_almost_empty_attestations_with_leak(spec, state):
 @spec_state_test
 def test_random_fill_attestations(spec, state):
     rng = Random(4567)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) // 3))
+    yield from run_with_participation(spec, state,
+                                      lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) // 3))
 
 
 @with_all_phases
@@ -223,14 +224,16 @@ def test_random_fill_attestations(spec, state):
 @leaking()
 def test_random_fill_attestations_with_leak(spec, state):
     rng = Random(4567)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) // 3))
+    yield from run_with_participation(spec, state,
+                                      lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) // 3))
 
 
 @with_all_phases
 @spec_state_test
 def test_almost_full_attestations(spec, state):
     rng = Random(8901)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) - 1))
+    yield from run_with_participation(spec, state,
+                                      lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) - 1))
 
 
 @with_all_phases
@@ -238,7 +241,8 @@ def test_almost_full_attestations(spec, state):
 @leaking()
 def test_almost_full_attestations_with_leak(spec, state):
     rng = Random(8901)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) - 1))
+    yield from run_with_participation(spec, state,
+                                      lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) - 1))
 
 
 @with_all_phases

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
@@ -200,7 +200,10 @@ def run_with_participation(spec, state, participation_fn):
 @spec_state_test
 def test_almost_empty_attestations(spec, state):
     rng = Random(1234)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), 1))
+
+    def participation_fn(slot, comm_index, comm):
+        return rng.sample(sorted(comm), 1)
+    yield from run_with_participation(spec, state, participation_fn)
 
 
 @with_all_phases
@@ -208,15 +211,20 @@ def test_almost_empty_attestations(spec, state):
 @leaking()
 def test_almost_empty_attestations_with_leak(spec, state):
     rng = Random(1234)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), 1))
+
+    def participation_fn(slot, comm_index, comm):
+        return rng.sample(sorted(comm), 1)
+    yield from run_with_participation(spec, state, participation_fn)
 
 
 @with_all_phases
 @spec_state_test
 def test_random_fill_attestations(spec, state):
     rng = Random(4567)
-    yield from run_with_participation(spec, state,
-                                      lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) // 3))
+
+    def participation_fn(slot, comm_index, comm):
+        return rng.sample(sorted(comm), len(comm) // 3)
+    yield from run_with_participation(spec, state, participation_fn)
 
 
 @with_all_phases
@@ -224,16 +232,20 @@ def test_random_fill_attestations(spec, state):
 @leaking()
 def test_random_fill_attestations_with_leak(spec, state):
     rng = Random(4567)
-    yield from run_with_participation(spec, state,
-                                      lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) // 3))
+
+    def participation_fn(slot, comm_index, comm):
+        return rng.sample(sorted(comm), len(comm) // 3)
+    yield from run_with_participation(spec, state, participation_fn)
 
 
 @with_all_phases
 @spec_state_test
 def test_almost_full_attestations(spec, state):
     rng = Random(8901)
-    yield from run_with_participation(spec, state,
-                                      lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) - 1))
+
+    def participation_fn(slot, comm_index, comm):
+        return rng.sample(sorted(comm), len(comm) - 1)
+    yield from run_with_participation(spec, state, participation_fn)
 
 
 @with_all_phases
@@ -241,8 +253,10 @@ def test_almost_full_attestations(spec, state):
 @leaking()
 def test_almost_full_attestations_with_leak(spec, state):
     rng = Random(8901)
-    yield from run_with_participation(spec, state,
-                                      lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) - 1))
+
+    def participation_fn(slot, comm_index, comm):
+        return rng.sample(sorted(comm), len(comm) - 1)
+    yield from run_with_participation(spec, state, participation_fn)
 
 
 @with_all_phases

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
@@ -200,7 +200,7 @@ def run_with_participation(spec, state, participation_fn):
 @spec_state_test
 def test_almost_empty_attestations(spec, state):
     rng = Random(1234)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, 1))
+    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), 1))
 
 
 @with_all_phases
@@ -208,14 +208,14 @@ def test_almost_empty_attestations(spec, state):
 @leaking()
 def test_almost_empty_attestations_with_leak(spec, state):
     rng = Random(1234)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, 1))
+    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), 1))
 
 
 @with_all_phases
 @spec_state_test
 def test_random_fill_attestations(spec, state):
     rng = Random(4567)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, len(comm) // 3))
+    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) // 3))
 
 
 @with_all_phases
@@ -223,14 +223,14 @@ def test_random_fill_attestations(spec, state):
 @leaking()
 def test_random_fill_attestations_with_leak(spec, state):
     rng = Random(4567)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, len(comm) // 3))
+    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) // 3))
 
 
 @with_all_phases
 @spec_state_test
 def test_almost_full_attestations(spec, state):
     rng = Random(8901)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, len(comm) - 1))
+    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) - 1))
 
 
 @with_all_phases
@@ -238,7 +238,7 @@ def test_almost_full_attestations(spec, state):
 @leaking()
 def test_almost_full_attestations_with_leak(spec, state):
     rng = Random(8901)
-    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, len(comm) - 1))
+    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(sorted(comm), len(comm) - 1))
 
 
 @with_all_phases

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
@@ -38,7 +38,7 @@ def _drop_random_one_third(_slot, _index, indices):
     assert committee_len >= 3
     filter_len = committee_len // 3
     participant_count = committee_len - filter_len
-    return rng.sample(indices, participant_count)
+    return rng.sample(sorted(indices), participant_count)
 
 
 @with_all_phases


### PR DESCRIPTION
## PR Description

According [the docs for `random.sample`](https://docs.python.org/3.9/library/random.html#random.sample):

> Deprecated since version 3.9: In the future, the population must be a sequence. **Instances of set are no longer supported. The set must first be converted to a list or tuple, preferably in a deterministic order so that the sample is reproducible.**

I used `sorted()` instead of `list()` to make things deterministic.

#### Fixed Warnings

```
tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py: 282 warnings
  /consensus-specs/tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py:307: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    return rng.sample(indices, participant_count)

tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py: 282 warnings
  /consensus-specs/tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py:284: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    return rng.sample(indices, participant_count)

tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py::test_is_assigned_to_sync_committee
tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py::test_is_assigned_to_sync_committee
tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py::test_is_assigned_to_sync_committee
  /consensus-specs/tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py:62: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    some_pubkeys = rng.sample(disqualified_pubkeys, sample_size)

tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py: 64 warnings
  /consensus-specs/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py:203: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, 1))

tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py: 64 warnings
  /consensus-specs/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py:211: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, 1))

tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py: 64 warnings
  /consensus-specs/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py:218: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, len(comm) // 3))

tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py: 64 warnings
  /consensus-specs/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py:226: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, len(comm) // 3))

tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py: 64 warnings
  /consensus-specs/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py:233: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, len(comm) - 1))

tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py: 64 warnings
  /consensus-specs/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py:241: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    yield from run_with_participation(spec, state, lambda slot, comm_index, comm: rng.sample(comm, len(comm) - 1))

tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py: 64 warnings
  /consensus-specs/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py:41: DeprecationWarning: Sampling from a set deprecated
  since Python 3.9 and will be removed in a subsequent version.
    return rng.sample(indices, participant_count)
```