### PR TITLE
Explicitly validate public key when processing Deposit

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1868,6 +1868,10 @@ def process_deposit(state: BeaconState, deposit: Deposit) -> None:
     amount = deposit.data.amount
     validator_pubkeys = [v.pubkey for v in state.validators]
     if pubkey not in validator_pubkeys:
+        # Validate the public key which is not checked by the deposit contract
+        if not bls.KeyValidate(pubkey):
+            return
+            
         # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
         deposit_message = DepositMessage(
             pubkey=deposit.data.pubkey,

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -107,6 +107,15 @@ def Sign(SK, message):
         return bls.Sign(SK.to_bytes(32, 'big'), message)
 
 
+@only_with_bls(alt_return=True)
+def KeyValidate(pubkey):
+    try:
+        result = bls.KeyValidate(pubkey)
+    except Exception:
+        result = False
+    finally:
+        return result
+
 @only_with_bls(alt_return=STUB_COORDINATES)
 def signature_to_G2(signature):
     return _signature_to_G2(signature)

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -116,6 +116,7 @@ def KeyValidate(pubkey):
     finally:
         return result
 
+
 @only_with_bls(alt_return=STUB_COORDINATES)
 def signature_to_G2(signature):
     return _signature_to_G2(signature)

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -110,7 +110,8 @@ def Sign(SK, message):
 @only_with_bls(alt_return=True)
 def KeyValidate(pubkey):
     try:
-        result = bls.KeyValidate(pubkey)
+        # Fallback to py_ecc as milagro_bls_binding has no KeyValidate binding
+        result = py_ecc_bls.KeyValidate(pubkey)
     except Exception:
         result = False
     finally:


### PR DESCRIPTION
Deposits are the only source of non-validated public keys, so suggesting to add explicit public key validation statement to `process_deposit` function. 

`bls.Verify` function (and its batch variants) is a bit ambiguous in the case if `BLSPubkey` is not valid (either invalid serialization or outside of the curve or outside of the group): whether it should return `false` or throw an error. 

In all other cases (besides `process_deposit`) `bls.Verify` can't receive an invalid `BLSPubkey` since all of them come from the state and are inherently valid. Reasoning that way it could make sense to throw error if invalid pubkey is passed to `bls.Verify` since it would mean kind of fatal implementation error. In that case suggested implicit public key validation makes sense. 