### PR TITLE
Add `block_to_light_client_header` helper

### DIFF
--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -118,8 +118,8 @@ def create_light_client_update(state: BeaconState,
     # `next_sync_committee` is only useful if the message is signed by the current sync committee
     if update_attested_period == update_signature_period:
         update.next_sync_committee = attested_state.next_sync_committee
-        update.next_sync_committee_branch = \
-            compute_merkle_proof_for_state(attested_state, NEXT_SYNC_COMMITTEE_INDEX)
+        update.next_sync_committee_branch = compute_merkle_proof_for_state(
+            attested_state, NEXT_SYNC_COMMITTEE_INDEX)
 
     # Indicate finality whenever possible
     if finalized_block is not None:
@@ -128,8 +128,8 @@ def create_light_client_update(state: BeaconState,
             assert hash_tree_root(update.finalized_header) == attested_state.finalized_checkpoint.root
         else:
             assert attested_state.finalized_checkpoint.root == Bytes32()
-        update.finality_branch = \
-            compute_merkle_proof_for_state(attested_state, FINALIZED_ROOT_INDEX)
+        update.finality_branch = compute_merkle_proof_for_state(
+            attested_state, FINALIZED_ROOT_INDEX)
 
     update.sync_aggregate = block.message.body.sync_aggregate
     update.signature_slot = block.message.slot

--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -11,6 +11,7 @@
 - [Introduction](#introduction)
 - [Helper functions](#helper-functions)
   - [`compute_merkle_proof_for_state`](#compute_merkle_proof_for_state)
+  - [`block_to_light_client_header`](#block_to_light_client_header)
 - [Deriving light client data](#deriving-light-client-data)
   - [`create_light_client_bootstrap`](#create_light_client_bootstrap)
   - [`create_light_client_update`](#create_light_client_update)
@@ -34,6 +35,19 @@ def compute_merkle_proof_for_state(state: BeaconState,
     ...
 ```
 
+### `block_to_light_client_header`
+
+```python
+def block_to_light_client_header(block: SignedBeaconBlock) -> BeaconBlockHeader:
+    return BeaconBlockHeader(
+        slot=block.message.slot,
+        proposer_index=block.message.proposer_index,
+        parent_root=block.message.parent_root,
+        state_root=block.message.state_root,
+        body_root=hash_tree_root(block.message.body),
+    )
+```
+
 ## Deriving light client data
 
 Full nodes are expected to derive light client data from historic blocks and states and provide it to other clients.
@@ -55,13 +69,7 @@ def create_light_client_bootstrap(state: BeaconState,
     assert hash_tree_root(header) == hash_tree_root(block.message)
 
     return LightClientBootstrap(
-        header=BeaconBlockHeader(
-            slot=state.latest_block_header.slot,
-            proposer_index=state.latest_block_header.proposer_index,
-            parent_root=state.latest_block_header.parent_root,
-            state_root=hash_tree_root(state),
-            body_root=state.latest_block_header.body_root,
-        ),
+        header=block_to_light_client_header(block),
         current_sync_committee=state.current_sync_committee,
         current_sync_committee_branch=compute_merkle_proof_for_state(state, CURRENT_SYNC_COMMITTEE_INDEX),
     )
@@ -103,42 +111,30 @@ def create_light_client_update(state: BeaconState,
     assert hash_tree_root(attested_header) == hash_tree_root(attested_block.message) == block.message.parent_root
     update_attested_period = compute_sync_committee_period_at_slot(attested_block.message.slot)
 
+    update = LightClientUpdate()
+
+    update.attested_header = block_to_light_client_header(attested_block)
+
     # `next_sync_committee` is only useful if the message is signed by the current sync committee
     if update_attested_period == update_signature_period:
-        next_sync_committee = attested_state.next_sync_committee
-        next_sync_committee_branch = compute_merkle_proof_for_state(attested_state, NEXT_SYNC_COMMITTEE_INDEX)
-    else:
-        next_sync_committee = SyncCommittee()
-        next_sync_committee_branch = [Bytes32() for _ in range(floorlog2(NEXT_SYNC_COMMITTEE_INDEX))]
+        update.next_sync_committee = attested_state.next_sync_committee
+        update.next_sync_committee_branch = \
+            compute_merkle_proof_for_state(attested_state, NEXT_SYNC_COMMITTEE_INDEX)
 
     # Indicate finality whenever possible
     if finalized_block is not None:
         if finalized_block.message.slot != GENESIS_SLOT:
-            finalized_header = BeaconBlockHeader(
-                slot=finalized_block.message.slot,
-                proposer_index=finalized_block.message.proposer_index,
-                parent_root=finalized_block.message.parent_root,
-                state_root=finalized_block.message.state_root,
-                body_root=hash_tree_root(finalized_block.message.body),
-            )
-            assert hash_tree_root(finalized_header) == attested_state.finalized_checkpoint.root
+            update.finalized_header = block_to_light_client_header(finalized_block)
+            assert hash_tree_root(update.finalized_header) == attested_state.finalized_checkpoint.root
         else:
             assert attested_state.finalized_checkpoint.root == Bytes32()
-            finalized_header = BeaconBlockHeader()
-        finality_branch = compute_merkle_proof_for_state(attested_state, FINALIZED_ROOT_INDEX)
-    else:
-        finalized_header = BeaconBlockHeader()
-        finality_branch = [Bytes32() for _ in range(floorlog2(FINALIZED_ROOT_INDEX))]
+        update.finality_branch = \
+            compute_merkle_proof_for_state(attested_state, FINALIZED_ROOT_INDEX)
 
-    return LightClientUpdate(
-        attested_header=attested_header,
-        next_sync_committee=next_sync_committee,
-        next_sync_committee_branch=next_sync_committee_branch,
-        finalized_header=finalized_header,
-        finality_branch=finality_branch,
-        sync_aggregate=block.message.body.sync_aggregate,
-        signature_slot=block.message.slot,
-    )
+    update.sync_aggregate = block.message.body.sync_aggregate
+    update.signature_slot = block.message.slot
+
+    return update
 ```
 
 Full nodes SHOULD provide the best derivable `LightClientUpdate` (according to `is_better_update`) for each sync committee period covering any epochs in range `[max(ALTAIR_FORK_EPOCH, current_epoch - MIN_EPOCHS_FOR_BLOCK_REQUESTS), current_epoch]` where `current_epoch` is defined by the current wall-clock time. Full nodes MAY also provide `LightClientUpdate` for other sync committee periods.

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
@@ -10,8 +10,8 @@ from eth2spec.test.context import (
 @spec_state_test
 def test_current_sync_committee_merkle_proof(spec, state):
     yield "object", state
-    current_sync_committee_branch = \
-        spec.compute_merkle_proof_for_state(state, spec.CURRENT_SYNC_COMMITTEE_INDEX)
+    current_sync_committee_branch = spec.compute_merkle_proof_for_state(
+        state, spec.CURRENT_SYNC_COMMITTEE_INDEX)
     yield "proof", {
         "leaf": "0x" + state.current_sync_committee.hash_tree_root().hex(),
         "leaf_index": spec.CURRENT_SYNC_COMMITTEE_INDEX,
@@ -31,8 +31,8 @@ def test_current_sync_committee_merkle_proof(spec, state):
 @spec_state_test
 def test_next_sync_committee_merkle_proof(spec, state):
     yield "object", state
-    next_sync_committee_branch = \
-        spec.compute_merkle_proof_for_state(state, spec.NEXT_SYNC_COMMITTEE_INDEX)
+    next_sync_committee_branch = spec.compute_merkle_proof_for_state(
+        state, spec.NEXT_SYNC_COMMITTEE_INDEX)
     yield "proof", {
         "leaf": "0x" + state.next_sync_committee.hash_tree_root().hex(),
         "leaf_index": spec.NEXT_SYNC_COMMITTEE_INDEX,
@@ -52,8 +52,8 @@ def test_next_sync_committee_merkle_proof(spec, state):
 @spec_state_test
 def test_finality_root_merkle_proof(spec, state):
     yield "object", state
-    finality_branch = \
-        spec.compute_merkle_proof_for_state(state, spec.FINALIZED_ROOT_INDEX)
+    finality_branch = spec.compute_merkle_proof_for_state(
+        state, spec.FINALIZED_ROOT_INDEX)
     yield "proof", {
         "leaf": "0x" + state.finalized_checkpoint.root.hex(),
         "leaf_index": spec.FINALIZED_ROOT_INDEX,

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_update_ranking.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_update_ranking.py
@@ -9,45 +9,23 @@ from eth2spec.test.helpers.attestations import (
 )
 from eth2spec.test.helpers.constants import MINIMAL
 from eth2spec.test.helpers.light_client import (
-    get_sync_aggregate,
-    signed_block_to_header,
+    create_update,
 )
 from eth2spec.test.helpers.state import (
     next_slots,
 )
-from math import floor
 
 
-def create_update(spec, test, with_next, with_finality, participation_rate):
+def create_test_update(spec, test, with_next, with_finality, participation_rate):
     attested_state, attested_block, finalized_block = test
-    num_participants = floor(spec.SYNC_COMMITTEE_SIZE * participation_rate)
-
-    attested_header = signed_block_to_header(spec, attested_block)
-
-    if with_next:
-        next_sync_committee = attested_state.next_sync_committee
-        next_sync_committee_branch = spec.compute_merkle_proof_for_state(attested_state, spec.NEXT_SYNC_COMMITTEE_INDEX)
-    else:
-        next_sync_committee = spec.SyncCommittee()
-        next_sync_committee_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.NEXT_SYNC_COMMITTEE_INDEX))]
-
-    if with_finality:
-        finalized_header = signed_block_to_header(spec, finalized_block)
-        finality_branch = spec.compute_merkle_proof_for_state(attested_state, spec.FINALIZED_ROOT_INDEX)
-    else:
-        finalized_header = spec.BeaconBlockHeader()
-        finality_branch = [spec.Bytes32() for _ in range(spec.floorlog2(spec.FINALIZED_ROOT_INDEX))]
-
-    sync_aggregate, signature_slot = get_sync_aggregate(spec, attested_state, num_participants)
-
-    return spec.LightClientUpdate(
-        attested_header=attested_header,
-        next_sync_committee=next_sync_committee,
-        next_sync_committee_branch=next_sync_committee_branch,
-        finalized_header=finalized_header,
-        finality_branch=finality_branch,
-        sync_aggregate=sync_aggregate,
-        signature_slot=signature_slot,
+    return create_update(
+        spec,
+        attested_state,
+        attested_block,
+        finalized_block,
+        with_next,
+        with_finality,
+        participation_rate,
     )
 
 
@@ -84,76 +62,76 @@ def test_update_ranking(spec, state):
     # Create updates (in descending order of quality)
     updates = [
         # Updates with sync committee finality
-        create_update(spec, fin, with_next=1, with_finality=1, participation_rate=1.0),
-        create_update(spec, lat, with_next=1, with_finality=1, participation_rate=1.0),
-        create_update(spec, fin, with_next=1, with_finality=1, participation_rate=0.8),
-        create_update(spec, lat, with_next=1, with_finality=1, participation_rate=0.8),
+        create_test_update(spec, fin, with_next=1, with_finality=1, participation_rate=1.0),
+        create_test_update(spec, lat, with_next=1, with_finality=1, participation_rate=1.0),
+        create_test_update(spec, fin, with_next=1, with_finality=1, participation_rate=0.8),
+        create_test_update(spec, lat, with_next=1, with_finality=1, participation_rate=0.8),
 
         # Updates without sync committee finality
-        create_update(spec, att, with_next=1, with_finality=1, participation_rate=1.0),
-        create_update(spec, att, with_next=1, with_finality=1, participation_rate=0.8),
+        create_test_update(spec, att, with_next=1, with_finality=1, participation_rate=1.0),
+        create_test_update(spec, att, with_next=1, with_finality=1, participation_rate=0.8),
 
         # Updates without indication of any finality
-        create_update(spec, att, with_next=1, with_finality=0, participation_rate=1.0),
-        create_update(spec, fin, with_next=1, with_finality=0, participation_rate=1.0),
-        create_update(spec, lat, with_next=1, with_finality=0, participation_rate=1.0),
-        create_update(spec, att, with_next=1, with_finality=0, participation_rate=0.8),
-        create_update(spec, fin, with_next=1, with_finality=0, participation_rate=0.8),
-        create_update(spec, lat, with_next=1, with_finality=0, participation_rate=0.8),
+        create_test_update(spec, att, with_next=1, with_finality=0, participation_rate=1.0),
+        create_test_update(spec, fin, with_next=1, with_finality=0, participation_rate=1.0),
+        create_test_update(spec, lat, with_next=1, with_finality=0, participation_rate=1.0),
+        create_test_update(spec, att, with_next=1, with_finality=0, participation_rate=0.8),
+        create_test_update(spec, fin, with_next=1, with_finality=0, participation_rate=0.8),
+        create_test_update(spec, lat, with_next=1, with_finality=0, participation_rate=0.8),
 
         # Updates with sync committee finality but no `next_sync_committee`
-        create_update(spec, sig, with_next=0, with_finality=1, participation_rate=1.0),
-        create_update(spec, fin, with_next=0, with_finality=1, participation_rate=1.0),
-        create_update(spec, lat, with_next=0, with_finality=1, participation_rate=1.0),
-        create_update(spec, sig, with_next=0, with_finality=1, participation_rate=0.8),
-        create_update(spec, fin, with_next=0, with_finality=1, participation_rate=0.8),
-        create_update(spec, lat, with_next=0, with_finality=1, participation_rate=0.8),
+        create_test_update(spec, sig, with_next=0, with_finality=1, participation_rate=1.0),
+        create_test_update(spec, fin, with_next=0, with_finality=1, participation_rate=1.0),
+        create_test_update(spec, lat, with_next=0, with_finality=1, participation_rate=1.0),
+        create_test_update(spec, sig, with_next=0, with_finality=1, participation_rate=0.8),
+        create_test_update(spec, fin, with_next=0, with_finality=1, participation_rate=0.8),
+        create_test_update(spec, lat, with_next=0, with_finality=1, participation_rate=0.8),
 
         # Updates without sync committee finality and also no `next_sync_committee`
-        create_update(spec, att, with_next=0, with_finality=1, participation_rate=1.0),
-        create_update(spec, att, with_next=0, with_finality=1, participation_rate=0.8),
+        create_test_update(spec, att, with_next=0, with_finality=1, participation_rate=1.0),
+        create_test_update(spec, att, with_next=0, with_finality=1, participation_rate=0.8),
 
         # Updates without indication of any finality nor `next_sync_committee`
-        create_update(spec, sig, with_next=0, with_finality=0, participation_rate=1.0),
-        create_update(spec, att, with_next=0, with_finality=0, participation_rate=1.0),
-        create_update(spec, fin, with_next=0, with_finality=0, participation_rate=1.0),
-        create_update(spec, lat, with_next=0, with_finality=0, participation_rate=1.0),
-        create_update(spec, sig, with_next=0, with_finality=0, participation_rate=0.8),
-        create_update(spec, att, with_next=0, with_finality=0, participation_rate=0.8),
-        create_update(spec, fin, with_next=0, with_finality=0, participation_rate=0.8),
-        create_update(spec, lat, with_next=0, with_finality=0, participation_rate=0.8),
+        create_test_update(spec, sig, with_next=0, with_finality=0, participation_rate=1.0),
+        create_test_update(spec, att, with_next=0, with_finality=0, participation_rate=1.0),
+        create_test_update(spec, fin, with_next=0, with_finality=0, participation_rate=1.0),
+        create_test_update(spec, lat, with_next=0, with_finality=0, participation_rate=1.0),
+        create_test_update(spec, sig, with_next=0, with_finality=0, participation_rate=0.8),
+        create_test_update(spec, att, with_next=0, with_finality=0, participation_rate=0.8),
+        create_test_update(spec, fin, with_next=0, with_finality=0, participation_rate=0.8),
+        create_test_update(spec, lat, with_next=0, with_finality=0, participation_rate=0.8),
 
         # Updates with low sync committee participation
-        create_update(spec, fin, with_next=1, with_finality=1, participation_rate=0.4),
-        create_update(spec, lat, with_next=1, with_finality=1, participation_rate=0.4),
-        create_update(spec, att, with_next=1, with_finality=1, participation_rate=0.4),
-        create_update(spec, att, with_next=1, with_finality=0, participation_rate=0.4),
-        create_update(spec, fin, with_next=1, with_finality=0, participation_rate=0.4),
-        create_update(spec, lat, with_next=1, with_finality=0, participation_rate=0.4),
-        create_update(spec, sig, with_next=0, with_finality=1, participation_rate=0.4),
-        create_update(spec, fin, with_next=0, with_finality=1, participation_rate=0.4),
-        create_update(spec, lat, with_next=0, with_finality=1, participation_rate=0.4),
-        create_update(spec, att, with_next=0, with_finality=1, participation_rate=0.4),
-        create_update(spec, sig, with_next=0, with_finality=0, participation_rate=0.4),
-        create_update(spec, att, with_next=0, with_finality=0, participation_rate=0.4),
-        create_update(spec, fin, with_next=0, with_finality=0, participation_rate=0.4),
-        create_update(spec, lat, with_next=0, with_finality=0, participation_rate=0.4),
+        create_test_update(spec, fin, with_next=1, with_finality=1, participation_rate=0.4),
+        create_test_update(spec, lat, with_next=1, with_finality=1, participation_rate=0.4),
+        create_test_update(spec, att, with_next=1, with_finality=1, participation_rate=0.4),
+        create_test_update(spec, att, with_next=1, with_finality=0, participation_rate=0.4),
+        create_test_update(spec, fin, with_next=1, with_finality=0, participation_rate=0.4),
+        create_test_update(spec, lat, with_next=1, with_finality=0, participation_rate=0.4),
+        create_test_update(spec, sig, with_next=0, with_finality=1, participation_rate=0.4),
+        create_test_update(spec, fin, with_next=0, with_finality=1, participation_rate=0.4),
+        create_test_update(spec, lat, with_next=0, with_finality=1, participation_rate=0.4),
+        create_test_update(spec, att, with_next=0, with_finality=1, participation_rate=0.4),
+        create_test_update(spec, sig, with_next=0, with_finality=0, participation_rate=0.4),
+        create_test_update(spec, att, with_next=0, with_finality=0, participation_rate=0.4),
+        create_test_update(spec, fin, with_next=0, with_finality=0, participation_rate=0.4),
+        create_test_update(spec, lat, with_next=0, with_finality=0, participation_rate=0.4),
 
         # Updates with very low sync committee participation
-        create_update(spec, fin, with_next=1, with_finality=1, participation_rate=0.2),
-        create_update(spec, lat, with_next=1, with_finality=1, participation_rate=0.2),
-        create_update(spec, att, with_next=1, with_finality=1, participation_rate=0.2),
-        create_update(spec, att, with_next=1, with_finality=0, participation_rate=0.2),
-        create_update(spec, fin, with_next=1, with_finality=0, participation_rate=0.2),
-        create_update(spec, lat, with_next=1, with_finality=0, participation_rate=0.2),
-        create_update(spec, sig, with_next=0, with_finality=1, participation_rate=0.2),
-        create_update(spec, fin, with_next=0, with_finality=1, participation_rate=0.2),
-        create_update(spec, lat, with_next=0, with_finality=1, participation_rate=0.2),
-        create_update(spec, att, with_next=0, with_finality=1, participation_rate=0.2),
-        create_update(spec, sig, with_next=0, with_finality=0, participation_rate=0.2),
-        create_update(spec, att, with_next=0, with_finality=0, participation_rate=0.2),
-        create_update(spec, fin, with_next=0, with_finality=0, participation_rate=0.2),
-        create_update(spec, lat, with_next=0, with_finality=0, participation_rate=0.2),
+        create_test_update(spec, fin, with_next=1, with_finality=1, participation_rate=0.2),
+        create_test_update(spec, lat, with_next=1, with_finality=1, participation_rate=0.2),
+        create_test_update(spec, att, with_next=1, with_finality=1, participation_rate=0.2),
+        create_test_update(spec, att, with_next=1, with_finality=0, participation_rate=0.2),
+        create_test_update(spec, fin, with_next=1, with_finality=0, participation_rate=0.2),
+        create_test_update(spec, lat, with_next=1, with_finality=0, participation_rate=0.2),
+        create_test_update(spec, sig, with_next=0, with_finality=1, participation_rate=0.2),
+        create_test_update(spec, fin, with_next=0, with_finality=1, participation_rate=0.2),
+        create_test_update(spec, lat, with_next=0, with_finality=1, participation_rate=0.2),
+        create_test_update(spec, att, with_next=0, with_finality=1, participation_rate=0.2),
+        create_test_update(spec, sig, with_next=0, with_finality=0, participation_rate=0.2),
+        create_test_update(spec, att, with_next=0, with_finality=0, participation_rate=0.2),
+        create_test_update(spec, fin, with_next=0, with_finality=0, participation_rate=0.2),
+        create_test_update(spec, lat, with_next=0, with_finality=0, participation_rate=0.2),
     ]
     yield "updates", updates
 

--- a/tests/core/pyspec/eth2spec/test/helpers/light_client.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/light_client.py
@@ -56,15 +56,15 @@ def create_update(spec,
 
     if with_next:
         update.next_sync_committee = attested_state.next_sync_committee
-        update.next_sync_committee_branch = \
-            spec.compute_merkle_proof_for_state(attested_state, spec.NEXT_SYNC_COMMITTEE_INDEX)
+        update.next_sync_committee_branch = spec.compute_merkle_proof_for_state(
+            attested_state, spec.NEXT_SYNC_COMMITTEE_INDEX)
 
     if with_finality:
         update.finalized_header = spec.block_to_light_client_header(finalized_block)
-        update.finality_branch = \
-            spec.compute_merkle_proof_for_state(attested_state, spec.FINALIZED_ROOT_INDEX)
+        update.finality_branch = spec.compute_merkle_proof_for_state(
+            attested_state, spec.FINALIZED_ROOT_INDEX)
 
-    update.sync_aggregate, update.signature_slot = \
-        get_sync_aggregate(spec, attested_state, num_participants)
+    update.sync_aggregate, update.signature_slot = get_sync_aggregate(
+        spec, attested_state, num_participants)
 
     return update


### PR DESCRIPTION
Introduce `block_to_light_client_header` helper function to enable future forks to override it with additional info (e.g., execution), without having to change the general light client logic.

Likewise, update existing light client data creation flow to use `block_to_light_client_header` and default-initialize empty fields.

Furthermore, generalize `create_update` helper to streamline test code using `block_to_light_client_header`.

Note: In Altair spec, LC header is the same as `BeaconBlockHeader`. however; future forks will extend it with more information.