### PR TITLE
Capella: use fork version in address change gossip

### DIFF
--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -63,7 +63,8 @@ The following validations MUST pass before forwarding the `signed_bls_to_executi
 
 - _[IGNORE]_ The `signed_bls_to_execution_change` is the first valid signed bls to execution change received
   for the validator with index `signed_bls_to_execution_change.message.validator_index`.
-- _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation.
+- _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation
+  using the signing domain implied by `ForkDigestValue` (_not_ the current head state).
 
 ### Transitioning the gossip
 


### PR DESCRIPTION
Presently `BlsToExecutionChange` messages are verified using the fork version from the head state, which means ones gossiped before the fork are required to be signed against the Bellatrix fork, making them invalid for inclusion in blocks.

@ajsutton suggested that we could remedy this by verifying them with respect to the fork version of the gossip topic. That way as soon as nodes subscribe to the `bls_to_execution_topic` with the Capella fork digest they can start collecting messages for inclusion in blocks post-fork. Nodes may subscribe as soon as they know about the upcoming fork, or a few epochs in advance.