### PR TITLE
EIP4844: compute_kzg_proof() now takes bytes as input

### DIFF
--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -370,11 +370,22 @@ def verify_kzg_proof_impl(polynomial_kzg: KZGCommitment,
 #### `compute_kzg_proof`
 
 ```python
-def compute_kzg_proof(polynomial: Polynomial, z: BLSFieldElement) -> KZGProof:
+def compute_kzg_proof(blob: Blob, z: Bytes32) -> KZGProof:
     """
-    Compute KZG proof at point `z` with `polynomial` being in evaluation form.
+    Compute KZG proof at point `z` for the polynomial represented by `blob`.
     Do this by computing the quotient polynomial in evaluation form: q(x) = (p(x) - p(z)) / (x - z).
     Public method.
+    """
+    polynomial = blob_to_polynomial(blob)
+    return compute_kzg_proof_impl(polynomial, bytes_to_bls_field(z))
+```
+
+#### `compute_kzg_proof_impl`
+
+```python
+def compute_kzg_proof_impl(polynomial: Polynomial, z: BLSFieldElement) -> KZGProof:
+    """
+    Helper function for compute_kzg_proof().
     """
     y = evaluate_polynomial_in_evaluation_form(polynomial, z)
     polynomial_shifted = [BLSFieldElement((int(p) - int(y)) % BLS_MODULUS) for p in polynomial]
@@ -430,7 +441,7 @@ def compute_aggregate_kzg_proof(blobs: Sequence[Blob]) -> KZGProof:
         blobs,
         commitments
     )
-    return compute_kzg_proof(aggregated_poly, evaluation_challenge)
+    return compute_kzg_proof_impl(aggregated_poly, evaluation_challenge)
 ```
 
 #### `verify_aggregate_kzg_proof`

--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -35,6 +35,7 @@
     - [`verify_kzg_proof`](#verify_kzg_proof)
     - [`verify_kzg_proof_impl`](#verify_kzg_proof_impl)
     - [`compute_kzg_proof`](#compute_kzg_proof)
+    - [`compute_kzg_proof_impl`](#compute_kzg_proof_impl)
     - [`compute_aggregated_poly_and_commitment`](#compute_aggregated_poly_and_commitment)
     - [`compute_aggregate_kzg_proof`](#compute_aggregate_kzg_proof)
     - [`verify_aggregate_kzg_proof`](#verify_aggregate_kzg_proof)
@@ -385,7 +386,7 @@ def compute_kzg_proof(blob: Blob, z: Bytes32) -> KZGProof:
 ```python
 def compute_kzg_proof_impl(polynomial: Polynomial, z: BLSFieldElement) -> KZGProof:
     """
-    Helper function for compute_kzg_proof().
+    Helper function for compute_kzg_proof() and compute_aggregate_kzg_proof().
     """
     y = evaluate_polynomial_in_evaluation_form(polynomial, z)
     polynomial_shifted = [BLSFieldElement((int(p) - int(y)) % BLS_MODULUS) for p in polynomial]

--- a/tests/core/pyspec/eth2spec/test/eip4844/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip4844/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -18,7 +18,7 @@ def test_verify_kzg_proof(spec, state):
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
     polynomial = spec.blob_to_polynomial(blob)
-    proof = spec.compute_kzg_proof(polynomial, x)
+    proof = spec.compute_kzg_proof_impl(polynomial, x)
 
     y = spec.evaluate_polynomial_in_evaluation_form(polynomial, x)
     assert spec.verify_kzg_proof_impl(commitment, x, y, proof)


### PR DESCRIPTION
We are trying to make all public KZG functions take bytes as input. This change should finish this job for all scalars. We might want to do the same for group elements (KZGProof and KZGCommitment) after this.