### PR TITLE
Update PROPOSER_SCORE_BOOST to 40 percent

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -84,8 +84,8 @@ CHURN_LIMIT_QUOTIENT: 65536
 
 # Fork choice
 # ---------------------------------------------------------------
-# 33%
-PROPOSER_SCORE_BOOST: 33
+# 40%
+PROPOSER_SCORE_BOOST: 40
 
 # Deposit contract
 # ---------------------------------------------------------------

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -81,8 +81,8 @@ CHURN_LIMIT_QUOTIENT: 32
 
 # Fork choice
 # ---------------------------------------------------------------
-# 33%
-PROPOSER_SCORE_BOOST: 33
+# 40%
+PROPOSER_SCORE_BOOST: 40
 
 
 # Deposit contract

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -76,7 +76,7 @@ Any of the above handlers that trigger an unhandled exception (e.g. a failed ass
 
 | Name                   | Value        |
 | ---------------------- | ------------ |
-| `PROPOSER_SCORE_BOOST` | `uint64(33)` |
+| `PROPOSER_SCORE_BOOST` | `uint64(40)` |
 
 - The proposer score boost is worth `PROPOSER_SCORE_BOOST` percentage of the committee's weight, i.e., for slot with committee weight `committee_weight` the boost weight is equal to `(committee_weight * PROPOSER_SCORE_BOOST) // 100`.
 


### PR DESCRIPTION
***PR up for review until May 20***

An off-by-one mistake in #2888 led to a reconsideration of the `PROPOSER_SCORE_BOOST` parameter. This PR updates the parameter to 40%. 

The motivation for changing this parameter and arguments for picking the new value can be found [here](https://notes.ethereum.org/@casparschwa/H1T0k7b85).