### PR TITLE
EIP4844: Update `MAX_BLOBS_PER_BLOCK` to 4

### DIFF
--- a/presets/mainnet/eip4844.yaml
+++ b/presets/mainnet/eip4844.yaml
@@ -4,5 +4,5 @@
 # ---------------------------------------------------------------
 # `uint64(4096)`
 FIELD_ELEMENTS_PER_BLOB: 4096
-# `uint64(2**4)` (= 16)
-MAX_BLOBS_PER_BLOCK: 16
+# `uint64(2**2)` (= 4)
+MAX_BLOBS_PER_BLOCK: 4

--- a/presets/minimal/eip4844.yaml
+++ b/presets/minimal/eip4844.yaml
@@ -4,5 +4,5 @@
 # ---------------------------------------------------------------
 # [customized]
 FIELD_ELEMENTS_PER_BLOB: 4
-# `uint64(2**4)` (= 16)
-MAX_BLOBS_PER_BLOCK: 16
+# `uint64(2**2)` (= 4)
+MAX_BLOBS_PER_BLOCK: 4

--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -63,7 +63,7 @@ This upgrade adds blobs to the beacon chain as part of EIP-4844. This is an exte
 
 | Name | Value |
 | - | - |
-| `MAX_BLOBS_PER_BLOCK` | `uint64(2**4)` (= 16) |
+| `MAX_BLOBS_PER_BLOCK` | `uint64(2**2)` (= 4) |
 
 ## Configuration
 

--- a/tests/core/pyspec/eth2spec/test/eip4844/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/eip4844/sanity/test_blocks.py
@@ -30,11 +30,11 @@ def test_one_blob(spec, state):
 
 @with_eip4844_and_later
 @spec_state_test
-def test_multiple_blobs(spec, state):
+def test_max_blobs(spec, state):
     yield 'pre', state
 
     block = build_empty_block_for_next_slot(spec, state)
-    opaque_tx, _, blob_kzg_commitments = get_sample_opaque_tx(spec, blob_count=5)
+    opaque_tx, _, blob_kzg_commitments = get_sample_opaque_tx(spec, blob_count=spec.MAX_BLOBS_PER_BLOCK)
     block.body.blob_kzg_commitments = blob_kzg_commitments
     block.body.execution_payload.transactions = [opaque_tx]
     signed_block = state_transition_and_sign_block(spec, state, block)

--- a/tests/core/pyspec/eth2spec/test/eip4844/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/eip4844/unittests/validator/test_validator.py
@@ -45,5 +45,5 @@ def test_validate_blobs_sidecar_two_blobs(spec, state):
 
 @with_eip4844_and_later
 @spec_state_test
-def test_validate_blobs_sidecar_ten_blobs(spec, state):
-    _run_validate_blobs_sidecar_test(spec, state, blob_count=10)
+def test_validate_blobs_sidecar_max_blobs(spec, state):
+    _run_validate_blobs_sidecar_test(spec, state, blob_count=spec.MAX_BLOBS_PER_BLOCK)


### PR DESCRIPTION
Update `MAX_BLOBS_PER_BLOCK` to 4 to align with the [EIP](https://eips.ethereum.org/EIPS/eip-4844)

Currently, the `TARGET_DATA_GAS_PER_BLOCK` and `MAX_DATA_GAS_PER_BLOCK` have chosen to target two blobs (0.25 MB) and a maximum of four blobs (0.5 MB) per block
