### PR TITLE
process_withdrawals conducive to blinded payloads

### DIFF
--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -283,7 +283,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 #### New `get_expected_withdrawals`
 
 ```python
-def get_expected_withdrawals(state: BeaconState) -> Sequence[Withdrawal]:
+def get_expected_withdrawals(state: BeaconState) -> List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]:
     epoch = get_current_epoch(state)
     withdrawal_index = state.next_withdrawal_index
     validator_index = state.next_withdrawal_validator_index
@@ -318,10 +318,10 @@ def get_expected_withdrawals(state: BeaconState) -> Sequence[Withdrawal]:
 ```python
 def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
     expected_withdrawals = get_expected_withdrawals(state)
-    assert len(payload.withdrawals) == len(expected_withdrawals)
 
-    for expected_withdrawal, withdrawal in zip(expected_withdrawals, payload.withdrawals):
-        assert withdrawal == expected_withdrawal
+    assert (hash_tree_root(payload.withdrawals) == hash_tree_root(expected_withdrawals))
+
+    for withdrawal in expected_withdrawals:
         decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
     if len(expected_withdrawals) > 0:
         latest_withdrawal = expected_withdrawals[-1]


### PR DESCRIPTION
While implementing `capella` I noticed something that needs discussion. This PR as a place to have that discussion.

### Context

A core component of the [`builder-specs`](https://github.com/ethereum/builder-specs) is the [`BlindedBeaconBlockBody`](https://github.com/ethereum/builder-specs/blob/main/specs/builder.md#blindedbeaconblockbody), which differs from a normal [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#beaconblockbody) in that it replaces the `execution_payload` with an `execution_payload_header`. The purpose of this is to blind the `transactions` field of the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#executionpayload).

But in `capella`, the [modified `ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#executionpayload) now also contains a `withdrawals` field. This means that when using the `builder-api` to propose a block, the `withdrawals` field will also be blinded.

#### Solution

As it turns out, this isn't a problem. The solution is shown in the proposed changes.

To verify the payload all we need to do is:
```
assert (hash_tree_root(payload.withdrawals) == hash_tree_root(expected_withdrawals))
```
We don't actually need the `withdrawals` in the payload. Once we've verified the roots match, we can apply the `expected_withdrawals` to the `state` as they're the same.

Written this way, the spec provides the same guarantees, but it's easier to reason about in the `BlindedBeaconBlock` case.

#### Additional Comments

This is possible because unlike `transactions`, `withdrawals` are deterministic for every block. This means we actually **don't even need to transmit `withdrawals` with every beacon block**. We could save space in every block by replacing `withdrawals` in [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#executionpayload) with `withdrawals_root` just like the [`ExecutionPayloadHeader`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#executionpayloadheader).

The downside is that this would break the symmetry between [the `capella` `ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#executionpayload) and [the proposed `ExecutionPayloadV2`](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#executionpayloadv2), as the full array of `Withdrawal`s will still need to be sent to the execution engine.








