### PR TITLE
capella: add withdrawal boost factor constant

### DIFF
--- a/presets/mainnet/capella.yaml
+++ b/presets/mainnet/capella.yaml
@@ -4,6 +4,8 @@
 # ---------------------------------------------------------------
 # 2**8 (= 256) withdrawals
 MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 256
+# 1
+WITHDRAWAL_BOOST_FACTOR: 1
 
 
 # State list lengths

--- a/presets/minimal/capella.yaml
+++ b/presets/minimal/capella.yaml
@@ -4,6 +4,8 @@
 # ---------------------------------------------------------------
 # [customized] 16 for more interesting tests at low validator count
 MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 16
+# [customized] 10 for more interesting tests ;)
+WITHDRAWAL_BOOST_FACTOR: 10
 
 
 # State list lengths

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -80,6 +80,7 @@ We define the following Python custom types for type hinting and readability:
 | Name | Value |
 | - | - |
 | `MAX_PARTIAL_WITHDRAWALS_PER_EPOCH` | `uint64(2**8)` (= 256) |
+| `WITHDRAWAL_BOOST_FACTOR` | `1` |
 
 ### State list lengths
 
@@ -256,6 +257,8 @@ class BeaconState(Container):
 def withdraw_balance(state: BeaconState, validator_index: ValidatorIndex, amount: Gwei) -> None:
     # Decrease the validator's balance
     decrease_balance(state, validator_index, amount)
+    # Apply the boost factor for custom network configurations
+    amount *= WITHDRAWAL_BOOST_FACTOR
     # Create a corresponding withdrawal receipt
     withdrawal = Withdrawal(
         index=state.next_withdrawal_index,


### PR DESCRIPTION
A `WITHDRAWAL_BOOST_FACTOR` should always be `1` but can be used to inflate total supply through withdrawals in tests or testnet environments.

Opening this up for discussion. Context https://github.com/eth-clients/goerli/issues/129

cc @parithosh 