### PR TITLE
EIP4844: Update cryptography API and Fiat-Shamir logic

### DIFF
--- a/presets/mainnet/eip4844.yaml
+++ b/presets/mainnet/eip4844.yaml
@@ -4,7 +4,5 @@
 # ---------------------------------------------------------------
 # `uint64(4096)`
 FIELD_ELEMENTS_PER_BLOB: 4096
-# `uint64(32)`
-BYTES_PER_FIELD_ELEMENT: 32
 # `uint64(2**4)` (= 16)
 MAX_BLOBS_PER_BLOCK: 16

--- a/presets/mainnet/eip4844.yaml
+++ b/presets/mainnet/eip4844.yaml
@@ -4,5 +4,7 @@
 # ---------------------------------------------------------------
 # `uint64(4096)`
 FIELD_ELEMENTS_PER_BLOB: 4096
+# `uint64(32)`
+BYTES_PER_FIELD_ELEMENT: 32
 # `uint64(2**4)` (= 16)
 MAX_BLOBS_PER_BLOCK: 16

--- a/presets/minimal/eip4844.yaml
+++ b/presets/minimal/eip4844.yaml
@@ -4,5 +4,7 @@
 # ---------------------------------------------------------------
 # [customized]
 FIELD_ELEMENTS_PER_BLOB: 4
+# `uint64(32)`
+BYTES_PER_FIELD_ELEMENT: 32
 # `uint64(2**4)` (= 16)
 MAX_BLOBS_PER_BLOCK: 16

--- a/presets/minimal/eip4844.yaml
+++ b/presets/minimal/eip4844.yaml
@@ -4,7 +4,5 @@
 # ---------------------------------------------------------------
 # [customized]
 FIELD_ELEMENTS_PER_BLOB: 4
-# `uint64(32)`
-BYTES_PER_FIELD_ELEMENT: 32
 # `uint64(2**4)` (= 16)
 MAX_BLOBS_PER_BLOCK: 16

--- a/setup.py
+++ b/setup.py
@@ -590,7 +590,6 @@ class EIP4844SpecBuilder(BellatrixSpecBuilder):
         return super().imports(preset_name) + f'''
 from eth2spec.utils import kzg
 from eth2spec.bellatrix import {preset_name} as bellatrix
-from eth2spec.utils.ssz.ssz_typing import ByteVector
 '''
 
 

