### PR TITLE
Rename `from_bls_pubkey` to `from_bls_withdrawal_pubkey`

### DIFF
--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -120,7 +120,7 @@ class Withdrawal(Container):
 ```python
 class BLSToExecutionChange(Container):
     validator_index: ValidatorIndex
-    from_bls_pubkey: BLSPubkey
+    from_bls_withdrawal_pubkey: BLSPubkey
     to_execution_address: ExecutionAddress
 ```
 
@@ -478,11 +478,11 @@ def process_bls_to_execution_change(state: BeaconState,
     validator = state.validators[address_change.validator_index]
 
     assert validator.withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX
-    assert validator.withdrawal_credentials[1:] == hash(address_change.from_bls_pubkey)[1:]
+    assert validator.withdrawal_credentials[1:] == hash(address_change.from_bls_withdrawal_pubkey)[1:]
 
     domain = get_domain(state, DOMAIN_BLS_TO_EXECUTION_CHANGE)
     signing_root = compute_signing_root(address_change, domain)
-    assert bls.Verify(address_change.from_bls_pubkey, signing_root, signed_address_change.signature)
+    assert bls.Verify(address_change.from_bls_withdrawal_pubkey, signing_root, signed_address_change.signature)
 
     validator.withdrawal_credentials = (
         ETH1_ADDRESS_WITHDRAWAL_PREFIX

--- a/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_bls_to_execution_change.py
+++ b/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_bls_to_execution_change.py
@@ -51,7 +51,7 @@ def get_signed_address_change(spec, state, validator_index=None, withdrawal_pubk
     domain = spec.get_domain(state, spec.DOMAIN_BLS_TO_EXECUTION_CHANGE)
     address_change = spec.BLSToExecutionChange(
         validator_index=validator_index,
-        from_bls_pubkey=withdrawal_pubkey,
+        from_bls_withdrawal_pubkey=withdrawal_pubkey,
         to_execution_address=b'\x42' * 20,
     )
 
@@ -176,7 +176,7 @@ def test_fail_already_0x01(spec, state):
 
 @with_capella_and_later
 @spec_state_test
-def test_fail_incorrect_from_bls_pubkey(spec, state):
+def test_fail_incorrect_from_bls_withdrawal_pubkey(spec, state):
     # Create for one validator beyond the validator list length
     validator_index = 2
     signed_address_change = get_signed_address_change(


### PR DESCRIPTION
`from_bls_pubkey` could be confused with the bls signing key. I think it's better to be explicit and call it `from_bls_withdrawal_pubkey` which aligns with the phase 0 validator spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/validator.md#bls_withdrawal_prefix