### PR TITLE
Add `LightClientBootstrap`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -481,6 +481,7 @@ def get_generalized_index(ssz_class: Any, *path: Sequence[PyUnion[int, SSZVariab
     def hardcoded_ssz_dep_constants(cls) -> Dict[str, str]:
         constants = {
             'FINALIZED_ROOT_INDEX': 'GeneralizedIndex(105)',
+            'CURRENT_SYNC_COMMITTEE_INDEX': 'GeneralizedIndex(54)',
             'NEXT_SYNC_COMMITTEE_INDEX': 'GeneralizedIndex(55)',
         }
         return {**super().hardcoded_ssz_dep_constants(), **constants}

--- a/tests/core/pyspec/eth2spec/test/altair/merkle/test_single_proof.py
+++ b/tests/core/pyspec/eth2spec/test/altair/merkle/test_single_proof.py
@@ -7,6 +7,25 @@ from eth2spec.test.helpers.merkle import build_proof
 
 @with_altair_and_later
 @spec_state_test
+def test_current_sync_committee_merkle_proof(spec, state):
+    yield "state", state
+    current_sync_committee_branch = build_proof(state.get_backing(), spec.CURRENT_SYNC_COMMITTEE_INDEX)
+    yield "proof", {
+        "leaf": "0x" + state.current_sync_committee.hash_tree_root().hex(),
+        "leaf_index": spec.CURRENT_SYNC_COMMITTEE_INDEX,
+        "branch": ['0x' + root.hex() for root in current_sync_committee_branch]
+    }
+    assert spec.is_valid_merkle_branch(
+        leaf=state.current_sync_committee.hash_tree_root(),
+        branch=current_sync_committee_branch,
+        depth=spec.floorlog2(spec.CURRENT_SYNC_COMMITTEE_INDEX),
+        index=spec.get_subtree_index(spec.CURRENT_SYNC_COMMITTEE_INDEX),
+        root=state.hash_tree_root(),
+    )
+
+
+@with_altair_and_later
+@spec_state_test
 def test_next_sync_committee_merkle_proof(spec, state):
     yield "state", state
     next_sync_committee_branch = build_proof(state.get_backing(), spec.NEXT_SYNC_COMMITTEE_INDEX)

--- a/tests/core/pyspec/eth2spec/test/altair/sync_protocol/test_update_ranking.py
+++ b/tests/core/pyspec/eth2spec/test/altair/sync_protocol/test_update_ranking.py
@@ -85,10 +85,8 @@ def test_update_ranking(spec, state):
     # Create updates (in descending order of quality)
     updates = [
         # Updates with sync committee finality
-        create_update(spec, sig, with_next_sync_committee=0, with_finality=1, participation_rate=1.0),
         create_update(spec, fin, with_next_sync_committee=1, with_finality=1, participation_rate=1.0),
         create_update(spec, lat, with_next_sync_committee=1, with_finality=1, participation_rate=1.0),
-        create_update(spec, sig, with_next_sync_committee=0, with_finality=1, participation_rate=0.8),
         create_update(spec, fin, with_next_sync_committee=1, with_finality=1, participation_rate=0.8),
         create_update(spec, lat, with_next_sync_committee=1, with_finality=1, participation_rate=0.8),
 
@@ -97,34 +95,66 @@ def test_update_ranking(spec, state):
         create_update(spec, att, with_next_sync_committee=1, with_finality=1, participation_rate=0.8),
 
         # Updates without indication of any finality
-        create_update(spec, sig, with_next_sync_committee=0, with_finality=0, participation_rate=1.0),
         create_update(spec, att, with_next_sync_committee=1, with_finality=0, participation_rate=1.0),
         create_update(spec, fin, with_next_sync_committee=1, with_finality=0, participation_rate=1.0),
         create_update(spec, lat, with_next_sync_committee=1, with_finality=0, participation_rate=1.0),
-        create_update(spec, sig, with_next_sync_committee=0, with_finality=0, participation_rate=0.8),
         create_update(spec, att, with_next_sync_committee=1, with_finality=0, participation_rate=0.8),
         create_update(spec, fin, with_next_sync_committee=1, with_finality=0, participation_rate=0.8),
         create_update(spec, lat, with_next_sync_committee=1, with_finality=0, participation_rate=0.8),
 
+        # Updates with sync committee finality but no `next_sync_committee`
+        create_update(spec, sig, with_next_sync_committee=0, with_finality=1, participation_rate=1.0),
+        create_update(spec, fin, with_next_sync_committee=0, with_finality=1, participation_rate=1.0),
+        create_update(spec, lat, with_next_sync_committee=0, with_finality=1, participation_rate=1.0),
+        create_update(spec, sig, with_next_sync_committee=0, with_finality=1, participation_rate=0.8),
+        create_update(spec, fin, with_next_sync_committee=0, with_finality=1, participation_rate=0.8),
+        create_update(spec, lat, with_next_sync_committee=0, with_finality=1, participation_rate=0.8),
+
+        # Updates without sync committee finality and also no `next_sync_committee`
+        create_update(spec, att, with_next_sync_committee=0, with_finality=1, participation_rate=1.0),
+        create_update(spec, att, with_next_sync_committee=0, with_finality=1, participation_rate=0.8),
+
+        # Updates without indication of any finality nor `next_sync_committee`
+        create_update(spec, sig, with_next_sync_committee=0, with_finality=0, participation_rate=1.0),
+        create_update(spec, att, with_next_sync_committee=0, with_finality=0, participation_rate=1.0),
+        create_update(spec, fin, with_next_sync_committee=0, with_finality=0, participation_rate=1.0),
+        create_update(spec, lat, with_next_sync_committee=0, with_finality=0, participation_rate=1.0),
+        create_update(spec, sig, with_next_sync_committee=0, with_finality=0, participation_rate=0.8),
+        create_update(spec, att, with_next_sync_committee=0, with_finality=0, participation_rate=0.8),
+        create_update(spec, fin, with_next_sync_committee=0, with_finality=0, participation_rate=0.8),
+        create_update(spec, lat, with_next_sync_committee=0, with_finality=0, participation_rate=0.8),
+
         # Updates with low sync committee participation
-        create_update(spec, sig, with_next_sync_committee=0, with_finality=1, participation_rate=0.4),
         create_update(spec, fin, with_next_sync_committee=1, with_finality=1, participation_rate=0.4),
         create_update(spec, lat, with_next_sync_committee=1, with_finality=1, participation_rate=0.4),
         create_update(spec, att, with_next_sync_committee=1, with_finality=1, participation_rate=0.4),
-        create_update(spec, sig, with_next_sync_committee=0, with_finality=0, participation_rate=0.4),
         create_update(spec, att, with_next_sync_committee=1, with_finality=0, participation_rate=0.4),
         create_update(spec, fin, with_next_sync_committee=1, with_finality=0, participation_rate=0.4),
         create_update(spec, lat, with_next_sync_committee=1, with_finality=0, participation_rate=0.4),
+        create_update(spec, sig, with_next_sync_committee=0, with_finality=1, participation_rate=0.4),
+        create_update(spec, fin, with_next_sync_committee=0, with_finality=1, participation_rate=0.4),
+        create_update(spec, lat, with_next_sync_committee=0, with_finality=1, participation_rate=0.4),
+        create_update(spec, att, with_next_sync_committee=0, with_finality=1, participation_rate=0.4),
+        create_update(spec, sig, with_next_sync_committee=0, with_finality=0, participation_rate=0.4),
+        create_update(spec, att, with_next_sync_committee=0, with_finality=0, participation_rate=0.4),
+        create_update(spec, fin, with_next_sync_committee=0, with_finality=0, participation_rate=0.4),
+        create_update(spec, lat, with_next_sync_committee=0, with_finality=0, participation_rate=0.4),
 
         # Updates with very low sync committee participation
-        create_update(spec, sig, with_next_sync_committee=0, with_finality=1, participation_rate=0.2),
         create_update(spec, fin, with_next_sync_committee=1, with_finality=1, participation_rate=0.2),
         create_update(spec, lat, with_next_sync_committee=1, with_finality=1, participation_rate=0.2),
         create_update(spec, att, with_next_sync_committee=1, with_finality=1, participation_rate=0.2),
-        create_update(spec, sig, with_next_sync_committee=0, with_finality=0, participation_rate=0.2),
         create_update(spec, att, with_next_sync_committee=1, with_finality=0, participation_rate=0.2),
         create_update(spec, fin, with_next_sync_committee=1, with_finality=0, participation_rate=0.2),
         create_update(spec, lat, with_next_sync_committee=1, with_finality=0, participation_rate=0.2),
+        create_update(spec, sig, with_next_sync_committee=0, with_finality=1, participation_rate=0.2),
+        create_update(spec, fin, with_next_sync_committee=0, with_finality=1, participation_rate=0.2),
+        create_update(spec, lat, with_next_sync_committee=0, with_finality=1, participation_rate=0.2),
+        create_update(spec, att, with_next_sync_committee=0, with_finality=1, participation_rate=0.2),
+        create_update(spec, sig, with_next_sync_committee=0, with_finality=0, participation_rate=0.2),
+        create_update(spec, att, with_next_sync_committee=0, with_finality=0, participation_rate=0.2),
+        create_update(spec, fin, with_next_sync_committee=0, with_finality=0, participation_rate=0.2),
+        create_update(spec, lat, with_next_sync_committee=0, with_finality=0, participation_rate=0.2),
     ]
     yield "updates", updates
 


### PR DESCRIPTION
Introduces a new `LightClientBootstrap` structure to allow setting up a
`LightClientStore` with the initial sync committee and block header from
a user-configured trusted block root.

This leads to new cases where the `LightClientStore` is only aware of
the current but not the next sync committee. As a side effect of these
new cases, the store's `finalized_header` may now  advance into the next
sync committee period before a corresponding `LightClientUpdate` with
the new sync committee is obtained, improving responsiveness.

Note that so far, `LightClientUpdate.attested_header.slot` needed to be
newer than `LightClientStore.finalized_header.slot`. However, it is now
necessary to also consider certain older updates to try and backfill the
`next_sync_committee`. The `is_better_update` helper is also updated to
improve `best_valid_update` tracking.