### PR TITLE
Fix EIP4844 `previous_version` field in tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/fork_transition.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_transition.py
@@ -165,6 +165,9 @@ def do_fork(state, spec, post_spec, fork_epoch, with_block=True, operation_dict=
     elif post_spec.fork == CAPELLA:
         assert state.fork.previous_version == post_spec.config.BELLATRIX_FORK_VERSION
         assert state.fork.current_version == post_spec.config.CAPELLA_FORK_VERSION
+    elif post_spec.fork == EIP4844:
+        assert state.fork.previous_version == post_spec.config.CAPELLA_FORK_VERSION
+        assert state.fork.current_version == post_spec.config.EIP4844_FORK_VERSION
 
     if with_block:
         return state, _state_transition_and_sign_block_at_slot(post_spec, state, operation_dict=operation_dict)

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -60,7 +60,7 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
         previous_version = spec.config.BELLATRIX_FORK_VERSION
         current_version = spec.config.CAPELLA_FORK_VERSION
     elif spec.fork == EIP4844:
-        previous_version = spec.config.BELLATRIX_FORK_VERSION
+        previous_version = spec.config.CAPELLA_FORK_VERSION
         current_version = spec.config.EIP4844_FORK_VERSION
 
     state = spec.BeaconState(


### PR DESCRIPTION
Fix the genesis state of tests.

After #3044, `EIP4844`'s `state.fork.previous_version` should be `CAPELLA_FORK_VERSION`.

Thank @terencechain for the report.
