### PR TITLE
EIP4844: couple beacon block and blob sidecar for p2p

### DIFF
--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -113,7 +113,7 @@ Alias `signed_blobs_sidecar = signed_beacon_block_and_blobs_sidecar.blobs_sideca
 - _[IGNORE]_ The sidecar is the first sidecar with valid signature received for the `(proposer_index, sidecar.beacon_block_slot)` combination,
   where `proposer_index` is the validator index of the beacon block proposer of `sidecar.beacon_block_slot`
 
-Once both sidecar and beacon block are received, `validate_blobs_sidecar` can unlock the data-availability fork-choice dependency.
+Once the sidecar and beacon block are received together, `validate_blobs_sidecar` can unlock the data-availability fork-choice dependency.
 
 ### Transitioning the gossip
 

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -14,11 +14,11 @@ The specification of these changes continues in the same format as the network s
   - [Containers](#containers)
     - [`BlobsSidecar`](#blobssidecar)
     - [`SignedBlobsSidecar`](#signedblobssidecar)
+    - [`SignedBeaconBlockAndBlobsSidecar`](#signedbeaconblockandblobssidecar)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`beacon_block`](#beacon_block)
-        - [`blobs_sidecar`](#blobs_sidecar)
+        - [`beacon_block_and_blob_sidecar`](#beacon_block_and_blob_sidecar)
     - [Transitioning the gossip](#transitioning-the-gossip)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
@@ -94,14 +94,14 @@ EIP4844 introduces a new global topic for beacon block and blobs-sidecars.
 
 This topic is used to propagate new signed and coupled beacon blocks and blobs sidecars to all nodes on the networks.
 
-The following validations MUST pass before forwarding the `signed_beacon_block_and_blobs_sidecar` on the network;
+The following validations MUST pass before forwarding the `signed_beacon_block_and_blobs_sidecar` on the network.  
 Alias `signed_beacon_block = signed_beacon_block_and_blobs_sidecar.beacon_block`, `block = signed_beacon_block.message`, `execution_payload = block.body.execution_payload`.
 - _[REJECT]_ The KZG commitments of the blobs are all correctly encoded compressed BLS G1 Points.
   -- i.e. `all(bls.KeyValidate(commitment) for commitment in block.body.blob_kzg_commitments)`
 - _[REJECT]_ The KZG commitments correspond to the versioned hashes in the transactions list.
   -- i.e. `verify_kzg_commitments_against_transactions(block.body.execution_payload.transactions, block.body.blob_kzg_commitments)`
 
-Alias `sidecar = signed_beacon_block_and_blobs_sidecar.blobs_sidecar.message`.
+Alias `signed_blobs_sidecar = signed_beacon_block_and_blobs_sidecar.blobs_sidecar`, `sidecar = signed_blobs_sidecar.message`.
 - _[IGNORE]_ the `sidecar.beacon_block_slot` is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) -- i.e. `sidecar.beacon_block_slot == current_slot`.
 - _[REJECT]_ the `sidecar.blobs` are all well formatted, i.e. the `BLSFieldElement` in valid range (`x < BLS_MODULUS`).
 - _[REJECT]_ The KZG proof is a correctly encoded compressed BLS G1 Point -- i.e. `bls.KeyValidate(blobs_sidecar.kzg_aggregated_proof)`
@@ -114,7 +114,6 @@ Alias `sidecar = signed_beacon_block_and_blobs_sidecar.blobs_sidecar.message`.
   where `proposer_index` is the validator index of the beacon block proposer of `sidecar.beacon_block_slot`
 
 Once both sidecar and beacon block are received, `validate_blobs_sidecar` can unlock the data-availability fork-choice dependency.
-
 
 ### Transitioning the gossip
 

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -102,7 +102,7 @@ Alias `signed_beacon_block = signed_beacon_block_and_blobs_sidecar.beacon_block`
   -- i.e. `verify_kzg_commitments_against_transactions(block.body.execution_payload.transactions, block.body.blob_kzg_commitments)`
 
 Alias `signed_blobs_sidecar = signed_beacon_block_and_blobs_sidecar.blobs_sidecar`, `sidecar = signed_blobs_sidecar.message`.
-- _[IGNORE]_ the `sidecar.beacon_block_slot` is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) -- i.e. `sidecar.beacon_block_slot == current_slot`.
+- _[IGNORE]_ the `sidecar.beacon_block_slot` is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) -- i.e. `sidecar.beacon_block_slot == block.slot`.
 - _[REJECT]_ the `sidecar.blobs` are all well formatted, i.e. the `BLSFieldElement` in valid range (`x < BLS_MODULUS`).
 - _[REJECT]_ The KZG proof is a correctly encoded compressed BLS G1 Point -- i.e. `bls.KeyValidate(blobs_sidecar.kzg_aggregated_proof)`
 - _[REJECT]_ the beacon proposer signature, `signed_blobs_sidecar.signature`, is valid -- i.e.

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -18,7 +18,7 @@ The specification of these changes continues in the same format as the network s
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`beacon_block_and_blob_sidecar`](#beacon_block_and_blob_sidecar)
+        - [`beacon_block_and_blobs_sidecar`](#beacon_block_and_blobs_sidecar)
     - [Transitioning the gossip](#transitioning-the-gossip)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
@@ -83,14 +83,14 @@ The new topics along with the type of the `data` field of a gossipsub message ar
 
 | Name | Message Type |
 | - | - |
-| `beacon_block_and_blob_sidecar` | `SignedBeaconBlockAndBlobsSidecar` (new) |
+| `beacon_block_and_blobs_sidecar` | `SignedBeaconBlockAndBlobsSidecar` (new) |
 
 
 #### Global topics
 
 EIP4844 introduces a new global topic for beacon block and blobs-sidecars.
 
-##### `beacon_block_and_blob_sidecar`
+##### `beacon_block_and_blobs_sidecar`
 
 This topic is used to propagate new signed and coupled beacon blocks and blobs sidecars to all nodes on the networks.
 

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -63,7 +63,7 @@ class SignedBlobsSidecar(Container):
 ```python
 class SignedBeaconBlockAndBlobsSidecar(Container):
     beacon_block: SignedBeaconBlock
