### PR TITLE
Clarify BeaconBlockAndBlobsSidecarByRoot no blob available

### DIFF
--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -185,7 +185,7 @@ No more than `MAX_REQUEST_BLOCKS` may be requested at a time.
 The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `SignedBeaconBlockAndBlobsSidecar` payload.
 
-Clients MUST support requesting blocks and sidecars since `minimum_request_epoch`, where `minimum_request_epoch = max(EIP4844_FORK_EPOCH, finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS)`. If any root in the request content references a block earlier than `minimum_request_epoch`, peers SHOULD respond with error code `3: ResourceUnavailable`.
+Clients MUST support requesting blocks and sidecars since `minimum_request_epoch`, where `minimum_request_epoch = max(finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS, EIP4844_FORK_EPOCH)`. If any root in the request content references a block earlier than `minimum_request_epoch`, peers SHOULD respond with error code `3: ResourceUnavailable`.
 
 Clients MUST respond with at least one block and sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -185,10 +185,7 @@ No more than `MAX_REQUEST_BLOCKS` may be requested at a time.
 The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `SignedBeaconBlockAndBlobsSidecar` payload.
 
-If any root in the request content references a block outside of the range `[max(EIP4844_FORK_EPOCH, finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS), current_epoch]`
- peers SHOULD respond with error code `3: ResourceUnavailable`.
-
-Clients MUST support requesting blocks and sidecars since the latest finalized epoch.
+Clients MUST support requesting blocks and sidecars since `minimum_request_epoch`, where `minimum_request_epoch = max(EIP4844_FORK_EPOCH, finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS)`. If any root in the request content references a block earlier than `minimum_request_epoch`, peers SHOULD respond with error code `3: ResourceUnavailable`.
 
 Clients MUST respond with at least one block and sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -185,6 +185,9 @@ No more than `MAX_REQUEST_BLOCKS` may be requested at a time.
 The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `SignedBeaconBlockAndBlobsSidecar` payload.
 
+If any root in the request content references a block outside of the range `[max(EIP4844_FORK_EPOCH, finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS), current_epoch]`
+ peers SHOULD respond with error code `3: ResourceUnavailable`.
+
 Clients MUST support requesting blocks and sidecars since the latest finalized epoch.
 
 Clients MUST respond with at least one block and sidecar, if they have it.


### PR DESCRIPTION
Peers may not know the slot of a block when requesting by root. So they may request a root via BeaconBlockAndBlobsSidecarByRoot which does not have any associated blob.
- Details of the edge case: https://github.com/ethereum/consensus-specs/issues/3113

This situation only applies before finalizing EIP4844_FORK_EPOCH. From discussions in https://github.com/ethereum/consensus-specs/pull/3139 a simple solution that requires a retry is the best trade-off to minimize complexity.

I picked the error code `3: ResourceUnavailable` without strong reasoning. Happy to change to another more meaningful one.