### PR TITLE
Include Bellatrix p2p interface specs into pyspec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -891,6 +891,7 @@ class PySpecCommand(Command):
                     specs/bellatrix/fork.md
                     specs/bellatrix/fork-choice.md
                     specs/bellatrix/validator.md
+                    specs/bellatrix/p2p-interface.md
                     sync/optimistic.md
                 """
             if self.spec_fork == CAPELLA:


### PR DESCRIPTION
Although Bellatrix p2p spec has no executable code blocks, I suggest including it into pyspec for consistency and completeness.