### PR TITLE
Bump dep packages version and fix lint issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ lint: pyspec
 
 lint_generators: pyspec
 	. venv/bin/activate; cd $(TEST_GENERATORS_DIR); \
-	flake8  --config $(LINTER_CONFIG_FILE)
+	flake8 --config $(LINTER_CONFIG_FILE)
 
 compile_deposit_contract:
 	@cd $(SOLIDITY_DEPOSIT_CONTRACT_DIR)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 def installPackage(package: str):
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
 
-RUAMEL_YAML_VERSION = "ruamel.yaml==0.16.5"
+RUAMEL_YAML_VERSION = "ruamel.yaml==0.17.21"
 try:
     import ruamel.yaml
 except ImportError:
@@ -78,6 +78,7 @@ class VariableDefinition(NamedTuple):
     type_name: Optional[str]
     value: str
     comment: Optional[str]  # e.g. "noqa: E501"
+    type_hint: Optional[str]  # e.g., "Final"
 
 
 class SpecObject(NamedTuple):
@@ -152,18 +153,18 @@ def _get_eth2_spec_comment(child: LinkRefDef) -> Optional[str]:
     return title[len(ETH2_SPEC_COMMENT_PREFIX):].strip()
 
 
-def _parse_value(name: str, typed_value: str) -> VariableDefinition:
+def _parse_value(name: str, typed_value: str, type_hint: Optional[str]=None) -> VariableDefinition:
     comment = None
     if name == "BLS12_381_Q":
         comment = "noqa: E501"
 
     typed_value = typed_value.strip()
     if '(' not in typed_value:
-        return VariableDefinition(type_name=None, value=typed_value, comment=comment)
+        return VariableDefinition(type_name=None, value=typed_value, comment=comment, type_hint=type_hint)
     i = typed_value.index('(')
     type_name = typed_value[:i]
 
-    return VariableDefinition(type_name=type_name, value=typed_value[i+1:-1], comment=comment)
+    return VariableDefinition(type_name=type_name, value=typed_value[i+1:-1], comment=comment, type_hint=type_hint)
 
 
 def get_spec(file_name: Path, preset: Dict[str, str], config: Dict[str, str]) -> SpecObject:
@@ -241,10 +242,13 @@ def get_spec(file_name: Path, preset: Dict[str, str], config: Dict[str, str]) ->
 
                     value_def = _parse_value(name, value)
                     if name in preset:
-                        preset_vars[name] = VariableDefinition(value_def.type_name, preset[name], value_def.comment)
+                        preset_vars[name] = VariableDefinition(value_def.type_name, preset[name], value_def.comment, None)
                     elif name in config:
-                        config_vars[name] = VariableDefinition(value_def.type_name, config[name], value_def.comment)
+                        config_vars[name] = VariableDefinition(value_def.type_name, config[name], value_def.comment, None)
                     else:
+                        if name == 'ENDIANNESS':
+                            # Deal with mypy Literal typing check
+                            value_def = _parse_value(name, value, type_hint='Final')
                         constant_vars[name] = value_def
 
         elif isinstance(child, LinkRefDef):
