### PR TITLE
Handle unavailable data outside of prune window

### DIFF
--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -164,15 +164,16 @@ def validate_blobs_sidecar(slot: Slot,
 
 #### `is_data_available`
 
-The implementation of `is_data_available` is meant to change with later sharding upgrades.
+The implementation of `is_data_available` will become more sophisticated during later sharding upgrades.
 Initially, it requires every verifying actor to retrieve the matching `BlobsSidecar`,
 and validate the sidecar with `validate_blobs_sidecar`.
 
-The block MUST NOT be considered valid until a valid `BlobsSidecar` has been downloaded.
+The block MUST NOT be considered valid until a valid `BlobsSidecar` has been downloaded. Blocks that have been previously validated as available SHOULD be considered available even if the associated `BlobsSidecar` has subsequently been pruned.
 
 ```python
 def is_data_available(slot: Slot, beacon_block_root: Root, blob_kzg_commitments: Sequence[KZGCommitment]) -> bool:
-    # `retrieve_blobs_sidecar` is implementation dependent, raises an exception if not available.
+    # `retrieve_blobs_sidecar` is implementation and context dependent, raises an exception if not available.
+    # Note: the p2p network does not guarantee sidecar retrieval outside of `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS`
     sidecar = retrieve_blobs_sidecar(slot, beacon_block_root)
 
     # For testing, `retrieve_blobs_sidecar` returns "TEST".

--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -219,7 +219,7 @@ may not be available beyond the initial distribution via gossip.
 Before consuming the next response chunk, the response reader SHOULD verify the blobs sidecar is well-formatted and
 correct w.r.t. the expected KZG commitments through `validate_blobs_sidecar`.
 
-`BlobsSidecarsByRange` is primarily used to sync blobs that may have been missed on gossip.
+`BlobsSidecarsByRange` is primarily used to sync blobs that may have been missed on gossip and to sync within the `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` window.
 
 The request MUST be encoded as an SSZ-container.
 


### PR DESCRIPTION
I believe this captures the intention of the discussion from #3141. This does not actually change the spec, it just clarifies what to do in a few scenarios. namely:

1. It notes that `retrieve_blobs_sidecar` might fail on the p2p network outside of the prune window. Thus `is_data_available` would fail in this scenario due to the exception thrown
2. It also notes that "Blocks that have been previously validated as available SHOULD be considered available even if the associated `BlobsSidecar` has subsequently been pruned." This is to avoid interactions with pruning and re-orgs past the depth. If a client has validated that a block's sidecar is available, and then re-orgs to this sidecar at a depth past the prune window, the client does not need to re-assert the availability.

