### PR TITLE
Add `historical_summaries` setup to `fork.md`

### DIFF
--- a/specs/capella/fork.md
+++ b/specs/capella/fork.md
@@ -129,8 +129,10 @@ def upgrade_to_capella(pre: bellatrix.BeaconState) -> BeaconState:
         # Execution-layer
         latest_execution_payload_header=latest_execution_payload_header,
         # Withdrawals
-        next_withdrawal_index=WithdrawalIndex(0),
-        next_withdrawal_validator_index=ValidatorIndex(0),
+        next_withdrawal_index=WithdrawalIndex(0),  # [New in Capella]
+        next_withdrawal_validator_index=ValidatorIndex(0),  # [New in Capella]
+        # Deep history valid from Capella onwards
+        historical_summaries=List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]([]),  # [New in Capella]
     )
 
     return post

--- a/specs/eip4844/fork.md
+++ b/specs/eip4844/fork.md
@@ -131,6 +131,8 @@ def upgrade_to_eip4844(pre: capella.BeaconState) -> BeaconState:
         # Withdrawals
         next_withdrawal_index=pre.next_withdrawal_index,
         next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
+        # Deep history valid from Capella onwards
+        historical_summaries=pre.historical_summaries,
     )
 
     return post


### PR DESCRIPTION
Thank @g11tech for pointing it out!

### Issue
#3165 added a new field to `BeaconState` so we should have updated `eip4844/fork.md` correspondingly.

### How I fixed it
- [eip4844/fork.md] Add `historical_summaries=pre.historical_summaries`
-  [capella/fork.md] To make it clear, add `historical_summaries=List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]([])`. (it's the default value though)

Note: This PR should only change EIP-4844 logic and test vectors.

@djrtwo 
I can push a hotfix test vector release `v1.3.0-rc.0-hotfix` this week, or should we cut a `v1.3.0-rc.1`?