### PR TITLE
Not allow slashed validator to become a proposer

### DIFF
--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -226,6 +226,7 @@ def get_beacon_proposer_index(state: BeaconState) -> ValidatorIndex:
     """
     Return the beacon proposer index at the current slot.
     """
+    # [New in Deneb]
     if state.latest_block_header.slot == state.slot:
         return state.latest_block_header.proposer_index
     

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -245,7 +245,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     if is_execution_enabled(state, block.body):
         process_withdrawals(state, block.body.execution_payload)
         process_execution_payload(state, block.body.execution_payload, EXECUTION_ENGINE)  # [Modified in Deneb]
-    process_randao(state, block.body) 
+    process_randao(state, block.body)
     process_eth1_data(state, block.body)
     process_operations(state, block.body)
     process_sync_aggregate(state, block.body.sync_aggregate)

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -286,7 +286,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
     epoch = get_current_epoch(state)
     # Verify RANDAO reveal
-    proposer = state.validators[get_latest_block_proposer_index(state)]
+    proposer = state.validators[get_latest_block_proposer_index(state)]  # [Modified in Deneb]
     signing_root = compute_signing_root(epoch, get_domain(state, DOMAIN_RANDAO))
     assert bls.Verify(proposer.pubkey, signing_root, body.randao_reveal)
     # Mix in RANDAO reveal

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -27,13 +27,9 @@
     - [`tx_peek_blob_versioned_hashes`](#tx_peek_blob_versioned_hashes)
     - [`verify_kzg_commitments_against_transactions`](#verify_kzg_commitments_against_transactions)
     - [Modified `compute_proposer_index`](#modified-compute_proposer_index)
-    - [New `get_latest_block_proposer_index`](#new-get_latest_block_proposer_index)
-    - [Modified `slash_validator`](#modified-slash_validator)
+    - [Modified `get_beacon_proposer_index`](#modified-get_beacon_proposer_index)
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
   - [Block processing](#block-processing)
-    - [Modified `process_randao`](#modified-process_randao)
-    - [Modified `process_attestation`](#modified-process_attestation)
-    - [Modified `process_sync_aggregate`](#modified-process_sync_aggregate)
     - [Execution payload](#execution-payload)
       - [`process_execution_payload`](#process_execution_payload)
     - [Blob KZG commitments](#blob-kzg-commitments)
@@ -221,44 +217,22 @@ def compute_proposer_index(state: BeaconState, indices: Sequence[ValidatorIndex]
         i += 1
 ```
 
-#### New `get_latest_block_proposer_index`
+#### Modified `get_beacon_proposer_index`
+
+*Note:* Modified to read proposer index from the state to ensure the output stays unaffected if proposing validator gets slashed.
 
 ```python
-def get_latest_block_proposer_index(state: BeaconState) -> ValidatorIndex:
+def get_beacon_proposer_index(state: BeaconState) -> ValidatorIndex:
     """
-    Return validator index of the latest block proposer.
+    Return the beacon proposer index at the current slot.
     """
-    return state.latest_block_header.proposer_index
-```
-
-#### Modified `slash_validator`
-
-*Note:* The only change to this function is a switch to `get_latest_block_proposer_index`.
-
-```python
-def slash_validator(state: BeaconState,
-                    slashed_index: ValidatorIndex,
-                    whistleblower_index: ValidatorIndex=None) -> None:
-    """
-    Slash the validator with index ``slashed_index``.
-    """
+    if state.latest_block_header.slot == state.slot:
+        return state.latest_block_header.proposer_index
+    
     epoch = get_current_epoch(state)
-    initiate_validator_exit(state, slashed_index)
-    validator = state.validators[slashed_index]
-    validator.slashed = True
-    validator.withdrawable_epoch = max(validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR))
-    state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
-    slashing_penalty = validator.effective_balance // MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX
-    decrease_balance(state, slashed_index, slashing_penalty)
-
-    # Apply proposer and whistleblower rewards
-    proposer_index = get_latest_block_proposer_index(state)  # [Modified in Deneb]
-    if whistleblower_index is None:
-        whistleblower_index = proposer_index
-    whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
-    proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
-    increase_balance(state, proposer_index, proposer_reward)
-    increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+    seed = hash(get_seed(state, epoch, DOMAIN_BEACON_PROPOSER) + uint_to_bytes(state.slot))
+    indices = get_active_validator_indices(state, epoch)
+    return compute_proposer_index(state, indices, seed)
 ```
 
 ## Beacon chain state transition function
@@ -271,101 +245,12 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     if is_execution_enabled(state, block.body):
         process_withdrawals(state, block.body.execution_payload)
         process_execution_payload(state, block.body.execution_payload, EXECUTION_ENGINE)  # [Modified in Deneb]
-    process_randao(state, block.body)  # [Modified in Deneb]
+    process_randao(state, block.body) 
     process_eth1_data(state, block.body)
-    process_operations(state, block.body)  # [Modified in Deneb]
-    process_sync_aggregate(state, block.body.sync_aggregate)  # [Modified in Deneb]
+    process_operations(state, block.body)
+    process_sync_aggregate(state, block.body.sync_aggregate)
     process_blob_kzg_commitments(state, block.body)  # [New in Deneb]
 ```
-
-#### Modified `process_randao`
-
-*Note:* The only change to this function is a switch to `get_latest_block_proposer_index`.
-
-```python
-def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
-    epoch = get_current_epoch(state)
-    # Verify RANDAO reveal
-    proposer = state.validators[get_latest_block_proposer_index(state)]  # [Modified in Deneb]
-    signing_root = compute_signing_root(epoch, get_domain(state, DOMAIN_RANDAO))
-    assert bls.Verify(proposer.pubkey, signing_root, body.randao_reveal)
-    # Mix in RANDAO reveal
-    mix = xor(get_randao_mix(state, epoch), hash(body.randao_reveal))
-    state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR] = mix
-```
-
-#### Modified `process_attestation`
-
-*Note:* The only change to this function is a switch to `get_latest_block_proposer_index`.
-
-```python
-def process_attestation(state: BeaconState, attestation: Attestation) -> None:
-    data = attestation.data
-    assert data.target.epoch in (get_previous_epoch(state), get_current_epoch(state))
-    assert data.target.epoch == compute_epoch_at_slot(data.slot)
-    assert data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= data.slot + SLOTS_PER_EPOCH
-    assert data.index < get_committee_count_per_slot(state, data.target.epoch)
-
-    committee = get_beacon_committee(state, data.slot, data.index)
-    assert len(attestation.aggregation_bits) == len(committee)
-
-    # Participation flag indices
-    participation_flag_indices = get_attestation_participation_flag_indices(state, data, state.slot - data.slot)
-
-    # Verify signature
-    assert is_valid_indexed_attestation(state, get_indexed_attestation(state, attestation))
-
-    # Update epoch participation flags
-    if data.target.epoch == get_current_epoch(state):
-        epoch_participation = state.current_epoch_participation
-    else:
-        epoch_participation = state.previous_epoch_participation
-
-    proposer_reward_numerator = 0
-    for index in get_attesting_indices(state, data, attestation.aggregation_bits):
-        for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):
-            if flag_index in participation_flag_indices and not has_flag(epoch_participation[index], flag_index):
-                epoch_participation[index] = add_flag(epoch_participation[index], flag_index)
-                proposer_reward_numerator += get_base_reward(state, index) * weight
-
-    # Reward proposer
-    proposer_reward_denominator = (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT) * WEIGHT_DENOMINATOR // PROPOSER_WEIGHT
-    proposer_reward = Gwei(proposer_reward_numerator // proposer_reward_denominator)
-    increase_balance(state, get_latest_block_proposer_index(state), proposer_reward)  # [Modified in Deneb]
-```
-
-#### Modified `process_sync_aggregate`
-
-*Note:* The only change to this function is a switch to `get_latest_block_proposer_index`.
-
-```python
-def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) -> None:
-    # Verify sync committee aggregate signature signing over the previous slot block root
-    committee_pubkeys = state.current_sync_committee.pubkeys
-    participant_pubkeys = [pubkey for pubkey, bit in zip(committee_pubkeys, sync_aggregate.sync_committee_bits) if bit]
-    previous_slot = max(state.slot, Slot(1)) - Slot(1)
-    domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
-    signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
-    assert eth_fast_aggregate_verify(participant_pubkeys, signing_root, sync_aggregate.sync_committee_signature)
-
-    # Compute participant and proposer rewards
-    total_active_increments = get_total_active_balance(state) // EFFECTIVE_BALANCE_INCREMENT
-    total_base_rewards = Gwei(get_base_reward_per_increment(state) * total_active_increments)
-    max_participant_rewards = Gwei(total_base_rewards * SYNC_REWARD_WEIGHT // WEIGHT_DENOMINATOR // SLOTS_PER_EPOCH)
-    participant_reward = Gwei(max_participant_rewards // SYNC_COMMITTEE_SIZE)
-    proposer_reward = Gwei(participant_reward * PROPOSER_WEIGHT // (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT))
-
-    # Apply participant and proposer rewards
-    all_pubkeys = [v.pubkey for v in state.validators]
-    committee_indices = [ValidatorIndex(all_pubkeys.index(pubkey)) for pubkey in state.current_sync_committee.pubkeys]
-    for participant_index, participation_bit in zip(committee_indices, sync_aggregate.sync_committee_bits):
-        if participation_bit:
-            increase_balance(state, participant_index, participant_reward)
-            increase_balance(state, get_latest_block_proposer_index(state), proposer_reward)  # [Modified in Deneb]
-        else:
-            decrease_balance(state, participant_index, participant_reward)
-```
-
 
 #### Execution payload
 

--- a/tests/core/pyspec/eth2spec/test/deneb/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/unittests/validator/test_validator.py
@@ -161,6 +161,7 @@ def test_blob_sidecar_signature_incorrect(spec, state):
 @with_deneb_and_later
 @spec_state_test
 def test_slashed_validator_not_elected_for_proposal(spec, state):
+    spec.process_slots(state, state.slot + 1)
     proposer_index = spec.get_beacon_proposer_index(state)
     state.validators[proposer_index].slashed = True
 

--- a/tests/core/pyspec/eth2spec/test/deneb/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/unittests/validator/test_validator.py
@@ -3,8 +3,6 @@ from eth2spec.test.context import (
     spec_state_test,
     with_deneb_and_later,
     expect_assertion_error,
-    with_phases,
-    PHASE0, ALTAIR, CAPELLA,
 )
 from eth2spec.test.helpers.execution_payload import (
     compute_el_block_hash,
@@ -160,21 +158,10 @@ def test_blob_sidecar_signature_incorrect(spec, state):
     assert not spec.verify_blob_sidecar_signature(state, signed_blob_sidecar)
 
 
-@with_phases([PHASE0, ALTAIR, CAPELLA])
-@spec_state_test
-def test_slashed_validator_elected_for_proposal(spec, state):
-    spec.process_slots(state, state.slot + 1)
-    slashed_proposer_index = spec.get_beacon_proposer_index(state)
-    spec.slash_validator(state, slashed_proposer_index)
-
-    assert spec.get_beacon_proposer_index(state) == slashed_proposer_index
-
-
 @with_deneb_and_later
 @spec_state_test
 def test_slashed_validator_not_elected_for_proposal(spec, state):
-    spec.process_slots(state, state.slot + 1)
-    slashed_proposer_index = spec.get_beacon_proposer_index(state)
-    spec.slash_validator(state, slashed_proposer_index)
+    proposer_index = spec.get_beacon_proposer_index(state)
+    state.validators[proposer_index].slashed = True
 
-    assert spec.get_beacon_proposer_index(state) != slashed_proposer_index
+    assert spec.get_beacon_proposer_index(state) != proposer_index

--- a/tests/core/pyspec/eth2spec/test/helpers/proposer_slashings.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/proposer_slashings.py
@@ -1,5 +1,5 @@
 from eth2spec.test.helpers.block_header import sign_block_header
-from eth2spec.test.helpers.forks import is_post_altair, is_post_bellatrix, is_post_deneb
+from eth2spec.test.helpers.forks import is_post_altair, is_post_bellatrix
 from eth2spec.test.helpers.keys import pubkey_to_privkey
 from eth2spec.test.helpers.state import get_balance
 from eth2spec.test.helpers.sync_committee import (

--- a/tests/core/pyspec/eth2spec/test/helpers/proposer_slashings.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/proposer_slashings.py
@@ -1,5 +1,5 @@
 from eth2spec.test.helpers.block_header import sign_block_header
-from eth2spec.test.helpers.forks import is_post_altair, is_post_bellatrix
+from eth2spec.test.helpers.forks import is_post_altair, is_post_bellatrix, is_post_deneb
 from eth2spec.test.helpers.keys import pubkey_to_privkey
 from eth2spec.test.helpers.state import get_balance
 from eth2spec.test.helpers.sync_committee import (
@@ -24,6 +24,8 @@ def check_proposer_slashing_effect(spec, pre_state, state, slashed_index, block=
     assert slashed_validator.withdrawable_epoch < spec.FAR_FUTURE_EPOCH
 
     proposer_index = spec.get_beacon_proposer_index(state)
+    if is_post_deneb(spec):
+        proposer_index = spec.get_latest_block_proposer_index(state)
     slash_penalty = state.validators[slashed_index].effective_balance // get_min_slashing_penalty_quotient(spec)
     whistleblower_reward = state.validators[slashed_index].effective_balance // spec.WHISTLEBLOWER_REWARD_QUOTIENT
 

--- a/tests/core/pyspec/eth2spec/test/helpers/proposer_slashings.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/proposer_slashings.py
@@ -24,8 +24,6 @@ def check_proposer_slashing_effect(spec, pre_state, state, slashed_index, block=
     assert slashed_validator.withdrawable_epoch < spec.FAR_FUTURE_EPOCH
 
     proposer_index = spec.get_beacon_proposer_index(state)
-    if is_post_deneb(spec):
-        proposer_index = spec.get_latest_block_proposer_index(state)
     slash_penalty = state.validators[slashed_index].effective_balance // get_min_slashing_penalty_quotient(spec)
     whistleblower_reward = state.validators[slashed_index].effective_balance // spec.WHISTLEBLOWER_REWARD_QUOTIENT
 

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attestation.py
@@ -6,6 +6,7 @@ from eth2spec.test.context import (
     low_balances,
     with_custom_state,
     single_phase,
+    with_altair_and_later,
 )
 from eth2spec.test.helpers.attestations import (
     run_attestation_processing,
@@ -19,6 +20,7 @@ from eth2spec.test.helpers.state import (
     transition_to_slot_via_block,
 )
 from eth2spec.utils.ssz.ssz_typing import Bitlist
+from eth2spec.test.helpers.block import build_empty_block
 
 
 @with_all_phases
@@ -564,3 +566,23 @@ def test_invalid_incorrect_target_included_after_epoch_delay(spec, state):
     sign_attestation(spec, state, attestation)
 
     yield from run_attestation_processing(spec, state, attestation, valid=False)
+
+
+@with_altair_and_later
+@spec_state_test
+def test_slashed_proposer_rewarded_for_attestation_inclusion(spec, state):
+    attestation = get_valid_attestation(spec, state, signed=True)
+    next_slots(spec, state, spec.MIN_ATTESTATION_INCLUSION_DELAY)
+
+    # Process block header as proposer index is read from the state since Deneb
+    block = build_empty_block(spec, state)
+    spec.process_block_header(state, block)
+
+    # Slash proposer
+    state.validators[block.proposer_index].slashed = True
+    pre_state_proposer_balance = state.balances[block.proposer_index]
+
+    yield from run_attestation_processing(spec, state, attestation)
+
+    # Check proposer gets rewarded
+    assert state.balances[block.proposer_index] > pre_state_proposer_balance

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
@@ -28,7 +28,7 @@ def run_attester_slashing_processing(spec, state, attester_slashing, valid=True)
     If ``valid == False``, run expecting ``AssertionError``
     """
 
-    # Makes `get_latest_block_proposer_index` respond properly
+    # Makes `get_beacon_proposer_index` respond properly
     if is_post_deneb(spec):
         block = build_empty_block_for_next_slot(spec, state)
         spec.process_slots(state, state.slot + 1)

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
@@ -15,6 +15,8 @@ from eth2spec.test.helpers.state import (
     get_balance,
     next_epoch_via_block,
 )
+from eth2spec.test.helpers.block import build_empty_block_for_next_slot
+from eth2spec.test.helpers.forks import is_post_deneb
 
 
 def run_attester_slashing_processing(spec, state, attester_slashing, valid=True):
@@ -25,6 +27,12 @@ def run_attester_slashing_processing(spec, state, attester_slashing, valid=True)
       - post-state ('post').
     If ``valid == False``, run expecting ``AssertionError``
     """
+
+    # Makes `get_latest_block_proposer_index` respond properly
+    if is_post_deneb(spec):
+        block = build_empty_block_for_next_slot(spec, state)
+        spec.process_slots(state, state.slot + 1)
+        spec.process_block_header(state, block)
 
     yield 'pre', state
     yield 'attester_slashing', attester_slashing

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_block_header.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_block_header.py
@@ -93,9 +93,10 @@ def test_invalid_proposer_slashed(spec, state):
     next_slot(spec, stub_state)
     proposer_index = spec.get_beacon_proposer_index(stub_state)
 
+    # build a block
+    block = build_empty_block_for_next_slot(spec, state)
+
     # set proposer to slashed
     state.validators[proposer_index].slashed = True
-
-    block = build_empty_block_for_next_slot(spec, state)
 
     yield from run_block_header_processing(spec, state, block, valid=False)

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_proposer_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_proposer_slashing.py
@@ -18,7 +18,7 @@ def run_proposer_slashing_processing(spec, state, proposer_slashing, valid=True)
 
     pre_state = state.copy()
 
-    # Makes `get_latest_block_proposer_index` respond properly
+    # Makes `get_beacon_proposer_index` respond properly
     if is_post_deneb(spec):
         block = build_empty_block_for_next_slot(spec, state)
         spec.process_slots(state, state.slot + 1)

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_proposer_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_proposer_slashing.py
@@ -4,6 +4,7 @@ from eth2spec.test.helpers.block_header import sign_block_header
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.test.helpers.proposer_slashings import get_valid_proposer_slashing, check_proposer_slashing_effect
 from eth2spec.test.helpers.state import next_epoch
+from eth2spec.test.helpers.forks import is_post_deneb
 
 
 def run_proposer_slashing_processing(spec, state, proposer_slashing, valid=True):
@@ -16,6 +17,12 @@ def run_proposer_slashing_processing(spec, state, proposer_slashing, valid=True)
     """
 
     pre_state = state.copy()
+
+    # Makes `get_latest_block_proposer_index` respond properly
+    if is_post_deneb(spec):
+        block = build_empty_block_for_next_slot(spec, state)
+        spec.process_slots(state, state.slot + 1)
+        spec.process_block_header(state, block)
 
     yield 'pre', state
     yield 'proposer_slashing', proposer_slashing

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
@@ -2,7 +2,8 @@ from eth2spec.test.context import (
     spec_state_test,
     always_bls, with_phases, with_all_phases,
 )
-from eth2spec.test.helpers.constants import PHASE0
+
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR, BELLATRIX, CAPELLA
 from eth2spec.test.helpers.attestations import build_attestation_data, get_valid_attestation
 from eth2spec.test.helpers.block import build_empty_block
 from eth2spec.test.helpers.deposits import prepare_state_and_deposit
@@ -476,3 +477,12 @@ def test_get_aggregate_and_proof_signature(spec, state):
         privkey=privkey,
         pubkey=pubkey,
     )
+
+
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA])
+@spec_state_test
+def test_slashed_validator_elected_for_proposal(spec, state):
+    proposer_index = spec.get_beacon_proposer_index(state)
+    state.validators[proposer_index].slashed = True
+
+    assert spec.get_beacon_proposer_index(state) == proposer_index


### PR DESCRIPTION
Checks if validator is slashed in the beacon block proposer selection.

There is a slight contradiction in the spec where it is allowed for a slashed validator to become a proposer while a block from slashed proposer is rejected. Considering a trivial possibility of this contradiction to take into effect, this change is more like a cosmetic fix. Opening a PR to see whether it will have any traction.

If we decide to merge we may also want to cover this case with a test (and fix broken tests).

*UPD:* We would need a HF to roll out this change, otherwise, one may slash itself (if eligible to propose) and induce a network split.

This change doesn't affect processing historical blocks as blocks proposed by slashed validators couldn't be included into canonical chain.