### PR TITLE
cleanup explicit fork enumerations in tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_config_override.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_config_override.py
@@ -4,10 +4,11 @@ from eth2spec.test.context import (
     with_all_phases,
     with_phases,
 )
-from eth2spec.test.helpers.constants import ALTAIR
-from eth2spec.test.helpers.forks import (
-    is_post_capella, is_post_eip4844,
+from eth2spec.test.helpers.constants import (
+    PHASE0, ALTAIR,
+    ALL_PHASES,
 )
+from eth2spec.test.helpers.forks import is_post_fork
 
 
 @with_phases([ALTAIR])
@@ -30,29 +31,28 @@ def test_config_override(spec, state):
 @with_all_phases
 @spec_state_test_with_matching_config
 def test_override_config_fork_epoch(spec, state):
-    if state.fork.current_version == spec.config.GENESIS_FORK_VERSION:
-        return
+    # Fork schedule must be consistent with state fork
+    epoch = spec.get_current_epoch(state)
+    if is_post_fork(spec.fork, ALTAIR):
+        assert state.fork.current_version == spec.compute_fork_version(epoch)
+    else:
+        assert state.fork.current_version == spec.config.GENESIS_FORK_VERSION
 
-    assert spec.config.ALTAIR_FORK_EPOCH == spec.GENESIS_EPOCH
-    if state.fork.current_version == spec.config.ALTAIR_FORK_VERSION:
-        return
+    # Identify state fork
+    state_fork = None
+    for fork in [fork for fork in ALL_PHASES if is_post_fork(spec.fork, fork)]:
+        if fork == PHASE0:
+            fork_version_field = 'GENESIS_FORK_VERSION'
+        else:
+            fork_version_field = fork.upper() + '_FORK_VERSION'
+        if state.fork.current_version == getattr(spec.config, fork_version_field):
+            state_fork = fork
+            break
+    assert state_fork is not None
 
-    assert spec.config.BELLATRIX_FORK_EPOCH == spec.GENESIS_EPOCH
-    if state.fork.current_version == spec.config.BELLATRIX_FORK_VERSION:
-        return
-
-    if is_post_capella(spec):
-        assert spec.config.CAPELLA_FORK_EPOCH == spec.GENESIS_EPOCH
-        if state.fork.current_version == spec.config.CAPELLA_FORK_VERSION:
-            return
-
-    if is_post_eip4844(spec):
-        assert spec.config.EIP4844_FORK_EPOCH == spec.GENESIS_EPOCH
-        if state.fork.current_version == spec.config.EIP4844_FORK_VERSION:
-            return
-
-    assert spec.config.SHARDING_FORK_EPOCH == spec.GENESIS_EPOCH
-    if state.fork.current_version == spec.config.SHARDING_FORK_VERSION:
-        return
-
-    assert False  # Fork is missing
+    # Check that all prior forks have already been triggered
+    for fork in [fork for fork in ALL_PHASES if is_post_fork(state_fork, fork)]:
+        if fork == PHASE0:
+            continue
+        fork_epoch_field = fork.upper() + '_FORK_EPOCH'
+        assert getattr(spec.config, fork_epoch_field) <= epoch

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -11,7 +11,7 @@ from eth2spec.utils import bls
 
 from .exceptions import SkippedTest
 from .helpers.constants import (
-    PHASE0, ALTAIR, BELLATRIX, CAPELLA, EIP4844, SHARDING,
+    PHASE0, ALTAIR, BELLATRIX, CAPELLA, EIP4844,
     MINIMAL, MAINNET,
     ALL_PHASES,
     ALL_FORK_UPGRADES,
@@ -267,7 +267,7 @@ def spec_test(fn):
     return vector_test()(bls_switch(fn))
 
 
-# shorthand for decorating @spectest() @with_state @single_phase
+# shorthand for decorating @spec_test() @with_state @single_phase
 def spec_state_test(fn):
     return spec_test(with_state(single_phase(fn)))
 
@@ -291,30 +291,16 @@ def _check_current_version(spec, state, version_name):
 
 
 def config_fork_epoch_overrides(spec, state):
-    overrides = {}
     if state.fork.current_version == spec.config.GENESIS_FORK_VERSION:
-        pass
-    elif _check_current_version(spec, state, ALTAIR):
-        overrides['ALTAIR_FORK_EPOCH'] = spec.GENESIS_EPOCH
-    elif _check_current_version(spec, state, BELLATRIX):
-        overrides['ALTAIR_FORK_EPOCH'] = spec.GENESIS_EPOCH
-        overrides['BELLATRIX_FORK_EPOCH'] = spec.GENESIS_EPOCH
-    elif _check_current_version(spec, state, CAPELLA):
-        overrides['ALTAIR_FORK_EPOCH'] = spec.GENESIS_EPOCH
-        overrides['BELLATRIX_FORK_EPOCH'] = spec.GENESIS_EPOCH
-        overrides['CAPELLA_FORK_EPOCH'] = spec.GENESIS_EPOCH
-    elif _check_current_version(spec, state, EIP4844):
-        overrides['ALTAIR_FORK_EPOCH'] = spec.GENESIS_EPOCH
-        overrides['BELLATRIX_FORK_EPOCH'] = spec.GENESIS_EPOCH
-        overrides['EIP4844_FORK_EPOCH'] = spec.GENESIS_EPOCH
-    elif _check_current_version(spec, state, SHARDING):
-        overrides['ALTAIR_FORK_EPOCH'] = spec.GENESIS_EPOCH
-        overrides['BELLATRIX_FORK_EPOCH'] = spec.GENESIS_EPOCH
-        overrides['CAPELLA_FORK_EPOCH'] = spec.GENESIS_EPOCH
-        overrides['SHARDING_FORK_EPOCH'] = spec.GENESIS_EPOCH
-    else:
-        assert False  # Fork is missing
-    return overrides
+        return {}
+
+    for fork in ALL_PHASES:
+        if fork != PHASE0 and _check_current_version(spec, state, fork):
+            overrides = {}
+            for f in ALL_PHASES:
+                if f != PHASE0 and is_post_fork(fork, f):
+                    overrides[f.upper() + '_FORK_EPOCH'] = spec.GENESIS_EPOCH
+            return overrides
 
 
 def spec_state_test_with_matching_config(fn):


### PR DESCRIPTION
Fork epoch override test decorators were still referring to `SHARDING`. Replace the implementation with one that needs less maintenance.