### PR TITLE
Update BLS test format: output `null` for invalid case

### DIFF
--- a/tests/formats/bls/aggregate.md
+++ b/tests/formats/bls/aggregate.md
@@ -8,11 +8,11 @@ The test data is declared in a `data.yaml` file:
 
 ```yaml
 input: List[BLS Signature] -- list of input BLS signatures
-output: BLS Signature -- expected output, single BLS signature or empty.
+output: BLS Signature -- expected output, single BLS signature or `null`.
 ```
 
 - `BLS Signature` here is encoded as a string: hexadecimal encoding of 96 bytes (192 nibbles), prefixed with `0x`.
-- No output value if the input is invalid.
+- output value is `null` if the input is invalid.
 
 All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
 

--- a/tests/formats/bls/eth_aggregate_pubkeys.md
+++ b/tests/formats/bls/eth_aggregate_pubkeys.md
@@ -8,11 +8,11 @@ The test data is declared in a `data.yaml` file:
 
 ```yaml
 input: List[BLS Pubkey] -- list of input BLS pubkeys
-output: BLSPubkey -- expected output, single BLS pubkeys or empty.
+output: BLSPubkey -- expected output, single BLS pubkeys or `null`.
 ```
 
 - `BLS Pubkey` here is encoded as a string: hexadecimal encoding of 48 bytes (96 nibbles), prefixed with `0x`.
-- No output value if the input is invalid.
+- output value is `null` if the input is invalid.
 
 ## Condition
 

--- a/tests/formats/bls/sign.md
+++ b/tests/formats/bls/sign.md
@@ -10,7 +10,12 @@ The test data is declared in a `data.yaml` file:
 input:
   privkey: bytes32 -- the private key used for signing
   message: bytes32 -- input message to sign (a hash)
-output: BLS Signature -- expected output, single BLS signature or empty.
+output: BLS Signature -- expected output, single BLS signature or `null`.
 ```
 
-All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
+- All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
+- output value is `null` if the input is invalid.
+
+## Condition
+
+The `sign` handler should sign `message` with `privkey`, and the resulting signature should match the expected `output`.


### PR DESCRIPTION
In #2982, we [updated our test vector YAML representer to output `null` when the value is Python `None`](https://github.com/ethereum/consensus-specs/blob/9ec97badf3ee924aae0ee92cf6c957fbe3b7ef4b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py#L100-L103).

Before that PR, it was:
```yaml
output:
```

After that PR, it becomes:
```yaml
output: null
```

IMHO it's better to use only one rule for both cases. This PR changes the BLS test format to align with sync test format. `null` seems clearer than empty.

p.s. `null` is used in engine APIs and that was why I changed our YAML representer in #2982

/cc @asanso for updating `bls12-381-tests` test suite.