### PR TITLE
Use Capella fork version for BLSToExecution

### DIFF
--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -59,15 +59,15 @@ See Capella [state transition document](./beacon-chain.md#beaconblockbody) for f
 
 This topic is used to propagate signed bls to execution change messages to be included in future blocks.
 
-Let `head_state` be a post state of the head of canonical chain.
+Let `system_clock_epoch` be an epoch number according to the local system clock of a node.
 The following validations MUST pass before forwarding the `signed_bls_to_execution_change` on the network:
 
 - _[IGNORE]_ The `signed_bls_to_execution_change` is the first valid signed bls to execution change received
   for the validator with index `signed_bls_to_execution_change.message.validator_index`.
-- If `get_current_epoch(head_state) < CAPELLA_FORK_EPOCH`:
+- If `system_clock_epoch < CAPELLA_FORK_EPOCH`:
   - _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation 
   using `CAPELLA_FORK_VERSION` in signing domain computation.
-- If `get_current_epoch(head_state) >= CAPELLA_FORK_EPOCH`:
+- If `system_clock_epoch >= CAPELLA_FORK_EPOCH`:
   - _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation.
 
 ### Transitioning the gossip

--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -59,11 +59,16 @@ See Capella [state transition document](./beacon-chain.md#beaconblockbody) for f
 
 This topic is used to propagate signed bls to execution change messages to be included in future blocks.
 
+Let `head_state` be a post state of the head of canonical chain.
 The following validations MUST pass before forwarding the `signed_bls_to_execution_change` on the network:
 
 - _[IGNORE]_ The `signed_bls_to_execution_change` is the first valid signed bls to execution change received
   for the validator with index `signed_bls_to_execution_change.message.validator_index`.
-- _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation.
+- If `get_current_epoch(head_state) < CAPELLA_FORK_EPOCH`:
+  - _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation 
+  using `head_state.fork.current_version` in signing domain computation.
+- If `get_current_epoch(head_state) >= CAPELLA_FORK_EPOCH`:
+  - _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation.
 
 ### Transitioning the gossip
 

--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -66,7 +66,7 @@ The following validations MUST pass before forwarding the `signed_bls_to_executi
   for the validator with index `signed_bls_to_execution_change.message.validator_index`.
 - If `get_current_epoch(head_state) < CAPELLA_FORK_EPOCH`:
   - _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation 
-  using `head_state.fork.current_version` in signing domain computation.
+  using `CAPELLA_FORK_VERSION` in signing domain computation.
 - If `get_current_epoch(head_state) >= CAPELLA_FORK_EPOCH`:
   - _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation.
 


### PR DESCRIPTION
A stopgap fix for BLSToExecution gossip validation:
* Use Capella fork version If a node is in the pre-Capella state according to a wall clock,
* Otherwise, use a fork version that is relevant.

This fix only make sense if we can't afford a general fix of gossip messages validation because of additional engineering complexity. The general fix would be to always use a fork version from a gossip topic to compute signing domain across all topics.