### PR TITLE
eip4844: move excess data gas field to end of execution payload for merkle proof path compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1169,7 +1169,7 @@ setup(
         "pycryptodome==3.15.0",
         "py_ecc==6.0.0",
         "milagro_bls_binding==1.9.0",
-        "remerkleable==0.1.26",
+        "remerkleable==0.1.27",
         "trie==2.0.2",
         RUAMEL_YAML_VERSION,
         "lru-dict==1.1.8",

--- a/setup.py
+++ b/setup.py
@@ -1169,7 +1169,7 @@ setup(
         "pycryptodome==3.15.0",
         "py_ecc==6.0.0",
         "milagro_bls_binding==1.9.0",
-        "remerkleable==0.1.25",
+        "remerkleable==0.1.26",
         "trie==2.0.2",
         RUAMEL_YAML_VERSION,
         "lru-dict==1.1.8",

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -242,7 +242,7 @@ class BeaconState(Container):
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
     # Execution
-    latest_execution_payload_header: ExecutionPayloadHeader
+    latest_execution_payload_header: ExecutionPayloadHeader  # [Modified in Capella]
     # Withdrawals
     next_withdrawal_index: WithdrawalIndex  # [New in Capella]
     next_withdrawal_validator_index: ValidatorIndex  # [New in Capella]

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -108,11 +108,11 @@ class ExecutionPayload(Container):
     timestamp: uint64
     extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
     base_fee_per_gas: uint256
-    excess_data_gas: uint256  # [New in Deneb]
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    excess_data_gas: uint256  # [New in Deneb]
 ```
 
 #### `ExecutionPayloadHeader`
@@ -132,11 +132,11 @@ class ExecutionPayloadHeader(Container):
     timestamp: uint64
     extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
     base_fee_per_gas: uint256
-    excess_data_gas: uint256  # [New in Deneb]
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
     transactions_root: Root
     withdrawals_root: Root
+    excess_data_gas: uint256  # [New in Deneb]
 ```
 
 ## Helper functions
@@ -230,10 +230,10 @@ def process_execution_payload(state: BeaconState, payload: ExecutionPayload, exe
         timestamp=payload.timestamp,
         extra_data=payload.extra_data,
         base_fee_per_gas=payload.base_fee_per_gas,
-        excess_data_gas=payload.excess_data_gas,  # [New in Deneb]
         block_hash=payload.block_hash,
         transactions_root=hash_tree_root(payload.transactions),
         withdrawals_root=hash_tree_root(payload.withdrawals),
+        excess_data_gas=payload.excess_data_gas,  # [New in Deneb]
     )
 ```
 

--- a/tests/core/pyspec/eth2spec/test/helpers/capella/fork.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/capella/fork.py
@@ -29,14 +29,12 @@ def run_fork_test(post_spec, pre_state):
         'inactivity_scores',
         # Sync
         'current_sync_committee', 'next_sync_committee',
-        # Execution
-        'latest_execution_payload_header',
     ]
     for field in stable_fields:
         assert getattr(pre_state, field) == getattr(post_state, field)
 
     # Modified fields
-    modified_fields = ['fork']
+    modified_fields = ['fork', 'latest_execution_payload_header']
     for field in modified_fields:
         assert getattr(pre_state, field) != getattr(post_state, field)
 


### PR DESCRIPTION
This keeps the other fields in the same position, to avoid merkle-proof format changes