### PR TITLE
Request-friendly multiproofs

### DIFF
--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -18,8 +18,8 @@
     - [`generalized_index_child`](#generalized_index_child)
     - [`generalized_index_parent`](#generalized_index_parent)
 - [Merkle multiproofs](#merkle-multiproofs)
-    - [Simple multiproofs](#simple-multiproofs)
-    - [Compact multiproofs](#compact-multiproofs)
+  - [Simple multiproofs](#simple-multiproofs)
+  - [Compact multiproofs](#compact-multiproofs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->

--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -397,17 +397,19 @@ We provide a function to convert generalized indices to a proof descriptor:
 
 ```python
 def compute_proof_descriptor(indices: Sequence[GeneralizedIndex]) -> Bytes:
-    # include all helper indices
-    indices = set(indices).union(get_helper_indices(indices))
+    # include all useful helper indices
+    indices = set().union(
+        *[get_helper_indices(index) for index in indices]
+    ).difference(
+        *[get_path_indices(index) for index in indices]
+    ).union(indices)
     # sort indices in-order
     indices = sorted(indices, key=bin)
 
     # convert indices to bitstring
-    prev_index = 1
     bitstring = ''
     for index in indices:
-        bitstring += '0' * max(index.bit_length() - prev_index.bit_length(), 0) + '1'
-        prev_index = index
+        bitstring += '0' * (len(bin(index)) - len(bin(index).rstrip('0'))) + '1'
 
     # append zero bits to byte-align the descriptor
     if len(bitstring) % 8 != 0:

--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -18,6 +18,8 @@
     - [`generalized_index_child`](#generalized_index_child)
     - [`generalized_index_parent`](#generalized_index_parent)
 - [Merkle multiproofs](#merkle-multiproofs)
+    - [`Static multiproofs`](#static-multiproofs)
+    - [`Dynamic multiproofs`](#dynamic-multiproofs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->


### PR DESCRIPTION
The existing multiproof format has the convenient property that in the single-leaf case, the proof is identical to a normal single-leaf proof.

Unfortunately, this format suffers from some drawbacks, clearly seen when used in dynamic proof usecases.

1. Requesting a proof via generalized indices puts preprocessing burden on proof servers.
    - Proof servers must calculate helper indices and try to optimize traversal through the tree to the proof nodes.
2. Requesting a proof via generalized indices requires serializing indices which is not bandwidth efficient.
    - At best, generalized indices can be encoded as varint or uint64s.

This compact multiproof format mitigates these drawbacks and is friendly to dynamic requests.
Instead of describing a proof via requested generalized indices, it is described by a bitstring that details the shape of the proof, called a 'proof descriptor' in this PR.

1. Requesting a proof via a descriptor minimizes preprocessing burden on proof servers.
    - Proof servers can use the descriptor directly to traverse the tree for proof nodes.
2. Requesting a proof via a descriptor minimizes the bandwidth required to describe the proof.
    - The descriptor requires 2N - 1 _bits_ to encode, where N is the number of requested + helper nodes.

For proof consumers, there are a few differences between this format and the existing format.
- This format makes no distinction between leaves and helpers, they are all lumped together
- This format requires consumers to create the proof descriptor

This format is suitable for standardized APIs that require dynamic multiproofs, like: https://github.com/ethereum/beacon-APIs/pull/267

cc @zsfelfoldi