### PR TITLE
EIP4844: modify `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` to 18 days

### DIFF
--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -33,10 +33,10 @@ The specification of these changes continues in the same format as the network s
 
 ## Configuration
 
-| Name                                     | Value                               | Description                                                         |
-|------------------------------------------|-------------------------------------|---------------------------------------------------------------------|
-| `MAX_REQUEST_BLOBS_SIDECARS`             | `2**7` (= 128)                      | Maximum number of blobs sidecars in a single request                |
-| `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` | `2**13` (= 8192 epochs, ~1.2 months) | The minimum epoch range over which a node must serve blobs sidecars |
+| Name                                     | Value                             | Description                                                         |
+|------------------------------------------|-----------------------------------|---------------------------------------------------------------------|
+| `MAX_REQUEST_BLOBS_SIDECARS`             | `2**7` (= 128)                    | Maximum number of blobs sidecars in a single request                |
+| `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` | `2**12` (= 4096 epochs, ~18 days) | The minimum epoch range over which a node must serve blobs sidecars |
 
 ## Containers
 


### PR DESCRIPTION
Part of #3043

As discussed during Devcon, 1.2 months is a bit long as the upper bound for storing the blobs. 2 weeks seems sufficient for any use case we are aware of, and some may argue even shorter. This reduces the storage requirement to 137GB, assuming 1mb target