-    blobs_sidecar: SignedBlobsSidecar
+    blobs_sidecar: BlobsSidecar
 ```
 
 ## The gossip domain: gossipsub
@@ -101,17 +101,10 @@ Alias `signed_beacon_block = signed_beacon_block_and_blobs_sidecar.beacon_block`
 - _[REJECT]_ The KZG commitments correspond to the versioned hashes in the transactions list.
   -- i.e. `verify_kzg_commitments_against_transactions(block.body.execution_payload.transactions, block.body.blob_kzg_commitments)`
 
-Alias `signed_blobs_sidecar = signed_beacon_block_and_blobs_sidecar.blobs_sidecar`, `sidecar = signed_blobs_sidecar.message`.
+Alias `sidecar = signed_beacon_block_and_blobs_sidecar.blobs_sidecar`.
 - _[IGNORE]_ the `sidecar.beacon_block_slot` is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) -- i.e. `sidecar.beacon_block_slot == block.slot`.
 - _[REJECT]_ the `sidecar.blobs` are all well formatted, i.e. the `BLSFieldElement` in valid range (`x < BLS_MODULUS`).
 - _[REJECT]_ The KZG proof is a correctly encoded compressed BLS G1 Point -- i.e. `bls.KeyValidate(blobs_sidecar.kzg_aggregated_proof)`
-- _[REJECT]_ the beacon proposer signature, `signed_blobs_sidecar.signature`, is valid -- i.e.
-    - Let `domain = get_domain(state, DOMAIN_BLOBS_SIDECAR, sidecar.beacon_block_slot // SLOTS_PER_EPOCH)`
-    - Let `signing_root = compute_signing_root(sidecar, domain)`
-    - Verify `bls.Verify(proposer_pubkey, signing_root, signed_blobs_sidecar.signature) is True`,   
-      where `proposer_pubkey` is the pubkey of the beacon block proposer of `sidecar.beacon_block_slot`
-- _[IGNORE]_ The sidecar is the first sidecar with valid signature received for the `(proposer_index, sidecar.beacon_block_slot)` combination,
-  where `proposer_index` is the validator index of the beacon block proposer of `sidecar.beacon_block_slot`
 
 Once the sidecar and beacon block are received together, `validate_blobs_sidecar` can unlock the data-availability fork-choice dependency.
 

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -23,10 +23,12 @@
   - [`compute_proof_from_blobs`](#compute_proof_from_blobs)
   - [`get_blobs_and_kzg_commitments`](#get_blobs_and_kzg_commitments)
 - [Beacon chain responsibilities](#beacon-chain-responsibilities)
-  - [Block proposal](#block-proposal)
+  - [Block and sidecar proposal](#block-and-sidecar-proposal)
     - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
       - [Blob KZG commitments](#blob-kzg-commitments)
-  - [Beacon Block publishing time](#beacon-block-publishing-time)
+    - [Constructing the `SignedBeaconBlockAndBlobsSidecar`](#constructing-the-signedbeaconblockandblobssidecar)
+      - [Block](#block)
+      - [Sidecar](#sidecar)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->

--- a/tests/core/pyspec/eth2spec/test/eip4844/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/eip4844/unittests/validator/test_validator.py
@@ -12,7 +12,6 @@ from eth2spec.test.helpers.sharding import (
     get_sample_opaque_tx,
     get_sample_blob,
 )
-from eth2spec.test.helpers.keys import privkeys
 
 
 @with_eip4844_and_later
@@ -38,8 +37,6 @@ def _run_validate_blobs_sidecar_test(spec, state, blob_count):
     state_transition_and_sign_block(spec, state, block)
 
     blobs_sidecar = spec.get_blobs_sidecar(block, blobs)
-    privkey = privkeys[1]
-    spec.get_signed_blobs_sidecar(state, blobs_sidecar, privkey)
     expected_commitments = [spec.blob_to_kzg_commitment(blobs[i]) for i in range(blob_count)]
     spec.validate_blobs_sidecar(block.slot, block.hash_tree_root(), expected_commitments, blobs_sidecar)
 


### PR DESCRIPTION
Part of #3043

Here we couple beacon block and blob sidecar under a single gossip topic- `beacon_block_and_blob_sidecar`. We introduce a new network container `SignedBeaconBlockAndBlobsSidecar` which consists of `SignedBeaconBlock` and `SignedBlobsSidecar`. We also combined the previous gossips `beacon_block` and `blobs_sidecar` validations under `beacon_block_and_blob_sidecar`. I think we can get rid of `blob.beacon_block_root` and `blob.beacon_block_slot`, I'm curious to hear more thoughts

cc @protolambda @Inphi 

Rationale for coupling: https://notes.ethereum.org/RLOGb1hYQ0aWt3hcVgzhgQ?#Gossip
