### PR TITLE
EIP4844: Remove `DOMAIN_BLOBS_SIDECAR`

### DIFF
--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -12,7 +12,6 @@
 - [Custom types](#custom-types)
 - [Constants](#constants)
   - [Blob](#blob)
-  - [Domain types](#domain-types)
 - [Preset](#preset)
   - [Execution](#execution)
 - [Configuration](#configuration)
@@ -56,12 +55,6 @@ This upgrade adds blobs to the beacon chain as part of EIP-4844.
 | - | - |
 | `BLOB_TX_TYPE` | `uint8(0x05)` |
 | `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` | 
-
-### Domain types
-
-| Name | Value |
-| - | - |
-| `DOMAIN_BLOBS_SIDECAR` | `DomainType('0x0a000000')` |
 
 ## Preset
 


### PR DESCRIPTION
`DOMAIN_BLOBS_SIDECAR` is no longer used after we coupled `blobs_sidecar` and `beacon_block` under the same gossip. This PR removes it from the spec