### PR TITLE
Fix initialization of VERSIONED_HASH_VERSION_KZG

### DIFF
--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -55,7 +55,7 @@ This upgrade adds blobs to the beacon chain as part of EIP-4844. This is an exte
 | Name | Value |
 | - | - |
 | `BLOB_TX_TYPE` | `uint8(0x05)` |
-| `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` | 
+| `VERSIONED_HASH_VERSION_KZG` | `Bytes1('0x01')` | 
 
 ## Preset
 


### PR DESCRIPTION
See https://github.com/protolambda/remerkleable/issues/15
In current `dev` inits with `00`
btw, checked the whole spec and have not found another similar bad BytesXX initializations