### PR TITLE
Remove `@disable_process_reveal_deadlines` from `sanity/test_blocks.py`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -34,7 +34,6 @@ from eth2spec.test.context import (
     spec_test, spec_state_test, dump_skipping_message,
     with_phases, with_all_phases, single_phase,
     expect_assertion_error, always_bls,
-    disable_process_reveal_deadlines,
     with_presets,
     with_custom_state,
     large_validator_set,
@@ -840,7 +839,6 @@ def test_attestation(spec, state):
 
 @with_all_phases
 @spec_state_test
-@disable_process_reveal_deadlines
 def test_voluntary_exit(spec, state):
     validator_index = spec.get_active_validator_indices(state, spec.get_current_epoch(state))[-1]
 
@@ -890,7 +888,6 @@ def test_double_validator_exit_same_block(spec, state):
 
 @with_all_phases
 @spec_state_test
-@disable_process_reveal_deadlines
 def test_multiple_different_validator_exits_same_block(spec, state):
     validator_indices = [
         spec.get_active_validator_indices(state, spec.get_current_epoch(state))[i]
@@ -923,7 +920,6 @@ def test_multiple_different_validator_exits_same_block(spec, state):
 
 @with_all_phases
 @spec_state_test
-@disable_process_reveal_deadlines
 def test_slash_and_exit_same_index(spec, state):
     validator_index = spec.get_active_validator_indices(state, spec.get_current_epoch(state))[-1]
     yield from run_slash_and_exit(spec, state, validator_index, validator_index, valid=False)
@@ -931,7 +927,6 @@ def test_slash_and_exit_same_index(spec, state):
 
 @with_all_phases
 @spec_state_test
-@disable_process_reveal_deadlines
 def test_slash_and_exit_diff_index(spec, state):
     slash_index = spec.get_active_validator_indices(state, spec.get_current_epoch(state))[-1]
     exit_index = spec.get_active_validator_indices(state, spec.get_current_epoch(state))[-2]


### PR DESCRIPTION
Per #2904
Remove `@disable_process_reveal_deadlines` from `test_blocks.py` so that it won't be printed in the test vector meta.

