### PR TITLE
MUST use `GENESIS_FORK_VERSION` to sign `BLSToExecutionChange` message

### DIFF
--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -472,7 +472,8 @@ def process_bls_to_execution_change(state: BeaconState,
     assert validator.withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX
     assert validator.withdrawal_credentials[1:] == hash(address_change.from_bls_pubkey)[1:]
 
-    domain = get_domain(state, DOMAIN_BLS_TO_EXECUTION_CHANGE)
+    # Fork-agnostic domain since address changes are valid across forks
+    domain = compute_domain(DOMAIN_BLS_TO_EXECUTION_CHANGE, genesis_validators_root=state.genesis_validators_root)
     signing_root = compute_signing_root(address_change, domain)
     assert bls.Verify(address_change.from_bls_pubkey, signing_root, signed_address_change.signature)
 

--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -59,10 +59,10 @@ See Capella [state transition document](./beacon-chain.md#beaconblockbody) for f
 
 This topic is used to propagate signed bls to execution change messages to be included in future blocks.
 
-Let `system_clock_epoch` be an epoch number according to the local system clock of a node.
 The following validations MUST pass before forwarding the `signed_bls_to_execution_change` on the network:
 
-- _[IGNORE]_ `system_clock_epoch >= CAPELLA_FORK_EPOCH`.
+- _[IGNORE]_ `current_epoch >= CAPELLA_FORK_EPOCH`,
+  where `current_epoch` is defined by the current wall-clock time.
 - _[IGNORE]_ The `signed_bls_to_execution_change` is the first valid signed bls to execution change received
   for the validator with index `signed_bls_to_execution_change.message.validator_index`.
 - _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation.

--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -59,8 +59,10 @@ See Capella [state transition document](./beacon-chain.md#beaconblockbody) for f
 
 This topic is used to propagate signed bls to execution change messages to be included in future blocks.
 
+Let `system_clock_epoch` be an epoch number according to the local system clock of a node.
 The following validations MUST pass before forwarding the `signed_bls_to_execution_change` on the network:
 
+- _[IGNORE]_ `system_clock_epoch >= CAPELLA_FORK_EPOCH`.
 - _[IGNORE]_ The `signed_bls_to_execution_change` is the first valid signed bls to execution change received
   for the validator with index `signed_bls_to_execution_change.message.validator_index`.
 - _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation.

--- a/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_bls_to_execution_change.py
+++ b/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_bls_to_execution_change.py
@@ -199,3 +199,12 @@ def test_invalid_previous_fork_version(spec, state):
     signed_address_change = get_signed_address_change(spec, state, fork_version=state.fork.previous_version)
 
     yield from run_bls_to_execution_change_processing(spec, state, signed_address_change, valid=False)
+
+
+@with_capella_and_later
+@spec_state_test
+@always_bls
+def test_invalid_genesis_validators_root(spec, state):
+    signed_address_change = get_signed_address_change(spec, state, genesis_validators_root=b'\x99' * 32)
+
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change, valid=False)

--- a/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_bls_to_execution_change.py
+++ b/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_bls_to_execution_change.py
@@ -177,14 +177,19 @@ def test_invalid_bad_signature(spec, state):
 @with_capella_and_later
 @spec_state_test
 @always_bls
-def test_current_fork_version(spec, state):
-    """
-    It should be identical to the `test_success` test case.
-    It is just for comparing with `test_invalid_previous_fork_version`.
-    """
-    signed_address_change = get_signed_address_change(spec, state, fork_version=state.fork.current_version)
+def test_genesis_fork_version(spec, state):
+    signed_address_change = get_signed_address_change(spec, state, fork_version=spec.config.GENESIS_FORK_VERSION)
 
     yield from run_bls_to_execution_change_processing(spec, state, signed_address_change)
+
+
+@with_capella_and_later
+@spec_state_test
+@always_bls
+def test_invalid_current_fork_version(spec, state):
+    signed_address_change = get_signed_address_change(spec, state, fork_version=state.fork.current_version)
+
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change, valid=False)
 
 
 @with_capella_and_later

--- a/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
@@ -2,8 +2,12 @@ from eth2spec.utils import bls
 from eth2spec.test.helpers.keys import pubkeys, privkeys, pubkey_to_privkey
 
 
-def get_signed_address_change(spec, state, validator_index=None, withdrawal_pubkey=None, to_execution_address=None,
-                              fork_version=None):
+def get_signed_address_change(spec, state,
+                              validator_index=None,
+                              withdrawal_pubkey=None,
+                              to_execution_address=None,
+                              fork_version=None,
+                              genesis_validators_root=None):
     if validator_index is None:
         validator_index = 0
 
@@ -17,10 +21,14 @@ def get_signed_address_change(spec, state, validator_index=None, withdrawal_pubk
     if to_execution_address is None:
         to_execution_address = b'\x42' * 20
 
+    if genesis_validators_root is None:
+        genesis_validators_root = spec.genesis_validators_root
+
     domain = spec.compute_domain(
         spec.DOMAIN_BLS_TO_EXECUTION_CHANGE,
         fork_version=fork_version,
-        genesis_validators_root=state.genesis_validators_root)
+        genesis_validators_root=genesis_validators_root,
+    )
 
     address_change = spec.BLSToExecutionChange(
         validator_index=validator_index,

--- a/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
@@ -17,10 +17,10 @@ def get_signed_address_change(spec, state, validator_index=None, withdrawal_pubk
     if to_execution_address is None:
         to_execution_address = b'\x42' * 20
 
-    if fork_version is None:
-        domain = spec.get_domain(state, spec.DOMAIN_BLS_TO_EXECUTION_CHANGE)
-    else:
-        domain = spec.compute_domain(spec.DOMAIN_BLS_TO_EXECUTION_CHANGE, fork_version, state.genesis_validators_root)
+    domain = spec.compute_domain(
+        spec.DOMAIN_BLS_TO_EXECUTION_CHANGE,
+        fork_version=fork_version,
+        genesis_validators_root=state.genesis_validators_root)
 
     address_change = spec.BLSToExecutionChange(
         validator_index=validator_index,

--- a/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/bls_to_execution_changes.py
@@ -22,7 +22,7 @@ def get_signed_address_change(spec, state,
         to_execution_address = b'\x42' * 20
 
     if genesis_validators_root is None:
-        genesis_validators_root = spec.genesis_validators_root
+        genesis_validators_root = state.genesis_validators_root
 
     domain = spec.compute_domain(
         spec.DOMAIN_BLS_TO_EXECUTION_CHANGE,


### PR DESCRIPTION
As https://github.com/ethereum/pm/issues/702 discussion, making `BLSToExecutionChange` fork-agnostic could make it easier to handle the message generation and validation.

Changes:
1. MUST use `GENESIS_FORK_VERSION` to sign `BLSToExecutionChange` message.
     - Note: `state.genesis_validators_root` is still part of the source of the `BLSToExecutionChange` domain. (`Deposit` domain does NOT use `state.genesis_validators_root` as part of the source) .
2. [Replace #3176]: Ignore `signed_bls_to_execution_change` message  before `CAPELLA_FORK_EPOCH` 

Considerations/discussions:
- Replay protection: I'd argue that the forked chains may also use the same fork version pattern as Ethereum mainnet anyway. What we can do is encourage and educate users to send `BLSToExecutionChange` fast.