### PR TITLE
Fix `slash_random_validators`: make `fraction=0` return 0 indices

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/random.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/random.py
@@ -90,7 +90,7 @@ def slash_random_validators(spec, state, rng, fraction=0.5):
     for index in range(len(state.validators)):
         # slash at least one validator
         sampled = rng.random() < fraction
-        if index == 0 or sampled:
+        if sampled:
             spec.slash_validator(state, index)
             slashed_indices.append(index)
     return slashed_indices


### PR DESCRIPTION
### Issue

`slash_random_validators` function would force slash `state.validators[0]`.
However, we expect it doesn't slash any validator when we call `randomize_state(spec, state, slash_fraction=0)`.

### Proposed fix

Remove `index == 0` condition.

Note: it would change many randomized test vectors.