### PR TITLE
EIP-4844: Remove shard field from BlobsSidecar

### DIFF
--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -110,7 +110,6 @@ Before publishing a prepared beacon block proposal, the corresponding blobs are 
 blobs_sidecar = BlobsSidecar(
     beacon_block_root=hash_tree_root(beacon_block)
     beacon_block_slot=beacon_block.slot
-    shard=0,
     blobs=blobs,
 )
 ```


### PR DESCRIPTION
We no longer need the placeholder `shard` field in the `BlobsSidecar` because with danksharding we'll most likely use a transaction-index, rather than index blobs by a shard.