### PR TITLE
deprecate phase 0-only versions of beacon_blocks_by_{range,root}

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -745,6 +745,8 @@ For example, if slot 4 were empty in the previous example, the returned array wo
 
 `step` is deprecated and must be set to 1. Clients may respond with a single block if a larger step is returned during the deprecation transition period.
 
+`/eth2/beacon_chain/req/beacon_blocks_by_range/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
+
 `BeaconBlocksByRange` is primarily used to sync historical blocks.
 
 The request MUST be encoded as an SSZ-container.
@@ -830,6 +832,8 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 
 Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
+
+`/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 
 #### Ping
 


### PR DESCRIPTION
There haven't been any phase0 blocks in mainnet or any of the still-supported testnets in [`MIN_EPOCHS_FOR_BLOCK_REQUESTS`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#configuration) regardless, so the spec already technically supports not serving said blocks.

https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/p2p-interface.md#beaconblocksbyrange-v2 and https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/p2p-interface.md#beaconblocksbyroot-v2 work across all supported forks, including phase 0, and any CL client supporting Altair or newer already has to support those messages, so this maintains req/resp compatibility for phase 0 blocks.