### PR TITLE
EIP4844: Introduce bytes_to_bls_field() helper

### DIFF
--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -17,6 +17,7 @@
     - [`reverse_bits`](#reverse_bits)
     - [`bit_reversal_permutation`](#bit_reversal_permutation)
   - [BLS12-381 helpers](#bls12-381-helpers)
+    - [`bytes_to_bls_field`](#bytes_to_bls_field)
     - [`bls_modular_inverse`](#bls_modular_inverse)
     - [`div`](#div)
     - [`g1_lincomb`](#g1_lincomb)
@@ -110,6 +111,16 @@ def bit_reversal_permutation(l: Sequence[T]) -> Sequence[T]:
 ```
 
 ### BLS12-381 helpers
+
+#### `bytes_to_bls_field`
+
+```python
+def bytes_to_bls_field(b: Bytes32) -> BLSFieldElement:
+    """
+    Convert bytes to a BLS field scalar. The output is not uniform over the BLS field.
+    """
+    return int.from_bytes(b, "little") % BLS_MODULUS
+```
 
 #### `bls_modular_inverse`
 

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -96,7 +96,7 @@ def hash_to_bls_field(x: Container) -> BLSFieldElement:
     Compute 32-byte hash of serialized container and convert it to BLS field.
     The output is not uniform over the BLS field.
     """
-    return int.from_bytes(hash(ssz_serialize(x)), "little") % BLS_MODULUS
+    return bytes_to_bls_field(hash(ssz_serialize(x)))
 ```
 
 ### `compute_powers`


### PR DESCRIPTION
This commit improves the separation between BLS cryptography and Ethereum SSZ logic.

Now the BLS library just implements `bytes_to_bls_field()`. Then `hash_to_bls_field()` does the Ethereum SSZ magic and calls `bytes_to_bls_field()`.