### PR TITLE
Opti-sync: extend optimistic node definition

### DIFF
--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -91,7 +91,7 @@ def is_optimistic_candidate_block(opt_store: OptimisticStore, current_slot: Slot
 
 Let a node be an *optimistic node* if its fork choice is in one of the following states:
 1. `is_optimistic(opt_store, head) is True`
-1. Blocks from every viable (with respect to FFG) branch have transitioned from `NOT_VALIDATED` to `INVALIDATED`
+2. Blocks from every viable (with respect to FFG) branch have transitioned from `NOT_VALIDATED` to `INVALIDATED`
 leaving the block tree without viable branches
 
 Let only a validator on an optimistic node be an *optimistic validator*.

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -89,8 +89,12 @@ def is_optimistic_candidate_block(opt_store: OptimisticStore, current_slot: Slot
     return False
 ```
 
-Let only a node which returns `is_optimistic(opt_store, head) is True` be an *optimistic
-node*. Let only a validator on an optimistic node be an *optimistic validator*.
+Let a node be an *optimistic node* if its fork choice is in one of the following states:
+1. `is_optimistic(opt_store, head) is True`
+1. Blocks from every viable (with respect to FFG) branch have transitioned from `NOT_VALIDATED` to `INVALIDATED`
+leaving the block tree without viable branches
+
+Let only a validator on an optimistic node be an *optimistic validator*.
 
 When this specification only defines behaviour for an optimistic
 node/validator, but *not* for the non-optimistic case, assume default


### PR DESCRIPTION
Proposes to extend an *optimistic node* definition with the following condition:
* If fork choice state of a node ended up without viable branches in a block tree because blocks from every such branch were transitioned from `NOT_VALIDATED` to `INVALIDATED`

The motivation of this change is to prevent different and potentially dangerous behaviours handling this situation. For instance, CL implementation may revert its justified checkpoint in the store back to the previous one which is prone to surround voting. By stating that node must stay optimistic in this case we protect from such cases.

This exact statement attempts to discern the optimistic sync nature of no viable branch state from any other ways in which a node may come to the same state. In cases when a node comes to a state without viable branches in a way that is not related to optimistic sync, a node should not be an optimistic node.

cc @paulhauner @potuz @ajsutton 