### PR TITLE
Allow to verify BLSToExecutionChange from previous fork

### DIFF
--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -105,6 +105,7 @@ class BLSToExecutionChange(Container):
     validator_index: ValidatorIndex
     from_bls_pubkey: BLSPubkey
     to_execution_address: ExecutionAddress
+    signature_epoch: Epoch
 ```
 
 #### `SignedBLSToExecutionChange`
@@ -416,7 +417,7 @@ def process_bls_to_execution_change(state: BeaconState,
     assert validator.withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX
     assert validator.withdrawal_credentials[1:] == hash(address_change.from_bls_pubkey)[1:]
 
-    domain = get_domain(state, DOMAIN_BLS_TO_EXECUTION_CHANGE)
+    domain = get_domain(state, DOMAIN_BLS_TO_EXECUTION_CHANGE, address_change.signature_epoch)
     signing_root = compute_signing_root(address_change, domain)
     assert bls.Verify(address_change.from_bls_pubkey, signing_root, signed_address_change.signature)
 

--- a/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
@@ -21,6 +21,7 @@ def get_signed_address_change(spec, state, validator_index=None, withdrawal_pubk
         validator_index=validator_index,
         from_bls_pubkey=withdrawal_pubkey,
         to_execution_address=to_execution_address,
+        signature_epoch=spec.compute_epoch_at_slot(state.slot)
     )
 
     signing_root = spec.compute_signing_root(address_change, domain)


### PR DESCRIPTION
Inspired from `LightClientOptimisticUpdate.signature_slot` 

https://github.com/ethereum/consensus-specs/blob/302f54bfca5b3659edeebf7c4ba3fcdebbc75f2f/specs/altair/light-client/sync-protocol.md?plain=1#L117

allows to broadcast via p2p messages for both current and previous fork. If we don't want to increase the block size, the `signature_epoch` could only apply to a data structure used in p2p only.