### PR TITLE
Run on_tick before picking the head for proposal

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -281,7 +281,7 @@ the beginning of any `slot` during which `is_proposer(state, validator_index)` r
 To propose, the validator selects the `BeaconBlock`, `parent` which:
 
 1. In their view of fork choice is the head of the chain at the start of
-   `slot`, after applying any queued attestations from `slot - 1`.
+   `slot`, after running `on_tick` and applying any queued attestations from `slot - 1`.
 2. Is from a slot strictly less than the slot of the block about to be proposed,
    i.e. `parent.slot < slot`.
 


### PR DESCRIPTION
A follow up to https://github.com/ethereum/consensus-specs/pull/2878

It seems like running `on_tick` is intended by the original PR, otherwise, attestations of a previous slot couldn't be applied.

Currently, `on_tick` resets proposer boost in addition to advancing the current slot and may have some other logic in the future. Implicit reset of proposer boost became a source of confusion here https://github.com/ethereum/consensus-specs/pull/2895#issuecomment-1129946528. Thus, I think it's important to have `on_tick` explicitly mentioned in the validator's spec.

cc @potuz @michaelsproul 