### PR TITLE
tests/formats: update epoch and operations formats to reflect push-withdrawals

### DIFF
--- a/tests/formats/epoch_processing/README.md
+++ b/tests/formats/epoch_processing/README.md
@@ -41,7 +41,8 @@ Sub-transitions:
 - `effective_balance_updates`
 - `slashings_reset`
 - `randao_mixes_reset`
-- `historical_roots_update`
+- `historical_roots_update` (Phase0, Altair, Bellatrix only)
+- `historical_summaries_update` (Capella)
 - `participation_record_updates` (Phase 0 only)
 - `participation_flag_updates` (Altair)
 - `sync_committee_updates` (Altair)

--- a/tests/formats/epoch_processing/README.md
+++ b/tests/formats/epoch_processing/README.md
@@ -45,7 +45,5 @@ Sub-transitions:
 - `participation_record_updates` (Phase 0 only)
 - `participation_flag_updates` (Altair)
 - `sync_committee_updates` (Altair)
-- `full_withdrawals` (Capella)
-- `partial_withdrawals` (Capella)
 
 The resulting state should match the expected `post` state.

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -44,7 +44,7 @@ Operations:
 | `sync_aggregate`          | `SyncAggregate`              | `sync_aggregate`    | `process_sync_aggregate(state, sync_aggregate)` (new in Altair)                  |
 | `execution_payload`       | `ExecutionPayload`           | `execution_payload` | `process_execution_payload(state, execution_payload)` (new in Bellatrix)         |
 | `withdrawals`             | `ExecutionPayload`           | `execution_payload` | `process_withdrawals(state, execution_payload)` (new in Capella)                 |
-| `bls_to_execution_change` | `SignedBLSToExecutionChange` | `address_change`    | `process_bls_to_execution_change(state, signed_address_change)` (new in Capella) |
+| `bls_to_execution_change` | `SignedBLSToExecutionChange` | `address_change`    | `process_bls_to_execution_change(state, address_change)` (new in Capella) |
 
 Note that `block_header` is not strictly an operation (and is a full `Block`), but processed in the same manner, and hence included here.
 

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -33,17 +33,18 @@ This excludes the other parts of the block-transition.
 
 Operations:
 
-| *`operation-name`*      | *`operation-object`*  | *`input name`*       | *`processing call`*                                                  |
-|-------------------------|-----------------------|----------------------|----------------------------------------------------------------------|
-| `attestation`           | `Attestation`         | `attestation`        | `process_attestation(state, attestation)`                            |
-| `attester_slashing`     | `AttesterSlashing`    | `attester_slashing`  | `process_attester_slashing(state, attester_slashing)`                |
-| `block_header`          | `BeaconBlock`         | **`block`**          | `process_block_header(state, block)`                                 |
-| `deposit`               | `Deposit`             | `deposit`            | `process_deposit(state, deposit)`                                    |
-| `proposer_slashing`     | `ProposerSlashing`    | `proposer_slashing`  | `process_proposer_slashing(state, proposer_slashing)`                |
-| `voluntary_exit`        | `SignedVoluntaryExit` | `voluntary_exit`     | `process_voluntary_exit(state, voluntary_exit)`                      |
-| `sync_aggregate`        | `SyncAggregate`       | `sync_aggregate`     | `process_sync_aggregate(state, sync_aggregate)` (new in Altair)      |
-| `execution_payload`     | `ExecutionPayload`    | `execution_payload`  | `process_execution_payload(state, execution_payload)` (new in Bellatrix) |
-| `bls_to_execution_change` | `SignedBLSToExecutionChange` | `signed_address_change` | `process_bls_to_execution_change(state, signed_address_change)` (new in Capella) |
+| *`operation-name`*        | *`operation-object`*         | *`input name`*      | *`processing call`*                                                              |
+|---------------------------|------------------------------|---------------------|----------------------------------------------------------------------------------|
+| `attestation`             | `Attestation`                | `attestation`       | `process_attestation(state, attestation)`                                        |
+| `attester_slashing`       | `AttesterSlashing`           | `attester_slashing` | `process_attester_slashing(state, attester_slashing)`                            |
+| `block_header`            | `BeaconBlock`                | **`block`**         | `process_block_header(state, block)`                                             |
+| `deposit`                 | `Deposit`                    | `deposit`           | `process_deposit(state, deposit)`                                                |
+| `proposer_slashing`       | `ProposerSlashing`           | `proposer_slashing` | `process_proposer_slashing(state, proposer_slashing)`                            |
+| `voluntary_exit`          | `SignedVoluntaryExit`        | `voluntary_exit`    | `process_voluntary_exit(state, voluntary_exit)`                                  |
+| `sync_aggregate`          | `SyncAggregate`              | `sync_aggregate`    | `process_sync_aggregate(state, sync_aggregate)` (new in Altair)                  |
+| `execution_payload`       | `ExecutionPayload`           | `execution_payload` | `process_execution_payload(state, execution_payload)` (new in Bellatrix)         |
+| `withdrawals`             | `ExecutionPayload`           | `execution_payload` | `process_withdrawals(state, execution_payload)` (new in Capella)                 |
+| `bls_to_execution_change` | `SignedBLSToExecutionChange` | `address_change`    | `process_bls_to_execution_change(state, signed_address_change)` (new in Capella) |
 
 Note that `block_header` is not strictly an operation (and is a full `Block`), but processed in the same manner, and hence included here.
 


### PR DESCRIPTION
Update the test format docs to reflect the changes in #3068 (add withdrawal operations, remove the epoch processing).

- remove the epoch processing test entries
- add `process_withdrawals` entry
- fix input name of `process_bls_to_execution_change` entry
