### PR TITLE
Use `Gwei` for `Withdrawal` amount in mock-EE

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -26,6 +26,8 @@ def get_execution_payload_header(spec, execution_payload):
     )
     if is_post_capella(spec):
         payload_header.withdrawals_root = spec.hash_tree_root(execution_payload.withdrawals)
+    if is_post_eip4844(spec):
+        payload_header.excess_data_gas = execution_payload.excess_data_gas
     return payload_header
 
 
@@ -108,7 +110,7 @@ def get_withdrawal_rlp(spec, withdrawal):
         # address
         (Binary(20, 20), withdrawal.address),
         # amount
-        (big_endian_int, spec.uint256(withdrawal.amount) * (10**9)),
+        (big_endian_int, withdrawal.amount),
     ]
 
     sedes = List([schema for schema, _ in withdrawal_rlp])


### PR DESCRIPTION
Updates the EL block hash computation for pytests to match latest spec. Notably, use `Gwei` for `Withdrawal` amount consistently. Also fix `excess_data_gas` not being correctly accounted for.

https://github.com/ethereum/execution-apis/pull/354 https://github.com/ethereum/EIPs/pull/6325