--- a/setup.py
+++ b/setup.py
@@ -772,7 +772,7 @@ ignored_dependencies = [
     'uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'uint256',
     'bytes', 'byte', 'ByteList', 'ByteVector',
     'Dict', 'dict', 'field', 'ceillog2', 'floorlog2', 'Set',
-    'Optional', 'Sequence', 
+    'Optional', 'Sequence',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -616,7 +616,7 @@ KZG_SETUP_LAGRANGE = TESTING_KZG_SETUP_LAGRANGE
 ROOTS_OF_UNITY = kzg.compute_roots_of_unity(TESTING_FIELD_ELEMENTS_PER_BLOB)
 
 
-def retrieve_blobs_sidecar(slot: Slot, beacon_block_root: Root) -> BlobsSidecar:
+def retrieve_blobs_sidecar(slot: Slot, beacon_block_root: Root) -> Optional[BlobsSidecar]:
     return "TEST"'''
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -232,7 +232,7 @@ def get_spec(file_name: Path, preset: Dict[str, str], config: Dict[str, str]) ->
 
                     if not _is_constant_id(name):
                         # Check for short type declarations
-                        if value.startswith(("uint", "Bytes", "ByteList", "Union", "Vector", "List")):
+                        if value.startswith(("uint", "Bytes", "ByteList", "Union", "Vector", "List", "ByteVector")):
                             custom_types[name] = value
                         continue
 
@@ -590,6 +590,7 @@ class EIP4844SpecBuilder(BellatrixSpecBuilder):
         return super().imports(preset_name) + f'''
 from eth2spec.utils import kzg
 from eth2spec.bellatrix import {preset_name} as bellatrix
+from eth2spec.utils.ssz.ssz_typing import ByteVector
 '''
 
 
@@ -617,12 +618,13 @@ ROOTS_OF_UNITY = kzg.compute_roots_of_unity(TESTING_FIELD_ELEMENTS_PER_BLOB)
 
 
 def retrieve_blobs_sidecar(slot: Slot, beacon_block_root: Root) -> BlobsSidecar:
-    pass'''
+    return "TEST"'''
 
     @classmethod
     def hardcoded_custom_type_dep_constants(cls, spec_object) -> str:
         constants = {
             'FIELD_ELEMENTS_PER_BLOB': spec_object.preset_vars['FIELD_ELEMENTS_PER_BLOB'].value,
+            'BYTES_PER_FIELD_ELEMENT': spec_object.preset_vars['BYTES_PER_FIELD_ELEMENT'].value,
             'MAX_BLOBS_PER_BLOCK': spec_object.preset_vars['MAX_BLOBS_PER_BLOCK'].value,
         }
         return {**super().hardcoded_custom_type_dep_constants(spec_object), **constants}
@@ -771,7 +773,7 @@ ignored_dependencies = [
     'uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'uint256',
     'bytes', 'byte', 'ByteList', 'ByteVector',
     'Dict', 'dict', 'field', 'ceillog2', 'floorlog2', 'Set',
-    'Optional', 'Sequence',
+    'Optional', 'Sequence', 
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -622,8 +622,8 @@ def retrieve_blobs_sidecar(slot: Slot, beacon_block_root: Root) -> Optional[Blob
     @classmethod
     def hardcoded_custom_type_dep_constants(cls, spec_object) -> str:
         constants = {
+            'BYTES_PER_FIELD_ELEMENT': spec_object.constant_vars['BYTES_PER_FIELD_ELEMENT'].value,
             'FIELD_ELEMENTS_PER_BLOB': spec_object.preset_vars['FIELD_ELEMENTS_PER_BLOB'].value,
-            'BYTES_PER_FIELD_ELEMENT': spec_object.preset_vars['BYTES_PER_FIELD_ELEMENT'].value,
             'MAX_BLOBS_PER_BLOCK': spec_object.preset_vars['MAX_BLOBS_PER_BLOCK'].value,
         }
         return {**super().hardcoded_custom_type_dep_constants(spec_object), **constants}

--- a/setup.py
+++ b/setup.py
@@ -590,7 +590,6 @@ class EIP4844SpecBuilder(BellatrixSpecBuilder):
         return super().imports(preset_name) + f'''
 from eth2spec.utils import kzg
 from eth2spec.bellatrix import {preset_name} as bellatrix
-from eth2spec.utils.ssz.ssz_impl import serialize as ssz_serialize
 '''
 
 

--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -183,7 +183,7 @@ def is_data_available(slot: Slot, beacon_block_root: Root, blob_kzg_commitments:
     # `retrieve_blobs_sidecar` is implementation dependent, raises an exception if not available.
     sidecar = retrieve_blobs_sidecar(slot, beacon_block_root)
     if sidecar == "TEST":
-        return True # For testing; remove once we have a way to inject `BlobsSidecar` into tests
+        return True  # For testing; remove once we have a way to inject `BlobsSidecar` into tests
     validate_blobs_sidecar(slot, beacon_block_root, blob_kzg_commitments, sidecar)
 
     return True

--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -44,7 +44,7 @@ This upgrade adds blobs to the beacon chain as part of EIP-4844.
 
 | Name | SSZ equivalent | Description |
 | - | - | - |
-| `Blob` | `Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | |
+| `Blob` | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` | |
 | `VersionedHash` | `Bytes32` | |
 | `KZGCommitment` | `Bytes48` | Same as BLS standard "is valid pubkey" check but also allows `0x00..00` for point-at-infinity |
 
@@ -55,6 +55,7 @@ This upgrade adds blobs to the beacon chain as part of EIP-4844.
 | Name | Value |
 | - | - |
 | `BLOB_TX_TYPE` | `uint8(0x05)` |
+| `BYTES_PER_FIELD_ELEMENT` | `uint64(32)` |
 | `FIELD_ELEMENTS_PER_BLOB` | `uint64(4096)` |
 | `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` | 
 

--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -23,6 +23,8 @@
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
 - [Helper functions](#helper-functions)
   - [Misc](#misc)
+    - [`validate_blobs_sidecar`](#validate_blobs_sidecar)
+    - [`is_data_available`](#is_data_available)
     - [`kzg_commitment_to_versioned_hash`](#kzg_commitment_to_versioned_hash)
     - [`tx_peek_blob_versioned_hashes`](#tx_peek_blob_versioned_hashes)
     - [`verify_kzg_commitments_against_transactions`](#verify_kzg_commitments_against_transactions)

--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -23,8 +23,6 @@
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
 - [Helper functions](#helper-functions)
   - [Misc](#misc)
-    - [`validate_blobs_sidecar`](#validate_blobs_sidecar)
-    - [`is_data_available`](#is_data_available)
     - [`kzg_commitment_to_versioned_hash`](#kzg_commitment_to_versioned_hash)
     - [`tx_peek_blob_versioned_hashes`](#tx_peek_blob_versioned_hashes)
     - [`verify_kzg_commitments_against_transactions`](#verify_kzg_commitments_against_transactions)
@@ -182,6 +180,8 @@ but MUST NOT be considered valid until a valid `BlobsSidecar` has been downloade
 def is_data_available(slot: Slot, beacon_block_root: Root, blob_kzg_commitments: Sequence[KZGCommitment]) -> bool:
     # `retrieve_blobs_sidecar` is implementation dependent, raises an exception if not available.
     sidecar = retrieve_blobs_sidecar(slot, beacon_block_root)
+    if sidecar == "TEST":
+        return True # For testing; remove once we have a way to inject `BlobsSidecar` into tests
     validate_blobs_sidecar(slot, beacon_block_root, blob_kzg_commitments, sidecar)
 
     return True
@@ -244,7 +244,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     process_blob_kzg_commitments(state, block.body)  # [New in EIP-4844]
 
     # New in EIP-4844, note: Can sync optimistically without this condition, see note on `is_data_available`
-    assert is_data_available(block.slot, hash_tree_root(block), body.blob_kzg_commitments)
+    assert is_data_available(block.slot, hash_tree_root(block), block.body.blob_kzg_commitments)
 ```
 
 #### Execution payload

--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -46,7 +46,6 @@ This upgrade adds blobs to the beacon chain as part of EIP-4844.
 
 | Name | SSZ equivalent | Description |
 | - | - | - |
-| `Blob` | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` | |
 | `VersionedHash` | `Bytes32` | |
 
 ## Constants
@@ -56,8 +55,6 @@ This upgrade adds blobs to the beacon chain as part of EIP-4844.
 | Name | Value |
 | - | - |
 | `BLOB_TX_TYPE` | `uint8(0x05)` |
-| `BYTES_PER_FIELD_ELEMENT` | `uint64(32)` |
-| `FIELD_ELEMENTS_PER_BLOB` | `uint64(4096)` |
 | `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` | 
 
 ### Domain types

--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -48,7 +48,6 @@ This upgrade adds blobs to the beacon chain as part of EIP-4844.
 | - | - | - |
 | `Blob` | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` | |
 | `VersionedHash` | `Bytes32` | |
-| `KZGCommitment` | `Bytes48` | Same as BLS standard "is valid pubkey" check but also allows `0x00..00` for point-at-infinity |
 
 ## Constants
 

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -219,10 +219,10 @@ def g1_lincomb(points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElemen
 
 ```python
 def poly_lincomb(polys: Sequence[Polynomial],
-                 scalars: Sequence[BLSFieldElement]) -> Sequence[Polynomial]:
+                 scalars: Sequence[BLSFieldElement]) -> Polynomial:
     """
     Given a list of ``polynomials``, interpret it as a 2D matrix and compute the linear combination
-    of each column with `scalars`: return the resulting vector.
+    of each column with `scalars`: return the resulting polynomials.
     """
     result = [0] * len(polys[0])
     for v, s in zip(polys, scalars):

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -313,7 +313,7 @@ def compute_aggregated_poly_and_commitment(
     r_powers = compute_powers(r, len(kzg_commitments))
 
     # Create aggregated polynomial in evaluation form
-    aggregated_poly = Polynomial(vector_lincomb([blob_to_field_elements(blob for blob in blobs), r_powers))
+    aggregated_poly = Polynomial(vector_lincomb([blob_to_field_elements(blob) for blob in blobs], r_powers))
 
     # Compute commitment to aggregated polynomial
     aggregated_poly_commitment = KZGCommitment(g1_lincomb(kzg_commitments, r_powers))

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -152,12 +152,12 @@ def blob_to_polynomial(blob: Blob) -> Polynomial:
     """
     Convert a blob to list of BLS field scalars.
     """
-    r = Polynomial()
+    polynomial = Polynomial()
     for i in range(FIELD_ELEMENTS_PER_BLOB):
         value = int.from_bytes(blob[i * BYTES_PER_FIELD_ELEMENT: (i + 1) * BYTES_PER_FIELD_ELEMENT], ENDIANNESS)
         assert value < BLS_MODULUS
-        r[i] = value
-    return r
+        polynomial[i] = value
+    return polynomial
 ```
 
 #### `hash_to_bls_field`
@@ -178,9 +178,9 @@ def hash_to_bls_field(polys: Sequence[Polynomial],
     # Append each polynomial which is composed by field elements
     for poly in polys:
         for field_element in poly:
-            data += int.to_bytes(field_element, 32, ENDIANNESS)
+            data += int.to_bytes(field_element, BYTES_PER_FIELD_ELEMENT, ENDIANNESS)
 
-    # Append serialised G1 points
+    # Append serialized G1 points
     for commitment in comms:
         data += commitment
 

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -176,7 +176,7 @@ def hash_to_bls_field(initializer: bytes, polys: Sequence[Polynomial], comms: Se
     data += DOMAIN_SEPARATOR_SQUEEZE
     h = hash(data)
 
-    return bytes_to_bls_field(hash(data)), h
+    return bytes_to_bls_field(h), h
 ```
 
 #### `bls_modular_inverse`

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -62,6 +62,7 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 | Name | Value | Notes |
 | - | - | - |
 | `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` | Scalar field modulus of BLS12-381 |
+| `BYTES_PER_FIELD_ELEMENT` | `uint64(32)` | Bytes per BLS field element |
 
 ## Preset
 
@@ -69,7 +70,6 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 
 | Name | Value |
 | - | - |
-| `BYTES_PER_FIELD_ELEMENT` | `uint64(32)` |
 | `FIELD_ELEMENTS_PER_BLOB` | `uint64(4096)` |
 | `FIAT_SHAMIR_PROTOCOL_DOMAIN` | `b'FSBLOBVERIFY_V1_'` |
 

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -61,8 +61,7 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 
 | Name | Value | Notes |
 | - | - | - |
-| `BLS_MODULUS` | | `ROOTS_OF_UNITY` | `Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | Roots of unity of order FIELD_ELEMENTS_PER_BLOB over the BLS12-381 field |
-Roots of unity of order FIELD_ELEMENTS_PER_BLOB over the BLS12-381 field |
+| `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` | Scalar field modulus of BLS12-381 |
 
 ## Preset
 
@@ -72,7 +71,7 @@ Roots of unity of order FIELD_ELEMENTS_PER_BLOB over the BLS12-381 field |
 | - | - |
 | `BYTES_PER_FIELD_ELEMENT` | `uint64(32)` |
 | `FIELD_ELEMENTS_PER_BLOB` | `uint64(4096)` |
-| `FIAT_SHAMIR_PROTOCOL_DOMAIN` | `b'FSBLOBVERIFY_V1_'` | 
+| `FIAT_SHAMIR_PROTOCOL_DOMAIN` | `b'FSBLOBVERIFY_V1_'` |
 
 ### Crypto
 

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -149,13 +149,15 @@ def blob_to_field_elements(blob: Blob) -> Vector[BLSFieldElement, FIELD_ELEMENTS
     for i in range(FIELD_ELEMENTS_PER_BLOB):
         value = int.from_bytes(blob[i * BYTES_PER_FIELD_ELEMENT: (i + 1) * BYTES_PER_FIELD_ELEMENT], "little")
         assert value < BLS_MODULUS
-        r[i] = int.from_bytes(b, "little") % BLS_MODULUS
+        r[i] = value
 ```
 
 #### `hash_to_bls_field`
 
 ```python
-def hash_to_bls_field(initializer: bytes, polys: Sequence[Polynomial], comms: Sequence[KZGCommitment]) -> Tuple[BLSFieldElement, bytes]:
+def hash_to_bls_field(initializer: bytes,
+                      polys: Sequence[Polynomial],
+                      comms: Sequence[KZGCommitment]) -> Tuple[BLSFieldElement, bytes]:
     """
     Compute 32-byte hash of serialised polynomials and commitments concatenated.
     This hash is then converted to a BLS field element.

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -18,14 +18,19 @@
     - [`bit_reversal_permutation`](#bit_reversal_permutation)
   - [BLS12-381 helpers](#bls12-381-helpers)
     - [`bytes_to_bls_field`](#bytes_to_bls_field)
+    - [`hash_to_bls_field`](#hash_to_bls_field)
     - [`bls_modular_inverse`](#bls_modular_inverse)
     - [`div`](#div)
     - [`g1_lincomb`](#g1_lincomb)
     - [`vector_lincomb`](#vector_lincomb)
+    - [`compute_powers`](#compute_powers)
   - [KZG](#kzg)
     - [`blob_to_kzg_commitment`](#blob_to_kzg_commitment)
     - [`verify_kzg_proof`](#verify_kzg_proof)
     - [`compute_kzg_proof`](#compute_kzg_proof)
+    - [`compute_aggregated_poly_and_commitment`](#compute_aggregated_poly_and_commitment)
+    - [`compute_aggregate_kzg_proof`](#compute_aggregate_kzg_proof)
+    - [`verify_aggregate_kzg_proof`](#verify_aggregate_kzg_proof)
   - [Polynomials](#polynomials)
     - [`evaluate_polynomial_in_evaluation_form`](#evaluate_polynomial_in_evaluation_form)
 
@@ -202,7 +207,8 @@ def vector_lincomb(vectors: Sequence[Sequence[BLSFieldElement]],
     return [BLSFieldElement(x) for x in result]
 ```
 
-### `compute_powers`
+#### `compute_powers`
+
 ```python
 def compute_powers(x: BLSFieldElement, n: uint64) -> Sequence[BLSFieldElement]:
     """
@@ -271,8 +277,7 @@ def compute_kzg_proof(polynomial: Sequence[BLSFieldElement], z: BLSFieldElement)
     return KZGProof(g1_lincomb(bit_reversal_permutation(KZG_SETUP_LAGRANGE), quotient_polynomial))
 ```
 
-
-### `compute_aggregated_poly_and_commitment`
+#### `compute_aggregated_poly_and_commitment`
 
 ```python
 def compute_aggregated_poly_and_commitment(

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -23,7 +23,7 @@
     - [`bls_modular_inverse`](#bls_modular_inverse)
     - [`div`](#div)
     - [`g1_lincomb`](#g1_lincomb)
-    - [`vector_lincomb`](#vector_lincomb)
+    - [`poly_lincomb`](#poly_lincomb)
     - [`compute_powers`](#compute_powers)
   - [KZG](#kzg)
     - [`blob_to_kzg_commitment`](#blob_to_kzg_commitment)
@@ -215,17 +215,17 @@ def g1_lincomb(points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElemen
     return KZGCommitment(bls.G1_to_bytes48(result))
 ```
 
-#### `vector_lincomb`
+#### `poly_lincomb`
 
 ```python
-def vector_lincomb(vectors: Sequence[Sequence[BLSFieldElement]],
-                   scalars: Sequence[BLSFieldElement]) -> Sequence[BLSFieldElement]:
+def poly_lincomb(polys: Sequence[Polynomial],
+                 scalars: Sequence[BLSFieldElement]) -> Sequence[Polynomial]:
     """
-    Given a list of ``vectors``, interpret it as a 2D matrix and compute the linear combination
+    Given a list of ``polynomials``, interpret it as a 2D matrix and compute the linear combination
     of each column with `scalars`: return the resulting vector.
     """
-    result = [0] * len(vectors[0])
-    for v, s in zip(vectors, scalars):
+    result = [0] * len(polys[0])
+    for v, s in zip(polys, scalars):
         for i, x in enumerate(v):
             result[i] = (result[i] + int(s) * int(x)) % BLS_MODULUS
     return [BLSFieldElement(x) for x in result]
@@ -279,7 +279,7 @@ def verify_kzg_proof(polynomial_kzg: KZGCommitment,
 #### `compute_kzg_proof`
 
 ```python
-def compute_kzg_proof(polynomial: Sequence[BLSFieldElement], z: BLSFieldElement) -> KZGProof:
+def compute_kzg_proof(polynomial: Polynomial, z: BLSFieldElement) -> KZGProof:
     """
     Compute KZG proof at point `z` with `polynomial` being in evaluation form
     """
@@ -315,7 +315,7 @@ def compute_aggregated_poly_and_commitment(
     r_powers = compute_powers(r, len(kzg_commitments))
 
     # Create aggregated polynomial in evaluation form
-    aggregated_poly = Polynomial(vector_lincomb([blob_to_field_elements(blob) for blob in blobs], r_powers))
+    aggregated_poly = Polynomial(poly_lincomb([blob_to_field_elements(blob) for blob in blobs], r_powers))
 
     # Compute commitment to aggregated polynomial
     aggregated_poly_commitment = KZGCommitment(g1_lincomb(kzg_commitments, r_powers))

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -312,7 +312,7 @@ def compute_aggregated_poly_and_commitment(
     r_powers = compute_powers(r, len(kzg_commitments))
 
     # Create aggregated polynomial in evaluation form
-    aggregated_poly = Polynomial(vector_lincomb([blob_to_field_elements(blob for blob in blobs], r_powers))
+    aggregated_poly = Polynomial(vector_lincomb([blob_to_field_elements(blob for blob in blobs), r_powers))
 
     # Compute commitment to aggregated polynomial
     aggregated_poly_commitment = KZGCommitment(g1_lincomb(kzg_commitments, r_powers))

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -294,12 +294,42 @@ def compute_aggregated_poly_and_commitment(
     return aggregated_poly, aggregated_poly_commitment
 ```
 
+#### `compute_aggregate_kzg_proof`
+
+```python
+def compute_aggregate_kzg_proof(blobs: Sequence[Blob]) -> KZGProof:
+    commitments = [blob_to_kzg_commitment(blob) for blob in blobs]
+    aggregated_poly, aggregated_poly_commitment = compute_aggregated_poly_and_commitment(blobs, commitments)
+    x = hash_to_bls_field([aggregated_poly],[aggregated_poly_commitment])
+    return compute_kzg_proof(aggregated_poly, x)
+```
+
+#### `verify_aggregate_kzg_proof`
+
+```python
+def verify_aggregate_kzg_proof(blobs: Sequence[Blob],
+                               expected_kzg_commitments: Sequence[KZGCommitment],
+                               kzg_aggregated_proof : KZGCommitment) -> bool:
+    aggregated_poly, aggregated_poly_commitment = compute_aggregated_poly_and_commitment(
+        blobs,
+        expected_kzg_commitments,
+    )
+
+    # Generate challenge `x` and evaluate the aggregated polynomial at `x`
+    x = hash_to_bls_field([aggregated_poly], [aggregated_poly_commitment])
+    # Evaluate aggregated polynomial at `x` (evaluation function checks for div-by-zero)
+    y = evaluate_polynomial_in_evaluation_form(aggregated_poly, x)
+
+    # Verify aggregated proof
+    return verify_kzg_proof(aggregated_poly_commitment, x, y, kzg_aggregated_proof)
+```
+
 ### Polynomials
 
 #### `evaluate_polynomial_in_evaluation_form`
 
 ```python
-def evaluate_polynomial_in_evaluation_form(polynomial: Sequence[BLSFieldElement],
+def evaluate_polynomial_in_evaluation_form(polynomial: Polynomial,
                                            z: BLSFieldElement) -> BLSFieldElement:
     """
     Evaluate a polynomial (in evaluation form) at an arbitrary point `z`

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -10,6 +10,8 @@
 - [Custom types](#custom-types)
 - [Constants](#constants)
 - [Preset](#preset)
+  - [Blob](#blob)
+  - [Crypto](#crypto)
   - [Trusted setup](#trusted-setup)
 - [Helper functions](#helper-functions)
   - [Bit-reversal permutation](#bit-reversal-permutation)
@@ -53,6 +55,7 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 | `KZGCommitment` | `Bytes48` | Same as BLS standard "is valid pubkey" check but also allows `0x00..00` for point-at-infinity |
 | `KZGProof` | `Bytes48` | Same as for `KZGCommitment` |
 | `Polynomial` | `Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | a polynomial in evaluation form |
+| `Blob` | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` | |
 
 ## Constants
 
@@ -62,7 +65,6 @@ Should we determine that they are required at a later point we can set
 | Name | Value | Notes |
 | - | - | - |
 | `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` | Scalar field modulus of BLS12-381 |
-| `ROOTS_OF_UNITY` | `Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | Roots of unity of order FIELD_ELEMENTS_PER_BLOB over the BLS12-381 field |
 | `DOMAIN_SEPARATOR_AGGREGATE_PROTOCOL` | `b""` | Fiat-Shamir domain separator random aggregation |
 | `DOMAIN_SEPARATOR_EVAL_PROTOCOL` | `b""` | Fiat-Shamir domain separator random evaluation |
 | `DOMAIN_SEPARATOR_FIELD_ELEMENT` | `b""` | Fiat-Shamir domain separator for field elements |
@@ -71,6 +73,19 @@ Should we determine that they are required at a later point we can set
 
 
 ## Preset
+
+### Blob
+
+| Name | Value |
+| - | - |
+| `BYTES_PER_FIELD_ELEMENT` | `uint64(32)` |
+| `FIELD_ELEMENTS_PER_BLOB` | `uint64(4096)` |
+
+### Crypto
+
+| Name | Value | Notes |
+| - | - | - |
+| `ROOTS_OF_UNITY` | `Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | Roots of unity of order FIELD_ELEMENTS_PER_BLOB over the BLS12-381 field |
 
 ### Trusted setup
 

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -55,13 +55,17 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 
 ## Constants
 
+*Note*: Domain separators are set to an empty string as they are not required according to current understanding (and are not "free").
+Should we determine that they are required at a later point we can set 
+
 | Name | Value | Notes |
 | - | - | - |
 | `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` | Scalar field modulus of BLS12-381 |
 | `ROOTS_OF_UNITY` | `Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | Roots of unity of order FIELD_ELEMENTS_PER_BLOB over the BLS12-381 field |
-| `DOMAIN_SEPARATOR_FIELD_ELEMENT` | `b"FIELD_ELEMENT"` | Fiat-Shamir domain separator for field elements |
-| `DOMAIN_SEPARATOR_POINT` | `b"POINT"` | Fiat-Shamir domain separator for G1 points |
-| `DOMAIN_SEPARATOR_SQUEEZE` | `b"SQUEEZE"` | Fiat-Shamir domain separator before hashing |
+| `DOMAIN_SEPARATOR_BLOB_PROTOCOL` | `b""` | Fiat-Shamir domain separator blob verification |
+| `DOMAIN_SEPARATOR_FIELD_ELEMENT` | `b""` | Fiat-Shamir domain separator for field elements |
+| `DOMAIN_SEPARATOR_POINT` | `b""` | Fiat-Shamir domain separator for G1 points |
+| `DOMAIN_SEPARATOR_SQUEEZE` | `b""` | Fiat-Shamir domain separator before hashing |
 
 
 ## Preset
@@ -155,7 +159,7 @@ def hash_to_bls_field(polys: Sequence[Polynomial], comms: Sequence[KZGCommitment
     This hash is then converted to a BLS field element.
     The output is not uniform over the BLS field.
     """
-    data = bytes()
+    data = DOMAIN_SEPARATOR_BLOB_PROTOCOL
 
     # Append each polynomial which is composed by field elements
     for poly in polys:

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -164,7 +164,7 @@ def blob_to_polynomial(blob: Blob) -> Polynomial:
 
 ```python
 def hash_to_bls_field(polys: Sequence[Polynomial],
-                      comms: Sequence[KZGCommitment]) -> Tuple[BLSFieldElement, Hash32]:
+                      comms: Sequence[KZGCommitment]) -> BLSFieldElement:
     """
     Compute 32-byte hash of serialized polynomials and commitments concatenated.
     This hash is then converted to a BLS field element, where the result is not uniform over the BLS field.
@@ -276,7 +276,7 @@ def evaluate_polynomial_in_evaluation_form(polynomial: Polynomial,
 
     result = 0
     for i in range(width):
-        result += div(int(polynomial[i]) * int(roots_of_unity_brp[i]), (z - roots_of_unity_brp[i]))
+        result += div(int(polynomial[i]) * int(roots_of_unity_brp[i]), (int(z) - roots_of_unity_brp[i]))
     result = result * (pow(z, width, BLS_MODULUS) - 1) * inverse_width % BLS_MODULUS
     return result
 ```

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -305,7 +305,7 @@ def compute_aggregated_poly_and_commitment(
 def compute_aggregate_kzg_proof(blobs: Sequence[Blob]) -> KZGProof:
     commitments = [blob_to_kzg_commitment(blob) for blob in blobs]
     aggregated_poly, aggregated_poly_commitment = compute_aggregated_poly_and_commitment(blobs, commitments)
-    x = hash_to_bls_field([aggregated_poly],[aggregated_poly_commitment])
+    x = hash_to_bls_field([aggregated_poly], [aggregated_poly_commitment])
     return compute_kzg_proof(aggregated_poly, x)
 ```
 
@@ -314,7 +314,7 @@ def compute_aggregate_kzg_proof(blobs: Sequence[Blob]) -> KZGProof:
 ```python
 def verify_aggregate_kzg_proof(blobs: Sequence[Blob],
                                expected_kzg_commitments: Sequence[KZGCommitment],
-                               kzg_aggregated_proof : KZGCommitment) -> bool:
+                               kzg_aggregated_proof: KZGCommitment) -> bool:
     aggregated_poly, aggregated_poly_commitment = compute_aggregated_poly_and_commitment(
         blobs,
         expected_kzg_commitments,

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -20,7 +20,7 @@
     - [`bit_reversal_permutation`](#bit_reversal_permutation)
   - [BLS12-381 helpers](#bls12-381-helpers)
     - [`bytes_to_bls_field`](#bytes_to_bls_field)
-    - [`blob_to_field_elements`](#blob_to_field_elements)
+    - [`blob_to_polynomial`](#blob_to_polynomial)
     - [`hash_to_bls_field`](#hash_to_bls_field)
     - [`bls_modular_inverse`](#bls_modular_inverse)
     - [`div`](#div)
@@ -145,10 +145,10 @@ def bytes_to_bls_field(b: Bytes32) -> BLSFieldElement:
     return int.from_bytes(b, ENDIANNESS) % BLS_MODULUS
 ```
 
-#### `blob_to_field_elements`
+#### `blob_to_polynomial`
 
 ```python
-def blob_to_field_elements(blob: Blob) -> Polynomial:
+def blob_to_polynomial(blob: Blob) -> Polynomial:
     """
     Convert a blob to list of BLS field scalars.
     """
@@ -289,7 +289,7 @@ KZG core functions. These are also defined in EIP-4844 execution specs.
 
 ```python
 def blob_to_kzg_commitment(blob: Blob) -> KZGCommitment:
-    return g1_lincomb(bit_reversal_permutation(KZG_SETUP_LAGRANGE), blob_to_field_elements(blob))
+    return g1_lincomb(bit_reversal_permutation(KZG_SETUP_LAGRANGE), blob_to_polynomial(blob))
 ```
 
 #### `verify_kzg_proof`
@@ -352,7 +352,7 @@ def compute_aggregated_poly_and_commitment(
     r2 = r_powers[-1] * r
 
     # Create aggregated polynomial in evaluation form
-    aggregated_poly = Polynomial(poly_lincomb([blob_to_field_elements(blob) for blob in blobs], r_powers))
+    aggregated_poly = Polynomial(poly_lincomb([blob_to_polynomial(blob) for blob in blobs], r_powers))
 
     # Compute commitment to aggregated polynomial
     aggregated_poly_commitment = KZGCommitment(g1_lincomb(kzg_commitments, r_powers))

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -135,21 +135,22 @@ def bytes_to_bls_field(b: Bytes32) -> BLSFieldElement:
     """
     Convert bytes to a BLS field scalar. The output is not uniform over the BLS field.
     """
-    return int.from_bytes(b, "little") % BLS_MODULUS
+    return int.from_bytes(b, ENDIANNESS) % BLS_MODULUS
 ```
 
 #### `blob_to_field_elements`
 
 ```python
-def blob_to_field_elements(blob: Blob) -> Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]:
+def blob_to_field_elements(blob: Blob) -> Polynomial:
     """
     Convert blob to list of BLS field scalars.
     """
-    r = Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]()
+    r = Polynomial()
     for i in range(FIELD_ELEMENTS_PER_BLOB):
-        value = int.from_bytes(blob[i * BYTES_PER_FIELD_ELEMENT: (i + 1) * BYTES_PER_FIELD_ELEMENT], "little")
+        value = int.from_bytes(blob[i * BYTES_PER_FIELD_ELEMENT: (i + 1) * BYTES_PER_FIELD_ELEMENT], ENDIANNESS)
         assert value < BLS_MODULUS
         r[i] = value
+    return r
 ```
 
 #### `hash_to_bls_field`

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -349,7 +349,7 @@ def compute_aggregated_poly_and_commitment(
     # Generate random linear combination challenges
     r = hash_to_bls_field(blobs, kzg_commitments)
     r_powers = compute_powers(r, len(kzg_commitments))
-    r2 = r_powers[-1] * r
+    r2 = int(r_powers[-1]) * r % BLS_MODULUS
 
     # Create aggregated polynomial in evaluation form
     aggregated_poly = Polynomial(poly_lincomb([blob_to_polynomial(blob) for blob in blobs], r_powers))

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -264,7 +264,7 @@ def evaluate_polynomial_in_evaluation_form(polynomial: Polynomial,
     """
     Evaluate a polynomial (in evaluation form) at an arbitrary point ``z``.
     Uses the barycentric formula:
-       f(z) = (1 - z**WIDTH) / WIDTH  *  sum_(i=0)^WIDTH  (f(DOMAIN[i]) * DOMAIN[i]) / (z - DOMAIN[i])
+       f(z) = (z**WIDTH - 1) / WIDTH  *  sum_(i=0)^WIDTH  (f(DOMAIN[i]) * DOMAIN[i]) / (z - DOMAIN[i])
     """
     width = len(polynomial)
     assert width == FIELD_ELEMENTS_PER_BLOB
@@ -318,13 +318,13 @@ def verify_kzg_proof(polynomial_kzg: KZGCommitment,
 def compute_kzg_proof(polynomial: Polynomial, z: BLSFieldElement) -> KZGProof:
     """
     Compute KZG proof at point `z` with `polynomial` being in evaluation form
+    Do this by computing the quotient polynomial in evaluation form: q(x) = (p(x) - p(z)) / (x - z)
     """
 
     # To avoid SSZ overflow/underflow, convert element into int
     polynomial = [int(i) for i in polynomial]
     z = int(z)
 
-    # Shift our polynomial first (in evaluation form we can't handle the division remainder)
     y = evaluate_polynomial_in_evaluation_form(polynomial, z)
     polynomial_shifted = [(p - int(y)) % BLS_MODULUS for p in polynomial]
 

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -61,7 +61,8 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 
 | Name | Value | Notes |
 | - | - | - |
-| `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` | Scalar field modulus of BLS12-381 |
+| `BLS_MODULUS` | | `ROOTS_OF_UNITY` | `Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | Roots of unity of order FIELD_ELEMENTS_PER_BLOB over the BLS12-381 field |
+Roots of unity of order FIELD_ELEMENTS_PER_BLOB over the BLS12-381 field |
 
 ## Preset
 
@@ -71,6 +72,7 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 | - | - |
 | `BYTES_PER_FIELD_ELEMENT` | `uint64(32)` |
 | `FIELD_ELEMENTS_PER_BLOB` | `uint64(4096)` |
+| `FIAT_SHAMIR_PROTOCOL_DOMAIN` | `b'FSBLOBVERIFY_V1_'` | 
 
 ### Crypto
 
@@ -170,9 +172,9 @@ def hash_to_bls_field(polys: Sequence[Polynomial],
     Return the BLS field element.
     """
     # Append the number of polynomials and the degree of each polynomial as a domain separator
-    num_polys = int.to_bytes(len(polys), 16, ENDIANNESS)
-    degree_poly = int.to_bytes(FIELD_ELEMENTS_PER_BLOB, 16, ENDIANNESS)
-    data = num_polys + degree_poly
+    num_polys = int.to_bytes(len(polys), 8, ENDIANNESS)
+    degree_poly = int.to_bytes(FIELD_ELEMENTS_PER_BLOB, 8, ENDIANNESS)
+    data = FIAT_SHAMIR_PROTOCOL_DOMAIN + degree_poly + num_polys
 
     # Append each polynomial which is composed by field elements
     for poly in polys:

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -18,6 +18,7 @@
     - [`bit_reversal_permutation`](#bit_reversal_permutation)
   - [BLS12-381 helpers](#bls12-381-helpers)
     - [`bytes_to_bls_field`](#bytes_to_bls_field)
+    - [`blob_to_field_elements`](#blob_to_field_elements)
     - [`hash_to_bls_field`](#hash_to_bls_field)
     - [`bls_modular_inverse`](#bls_modular_inverse)
     - [`div`](#div)

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -62,7 +62,7 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 | Name | Value | Notes |
 | - | - | - |
 | `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` | Scalar field modulus of BLS12-381 |
-| `BYTES_PER_FIELD_ELEMENT` | `uint64(32)` | Bytes per BLS field element |
+| `BYTES_PER_FIELD_ELEMENT` | `uint64(32)` | Bytes used to encode a BLS scalar field element |
 
 ## Preset
 

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -43,31 +43,6 @@ All behaviors and definitions defined in this document, and documents it extends
 All terminology, constants, functions, and protocol mechanics defined in the updated [Beacon Chain doc of EIP4844](./beacon-chain.md) are requisite for this document and used throughout.
 Please see related Beacon Chain doc before continuing and use them as a reference throughout.
 
-## Custom types
-
-| Name | SSZ equivalent | Description |
-| - | - | - |
-| `Polynomial` | `List[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | a polynomial in evaluation form |
-
-## Containers
-
-### `BlobsAndCommitments`
-
-```python
-class BlobsAndCommitments(Container):
-    blobs: List[Blob, MAX_BLOBS_PER_BLOCK]
-    kzg_commitments: List[KZGCommitment, MAX_BLOBS_PER_BLOCK]
-```
-
-### `PolynomialAndCommitment`
-
-```python
-class PolynomialAndCommitment(Container):
-    polynomial: Polynomial
-    kzg_commitment: KZGCommitment
-```
-
-
 ## Helpers
 
 ### `is_data_available`

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -11,8 +11,6 @@
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
 - [Helpers](#helpers)
-  - [`is_data_available`](#is_data_available)
-  - [`validate_blobs_sidecar`](#validate_blobs_sidecar)
   - [`get_blobs_and_kzg_commitments`](#get_blobs_and_kzg_commitments)
 - [Beacon chain responsibilities](#beacon-chain-responsibilities)
   - [Block proposal](#block-proposal)

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -77,33 +77,7 @@ def validate_blobs_sidecar(slot: Slot,
     kzg_aggregated_proof = blobs_sidecar.kzg_aggregated_proof
     assert len(expected_kzg_commitments) == len(blobs)
 
-    aggregated_poly, aggregated_poly_commitment = compute_aggregated_poly_and_commitment(
-        blobs,
-        expected_kzg_commitments,
-    )
-
-    # Generate challenge `x` and evaluate the aggregated polynomial at `x`
-    x = hash_to_bls_field(
-        PolynomialAndCommitment(polynomial=aggregated_poly, kzg_commitment=aggregated_poly_commitment)
-    )
-    # Evaluate aggregated polynomial at `x` (evaluation function checks for div-by-zero)
-    y = evaluate_polynomial_in_evaluation_form(aggregated_poly, x)
-
-    # Verify aggregated proof
-    assert verify_kzg_proof(aggregated_poly_commitment, x, y, kzg_aggregated_proof)
-```
-
-### `compute_proof_from_blobs`
-
-```python
-def compute_proof_from_blobs(blobs: Sequence[Blob]) -> KZGProof:
-    commitments = [blob_to_kzg_commitment(blob) for blob in blobs]
-    aggregated_poly, aggregated_poly_commitment = compute_aggregated_poly_and_commitment(blobs, commitments)
-    x = hash_to_bls_field(PolynomialAndCommitment(
-        polynomial=aggregated_poly,
-        kzg_commitment=aggregated_poly_commitment,
-    ))
-    return compute_kzg_proof(aggregated_poly, x)
+    assert verify_aggregate_kzg_proof(blobs, expected_kzg_commitments, kzg_aggregated_proof)
 ```
 
 ### `get_blobs_and_kzg_commitments`
@@ -160,7 +134,7 @@ def get_blobs_sidecar(block: BeaconBlock, blobs: Sequence[Blob]) -> BlobsSidecar
         beacon_block_root=hash_tree_root(block),
         beacon_block_slot=block.slot,
         blobs=blobs,
-        kzg_aggregated_proof=compute_proof_from_blobs(blobs),
+        kzg_aggregated_proof=compute_aggregate_kzg_proof(blobs),
     )
 ```
 

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -10,17 +10,9 @@
 
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
-- [Custom types](#custom-types)
-- [Containers](#containers)
-  - [`BlobsAndCommitments`](#blobsandcommitments)
-  - [`PolynomialAndCommitment`](#polynomialandcommitment)
 - [Helpers](#helpers)
   - [`is_data_available`](#is_data_available)
-  - [`hash_to_bls_field`](#hash_to_bls_field)
-  - [`compute_powers`](#compute_powers)
-  - [`compute_aggregated_poly_and_commitment`](#compute_aggregated_poly_and_commitment)
   - [`validate_blobs_sidecar`](#validate_blobs_sidecar)
-  - [`compute_proof_from_blobs`](#compute_proof_from_blobs)
   - [`get_blobs_and_kzg_commitments`](#get_blobs_and_kzg_commitments)
 - [Beacon chain responsibilities](#beacon-chain-responsibilities)
   - [Block proposal](#block-proposal)
@@ -62,7 +54,6 @@ def is_data_available(slot: Slot, beacon_block_root: Root, blob_kzg_commitments:
 
     return True
 ```
-
 
 ### `validate_blobs_sidecar`
 

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -88,52 +88,6 @@ def is_data_available(slot: Slot, beacon_block_root: Root, blob_kzg_commitments:
     return True
 ```
 
-### `hash_to_bls_field`
-
-```python
-def hash_to_bls_field(x: Container) -> BLSFieldElement:
-    """
-    Compute 32-byte hash of serialized container and convert it to BLS field.
-    The output is not uniform over the BLS field.
-    """
-    return bytes_to_bls_field(hash(ssz_serialize(x)))
-```
-
-### `compute_powers`
-```python
-def compute_powers(x: BLSFieldElement, n: uint64) -> Sequence[BLSFieldElement]:
-    """
-    Return ``x`` to power of [0, n-1].
-    """
-    current_power = 1
-    powers = []
-    for _ in range(n):
-        powers.append(BLSFieldElement(current_power))
-        current_power = current_power * int(x) % BLS_MODULUS
-    return powers
-```
-
-### `compute_aggregated_poly_and_commitment`
-
-```python
-def compute_aggregated_poly_and_commitment(
-        blobs: Sequence[Blob],
-        kzg_commitments: Sequence[KZGCommitment]) -> Tuple[Polynomial, KZGCommitment]:
-    """
-    Return the aggregated polynomial and aggregated KZG commitment.
-    """
-    # Generate random linear combination challenges
-    r = hash_to_bls_field(BlobsAndCommitments(blobs=blobs, kzg_commitments=kzg_commitments))
-    r_powers = compute_powers(r, len(kzg_commitments))
-
-    # Create aggregated polynomial in evaluation form
-    aggregated_poly = Polynomial(vector_lincomb(blobs, r_powers))
-
-    # Compute commitment to aggregated polynomial
-    aggregated_poly_commitment = KZGCommitment(g1_lincomb(kzg_commitments, r_powers))
-
-    return aggregated_poly, aggregated_poly_commitment
-```
 
 ### `validate_blobs_sidecar`
 

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -37,40 +37,6 @@ Please see related Beacon Chain doc before continuing and use them as a referenc
 
 ## Helpers
 
-### `is_data_available`
-
-The implementation of `is_data_available` is meant to change with later sharding upgrades.
-Initially, it requires every verifying actor to retrieve the matching `BlobsSidecar`,
-and validate the sidecar with `validate_blobs_sidecar`.
-
-Without the sidecar the block may be processed further optimistically,
-but MUST NOT be considered valid until a valid `BlobsSidecar` has been downloaded.
-
-```python
-def is_data_available(slot: Slot, beacon_block_root: Root, blob_kzg_commitments: Sequence[KZGCommitment]) -> bool:
-    # `retrieve_blobs_sidecar` is implementation dependent, raises an exception if not available.
-    sidecar = retrieve_blobs_sidecar(slot, beacon_block_root)
-    validate_blobs_sidecar(slot, beacon_block_root, blob_kzg_commitments, sidecar)
-
-    return True
-```
-
-### `validate_blobs_sidecar`
-
-```python
-def validate_blobs_sidecar(slot: Slot,
-                           beacon_block_root: Root,
-                           expected_kzg_commitments: Sequence[KZGCommitment],
-                           blobs_sidecar: BlobsSidecar) -> None:
-    assert slot == blobs_sidecar.beacon_block_slot
-    assert beacon_block_root == blobs_sidecar.beacon_block_root
-    blobs = blobs_sidecar.blobs
-    kzg_aggregated_proof = blobs_sidecar.kzg_aggregated_proof
-    assert len(expected_kzg_commitments) == len(blobs)
-
-    assert verify_aggregate_kzg_proof(blobs, expected_kzg_commitments, kzg_aggregated_proof)
-```
-
 ### `get_blobs_and_kzg_commitments`
 
 The interface to retrieve blobs and corresponding kzg commitments.

--- a/tests/core/pyspec/eth2spec/test/eip4844/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip4844/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -1,0 +1,20 @@
+from eth2spec.test.context import (
+    spec_state_test,
+    with_eip4844_and_later,
+)
+from eth2spec.test.helpers.sharding import (
+    get_sample_blob,
+)
+
+
+@with_eip4844_and_later
+@spec_state_test
+def test_verify_kzg_proof(spec, state):
+    x = 3
+    blob = get_sample_blob(spec)
+    commitment = spec.blob_to_kzg_commitment(blob)
+    polynomial = spec.blob_to_field_elements(blob)
+    proof = spec.compute_kzg_proof(polynomial, x)
+
+    y = spec.evaluate_polynomial_in_evaluation_form(polynomial, x)
+    assert spec.verify_kzg_proof(commitment, x, y, proof)

--- a/tests/core/pyspec/eth2spec/test/eip4844/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip4844/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -13,7 +13,7 @@ def test_verify_kzg_proof(spec, state):
     x = 3
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
-    polynomial = spec.blob_to_field_elements(blob)
+    polynomial = spec.blob_to_polynomial(blob)
     proof = spec.compute_kzg_proof(polynomial, x)
 
     y = spec.evaluate_polynomial_in_evaluation_form(polynomial, x)

--- a/tests/core/pyspec/eth2spec/test/eip4844/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/eip4844/unittests/validator/test_validator.py
@@ -10,24 +10,8 @@ from eth2spec.test.context import (
 )
 from eth2spec.test.helpers.sharding import (
     get_sample_opaque_tx,
-    get_sample_blob,
 )
 from eth2spec.test.helpers.keys import privkeys
-
-
-@with_eip4844_and_later
-@spec_state_test
-def test_verify_kzg_proof(spec, state):
-    x = 3
-    polynomial = get_sample_blob(spec)
-    polynomial = [int(i) for i in polynomial]
-    commitment = spec.blob_to_kzg_commitment(polynomial)
-
-    # Get the proof
-    proof = spec.compute_kzg_proof(polynomial, x)
-
-    y = spec.evaluate_polynomial_in_evaluation_form(polynomial, x)
-    assert spec.verify_kzg_proof(commitment, x, y, proof)
 
 
 def _run_validate_blobs_sidecar_test(spec, state, blob_count):

--- a/tests/core/pyspec/eth2spec/test/helpers/sharding.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/sharding.py
@@ -53,10 +53,16 @@ def get_sample_blob(spec, rng=None):
     if rng is None:
         rng = random.Random(5566)
 
-    return spec.Blob([
+    values = [
         rng.randint(0, spec.BLS_MODULUS - 1)
         for _ in range(spec.FIELD_ELEMENTS_PER_BLOB)
-    ])
+    ]
+
+    b = bytes()
+    for v in values:
+        b.append(v.to_bytes(32, "little"))
+
+    return spec.Blob(b)
 
 
 def get_sample_opaque_tx(spec, blob_count=1, rng=None):

--- a/tests/core/pyspec/eth2spec/test/helpers/sharding.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/sharding.py
@@ -60,7 +60,7 @@ def get_sample_blob(spec, rng=None):
 
     b = bytes()
     for v in values:
-        b.append(v.to_bytes(32, "little"))
+        b += v.to_bytes(32, spec.ENDIANNESS)
 
     return spec.Blob(b)
 


### PR DESCRIPTION
This PR does a few things with the cryptography of EIP-4844.

Most importantly, it changes the public API of the KZG library to the following high-level API:
```
- verify_kzg_proof()
- compute_aggregate_kzg_proof()
- verify_aggregate_kzg_proof()
- blob_to_kzg_commitment()
```
compared to the old much more low-level API:
```
- compute_powers()
- matrix_lincomb()
- lincomb()
- bytes_to_bls_field()
- evaluate_polynomial_in_evaluation_form()
- verify_kzg_proof()
- compute_kzg_proof()
```

This means that all the cryptographic logic (including Fiat-Shamir) is now isolated and hidden in the KZG library and the `validator.md` file ends up being significantly simplified, only calling high-level KZG functions.

Some additional things that this PR does:
- Moves all EIP4844 cryptography into polynomial-commitments.md
- Improves the Fiat-Shamir stack by removing the need for SSZ and by introducing domain separators.

Future TODO tasks:
- Add unittests in `test_validator.py` that tests the high-level API