### PR TITLE
Send store.finalized block hash to EL

### DIFF
--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -77,9 +77,13 @@ The `finalized_block_hash` parameter MUST be set to return value of the followin
 def get_finalized_execution_payload_hash(store: Store) -> Hash32:
     finalized_block_root = store.finalized_checkpoint.root
     finalized_block = store.blocks[finalized_block_root]
-
-    # Returns Hash32() if no payload is yet finalized
-    return finalized_block.body.execution_payload.block_hash
+    
+    # Consider finalized blocks before Bellatrix
+    # Return Hash32() if no payload is yet finalized
+    if compute_epoch_at_slot(finalized_block.slot) >= BELLATRIX_FORK_EPOCH:
+        return finalized_block.body.execution_payload.block_hash
+    else:
+        return Hash32()
 ```
 
 ##### `safe_block_hash`

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -10,6 +10,7 @@
 - [Protocols](#protocols)
   - [`ExecutionEngine`](#executionengine)
     - [`notify_forkchoice_updated`](#notify_forkchoice_updated)
+      - [`finalized_block_hash`](#finalized_block_hash)
       - [`safe_block_hash`](#safe_block_hash)
 - [Helpers](#helpers)
   - [`PayloadAttributes`](#payloadattributes)

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -65,11 +65,22 @@ def notify_forkchoice_updated(self: ExecutionEngine,
 ```
 
 *Note*: The `(head_block_hash, finalized_block_hash)` values of the `notify_forkchoice_updated` function call maps on the `POS_FORKCHOICE_UPDATED` event defined in the [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions).
-As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice_updated` MUST be called with `finalized_block_hash = Hash32()`.
 
 *Note*: Client software MUST NOT call this function until the transition conditions are met on the PoW network, i.e. there exists a block for which `is_valid_terminal_pow_block` function returns `True`.
 
 *Note*: Client software MUST call this function to initiate the payload build process to produce the merge transition block; the `head_block_hash` parameter MUST be set to the hash of a terminal PoW block in this case.
+
+##### `finalized_block_hash`
+The `finalized_block_hash` parameter MUST be set to return value of the following function:
+
+```python
+def get_finalized_execution_payload_hash(store: Store) -> Hash32:
+    finalized_block_root = store.finalized_checkpoint.root
+    finalized_block = store.blocks[finalized_block_root]
+
+    # Returns Hash32() if no payload is yet finalized
+    return finalized_block.body.execution_payload.block_hash
+```
 
 ##### `safe_block_hash`
 

--- a/tests/core/pyspec/eth2spec/test/bellatrix/unittests/test_fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/unittests/test_fork_choice.py
@@ -1,0 +1,61 @@
+from eth2spec.test.context import (
+    spec_configured_state_test,
+    with_bellatrix_and_later,
+)
+from eth2spec.test.helpers.fork_choice import (
+    get_genesis_forkchoice_store_and_block,
+)
+from eth2spec.test.helpers.state import (
+    next_epoch,
+)
+
+
+@with_bellatrix_and_later
+@spec_configured_state_test({
+    'BELLATRIX_FORK_EPOCH': 0
+})
+def test_get_finalized_execution_payload_hash_equal_to_bellatrix_fork_epoch(spec, state):
+    store, _ = get_genesis_forkchoice_store_and_block(spec, state)
+
+    finalized_block = store.blocks[store.finalized_checkpoint.root]
+
+    finalized_execution_payload_hash = spec.get_finalized_execution_payload_hash(store)
+
+    assert spec.compute_epoch_at_slot(finalized_block.slot) == spec.config.BELLATRIX_FORK_EPOCH
+    assert finalized_execution_payload_hash == finalized_block.body.execution_payload.block_hash
+
+
+@with_bellatrix_and_later
+@spec_configured_state_test({
+    'BELLATRIX_FORK_EPOCH': 0
+})
+def test_get_finalized_execution_payload_hash_greater_than_bellatrix_fork_epoch(spec, state):
+    store, _ = get_genesis_forkchoice_store_and_block(spec, state)
+
+    next_epoch(spec, state)
+    time = store.time + spec.config.SECONDS_PER_SLOT * (spec.SLOTS_PER_EPOCH + 1)
+    spec.on_tick(store, time)
+
+    finalized_block = store.blocks[store.finalized_checkpoint.root]
+    # manipulate slot number
+    finalized_block.slot = spec.SLOTS_PER_EPOCH
+
+    finalized_execution_payload_hash = spec.get_finalized_execution_payload_hash(store)
+
+    assert spec.compute_epoch_at_slot(finalized_block.slot) > spec.config.BELLATRIX_FORK_EPOCH
+    assert finalized_execution_payload_hash == finalized_block.body.execution_payload.block_hash
+
+
+@with_bellatrix_and_later
+@spec_configured_state_test({
+    'BELLATRIX_FORK_EPOCH': 1
+})
+def test_get_finalized_execution_payload_hash_less_than_bellatrix_fork_epoch(spec, state):
+    store, _ = get_genesis_forkchoice_store_and_block(spec, state)
+
+    finalized_block = store.blocks[store.finalized_checkpoint.root]
+
+    finalized_execution_payload_hash = spec.get_finalized_execution_payload_hash(store)
+
+    assert spec.compute_epoch_at_slot(finalized_block.slot) < spec.config.BELLATRIX_FORK_EPOCH
+    assert finalized_execution_payload_hash == spec.Hash32()


### PR DESCRIPTION
Explicitly states that store's finalized checkpoint must be used to obtain `finalized_block_hash` that is sent to EL. Apparently, all CL clients are already following this logic.

@hwwhww we would need to create tests checking that `store.finalized` used instead of `head_state.finalized` to obtain `finalized_block_hash`. These values can't diverge according to current specification, as tips with finalized checkpoint not matching to the store's one are filtered out and not eligible for the head. Not sure if we can implement such tests without changing the fork choice spec.