### PR TITLE
EIP4844: various fixes

### DIFF
--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -33,10 +33,10 @@ The specification of these changes continues in the same format as the network s
 
 ## Configuration
 
-| Name                                     | Value                              | Description                                                         |
-|------------------------------------------|------------------------------------|---------------------------------------------------------------------|
-| `MAX_REQUEST_BLOBS_SIDECARS`             | `2**7` (= 128)                     | Maximum number of blobs sidecars in a single request                |
-| `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` | `2**13epoch` (= 8192, ~1.2 months) | The minimum epoch range over which a node must serve blobs sidecars |
+| Name                                     | Value                               | Description                                                         |
+|------------------------------------------|-------------------------------------|---------------------------------------------------------------------|
+| `MAX_REQUEST_BLOBS_SIDECARS`             | `2**7` (= 128)                      | Maximum number of blobs sidecars in a single request                |
+| `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` | `2**13` (= 8192epochs, ~1.2 months) | The minimum epoch range over which a node must serve blobs sidecars |
 
 ## Containers
 

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -36,7 +36,7 @@ The specification of these changes continues in the same format as the network s
 | Name                                     | Value                               | Description                                                         |
 |------------------------------------------|-------------------------------------|---------------------------------------------------------------------|
 | `MAX_REQUEST_BLOBS_SIDECARS`             | `2**7` (= 128)                      | Maximum number of blobs sidecars in a single request                |
-| `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` | `2**13` (= 8192epochs, ~1.2 months) | The minimum epoch range over which a node must serve blobs sidecars |
+| `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` | `2**13` (= 8192 epochs, ~1.2 months) | The minimum epoch range over which a node must serve blobs sidecars |
 
 ## Containers
 

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -33,10 +33,10 @@ The specification of these changes continues in the same format as the network s
 
 ## Configuration
 
-| Name                                     | Value                         | Description                                                         |
-|------------------------------------------|-------------------------------|---------------------------------------------------------------------|
-| `MAX_REQUEST_BLOBS_SIDECARS`             | `2**7` (= 128)                | Maximum number of blobs sidecars in a single request                |
-| `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` | `2**13` (= 8192, ~1.2 months) | The minimum epoch range over which a node must serve blobs sidecars |
+| Name                                     | Value                              | Description                                                         |
+|------------------------------------------|------------------------------------|---------------------------------------------------------------------|
+| `MAX_REQUEST_BLOBS_SIDECARS`             | `2**7` (= 128)                     | Maximum number of blobs sidecars in a single request                |
+| `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` | `2**13epoch` (= 8192, ~1.2 months) | The minimum epoch range over which a node must serve blobs sidecars |
 
 ## Containers
 
@@ -207,10 +207,7 @@ or disconnected at any time.
 
 *Note*: The above requirement implies that nodes that start from a recent weak subjectivity checkpoint
 MUST backfill the local blobs database to at least epoch `current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS`
-to be fully compliant with `BlobsSidecarsByRange` requests. To safely perform such a
-backfill of blocks to the recent state, the node MUST validate both (1) the
-proposer signatures and (2) that the blocks form a valid chain up to the most
-recent block referenced in the weak subjectivity state.
+to be fully compliant with `BlobsSidecarsByRange` requests.
 
 *Note*: Although clients that bootstrap from a weak subjectivity checkpoint can begin
 participating in the networking immediately, other peers MAY

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -245,7 +245,7 @@ def get_signed_blobs_sidecar(state: BeaconState, blobs_sidecar: BlobsSidecar, pr
     return SignedBlobsSidecar(message=blobs_sidecar, signature=signature)
 ```
 
-This `signed_blobs_sidecar` is then published to the global `blobs_sidecar` topic as soon as the `beacon_block` is published.
+This `signed_blobs_sidecar` is then published to the global `blobs_sidecar` topic as soon as the `signed_beacon_block` is published.
 
 After publishing the sidecar peers on the network may request the sidecar through sync-requests, or a local user may be interested.
 The validator MUST hold on to blobs for `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` epochs and serve when capable,


### PR DESCRIPTION
- Add unit `epoch` to `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS`
- The current backfill blob validation is incorrect. It looks like it was copy-pasted from backfill block validation. I removed it. It might be worth considering what backfill validation we want for the blob. To validate the signature, we need to change `BlobsSidecarsByRange` to `SignedBlobsSidecarsByRange`. It may be worth checking that blobs are canonical by cross-referencing with the local fork choice view 
- Validator broadcasts `signed_beacon_block`, not `beacon_block`