### PR TITLE
more execution payload tests and cleanup old ones

### DIFF
--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -298,8 +298,6 @@ def slash_validator(state: BeaconState,
     increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
 ```
 
-
-
 ## Beacon chain state transition function
 
 ### Execution engine

--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -1,6 +1,6 @@
-import os
 from random import Random
 
+from eth2spec.debug.random_value import get_random_bytes_list
 from eth2spec.test.helpers.execution_payload import (
     build_empty_execution_payload,
     get_execution_payload_header,
@@ -60,7 +60,6 @@ def run_success_test(spec, state):
 @spec_state_test
 def test_success_first_payload(spec, state):
     state = build_state_with_incomplete_transition(spec, state)
-    assert not spec.is_merge_transition_complete(state)
 
     yield from run_success_test(spec, state)
 
@@ -69,7 +68,6 @@ def test_success_first_payload(spec, state):
 @spec_state_test
 def test_success_regular_payload(spec, state):
     state = build_state_with_complete_transition(spec, state)
-    assert spec.is_merge_transition_complete(state)
 
     yield from run_success_test(spec, state)
 
@@ -311,22 +309,25 @@ def test_zero_length_transaction_regular_payload(spec, state):
 
 def build_randomized_execution_payload(spec, state, rng):
     execution_payload = build_empty_execution_payload(spec, state)
-    execution_payload.fee_recipient = spec.ExecutionAddress(os.urandom(20))
-    execution_payload.state_root = spec.Bytes32(os.urandom(32))
-    execution_payload.receipts_root = spec.Bytes32(os.urandom(32))
-    execution_payload.logs_bloom = spec.ByteVector[spec.BYTES_PER_LOGS_BLOOM](os.urandom(spec.BYTES_PER_LOGS_BLOOM))
+    execution_payload.fee_recipient = spec.ExecutionAddress(get_random_bytes_list(rng, 20))
+    execution_payload.state_root = spec.Bytes32(get_random_bytes_list(rng, 32))
+    execution_payload.receipts_root = spec.Bytes32(get_random_bytes_list(rng, 32))
+    execution_payload.logs_bloom = spec.ByteVector[spec.BYTES_PER_LOGS_BLOOM](
+        get_random_bytes_list(rng, spec.BYTES_PER_LOGS_BLOOM)
+    )
     execution_payload.block_number = rng.randint(0, 10e10)
     execution_payload.gas_limit = rng.randint(0, 10e10)
     execution_payload.gas_used = rng.randint(0, 10e10)
+    extra_data_length = rng.randint(0, spec.MAX_EXTRA_DATA_BYTES)
     execution_payload.extra_data = spec.ByteList[spec.MAX_EXTRA_DATA_BYTES](
-        os.urandom(rng.randint(0, spec.MAX_EXTRA_DATA_BYTES))
+        get_random_bytes_list(rng, extra_data_length)
     )
     execution_payload.base_fee_per_gas = rng.randint(0, 2**256 - 1)
-    execution_payload.block_hash = spec.Hash32(os.urandom(32))
+    execution_payload.block_hash = spec.Hash32(get_random_bytes_list(rng, 32))
 
     num_transactions = rng.randint(0, 100)
     execution_payload.transactions = [
-        spec.Transaction(os.urandom(rng.randint(0, 1000)))
+        spec.Transaction(get_random_bytes_list(rng, rng.randint(0, 1000)))
         for _ in range(num_transactions)
     ]
 

--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -1,3 +1,6 @@
+import os
+from random import Random
+
 from eth2spec.test.helpers.execution_payload import (
     build_empty_execution_payload,
     get_execution_payload_header,
@@ -46,14 +49,8 @@ def run_execution_payload_processing(spec, state, execution_payload, valid=True,
     assert state.latest_execution_payload_header == get_execution_payload_header(spec, execution_payload)
 
 
-@with_bellatrix_and_later
-@spec_state_test
-def test_success_first_payload(spec, state):
-    # pre-state
-    state = build_state_with_incomplete_transition(spec, state)
+def run_success_test(spec, state):
     next_slot(spec, state)
-
-    # execution payload
     execution_payload = build_empty_execution_payload(spec, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
@@ -61,12 +58,25 @@ def test_success_first_payload(spec, state):
 
 @with_bellatrix_and_later
 @spec_state_test
-def test_success_regular_payload(spec, state):
-    # pre-state
-    state = build_state_with_complete_transition(spec, state)
-    next_slot(spec, state)
+def test_success_first_payload(spec, state):
+    state = build_state_with_incomplete_transition(spec, state)
+    assert not spec.is_merge_transition_complete(state)
 
-    # execution payload
+    yield from run_success_test(spec, state)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_success_regular_payload(spec, state):
+    state = build_state_with_complete_transition(spec, state)
+    assert spec.is_merge_transition_complete(state)
+
+    yield from run_success_test(spec, state)
+
+
+def run_gap_slot_test(spec, state):
+    next_slot(spec, state)
+    next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
@@ -75,83 +85,66 @@ def test_success_regular_payload(spec, state):
 @with_bellatrix_and_later
 @spec_state_test
 def test_success_first_payload_with_gap_slot(spec, state):
-    # pre-state
     state = build_state_with_incomplete_transition(spec, state)
-    next_slot(spec, state)
-    next_slot(spec, state)
-
-    # execution payload
-    execution_payload = build_empty_execution_payload(spec, state)
-
-    yield from run_execution_payload_processing(spec, state, execution_payload)
+    yield from run_gap_slot_test(spec, state)
 
 
 @with_bellatrix_and_later
 @spec_state_test
 def test_success_regular_payload_with_gap_slot(spec, state):
-    # pre-state
     state = build_state_with_complete_transition(spec, state)
-    next_slot(spec, state)
-    next_slot(spec, state)
+    yield from run_gap_slot_test(spec, state)
 
-    # execution payload
+
+def run_bad_execution_test(spec, state):
+    # completely valid payload, but execution itself fails (e.g. block exceeds gas limit)
+    next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
 
-    yield from run_execution_payload_processing(spec, state, execution_payload)
+    yield from run_execution_payload_processing(spec, state, execution_payload, valid=False, execution_valid=False)
 
 
 @with_bellatrix_and_later
 @spec_state_test
 def test_bad_execution_first_payload(spec, state):
-    # completely valid payload, but execution itself fails (e.g. block exceeds gas limit)
-
-    # pre-state
     state = build_state_with_incomplete_transition(spec, state)
-    next_slot(spec, state)
-
-    # execution payload
-    execution_payload = build_empty_execution_payload(spec, state)
-
-    yield from run_execution_payload_processing(spec, state, execution_payload, valid=False, execution_valid=False)
+    yield from run_bad_execution_test(spec, state)
 
 
 @with_bellatrix_and_later
 @spec_state_test
 def test_bad_execution_regular_payload(spec, state):
-    # completely valid payload, but execution itself fails (e.g. block exceeds gas limit)
-
-    # pre-state
     state = build_state_with_complete_transition(spec, state)
+    yield from run_bad_execution_test(spec, state)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_bad_parent_hash_first_payload(spec, state):
+    state = build_state_with_incomplete_transition(spec, state)
     next_slot(spec, state)
 
-    # execution payload
     execution_payload = build_empty_execution_payload(spec, state)
+    execution_payload.parent_hash = b'\x55' * 32
 
-    yield from run_execution_payload_processing(spec, state, execution_payload, valid=False, execution_valid=False)
+    yield from run_execution_payload_processing(spec, state, execution_payload, valid=True)
 
 
 @with_bellatrix_and_later
 @spec_state_test
 def test_bad_parent_hash_regular_payload(spec, state):
-    # pre-state
     state = build_state_with_complete_transition(spec, state)
     next_slot(spec, state)
 
-    # execution payload
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.parent_hash = spec.Hash32()
 
     yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
 
 
-@with_bellatrix_and_later
-@spec_state_test
-def test_bad_random_first_payload(spec, state):
-    # pre-state
-    state = build_state_with_incomplete_transition(spec, state)
+def run_bad_prev_randao_test(spec, state):
     next_slot(spec, state)
 
-    # execution payload
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.prev_randao = b'\x42' * 32
 
@@ -160,26 +153,21 @@ def test_bad_random_first_payload(spec, state):
 
 @with_bellatrix_and_later
 @spec_state_test
-def test_bad_random_regular_payload(spec, state):
-    # pre-state
-    state = build_state_with_complete_transition(spec, state)
-    next_slot(spec, state)
-
-    # execution payload
-    execution_payload = build_empty_execution_payload(spec, state)
-    execution_payload.prev_randao = b'\x04' * 32
-
-    yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
+def test_bad_prev_randao_first_payload(spec, state):
+    state = build_state_with_incomplete_transition(spec, state)
+    yield from run_bad_prev_randao_test(spec, state)
 
 
 @with_bellatrix_and_later
 @spec_state_test
-def test_bad_everything_regular_payload(spec, state):
-    # pre-state
+def test_bad_pre_randao_regular_payload(spec, state):
     state = build_state_with_complete_transition(spec, state)
+    yield from run_bad_prev_randao_test(spec, state)
+
+
+def run_bad_everything_test(spec, state):
     next_slot(spec, state)
 
-    # execution payload
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.parent_hash = spec.Hash32()
     execution_payload.prev_randao = spec.Bytes32()
@@ -190,59 +178,195 @@ def test_bad_everything_regular_payload(spec, state):
 
 @with_bellatrix_and_later
 @spec_state_test
-def test_bad_timestamp_first_payload(spec, state):
-    # pre-state
+def test_bad_everything_first_payload(spec, state):
     state = build_state_with_incomplete_transition(spec, state)
+    yield from run_bad_everything_test(spec, state)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_bad_everything_regular_payload(spec, state):
+    state = build_state_with_complete_transition(spec, state)
+    yield from run_bad_everything_test(spec, state)
+
+
+def run_bad_timestamp_test(spec, state, is_future):
     next_slot(spec, state)
 
     # execution payload
     execution_payload = build_empty_execution_payload(spec, state)
-    execution_payload.timestamp = execution_payload.timestamp + 1
+    if is_future:
+        timestamp = execution_payload.timestamp + 1
+    else:
+        timestamp = execution_payload.timestamp - 1
+    execution_payload.timestamp = timestamp
 
     yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
 
 
 @with_bellatrix_and_later
 @spec_state_test
-def test_bad_timestamp_regular_payload(spec, state):
-    # pre-state
+def test_future_timestamp_first_payload(spec, state):
+    state = build_state_with_incomplete_transition(spec, state)
+    yield from run_bad_timestamp_test(spec, state, is_future=True)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_future_timestamp_regular_payload(spec, state):
     state = build_state_with_complete_transition(spec, state)
+    yield from run_bad_timestamp_test(spec, state, is_future=True)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_past_timestamp_first_payload(spec, state):
+    state = build_state_with_incomplete_transition(spec, state)
+    yield from run_bad_timestamp_test(spec, state, is_future=False)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_past_timestamp_regular_payload(spec, state):
+    state = build_state_with_complete_transition(spec, state)
+    yield from run_bad_timestamp_test(spec, state, is_future=False)
+
+
+def run_non_empty_extra_data_test(spec, state):
     next_slot(spec, state)
 
-    # execution payload
     execution_payload = build_empty_execution_payload(spec, state)
-    execution_payload.timestamp = execution_payload.timestamp + 1
+    execution_payload.extra_data = b'\x45' * 12
 
-    yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
+    yield from run_execution_payload_processing(spec, state, execution_payload)
+    assert state.latest_execution_payload_header.extra_data == execution_payload.extra_data
 
 
 @with_bellatrix_and_later
 @spec_state_test
 def test_non_empty_extra_data_first_payload(spec, state):
-    # pre-state
     state = build_state_with_incomplete_transition(spec, state)
-    next_slot(spec, state)
-
-    # execution payload
-    execution_payload = build_empty_execution_payload(spec, state)
-    execution_payload.extra_data = b'\x45' * 12
-
-    yield from run_execution_payload_processing(spec, state, execution_payload)
-
-    assert state.latest_execution_payload_header.extra_data == execution_payload.extra_data
+    yield from run_non_empty_extra_data_test(spec, state)
 
 
 @with_bellatrix_and_later
 @spec_state_test
 def test_non_empty_extra_data_regular_payload(spec, state):
-    # pre-state
     state = build_state_with_complete_transition(spec, state)
+    yield from run_non_empty_extra_data_test(spec, state)
+
+
+def run_non_empty_transactions_test(spec, state):
     next_slot(spec, state)
 
-    # execution payload
     execution_payload = build_empty_execution_payload(spec, state)
-    execution_payload.extra_data = b'\x45' * 12
+    num_transactions = 2
+    execution_payload.transactions = [
+        spec.Transaction(b'\x99' * 128)
+        for _ in range(num_transactions)
+    ]
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
+    assert state.latest_execution_payload_header.transactions_root == execution_payload.transactions.hash_tree_root()
 
-    assert state.latest_execution_payload_header.extra_data == execution_payload.extra_data
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_non_empty_transactions_first_payload(spec, state):
+    state = build_state_with_incomplete_transition(spec, state)
+    yield from run_non_empty_extra_data_test(spec, state)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_non_empty_transactions_regular_payload(spec, state):
+    state = build_state_with_complete_transition(spec, state)
+    yield from run_non_empty_extra_data_test(spec, state)
+
+
+def run_zero_length_transaction_test(spec, state):
+    next_slot(spec, state)
+
+    execution_payload = build_empty_execution_payload(spec, state)
+    execution_payload.transactions = [spec.Transaction(b'')]
+    assert len(execution_payload.transactions[0]) == 0
+
+    yield from run_execution_payload_processing(spec, state, execution_payload)
+    assert state.latest_execution_payload_header.transactions_root == execution_payload.transactions.hash_tree_root()
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_zero_length_transaction_first_payload(spec, state):
+    state = build_state_with_incomplete_transition(spec, state)
+    yield from run_zero_length_transaction_test(spec, state)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_zero_length_transaction_regular_payload(spec, state):
+    state = build_state_with_complete_transition(spec, state)
+    yield from run_zero_length_transaction_test(spec, state)
+
+
+def build_randomized_execution_payload(spec, state, rng):
+    execution_payload = build_empty_execution_payload(spec, state)
+    execution_payload.fee_recipient = spec.ExecutionAddress(os.urandom(20))
+    execution_payload.state_root = spec.Bytes32(os.urandom(32))
+    execution_payload.receipts_root = spec.Bytes32(os.urandom(32))
+    execution_payload.logs_bloom = spec.ByteVector[spec.BYTES_PER_LOGS_BLOOM](os.urandom(spec.BYTES_PER_LOGS_BLOOM))
+    execution_payload.block_number = rng.randint(0, 10e10)
+    execution_payload.gas_limit = rng.randint(0, 10e10)
+    execution_payload.gas_used = rng.randint(0, 10e10)
+    execution_payload.extra_data = spec.ByteList[spec.MAX_EXTRA_DATA_BYTES](
+        os.urandom(rng.randint(0, spec.MAX_EXTRA_DATA_BYTES))
+    )
+    execution_payload.base_fee_per_gas = rng.randint(0, 2**256 - 1)
+    execution_payload.block_hash = spec.Hash32(os.urandom(32))
+
+    num_transactions = rng.randint(0, 100)
+    execution_payload.transactions = [
+        spec.Transaction(os.urandom(rng.randint(0, 1000)))
+        for _ in range(num_transactions)
+    ]
+
+    return execution_payload
+
+
+def run_randomized_non_validated_execution_fields_test(spec, state, execution_valid=True, rng=Random(5555)):
+    next_slot(spec, state)
+    execution_payload = build_randomized_execution_payload(spec, state, rng)
+
+    yield from run_execution_payload_processing(
+        spec, state,
+        execution_payload,
+        valid=execution_valid, execution_valid=execution_valid
+    )
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_randomized_non_validated_execution_fields_first_payload__valid(spec, state):
+    state = build_state_with_incomplete_transition(spec, state)
+    yield from run_randomized_non_validated_execution_fields_test(spec, state)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_randomized_non_validated_execution_fields_regular_payload__valid(spec, state):
+    state = build_state_with_complete_transition(spec, state)
+    yield from run_randomized_non_validated_execution_fields_test(spec, state)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_randomized_non_validated_execution_fields_first_payload__invalid(spec, state):
+    state = build_state_with_incomplete_transition(spec, state)
+    yield from run_randomized_non_validated_execution_fields_test(spec, state, execution_valid=False)
+
+
+@with_bellatrix_and_later
+@spec_state_test
+def test_randomized_non_validated_execution_fields_regular_payload__invalid(spec, state):
+    state = build_state_with_complete_transition(spec, state)
+    yield from run_randomized_non_validated_execution_fields_test(spec, state, execution_valid=False)

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -61,14 +61,20 @@ def get_execution_payload_header(spec, execution_payload):
 
 
 def build_state_with_incomplete_transition(spec, state):
-    return build_state_with_execution_payload_header(spec, state, spec.ExecutionPayloadHeader())
+    state = build_state_with_execution_payload_header(spec, state, spec.ExecutionPayloadHeader())
+    assert not spec.is_merge_transition_complete(state)
+
+    return state
 
 
 def build_state_with_complete_transition(spec, state):
     pre_state_payload = build_empty_execution_payload(spec, state)
     payload_header = get_execution_payload_header(spec, pre_state_payload)
 
-    return build_state_with_execution_payload_header(spec, state, payload_header)
+    state = build_state_with_execution_payload_header(spec, state, payload_header)
+    assert spec.is_merge_transition_complete(state)
+
+    return state
 
 
 def build_state_with_execution_payload_header(spec, state, execution_payload_header):


### PR DESCRIPTION
* add some randomized payload tests
* add some non-empty transactions tests
* cleanup old tests

note! I use `os.urandom` for random bytes, but in python 3.9 [`random.randbytes()`](https://docs.python.org/3.9/library/random.html?highlight=random#random.randbytes) exists