### PR TITLE
Clarify slot ordering in phase0/BeaconBlocksByRange

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -778,7 +778,7 @@ disconnect and/or temporarily ban such an un-synced or semi-synced client.
 Clients MUST respond with at least the first block that exists in the range, if they have it,
 and no more than `MAX_REQUEST_BLOCKS` blocks.
 
-The following blocks, where they exist, MUST be sent in consecutive order.
+The following blocks, where they exist, MUST be sent in order of increasing slot number.
 
 Clients MAY limit the number of blocks in the response.
 


### PR DESCRIPTION
For phase0, there is an example in the spec that explicitly returns non-consecutive blocks (`[2, 3, 5]`), which is what prompted me to make this change. 

I came across this while digging into `BlobsSidecarsByRange` (https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/p2p-interface.md#blobssidecarsbyrange-v1) where there is a similar wording:

> The following blobs sidecars, where they exist, MUST be sent in consecutive order.

But no non-consecutive example as in the `phase0/BeaconBlocksByRange` spec. Should I change `BlobsSidecarsByRange` similarly from "consecutive" to "increasing order"?