### PR TITLE
EIP-4844: Optimistic Sync

### DIFF
--- a/specs/eip4844/optimistic_sync.md
+++ b/specs/eip4844/optimistic_sync.md
@@ -1,0 +1,22 @@
+# EIP-4844 -- Optimistic Sync
+
+This document is an extension of the [Optimistic Sync](/sync/optimistic.md) guide for EIP-4844.
+All behaviors and definitions defined in Optimistic Sync guide carry over unless explicitly noted or overridden.
+
+EIP-4844 extends the block validity requirement for [data availability](./validator.md#is_data_available). When a block transitions from `NOT_VALIDATED` -> `VALID`, its ancestors no longer unconditionally transition as well. But rather, only ancestors that do not have ancestors themselves with missing blocks can be considered `VALID`.
+
+```python
+def latest_valid_candidate_block(opt_store: OptimisticStore, block: BeaconBlock) -> BeaconBlock:
+    # Assuming the input `block` is VALID
+    chain = []
+    while True:
+        chain.append(block)
+        if not is_optimistic(opt_store, block) or block.parent_root == Root():
+            break
+        block = opt_store.blocks[block.parent_root]
+    b = next(b for b in reversed(chain)
+            if not is_data_available(b.slot, hash_tree_root(b.body), b.body.blob_kzgs), None)
+    return opt_store.blocks[b.parent_root] if b is not None else None
+```
+
+We define `latest_valid_candidate_block` as a function returning the most recent ancestor of a `VALID` block that can be transitioned from` NOT_VALIDATED` -> `VALID`. The ancestors of the block returned by the function can also be transitioned from `NOT_VALIDATED` to `VALID`.

--- a/specs/eip4844/optimistic_sync.md
+++ b/specs/eip4844/optimistic_sync.md
@@ -1,9 +1,23 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [EIP-4844 -- Optimistic Sync](#eip-4844----optimistic-sync)
+  - [Introduction](#introduction)
+  - [Helpers](#helpers)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # EIP-4844 -- Optimistic Sync
+
+## Introduction
 
 This document is an extension of the [Optimistic Sync](/sync/optimistic.md) guide for EIP-4844.
 All behaviors and definitions defined in Optimistic Sync guide carry over unless explicitly noted or overridden.
 
 EIP-4844 extends the block validity requirement for [data availability](./validator.md#is_data_available). When a block transitions from `NOT_VALIDATED` -> `VALID`, its ancestors no longer unconditionally transition as well. But rather, only ancestors that do not have ancestors themselves with missing blocks can be considered `VALID`.
+
+## Helpers
 
 ```python
 def latest_valid_candidate_block(opt_store: OptimisticStore, block: BeaconBlock) -> BeaconBlock:


### PR DESCRIPTION
With the data availability block requirement introduced for EIP-4844, we also need to tweak optimistic sync so it's consistent with which blocks are considered valid.

Right now, a `VALID` block means all of its ancestors will also become `VALID` blocks. This breaks with EIP-4844 when blob sidecars are introduced as an optimistcally imported block lacking its sidecar will be incorrectly promoted to `VALID`. This makes It then becomes easy for an attacker to trick peers into treating actual invalid blocks with missing data as valid.

To fix this we change the block used as a basis for the block status transition. When a block transitions from `NOT_VALIDATED` to `VALID`, identify the latest ancestor whereby all of its own ancestors satisfy data availability.

Here's an example illustrating this:

![image](https://user-images.githubusercontent.com/3516807/176781922-e42aaf19-384e-4ff1-80e2-c247d24ff464.png)

In the diagram, `B` is the only block missing data. We ignore both `A` and `B` to transition `C` and its ancestors from `NOT_VALIDATED` -> `VALID`.




cc: @terencechain