### PR TITLE
Add on_attester_slashing() to handlers list

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -48,6 +48,7 @@ The head block root associated with a `store` is defined as `get_head(store)`. A
 - `on_tick(store, time)` whenever `time > store.time` where `time` is the current Unix time
 - `on_block(store, block)` whenever a block `block: SignedBeaconBlock` is received
 - `on_attestation(store, attestation)` whenever an attestation `attestation` is received
+- `on_attester_slashing(store, attester_slashing)` whenever an attester slashing `attester_slashing` is received
 
 Any of the above handlers that trigger an unhandled exception (e.g. a failed assert or an out-of-range list access) are considered invalid. Invalid calls to handlers must not modify `store`.
 


### PR DESCRIPTION
When `on_attester_slashing()` was added it seems that the list of handlers at the start of the doc was not updated. This fixes that.