### PR TITLE
Fix some nits in eip4844 specs

### DIFF
--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -175,7 +175,7 @@ def is_data_available(slot: Slot, beacon_block_root: Root, blob_kzg_commitments:
     # `retrieve_blobs_sidecar` is implementation dependent, raises an exception if not available.
     sidecar = retrieve_blobs_sidecar(slot, beacon_block_root)
 
-    # For testing, `retrieve_blobs_sidecar` returns "TEST.
+    # For testing, `retrieve_blobs_sidecar` returns "TEST".
     # TODO: Remove it once we have a way to inject `BlobsSidecar` into tests.
     if isinstance(sidecar, str):
         return True

--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -347,8 +347,9 @@ def initialize_beacon_state_from_eth1(eth1_block_hash: Hash32,
 ```
 
 ### Disabling Withdrawals
+
 During testing we avoid Capella-specific updates to the state transition. We do this by replacing the following functions with a no-op implementation:
 - `process_withdrawals`
 - `process_bls_to_execution_change`
 
-The `get_expected_withdrawals` function is also modified to return an empty withdrawals list. As such, the PayloadAttributes used to update forkchoice does not contain withdrawals.
+The `get_expected_withdrawals` function is also modified to return an empty withdrawals list. As such, the `PayloadAttributes` used to update forkchoice does not contain withdrawals.

--- a/specs/eip4844/fork.md
+++ b/specs/eip4844/fork.md
@@ -58,7 +58,7 @@ def compute_fork_version(epoch: Epoch) -> Version:
 ### Fork trigger
 
 TBD. This fork is defined for testing purposes, the EIP may be combined with other consensus-layer upgrade.
-For now we assume the condition will be triggered at epoch `EIP4844_FORK_EPOCH`.
+For now, we assume the condition will be triggered at epoch `EIP4844_FORK_EPOCH`.
 
 Note that for the pure EIP-4844 networks, we don't apply `upgrade_to_eip4844` since it starts with EIP-4844 version logic.
 

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -61,7 +61,7 @@ class SignedBeaconBlockAndBlobsSidecar(Container):
 
 ## The gossip domain: gossipsub
 
-Some gossip meshes are upgraded in the fork of EIP4844 to support upgraded types.
+Some gossip meshes are upgraded in the fork of EIP-4844 to support upgraded types.
 
 ### Topics and messages
 
@@ -78,10 +78,9 @@ The new topics along with the type of the `data` field of a gossipsub message ar
 | - | - |
 | `beacon_block_and_blobs_sidecar` | `SignedBeaconBlockAndBlobsSidecar` (new) |
 
-
 #### Global topics
 
-EIP4844 introduces a new global topic for beacon block and blobs-sidecars.
+EIP-4844 introduces a new global topic for beacon block and blobs-sidecars.
 
 ##### `beacon_block`
 
@@ -97,16 +96,18 @@ This topic is used to propagate new signed and coupled beacon blocks and blobs s
 
 In addition to the gossip validations for the `beacon_block` topic from prior specifications, the following validations MUST pass before forwarding the `signed_beacon_block_and_blobs_sidecar` on the network.
 Alias `signed_beacon_block = signed_beacon_block_and_blobs_sidecar.beacon_block`, `block = signed_beacon_block.message`, `execution_payload = block.body.execution_payload`.
-- _[REJECT]_ The KZG commitments of the blobs are all correctly encoded compressed BLS G1 Points.
+- _[REJECT]_ The KZG commitments of the blobs are all correctly encoded compressed BLS G1 points
   -- i.e. `all(bls.KeyValidate(commitment) for commitment in block.body.blob_kzg_commitments)`
-- _[REJECT]_ The KZG commitments correspond to the versioned hashes in the transactions list.
+- _[REJECT]_ The KZG commitments correspond to the versioned hashes in the transactions list
   -- i.e. `verify_kzg_commitments_against_transactions(block.body.execution_payload.transactions, block.body.blob_kzg_commitments)`
 
 Alias `sidecar = signed_beacon_block_and_blobs_sidecar.blobs_sidecar`.
-- _[IGNORE]_ the `sidecar.beacon_block_slot` is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) -- i.e. `sidecar.beacon_block_slot == block.slot`.
+- _[IGNORE]_ the `sidecar.beacon_block_slot` is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance)
+  -- i.e. `sidecar.beacon_block_slot == block.slot`.
 - _[REJECT]_ the `sidecar.blobs` are all well formatted, i.e. the `BLSFieldElement` in valid range (`x < BLS_MODULUS`).
-- _[REJECT]_ The KZG proof is a correctly encoded compressed BLS G1 Point -- i.e. `bls.KeyValidate(blobs_sidecar.kzg_aggregated_proof)`
-- _[REJECT]_ The KZG commitments in the block are valid against the provided blobs sidecar.
+- _[REJECT]_ The KZG proof is a correctly encoded compressed BLS G1 point
+  -- i.e. `bls.KeyValidate(blobs_sidecar.kzg_aggregated_proof)`
+- _[REJECT]_ The KZG commitments in the block are valid against the provided blobs sidecar
   -- i.e. `validate_blobs_sidecar(block.slot, hash_tree_root(block), block.body.blob_kzg_commitments, sidecar)`
 
 ### Transitioning the gossip
@@ -147,10 +148,10 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 
 [1]: # (eth2spec: skip)
 
-| `fork_version`           | Chunk SSZ type             |
-| ------------------------ | -------------------------- |
-| `GENESIS_FORK_VERSION`   | `phase0.SignedBeaconBlock` |
-| `ALTAIR_FORK_VERSION`    | `altair.SignedBeaconBlock` |
+| `fork_version`           | Chunk SSZ type                |
+|--------------------------|-------------------------------|
+| `GENESIS_FORK_VERSION`   | `phase0.SignedBeaconBlock`    |
+| `ALTAIR_FORK_VERSION`    | `altair.SignedBeaconBlock`    |
 | `BELLATRIX_FORK_VERSION` | `bellatrix.SignedBeaconBlock` |
 | `CAPELLA_FORK_VERSION`   | `capella.SignedBeaconBlock`   |
 

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -32,7 +32,7 @@ This document represents the changes to be made in the code of an "honest valida
 This document is an extension of the [Capella -- Honest Validator](../capella/validator.md) guide.
 All behaviors and definitions defined in this document, and documents it extends, carry over unless explicitly noted or overridden.
 
-All terminology, constants, functions, and protocol mechanics defined in the updated [Beacon Chain doc of EIP4844](./beacon-chain.md) are requisite for this document and used throughout.
+All terminology, constants, functions, and protocol mechanics defined in the updated [Beacon Chain doc of EIP-4844](./beacon-chain.md) are requisite for this document and used throughout.
 Please see related Beacon Chain doc before continuing and use them as a reference throughout.
 
 ## Helpers


### PR DESCRIPTION
This PR fixes some minor nits I noticed when reading these:

* Replace "EIP4844" with "EIP-4844" where it makes sense.
  * It is written with a dash most of the time.
* Wrap `PayloadAttributes` in backticks as it's a code symbol.
* Remove period between sentence and em dash (`--`).
* Put the `i.e.` part on a separate line for consistency.
* Reformat a table so it's formatted properly.
* Make "point" in "BLS G1 point" lowercase.