### PR TITLE
Compute aggregate kzg proofs now takes the commitments as a parameter.

### DIFF
--- a/specs/eip4844/polynomial-commitments.md
+++ b/specs/eip4844/polynomial-commitments.md
@@ -366,11 +366,10 @@ def compute_aggregated_poly_and_commitment(
 #### `compute_aggregate_kzg_proof`
 
 ```python
-def compute_aggregate_kzg_proof(blobs: Sequence[Blob]) -> KZGProof:
-    commitments = [blob_to_kzg_commitment(blob) for blob in blobs]
+def compute_aggregate_kzg_proof(blobs: Sequence[Blob],kzg_commitments: Sequence[KZGCommitment]) -> KZGProof:
     aggregated_poly, aggregated_poly_commitment, evaluation_challenge = compute_aggregated_poly_and_commitment(
         blobs,
-        commitments
+        kzg_commitments
     )
     return compute_kzg_proof(aggregated_poly, evaluation_challenge)
 ```
@@ -392,3 +391,4 @@ def verify_aggregate_kzg_proof(blobs: Sequence[Blob],
     # Verify aggregated proof
     return verify_kzg_proof(aggregated_poly_commitment, evaluation_challenge, y, kzg_aggregated_proof)
 ```
+

--- a/specs/eip4844/validator.md
+++ b/specs/eip4844/validator.md
@@ -94,7 +94,7 @@ def get_blobs_sidecar(block: BeaconBlock, blobs: Sequence[Blob]) -> BlobsSidecar
         beacon_block_root=hash_tree_root(block),
         beacon_block_slot=block.slot,
         blobs=blobs,
-        kzg_aggregated_proof=compute_aggregate_kzg_proof(blobs),
+        kzg_aggregated_proof=compute_aggregate_kzg_proof(blobs, block.blob_kzg_commitments),
     )
 ```
 
@@ -105,3 +105,4 @@ The validator MUST hold on to sidecars for `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUES
 to ensure the data-availability of these blobs throughout the network.
 
 After `MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS` nodes MAY prune the sidecars and/or stop serving them.
+


### PR DESCRIPTION
This is a draft PR that arose from speaking with Dankrad.

The idea here is that (paraphrasing Dankrad): Each blob transaction will contain the commitment to that blob, so when one is building a block, they do not need to recompute the commitments from the blobs.

Questions to consider:

- Is it okay if we are supplied incorrect KZG commitments (ie what if one supplies the identity point with a kzg commitment)?

- Can we be sure that `block.kzg_commitments` will always contain the commitments in the right order (transaction order)?