### PR TITLE
Fix Name Discrepancy (WITHDRAWAL_QUEUE_LIMIT)

### DIFF
--- a/presets/mainnet/capella.yaml
+++ b/presets/mainnet/capella.yaml
@@ -9,7 +9,7 @@ MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 256
 # State list lengths
 # ---------------------------------------------------------------
 # 2**40 (= 1,099,511,627,776) withdrawals
-WITHDRAWALS_QUEUE_LIMIT: 1099511627776
+WITHDRAWAL_QUEUE_LIMIT: 1099511627776
 
 
 # Max operations per block

--- a/presets/minimal/capella.yaml
+++ b/presets/minimal/capella.yaml
@@ -9,7 +9,7 @@ MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 16
 # State list lengths
 # ---------------------------------------------------------------
 # 2**40 (= 1,099,511,627,776) withdrawals
-WITHDRAWALS_QUEUE_LIMIT: 1099511627776
+WITHDRAWAL_QUEUE_LIMIT: 1099511627776
 
 
 # Max operations per block


### PR DESCRIPTION
Fixes field `WITHDRAWALS_QUEUE_LIMIT` to `WITHDRAWAL_QUEUE_LIMIT` in the capella fork preset files.