### PR TITLE
[Minor Refactoring] remove unused param `spec` from `compute_committee_indices`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/sync_aggregate/test_process_sync_aggregate.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/sync_aggregate/test_process_sync_aggregate.py
@@ -31,7 +31,7 @@ from eth2spec.test.context import (
 @spec_state_test
 @always_bls
 def test_invalid_signature_bad_domain(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
 
     block = build_empty_block_for_next_slot(spec, state)
     block.body.sync_aggregate = spec.SyncAggregate(
@@ -52,7 +52,7 @@ def test_invalid_signature_bad_domain(spec, state):
 @spec_state_test
 @always_bls
 def test_invalid_signature_missing_participant(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     rng = random.Random(2020)
     random_participant = rng.choice(committee_indices)
 
@@ -116,7 +116,7 @@ def test_invalid_signature_infinite_signature_with_single_participant(spec, stat
 @spec_state_test
 @always_bls
 def test_invalid_signature_extra_participant(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     rng = random.Random(3030)
     random_participant = rng.choice(committee_indices)
 
@@ -140,7 +140,7 @@ def test_invalid_signature_extra_participant(spec, state):
 @with_presets([MINIMAL], reason="to create nonduplicate committee")
 @spec_state_test
 def test_sync_committee_rewards_nonduplicate_committee(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     committee_size = len(committee_indices)
     committee_bits = [True] * committee_size
     active_validator_count = len(spec.get_active_validator_indices(state, spec.get_current_epoch(state)))
@@ -156,7 +156,7 @@ def test_sync_committee_rewards_nonduplicate_committee(spec, state):
 @with_presets([MAINNET], reason="to create duplicate committee")
 @spec_state_test
 def test_sync_committee_rewards_duplicate_committee_no_participation(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     committee_size = len(committee_indices)
     committee_bits = [False] * committee_size
     active_validator_count = len(spec.get_active_validator_indices(state, spec.get_current_epoch(state)))
@@ -172,7 +172,7 @@ def test_sync_committee_rewards_duplicate_committee_no_participation(spec, state
 @with_presets([MAINNET], reason="to create duplicate committee")
 @spec_state_test
 def test_sync_committee_rewards_duplicate_committee_half_participation(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     committee_size = len(committee_indices)
     committee_bits = [True] * (committee_size // 2) + [False] * (committee_size // 2)
     assert len(committee_bits) == committee_size
@@ -189,7 +189,7 @@ def test_sync_committee_rewards_duplicate_committee_half_participation(spec, sta
 @with_presets([MAINNET], reason="to create duplicate committee")
 @spec_state_test
 def test_sync_committee_rewards_duplicate_committee_full_participation(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     committee_size = len(committee_indices)
     committee_bits = [True] * committee_size
     active_validator_count = len(spec.get_active_validator_indices(state, spec.get_current_epoch(state)))
@@ -205,7 +205,7 @@ def test_sync_committee_rewards_duplicate_committee_full_participation(spec, sta
 @spec_state_test
 @always_bls
 def test_sync_committee_rewards_not_full_participants(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     rng = random.Random(1010)
     committee_bits = [rng.choice([True, False]) for _ in committee_indices]
 
@@ -216,7 +216,7 @@ def test_sync_committee_rewards_not_full_participants(spec, state):
 @spec_state_test
 @always_bls
 def test_sync_committee_rewards_empty_participants(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     committee_bits = [False for _ in committee_indices]
 
     yield from run_successful_sync_committee_test(spec, state, committee_indices, committee_bits)
@@ -226,7 +226,7 @@ def test_sync_committee_rewards_empty_participants(spec, state):
 @spec_state_test
 @always_bls
 def test_invalid_signature_past_block(spec, state):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
 
     for _ in range(2):
         # NOTE: need to transition twice to move beyond the degenerate case at genesis
@@ -280,7 +280,7 @@ def test_invalid_signature_previous_committee(spec, state):
     # Use the previous sync committee to produce the signature.
     # Ensure that the pubkey sets are different.
     assert set(old_sync_committee.pubkeys) != set(state.current_sync_committee.pubkeys)
-    committee_indices = compute_committee_indices(spec, state, old_sync_committee)
+    committee_indices = compute_committee_indices(state, old_sync_committee)
 
     block = build_empty_block_for_next_slot(spec, state)
     block.body.sync_aggregate = spec.SyncAggregate(
@@ -322,7 +322,7 @@ def test_valid_signature_future_committee(spec, state):
     assert sync_committee != old_current_sync_committee
     assert sync_committee != old_next_sync_committee
 
-    committee_indices = compute_committee_indices(spec, state, sync_committee)
+    committee_indices = compute_committee_indices(state, sync_committee)
 
     block = build_empty_block_for_next_slot(spec, state)
     block.body.sync_aggregate = spec.SyncAggregate(
@@ -344,7 +344,7 @@ def test_valid_signature_future_committee(spec, state):
 @always_bls
 @with_presets([MINIMAL], reason="prefer short search to find matching proposer")
 def test_proposer_in_committee_without_participation(spec, state):
-    committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
+    committee_indices = compute_committee_indices(state, state.current_sync_committee)
 
     # NOTE: seem to reliably be getting a matching proposer in the first epoch w/ ``MINIMAL`` preset.
     for _ in range(spec.SLOTS_PER_EPOCH):
@@ -385,7 +385,7 @@ def test_proposer_in_committee_without_participation(spec, state):
 @always_bls
 @with_presets([MINIMAL], reason="prefer short search to find matching proposer")
 def test_proposer_in_committee_with_participation(spec, state):
-    committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
+    committee_indices = compute_committee_indices(state, state.current_sync_committee)
     participation = [True for _ in committee_indices]
 
     # NOTE: seem to reliably be getting a matching proposer in the first epoch w/ ``MINIMAL`` preset.
@@ -451,7 +451,7 @@ def test_sync_committee_with_participating_exited_member(spec, state):
     for _ in range(3):
         next_epoch_via_block(spec, state)
 
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     rng = random.Random(1010)
 
     exited_index = _exit_validator_from_committee_and_transition_state(
@@ -490,7 +490,7 @@ def test_sync_committee_with_nonparticipating_exited_member(spec, state):
     for _ in range(3):
         next_epoch_via_block(spec, state)
 
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     rng = random.Random(1010)
 
     exited_index = _exit_validator_from_committee_and_transition_state(
@@ -533,7 +533,7 @@ def test_sync_committee_with_participating_withdrawable_member(spec, state):
     for _ in range(3):
         next_epoch_via_block(spec, state)
 
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     rng = random.Random(1010)
 
     exited_index = _exit_validator_from_committee_and_transition_state(
@@ -572,7 +572,7 @@ def test_sync_committee_with_nonparticipating_withdrawable_member(spec, state):
     for _ in range(3):
         next_epoch_via_block(spec, state)
 
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
     rng = random.Random(1010)
 
     exited_index = _exit_validator_from_committee_and_transition_state(

--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/sync_aggregate/test_process_sync_aggregate_random.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/sync_aggregate/test_process_sync_aggregate_random.py
@@ -28,7 +28,7 @@ from eth2spec.test.context import (
 
 
 def _test_harness_for_randomized_test_case(spec, state, expect_duplicates=False, participation_fn=None):
-    committee_indices = compute_committee_indices(spec, state)
+    committee_indices = compute_committee_indices(state)
 
     if participation_fn:
         participating_indices = participation_fn(committee_indices)

--- a/tests/core/pyspec/eth2spec/test/helpers/light_client.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/light_client.py
@@ -39,7 +39,7 @@ def get_sync_aggregate(spec, state, num_participants=None, signature_slot=None):
     transition_to(spec, signature_state, signature_slot)
 
     # Fetch sync committee
-    committee_indices = compute_committee_indices(spec, signature_state)
+    committee_indices = compute_committee_indices(signature_state)
     committee_size = len(committee_indices)
 
     # By default, use full participation

--- a/tests/core/pyspec/eth2spec/test/helpers/multi_operations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/multi_operations.py
@@ -180,7 +180,7 @@ def get_random_voluntary_exits(spec, state, to_be_slashed_indices, rng):
 
 
 def get_random_sync_aggregate(spec, state, slot, block_root=None, fraction_participated=1.0, rng=Random(2099)):
-    committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
+    committee_indices = compute_committee_indices(state, state.current_sync_committee)
     participant_count = int(len(committee_indices) * fraction_participated)
     participant_indices = rng.sample(range(len(committee_indices)), participant_count)
     participants = [

--- a/tests/core/pyspec/eth2spec/test/helpers/proposer_slashings.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/proposer_slashings.py
@@ -30,7 +30,7 @@ def check_proposer_slashing_effect(spec, pre_state, state, slashed_index, block=
     # Altair introduces sync committee (SC) reward and penalty
     sc_reward_for_slashed = sc_penalty_for_slashed = sc_reward_for_proposer = sc_penalty_for_proposer = 0
     if is_post_altair(spec) and block is not None:
-        committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
+        committee_indices = compute_committee_indices(state, state.current_sync_committee)
         committee_bits = block.body.sync_aggregate.sync_committee_bits
         sc_reward_for_slashed, sc_penalty_for_slashed = compute_sync_committee_participant_reward_and_penalty(
             spec,

--- a/tests/core/pyspec/eth2spec/test/helpers/sync_committee.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/sync_committee.py
@@ -74,7 +74,7 @@ def compute_sync_committee_proposer_reward(spec, state, committee_indices, commi
     return spec.Gwei(participant_reward * participant_number)
 
 
-def compute_committee_indices(spec, state, committee=None):
+def compute_committee_indices(state, committee=None):
     """
     Given a ``committee``, calculate and return the related indices
     """
@@ -129,11 +129,7 @@ def run_sync_committee_processing(spec, state, block, expect_exception=False):
     if expect_exception:
         assert pre_state.balances == state.balances
     else:
-        committee_indices = compute_committee_indices(
-            spec,
-            state,
-            state.current_sync_committee,
-        )
+        committee_indices = compute_committee_indices(state, state.current_sync_committee)
         committee_bits = block.body.sync_aggregate.sync_committee_bits
         validate_sync_committee_rewards(
             spec,

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -773,7 +773,7 @@ def test_deposit_top_up(spec, state):
     # Altair introduces sync committee (sm) reward and penalty
     sync_committee_reward = sync_committee_penalty = 0
     if is_post_altair(spec):
-        committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
+        committee_indices = compute_committee_indices(state, state.current_sync_committee)
         committee_bits = block.body.sync_aggregate.sync_committee_bits
         sync_committee_reward, sync_committee_penalty = compute_sync_committee_participant_reward_and_penalty(
             spec,


### PR DESCRIPTION
Just remove the unused parameter.