### PR TITLE
Rename LC test check from `root` to `beacon_root`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
@@ -63,11 +63,11 @@ def get_checks(store):
     return {
         "finalized_header": {
             'slot': int(store.finalized_header.slot),
-            'root': encode_hex(store.finalized_header.hash_tree_root()),
+            'beacon_root': encode_hex(store.finalized_header.hash_tree_root()),
         },
         "optimistic_header": {
             'slot': int(store.optimistic_header.slot),
-            'root': encode_hex(store.optimistic_header.hash_tree_root()),
+            'beacon_root': encode_hex(store.optimistic_header.hash_tree_root()),
         },
     }
 

--- a/tests/formats/light_client/sync.md
+++ b/tests/formats/light_client/sync.md
@@ -26,11 +26,11 @@ Each step includes checks to verify the expected impact on the `store` object.
 ```yaml
 finalized_header: {
     slot: int,                -- Integer value from store.finalized_header.slot
-    root: string,             -- Encoded 32-byte value from store.finalized_header.hash_tree_root()
+    beacon_root: string,      -- Encoded 32-byte value from store.finalized_header.hash_tree_root()
 }
 optimistic_header: {
     slot: int,                -- Integer value from store.optimistic_header.slot
-    root: string,             -- Encoded 32-byte value from store.optimistic_header.hash_tree_root()
+    beacon_root: string,      -- Encoded 32-byte value from store.optimistic_header.hash_tree_root()
 }
 ```
 


### PR DESCRIPTION
Future light client tests will also incorporate execution payload data. To avoid confusion, rename the current `root` check to `beacon_root`. Doing this now, as #3066 already requires LC test runners to update.