### PR TITLE
Allow `LightClientUpdate` with genesis finality

### DIFF
--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -175,11 +175,11 @@ def validate_light_client_update(store: LightClientStore,
     if not is_finality_update(update):
         assert update.finalized_header == BeaconBlockHeader()
     else:
-        if update.finalized_header.slot != GENESIS_SLOT:
-            finalized_root = hash_tree_root(update.finalized_header)
-        else:
+        if update.finalized_header.slot == GENESIS_SLOT:
             finalized_root = Bytes32()
             assert update.finalized_header == BeaconBlockHeader()
+        else:
+            finalized_root = hash_tree_root(update.finalized_header)
         assert is_valid_merkle_branch(
             leaf=finalized_root,
             branch=update.finality_branch,

--- a/specs/altair/sync-protocol.md
+++ b/specs/altair/sync-protocol.md
@@ -170,8 +170,9 @@ def validate_light_client_update(store: LightClientStore,
     signature_period = compute_sync_committee_period(compute_epoch_at_slot(update.signature_slot))
     assert signature_period in (finalized_period, finalized_period + 1)
 
-    # Verify that the `finalized_header`, if present, actually is the finalized header saved in the
-    # state of the `attested_header`
+    # Verify that the `finality_branch`, if present, confirms `finalized_header`
+    # to match the finalized checkpoint root saved in the state of `attested_header`.
+    # Note that the genesis finalized checkpoint root is represented as a zero hash.
     if not is_finality_update(update):
         assert update.finalized_header == BeaconBlockHeader()
     else:


### PR DESCRIPTION
When `state.finalized_checkpoint` references the genesis slot, it points
to an empty `root`, instead of the actual genesis block hash. This patch
updates the `LightClientUpdate` logic to allow including finality proofs
for genesis `finalized_checkpoint.root`, better supporting non-mainnet.
When including such a finality proof, the proof is for the empty `root`,
but `finalized_header` is kept zeroed out to signify this edge case.