### PR TITLE
fix: outdated minimal capella.yaml

### DIFF
--- a/presets/minimal/capella.yaml
+++ b/presets/minimal/capella.yaml
@@ -8,10 +8,10 @@ MAX_BLS_TO_EXECUTION_CHANGES: 16
 
 # Execution
 # ---------------------------------------------------------------
-# [customized] 2**2 (= 4)
-MAX_WITHDRAWALS_PER_PAYLOAD: 4
+# 2**4 (= 16) withdrawals
+MAX_WITHDRAWALS_PER_PAYLOAD: 16
 
 # Withdrawals processing
 # ---------------------------------------------------------------
-# [customized] 2**4 (= 16) validators
-MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP: 16
+# 2**14 (= 16384) validators
+MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP: 16384


### PR DESCRIPTION
Align with current spec

https://github.com/ethereum/consensus-specs/blob/dev/presets/mainnet/capella.yaml#L17

https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#withdrawals-processing
https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#execution