### PR TITLE
Ensure that no duplidate block hashes in `sync/from_syncing_to_invalid` test case

### DIFF
--- a/tests/core/pyspec/eth2spec/test/bellatrix/sync/test_optimistic.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/sync/test_optimistic.py
@@ -64,6 +64,7 @@ def test_from_syncing_to_invalid(spec, state):
         block.body.execution_payload.parent_hash = (
             block_hashes[f'chain_a_{i - 1}'] if i != 0 else block_hashes['block_0']
         )
+        block.body.execution_payload.extra_data = spec.hash(bytes(f'chain_a_{i}', 'UTF-8'))
         block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
         block_hashes[f'chain_a_{i}'] = block.body.execution_payload.block_hash
 
@@ -80,6 +81,7 @@ def test_from_syncing_to_invalid(spec, state):
         block.body.execution_payload.parent_hash = (
             block_hashes[f'chain_b_{i - 1}'] if i != 0 else block_hashes['block_0']
         )
+        block.body.execution_payload.extra_data = spec.hash(bytes(f'chain_b_{i}', 'UTF-8'))
         block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
         block_hashes[f'chain_b_{i}'] = block.body.execution_payload.block_hash
 
@@ -92,8 +94,12 @@ def test_from_syncing_to_invalid(spec, state):
     # Now add block 4 to chain `b` with INVALID
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.parent_hash = signed_blocks_b[-1].message.body.execution_payload.block_hash
+    block.body.execution_payload.extra_data = spec.hash(bytes(f'chain_b_{i}', 'UTF-8'))
     block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
     block_hashes['chain_b_3'] = block.body.execution_payload.block_hash
+
+    # Ensure that no duplicate block hashes
+    assert len(block_hashes) == len(set(block_hashes.values()))
 
     signed_block = state_transition_and_sign_block(spec, state, block)
     payload_status = PayloadStatusV1(


### PR DESCRIPTION
Address #3172 

To make the block hashes unique, I fill the `block.body.execution_payload.extra_data` with distance values. Also, added an assertion to check this postcondition.