### PR TITLE
Optimistic Sync: remove INVALID_TERMINAL_BLOCK

### DIFF
--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -34,7 +34,6 @@ For brevity, we define two aliases for values of the `status` field on
 - Alias `INVALIDATED` to:
     - `INVALID`
     - `INVALID_BLOCK_HASH`
-    - `INVALID_TERMINAL_BLOCK`
 
 Let `head: BeaconBlock` be the result of calling of the fork choice
 algorithm at the time of block production. Let `head_block_root: Root` be the


### PR DESCRIPTION
A follow up to https://github.com/ethereum/execution-apis/pull/217