### PR TITLE
EIP4844: Clarify peers should not request blobs beyond range

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -213,7 +213,8 @@ Each _successful_ `response_chunk` MUST contain a single `BlobsSidecar` payload.
 Clients MUST keep a record of signed blobs sidecars seen on the epoch range
 `[max(current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS, DENEB_FORK_EPOCH), current_epoch]`
 where `current_epoch` is defined by the current wall-clock time,
-and clients MUST support serving requests of blobs on this range.
+and clients MUST support serving requests of blobs on this range. Clients MUST not request 
+signed blobs sidecars outside of the range.
 
 Peers that are unable to reply to blobs sidecars requests within the `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS`
 epoch range SHOULD respond with error code `3: ResourceUnavailable`.


### PR DESCRIPTION
We want to clarify the request behavior for `BlobsSidecarsByRange`.  The requester should or must not request blobs outside the retention period. Doing so will result in disconnection from honest peers that serves you `ResourceUnavailable`

cc @realbigsean