### PR TITLE
Remove fork-choice weight of slashed validators

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -178,9 +178,9 @@ def get_ancestor(store: Store, root: Root, slot: Slot) -> Root:
 ```python
 def get_latest_attesting_balance(store: Store, root: Root) -> Gwei:
     state = store.checkpoint_states[store.justified_checkpoint]
-    active_indices = get_active_validator_indices(state, get_current_epoch(state))
+    unslashed_and_active_indices = [i for i in get_active_validator_indices(state, get_current_epoch(state)) if not state.validators[i].slashed]
     attestation_score = Gwei(sum(
-        state.validators[i].effective_balance for i in active_indices
+        state.validators[i].effective_balance for i in unslashed_and_active_indices
         if (i in store.latest_messages
             and i not in store.equivocating_indices
             and get_ancestor(store, store.latest_messages[i].root, store.blocks[root].slot) == root)


### PR DESCRIPTION
Changing active_indices to unslashed_and_active indices. Presently, we give fork-choice weight to slashed but active validators, unless they are included in equivocating_indices, and also say: "`on_attester_slashing` should be called while syncing and a client MUST maintain the equivocation set of `AttesterSlashing`s from at least the latest finalized checkpoint." Some validator might have been slashed prior to the latest finalized checkpoint, but not yet exited, due to the exit queue being full, in which case some validators might count their fork-choice weight and others might not. If instead we use unslashed_and_active_indices, no one would count their fork-choice weight.