### PR TITLE
Fix typo in `bellatrix` p2p docs

### DIFF
--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -110,7 +110,7 @@ The following gossip validation from prior specifications MUST NOT be applied if
 ### Transitioning the gossip
 
 See gossip transition details found in the [Altair document](../altair/p2p-interface.md#transitioning-the-gossip) for
-details on how to handle transitioning gossip topics for EIP-4844.
+details on how to handle transitioning gossip topics.
 
 ## The Req/Resp domain
 


### PR DESCRIPTION
Seems like some bad copy pasta from an old edit

Fix: Just drop the reference to 4844 here