### PR TITLE
Clarify behavior for empty blobs sidecar

### DIFF
--- a/specs/eip4844/p2p-interface.md
+++ b/specs/eip4844/p2p-interface.md
@@ -226,6 +226,8 @@ The request MUST be encoded as an SSZ-container.
 The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `BlobsSidecar` payload.
 
+In cases where a slot contains empty blob, no `blobs_sidecar` is returned.
+
 Clients MUST keep a record of signed blobs sidecars seen on the epoch range
 `[max(current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS, EIP4844_FORK_EPOCH), current_epoch]`
 where `current_epoch` is defined by the current wall-clock time,
@@ -246,6 +248,8 @@ disconnect and/or temporarily ban such an un-synced or semi-synced client.
 
 Clients MUST respond with at least the first blobs sidecar that exists in the range, if they have it,
 and no more than `MAX_REQUEST_BLOBS_SIDECARS` sidecars.
+
+Clients MUST not respond with empty blobs sidecars.
 
 The following blobs sidecars, where they exist, MUST be sent in consecutive order.
 


### PR DESCRIPTION
Clarify that a peer must not respond a sidecar with empty blobs (i.e, `len(sidecar.blobs) == 0`) under RPC end point `/eth2/beacon_chain/req/blobs_sidecars_by_range/1/`. This behavior has caused some confusion on devnet3, so it'd be good to clarify it in the spec. A peer may use the kzg commitment in the block body to distinguish if the slot should have a sidecar or not