### PR TITLE
Fix codespell errors

### DIFF
--- a/presets/minimal/phase0.yaml
+++ b/presets/minimal/phase0.yaml
@@ -4,11 +4,11 @@
 # ---------------------------------------------------------------
 # [customized] Just 4 committees for slot for testing purposes
 MAX_COMMITTEES_PER_SLOT: 4
-# [customized] unsecure, but fast
+# [customized] insecure, but fast
 TARGET_COMMITTEE_SIZE: 4
 # 2**11 (= 2,048)
 MAX_VALIDATORS_PER_COMMITTEE: 2048
-# [customized] Faster, but unsecure.
+# [customized] Faster, but insecure.
 SHUFFLE_ROUND_COUNT: 10
 # 4
 HYSTERESIS_QUOTIENT: 4

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1327,7 +1327,7 @@ Requests are segregated by protocol ID to:
    1. This has the benefit that clients can explicitly choose which RFCs to deploy
       without buying into all other RFCs that may be included in that top-level version.
    2. Affording this level of granularity with a top-level protocol would imply creating as many variants
-      (e.g. /protocol/43-{a,b,c,d,...}) as the cartesian product of RFCs inflight, O(n^2).
+      (e.g. /protocol/43-{a,b,c,d,...}) as the cartesian product of RFCs in-flight, O(n^2).
 7. Allow us to simplify the payload of requests.
   Request-id’s and method-ids no longer need to be sent.
   The encoding/request type and version can all be handled by the framework.

--- a/tests/generators/random/generate.py
+++ b/tests/generators/random/generate.py
@@ -3,7 +3,7 @@ This test format currently uses code generation to assemble the tests
 as the current test infra does not have a facility to dynamically
 generate tests that can be seen by ``pytest``.
 
-This will likley change in future releases of the testing infra.
+This will likely change in future releases of the testing infra.
 
 NOTE: To add additional scenarios, add test cases below in ``_generate_randomized_scenarios``.
 """


### PR DESCRIPTION
New `codespell` (v2.2.0) was released 18 hours ago and raised some new typos.

```
#!/bin/bash -eo pipefail
pip install 'codespell<3.0.0,>=2.0.0' --user &&  make codespell
Collecting codespell<3.0.0,>=2.0.0
  Downloading codespell-2.2.0-py3-none-any.whl (202 kB)
     |████████████████████████████████| 202 kB 33.7 MB/s eta 0:00:01
Installing collected packages: codespell
Successfully installed codespell-2.2.0
WARNING: You are using pip version 21.2.4; however, version 22.2.2 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
codespell . --skip ./.git -I .codespell-whitelist
./presets/minimal/phase0.yaml:7: unsecure ==> insecure
./presets/minimal/phase0.yaml:11: unsecure ==> insecure
./specs/phase0/p2p-interface.md:1330: inflight ==> in-flight
./tests/generators/random/generate.py:6: likley ==> likely
make: *** [Makefile:134: codespell] Error 65

Exited with code exit status 2
CircleCI received exit code 2
```