### PR TITLE
Consistently use `compute_sync_committee_period_at_slot`

### DIFF
--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -84,13 +84,13 @@ def create_light_client_update(state: BeaconState,
     header = state.latest_block_header.copy()
     header.state_root = hash_tree_root(state)
     assert hash_tree_root(header) == hash_tree_root(block.message)
-    update_signature_period = compute_sync_committee_period(compute_epoch_at_slot(block.message.slot))
+    update_signature_period = compute_sync_committee_period_at_slot(block.message.slot)
 
     assert attested_state.slot == attested_state.latest_block_header.slot
     attested_header = attested_state.latest_block_header.copy()
     attested_header.state_root = hash_tree_root(attested_state)
     assert hash_tree_root(attested_header) == block.message.parent_root
-    update_attested_period = compute_sync_committee_period(compute_epoch_at_slot(attested_header.slot))
+    update_attested_period = compute_sync_committee_period_at_slot(attested_header.slot)
 
     # `next_sync_committee` is only useful if the message is signed by the current sync committee
     if update_attested_period == update_signature_period:
@@ -133,7 +133,7 @@ def create_light_client_update(state: BeaconState,
 Full nodes SHOULD provide the best derivable `LightClientUpdate` (according to `is_better_update`) for each sync committee period covering any epochs in range `[max(ALTAIR_FORK_EPOCH, current_epoch - MIN_EPOCHS_FOR_BLOCK_REQUESTS), current_epoch]` where `current_epoch` is defined by the current wall-clock time. Full nodes MAY also provide `LightClientUpdate` for other sync committee periods.
 
 - `LightClientUpdate` are assigned to sync committee periods based on their `attested_header.slot`
-- `LightClientUpdate` are only considered if `compute_sync_committee_period(compute_epoch_at_slot(update.attested_header.slot)) == compute_sync_committee_period(compute_epoch_at_slot(update.signature_slot))`
+- `LightClientUpdate` are only considered if `compute_sync_committee_period_at_slot(update.attested_header.slot) == compute_sync_committee_period_at_slot(update.signature_slot)`
 - Only `LightClientUpdate` with `next_sync_committee` as selected by fork choice are provided, regardless of ranking by `is_better_update`. To uniquely identify a non-finalized sync committee fork, all of `period`, `current_sync_committee` and `next_sync_committee` need to be incorporated, as sync committees may reappear over time.
 
 ### `create_light_client_finality_update`

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
@@ -110,7 +110,7 @@ def compute_start_slot_at_sync_committee_period(spec, sync_committee_period):
 
 
 def compute_start_slot_at_next_sync_committee_period(spec, state):
-    sync_committee_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(state.slot))
+    sync_committee_period = spec.compute_sync_committee_period_at_slot(state.slot)
     return compute_start_slot_at_sync_committee_period(spec, sync_committee_period + 1)
 
 

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py
@@ -68,8 +68,8 @@ def test_process_light_client_update_at_period_boundary(spec, state):
 
     # Forward to slot before next sync committee period so that next block is final one in period
     next_slots(spec, state, spec.UPDATE_TIMEOUT - 2)
-    store_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(store.optimistic_header.slot))
-    update_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(state.slot))
+    store_period = spec.compute_sync_committee_period_at_slot(store.optimistic_header.slot)
+    update_period = spec.compute_sync_committee_period_at_slot(state.slot)
     assert store_period == update_period
 
     attested_block = state_transition_with_full_block(spec, state, False, False)
@@ -112,8 +112,8 @@ def test_process_light_client_update_timeout(spec, state):
 
     # Forward to next sync committee period
     next_slots(spec, state, spec.UPDATE_TIMEOUT)
-    store_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(store.optimistic_header.slot))
-    update_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(state.slot))
+    store_period = spec.compute_sync_committee_period_at_slot(store.optimistic_header.slot)
+    update_period = spec.compute_sync_committee_period_at_slot(state.slot)
     assert store_period + 1 == update_period
 
     attested_block = state_transition_with_full_block(spec, state, False, False)
@@ -164,8 +164,8 @@ def test_process_light_client_update_finality_updated(spec, state):
     # Ensure that finality checkpoint has changed
     assert state.finalized_checkpoint.epoch == 3
     # Ensure that it's same period
-    store_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(store.optimistic_header.slot))
-    update_period = spec.compute_sync_committee_period(spec.compute_epoch_at_slot(state.slot))
+    store_period = spec.compute_sync_committee_period_at_slot(store.optimistic_header.slot)
+    update_period = spec.compute_sync_committee_period_at_slot(state.slot)
     assert store_period == update_period
 
     attested_block = blocks[-1]


### PR DESCRIPTION
A few LC functions were not yet updated to use a more concise function for computing sync committee period for a slot. Updating to that func.