### PR TITLE
Add summary diagnostics to spec test gen

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1041,7 +1041,7 @@ setup(
     extras_require={
         "test": ["pytest>=4.4", "pytest-cov", "pytest-xdist"],
         "lint": ["flake8==3.7.7", "mypy==0.812", "pylint==2.12.2"],
-        "generator": ["python-snappy==0.5.4"],
+        "generator": ["python-snappy==0.5.4", "filelock"],
     },
     install_requires=[
         "eth-utils>=1.3.0,<2",


### PR DESCRIPTION
Fixes #2919.

Due to the current architecture of the spec test gen, it was most straightforward to simply write the stats for each generator to a local file.

Remaining todo:
- [x] collect all stats into one top-level report
- [x] test it out
