### PR TITLE
Consider old finalized data available?

### DIFF
--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -173,6 +173,9 @@ but MUST NOT be considered valid until a valid `BlobsSidecar` has been downloade
 
 ```python
 def is_data_available(slot: Slot, beacon_block_root: Root, blob_kzg_commitments: Sequence[KZGCommitment]) -> bool:
+    if slot <= finalized_slot and slot < clock_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS:
+        return True
+
     # `retrieve_blobs_sidecar` is implementation dependent, raises an exception if not available.
     sidecar = retrieve_blobs_sidecar(slot, beacon_block_root)
     if sidecar == "TEST":

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -226,17 +226,16 @@ The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `BlobsSidecar` payload.
 
 Clients MUST keep a record of signed blobs sidecars seen on the epoch range
-`[max(GENESIS_EPOCH, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS), current_epoch]`
+`[min(finalized_epoch, max(GENESIS_EPOCH, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS)), current_epoch]`
 where `current_epoch` is defined by the current wall-clock time,
 and clients MUST support serving requests of blocks on this range.
 
-Peers that are unable to reply to block requests within the `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS`
-epoch range SHOULD respond with error code `3: ResourceUnavailable`.
+Peers that are unable to reply to block requests within the range above SHOULD respond with error code `3: ResourceUnavailable`.
 Such peers that are unable to successfully reply to this range of requests MAY get descored
 or disconnected at any time.
 
 *Note*: The above requirement implies that nodes that start from a recent weak subjectivity checkpoint
-MUST backfill the local blobs database to at least epoch `current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS`
+MUST backfill the local blobs database to at least the epoch range above
 to be fully compliant with `BlobsSidecarsByRange` requests.
 
 *Note*: Although clients that bootstrap from a weak subjectivity checkpoint can begin


### PR DESCRIPTION
When a node range syncs it can't know the head state's finalized checkpoint. When performing range sync, two scenarios:

**Network is finalizing**

According to current p2p spec, blobs older than MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS are pruned thus un-available via p2p. The node must consider `data_is_available == true`, to sync to the head and not deadlock.

**Network is not finalizing for longer than MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS**

A full node can't guarantee than a block's blobsSidecar was available for un-finalized blocks. It must request the blobsSidecar from the network, which it can since it's available according to current p2p spec. However this conflicts with the above scenario.

---

**Optimistic sync again?**

A node may consider its peer's status finalized checkpoint as correct. Then range sync till that point and, request blobs since are un-finalized. If a peer responds with no blobs for that epoch: the node can't differentiate between the peer withholding data  (dishonest) or that epoch being finalized (honest).

To be sure that a blob at `epoch < clock_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` is available the node has check that no epoch has been finalized up until current chain tip. To assert that condition, all blocks up to the head must be processed and imported. Whoever the head is unsafe until all un-finalized blobsSidecar are imported.

The node could optimistically import all blocks until a past epoch is finalized, then mark those blocks as `is_data_available == true` if older than MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS. Else attempt to request blobsSidecar for each block. 

Suggested sync sequence:

1. Sync blocks from start_epoch until clock_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS
2. Sync blocks + blobs from clock_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS until head
3. Then, if head's finalized_epoch < clock_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS fill blobsSidecars in that range

To sum-up If 3. true, the head is unsafe until all blobs are proven to be available.

Side-point, for nodes to be able to efficiently request that range, should they use by_root requests, or extend the serving range for by_range requests?