### PR TITLE
block gossip IGNORE on incomplete and REJECT on complete payload validation

### DIFF
--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -98,10 +98,10 @@ Alias `block = signed_beacon_block.message`, `execution_payload = block.body.exe
     - _[REJECT]_ The block's execution payload timestamp is correct with respect to the slot
        -- i.e. `execution_payload.timestamp == compute_timestamp_at_slot(state, block.slot)`.
     - If `exection_payload` verification of block's parent by an execution node is *not* complete:
-    	- [REJECT] The block's parent (defined by `block.parent_root`) passes all
+    	- [IGNORE] The block's parent (defined by `block.parent_root`) passes all
     	  validation (excluding execution node verification of the `block.body.execution_payload`).
     - otherwise:
-    	- [IGNORE] The block's parent (defined by `block.parent_root`) passes all
+    	- [REJECT] The block's parent (defined by `block.parent_root`) passes all
     	  validation (including execution node verification of the `block.body.execution_payload`).
 
 The following gossip validation from prior specifications MUST NOT be applied if the execution is enabled for the block -- i.e. `is_execution_enabled(state, block.body)`:


### PR DESCRIPTION
As written, it's inconsistent with
> Blocks with execution enabled will be permitted to propagate regardless of the validity of the execution payload. This prevents network segregation between optimistic and non-optimistic nodes.

If the verification of the block's parent by an execution node is not complete, then that's the condition under which it might be an optimistic block and to achieve the stated objective, should be `IGNORE`d rather than `REJECT`ed. If the verification of a block's parents by an execution node not(is not complete), then that block truly is invalid and it should be equivalent to the pre-merge
> [REJECT] The block's parent (defined by `block.parent_root`) passes validation.