@@ -337,7 +341,7 @@ from dataclasses import (
     field,
 )
 from typing import (
-    Any, Callable, Dict, Set, Sequence, Tuple, Optional, TypeVar, NamedTuple
+    Any, Callable, Dict, Set, Sequence, Tuple, Optional, TypeVar, NamedTuple, Final
 )
 
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root, copy, uint_to_bytes
@@ -703,7 +707,10 @@ def objects_to_spec(preset_name: str,
 
     def format_constant(name: str, vardef: VariableDefinition) -> str:
         if vardef.type_name is None:
-            out = f'{name} = {vardef.value}'
+            if vardef.type_hint is None:
+                out = f'{name} = {vardef.value}'
+            else:
+                out = f'{name}: {vardef.type_hint} = {vardef.value}'
         else:
             out = f'{name} = {vardef.type_name}({vardef.value})'
         if vardef.comment is not None:
@@ -1115,19 +1122,18 @@ setup(
     python_requires=">=3.8, <4",
     extras_require={
         "test": ["pytest>=4.4", "pytest-cov", "pytest-xdist"],
-        "lint": ["flake8==3.7.7", "mypy==0.812", "pylint==2.12.2"],
-        "generator": ["python-snappy==0.5.4", "filelock"],
+        "lint": ["flake8==5.0.4", "mypy==0.981", "pylint==2.15.3"],
+        "generator": ["python-snappy==0.6.1", "filelock"],
     },
     install_requires=[
-        "eth-utils>=1.3.0,<2",
-        "eth-typing>=2.1.0,<3.0.0",
-        "pycryptodome==3.9.4",
-        "py_ecc==5.2.0",
+        "eth-utils>=2.0.0,<3",
+        "eth-typing>=3.2.0,<4.0.0",
+        "pycryptodome==3.15.0",
+        "py_ecc==6.0.0",
         "milagro_bls_binding==1.9.0",
-        "dataclasses==0.6",
         "remerkleable==0.1.24",
         RUAMEL_YAML_VERSION,
-        "lru-dict==1.1.6",
+        "lru-dict==1.1.8",
         MARKO_VERSION,
     ]
 )

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -101,13 +101,13 @@ def reverse_bits(n: int, order: int) -> int:
 #### `bit_reversal_permutation`
 
 ```python
-def bit_reversal_permutation(l: Sequence[T]) -> Sequence[T]:
+def bit_reversal_permutation(sequence: Sequence[T]) -> Sequence[T]:
     """
     Return a copy with bit-reversed permutation. This operation is idempotent.
 
     The input and output are a sequence of generic type ``T`` objects.
     """
-    return [l[reverse_bits(i, len(l))] for i in range(len(l))]
+    return [sequence[reverse_bits(i, len(sequence))] for i in range(len(sequence))]
 ```
 
 ### BLS12-381 helpers

--- a/tests/core/pyspec/eth2spec/test/bellatrix/sync/test_optimistic.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/sync/test_optimistic.py
@@ -46,7 +46,7 @@ def test_from_syncing_to_invalid(spec, state):
 
     # Block 0
     block_0 = build_empty_block_for_next_slot(spec, state)
-    block_0.body.execution_payload.block_hash = spec.hash(bytes(f'block_0', 'UTF-8'))
+    block_0.body.execution_payload.block_hash = spec.hash(bytes('block_0', 'UTF-8'))
     signed_block = state_transition_and_sign_block(spec, state, block_0)
     yield from add_optimistic_block(spec, mega_store, signed_block, test_steps, status=PayloadStatusV1Status.VALID)
     assert spec.get_head(mega_store.fc_store) == mega_store.opt_store.head_block_root
@@ -84,7 +84,7 @@ def test_from_syncing_to_invalid(spec, state):
 
     # Now add block 4 to chain `b` with INVALID
     block = build_empty_block_for_next_slot(spec, state)
-    block.body.execution_payload.block_hash = spec.hash(bytes(f'chain_b_3', 'UTF-8'))
+    block.body.execution_payload.block_hash = spec.hash(bytes('chain_b_3', 'UTF-8'))
     block.body.execution_payload.parent_hash = signed_blocks_b[-1].message.body.execution_payload.block_hash
     signed_block = state_transition_and_sign_block(spec, state, block)
     payload_status = PayloadStatusV1(

--- a/tests/generators/bls/main.py
+++ b/tests/generators/bls/main.py
@@ -89,7 +89,7 @@ def case01_sign():
     # Edge case: privkey == 0
     expect_exception(bls.Sign, ZERO_PRIVKEY, message)
     expect_exception(milagro_bls.Sign, ZERO_PRIVKEY_BYTES, message)
-    yield f'sign_case_zero_privkey', {
+    yield 'sign_case_zero_privkey', {
         'input': {
             'privkey': encode_hex(ZERO_PRIVKEY_BYTES),
             'message': encode_hex(message),
@@ -153,7 +153,7 @@ def case02_verify():
     # Invalid pubkey and signature with the point at infinity
     assert not bls.Verify(G1_POINT_AT_INFINITY, SAMPLE_MESSAGE, G2_POINT_AT_INFINITY)
     assert not milagro_bls.Verify(G1_POINT_AT_INFINITY, SAMPLE_MESSAGE, G2_POINT_AT_INFINITY)
-    yield f'verify_infinity_pubkey_and_infinity_signature', {
+    yield 'verify_infinity_pubkey_and_infinity_signature', {
         'input': {
             'pubkey': encode_hex(G1_POINT_AT_INFINITY),
             'message': encode_hex(SAMPLE_MESSAGE),
@@ -177,7 +177,7 @@ def case03_aggregate():
     expect_exception(bls.Aggregate, [])
     # No signatures to aggregate. Follow IETF BLS spec, return `None` to represent INVALID.
     # https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-2.8
-    yield f'aggregate_na_signatures', {
+    yield 'aggregate_na_signatures', {
         'input': [],
         'output': None,
     }
@@ -185,7 +185,7 @@ def case03_aggregate():
     # Valid to aggregate G2 point at infinity
     aggregate_sig = bls.Aggregate([G2_POINT_AT_INFINITY])
     assert aggregate_sig == milagro_bls.Aggregate([G2_POINT_AT_INFINITY]) == G2_POINT_AT_INFINITY
-    yield f'aggregate_infinity_signature', {
+    yield 'aggregate_infinity_signature', {
         'input': [encode_hex(G2_POINT_AT_INFINITY)],
         'output': encode_hex(aggregate_sig),
     }
@@ -244,7 +244,7 @@ def case04_fast_aggregate_verify():
     # Invalid pubkeys and signature -- len(pubkeys) == 0 and signature == Z1_SIGNATURE
     assert not bls.FastAggregateVerify([], message, G2_POINT_AT_INFINITY)
     assert not milagro_bls.FastAggregateVerify([], message, G2_POINT_AT_INFINITY)
-    yield f'fast_aggregate_verify_na_pubkeys_and_infinity_signature', {
+    yield 'fast_aggregate_verify_na_pubkeys_and_infinity_signature', {
         'input': {
             'pubkeys': [],
             'message': encode_hex(message),
@@ -256,7 +256,7 @@ def case04_fast_aggregate_verify():
     # Invalid pubkeys and signature -- len(pubkeys) == 0 and signature == 0x00...
     assert not bls.FastAggregateVerify([], message, ZERO_SIGNATURE)
     assert not milagro_bls.FastAggregateVerify([], message, ZERO_SIGNATURE)
-    yield f'fast_aggregate_verify_na_pubkeys_and_zero_signature', {
+    yield 'fast_aggregate_verify_na_pubkeys_and_zero_signature', {
         'input': {
             'pubkeys': [],
             'message': encode_hex(message),
@@ -272,7 +272,7 @@ def case04_fast_aggregate_verify():
     aggregate_signature = bls.Aggregate(signatures)
     assert not bls.FastAggregateVerify(pubkeys_with_infinity, SAMPLE_MESSAGE, aggregate_signature)
     assert not milagro_bls.FastAggregateVerify(pubkeys_with_infinity, SAMPLE_MESSAGE, aggregate_signature)
-    yield f'fast_aggregate_verify_infinity_pubkey', {
+    yield 'fast_aggregate_verify_infinity_pubkey', {
         'input': {
             'pubkeys': [encode_hex(pubkey) for pubkey in pubkeys_with_infinity],
             'message': encode_hex(SAMPLE_MESSAGE),
@@ -300,7 +300,7 @@ def case05_aggregate_verify():
     aggregate_signature = bls.Aggregate(sigs)
     assert bls.AggregateVerify(pubkeys, messages, aggregate_signature)
     assert milagro_bls.AggregateVerify(pubkeys, messages, aggregate_signature)
-    yield f'aggregate_verify_valid', {
+    yield 'aggregate_verify_valid', {
         'input': {
             'pubkeys': pubkeys_serial,
             'messages': messages_serial,
@@ -312,7 +312,7 @@ def case05_aggregate_verify():
     tampered_signature = aggregate_signature[:4] + b'\xff\xff\xff\xff'
     assert not bls.AggregateVerify(pubkey, messages, tampered_signature)
     assert not milagro_bls.AggregateVerify(pubkeys, messages, tampered_signature)
-    yield f'aggregate_verify_tampered_signature', {
+    yield 'aggregate_verify_tampered_signature', {
         'input': {
             'pubkeys': pubkeys_serial,
             'messages': messages_serial,
@@ -324,7 +324,7 @@ def case05_aggregate_verify():
     # Invalid pubkeys and signature -- len(pubkeys) == 0 and signature == Z1_SIGNATURE
     assert not bls.AggregateVerify([], [], G2_POINT_AT_INFINITY)
     assert not milagro_bls.AggregateVerify([], [], G2_POINT_AT_INFINITY)
-    yield f'aggregate_verify_na_pubkeys_and_infinity_signature', {
+    yield 'aggregate_verify_na_pubkeys_and_infinity_signature', {
         'input': {
             'pubkeys': [],
             'messages': [],
@@ -336,7 +336,7 @@ def case05_aggregate_verify():
     # Invalid pubkeys and signature -- len(pubkeys) == 0 and signature == 0x00...
     assert not bls.AggregateVerify([], [], ZERO_SIGNATURE)
     assert not milagro_bls.AggregateVerify([], [], ZERO_SIGNATURE)
-    yield f'aggregate_verify_na_pubkeys_and_zero_signature', {
+    yield 'aggregate_verify_na_pubkeys_and_zero_signature', {
         'input': {
             'pubkeys': [],
             'messages': [],
@@ -350,7 +350,7 @@ def case05_aggregate_verify():
     messages_with_sample = messages + [SAMPLE_MESSAGE]
     assert not bls.AggregateVerify(pubkeys_with_infinity, messages_with_sample, aggregate_signature)
     assert not milagro_bls.AggregateVerify(pubkeys_with_infinity, messages_with_sample, aggregate_signature)
-    yield f'aggregate_verify_infinity_pubkey', {
+    yield 'aggregate_verify_infinity_pubkey', {
         'input': {
             'pubkeys': [encode_hex(pubkey) for pubkey in pubkeys_with_infinity],
             'messages': [encode_hex(message) for message in messages_with_sample],
@@ -375,7 +375,7 @@ def case06_eth_aggregate_pubkeys():
     # Valid pubkeys
     aggregate_pubkey = spec.eth_aggregate_pubkeys(PUBKEYS)
     assert aggregate_pubkey == milagro_bls._AggregatePKs(PUBKEYS)
-    yield f'eth_aggregate_pubkeys_valid_pubkeys', {
+    yield 'eth_aggregate_pubkeys_valid_pubkeys', {
         'input': [encode_hex(pubkey) for pubkey in PUBKEYS],
         'output': encode_hex(aggregate_pubkey),
     }
@@ -383,7 +383,7 @@ def case06_eth_aggregate_pubkeys():
     # Invalid pubkeys -- len(pubkeys) == 0
     expect_exception(spec.eth_aggregate_pubkeys, [])
     expect_exception(milagro_bls._AggregatePKs, [])
-    yield f'eth_aggregate_pubkeys_empty_list', {
+    yield 'eth_aggregate_pubkeys_empty_list', {
         'input': [],
         'output': None,
     }
@@ -391,7 +391,7 @@ def case06_eth_aggregate_pubkeys():
     # Invalid pubkeys -- [ZERO_PUBKEY]
     expect_exception(spec.eth_aggregate_pubkeys, [ZERO_PUBKEY])
     expect_exception(milagro_bls._AggregatePKs, [ZERO_PUBKEY])
-    yield f'eth_aggregate_pubkeys_zero_pubkey', {
+    yield 'eth_aggregate_pubkeys_zero_pubkey', {
         'input': [encode_hex(ZERO_PUBKEY)],
         'output': None,
     }
@@ -399,7 +399,7 @@ def case06_eth_aggregate_pubkeys():
     # Invalid pubkeys -- G1 point at infinity
     expect_exception(spec.eth_aggregate_pubkeys, [G1_POINT_AT_INFINITY])
     expect_exception(milagro_bls._AggregatePKs, [G1_POINT_AT_INFINITY])
-    yield f'eth_aggregate_pubkeys_infinity_pubkey', {
+    yield 'eth_aggregate_pubkeys_infinity_pubkey', {
         'input': [encode_hex(G1_POINT_AT_INFINITY)],
         'output': None,
     }
@@ -408,7 +408,7 @@ def case06_eth_aggregate_pubkeys():
     x40_pubkey = b'\x40' + b'\00' * 47
     expect_exception(spec.eth_aggregate_pubkeys, [x40_pubkey])
     expect_exception(milagro_bls._AggregatePKs, [x40_pubkey])
-    yield f'eth_aggregate_pubkeys_x40_pubkey', {
+    yield 'eth_aggregate_pubkeys_x40_pubkey', {
         'input': [encode_hex(x40_pubkey)],
         'output': None,
     }
@@ -455,7 +455,7 @@ def case07_eth_fast_aggregate_verify():
         tampered_signature = aggregate_signature[:-4] + b'\xff\xff\xff\xff'
         identifier = f'{pubkeys_serial}_{encode_hex(message)}'
         assert not spec.eth_fast_aggregate_verify(pubkeys, message, tampered_signature)
-        yield f'eth_fast_aggregate_verify_tampered_signature_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
+        yield 'eth_fast_aggregate_verify_tampered_signature_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
             'input': {
                 'pubkeys': pubkeys_serial,
                 'message': encode_hex(message),
@@ -466,7 +466,7 @@ def case07_eth_fast_aggregate_verify():
 
     # NOTE: Unlike `FastAggregateVerify`, len(pubkeys) == 0 and signature == G2_POINT_AT_INFINITY is VALID
     assert spec.eth_fast_aggregate_verify([], message, G2_POINT_AT_INFINITY)
-    yield f'eth_fast_aggregate_verify_na_pubkeys_and_infinity_signature', {
+    yield 'eth_fast_aggregate_verify_na_pubkeys_and_infinity_signature', {
         'input': {
             'pubkeys': [],
             'message': encode_hex(message),
@@ -477,7 +477,7 @@ def case07_eth_fast_aggregate_verify():
 
     # Invalid pubkeys and signature -- len(pubkeys) == 0 and signature == 0x00...
     assert not spec.eth_fast_aggregate_verify([], message, ZERO_SIGNATURE)
-    yield f'eth_fast_aggregate_verify_na_pubkeys_and_zero_signature', {
+    yield 'eth_fast_aggregate_verify_na_pubkeys_and_zero_signature', {
         'input': {
             'pubkeys': [],
             'message': encode_hex(message),
@@ -492,7 +492,7 @@ def case07_eth_fast_aggregate_verify():
     signatures = [bls.Sign(privkey, SAMPLE_MESSAGE) for privkey in PRIVKEYS]
     aggregate_signature = bls.Aggregate(signatures)
     assert not spec.eth_fast_aggregate_verify(pubkeys_with_infinity, SAMPLE_MESSAGE, aggregate_signature)
-    yield f'eth_fast_aggregate_verify_infinity_pubkey', {
+    yield 'eth_fast_aggregate_verify_infinity_pubkey', {
         'input': {
             'pubkeys': [encode_hex(pubkey) for pubkey in pubkeys_with_infinity],
             'message': encode_hex(SAMPLE_MESSAGE),


### PR DESCRIPTION
1. Bump dependencies
     - Update most dependencies to the latest version
     - Remove `dataclasses` dep because it's built-in in Python 3.7+
     - Somehow, `marko==1.2.2` is not backward compatible so I didn't update it
2. Fix the lint issues found by the newer linter
    - **E741 ambiguous variable name 'l'** in `bit_reversal_permutation`:
        - I renamed `l` to `sequence`. /cc @asn-d6 
    - **F541 f-string is missing placeholders**:
        - I cleaned up the strings
    - `from_bytes` has incompatible type "str"; expected "literal['little', 'big']":
       - This is annoying. [The solution is adding `Final` type hint](https://stackoverflow.com/questions/63891789/can-mypy-track-string-literals). I made some changes in `setup.py`