### PR TITLE
Update `remerkleable` to 0.1.25

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1131,7 +1131,7 @@ setup(
         "pycryptodome==3.15.0",
         "py_ecc==6.0.0",
         "milagro_bls_binding==1.9.0",
-        "remerkleable==0.1.24",
+        "remerkleable==0.1.25",
         RUAMEL_YAML_VERSION,
         "lru-dict==1.1.8",
         MARKO_VERSION,


### PR DESCRIPTION
`remerkleable` was updated to address potentially incorrect computation of `hash_tree_root` against default-initialized `Vector` objects. Switching to the fixed version.