### PR TITLE
Add `BLSToExecutionChange` `test_invalid_previous_fork_version` test case

### DIFF
--- a/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_bls_to_execution_change.py
+++ b/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_bls_to_execution_change.py
@@ -172,3 +172,25 @@ def test_invalid_bad_signature(spec, state):
     signed_address_change.signature = spec.BLSSignature(b'\x42' * 96)
 
     yield from run_bls_to_execution_change_processing(spec, state, signed_address_change, valid=False)
+
+
+@with_capella_and_later
+@spec_state_test
+@always_bls
+def test_current_fork_version(spec, state):
+    """
+    It should be identical to the `test_success` test case.
+    It is just for comparing with `test_invalid_previous_fork_version`.
+    """
+    signed_address_change = get_signed_address_change(spec, state, fork_version=state.fork.current_version)
+
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change)
+
+
+@with_capella_and_later
+@spec_state_test
+@always_bls
+def test_invalid_previous_fork_version(spec, state):
+    signed_address_change = get_signed_address_change(spec, state, fork_version=state.fork.previous_version)
+
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change, valid=False)

--- a/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
@@ -2,7 +2,8 @@ from eth2spec.utils import bls
 from eth2spec.test.helpers.keys import pubkeys, privkeys, pubkey_to_privkey
 
 
-def get_signed_address_change(spec, state, validator_index=None, withdrawal_pubkey=None, to_execution_address=None):
+def get_signed_address_change(spec, state, validator_index=None, withdrawal_pubkey=None, to_execution_address=None,
+                              fork_version=None):
     if validator_index is None:
         validator_index = 0
 
@@ -16,7 +17,11 @@ def get_signed_address_change(spec, state, validator_index=None, withdrawal_pubk
     if to_execution_address is None:
         to_execution_address = b'\x42' * 20
 
-    domain = spec.get_domain(state, spec.DOMAIN_BLS_TO_EXECUTION_CHANGE)
+    if fork_version is None:
+        domain = spec.get_domain(state, spec.DOMAIN_BLS_TO_EXECUTION_CHANGE)
+    else:
+        domain = spec.compute_domain(spec.DOMAIN_BLS_TO_EXECUTION_CHANGE, fork_version, state.genesis_validators_root)
+
     address_change = spec.BLSToExecutionChange(
         validator_index=validator_index,
         from_bls_pubkey=withdrawal_pubkey,


### PR DESCRIPTION
- Add an invalid test case where `SignedBLSToExecutionChange` is signed with the previous fork version.
- Add `test_current_fork_version` for comparing with `test_invalid_previous_fork_version`.