### PR TITLE
fix ambiguity of `transactions_root` / `withdrawals_root`

### DIFF
--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -200,7 +200,7 @@ class ExecutionPayloadHeader(Container):
     base_fee_per_gas: uint256
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
-    transactions_root: Root
+    transactions_htr: Root
 ```
 
 ## Helper functions
@@ -365,7 +365,7 @@ def process_execution_payload(state: BeaconState, payload: ExecutionPayload, exe
         extra_data=payload.extra_data,
         base_fee_per_gas=payload.base_fee_per_gas,
         block_hash=payload.block_hash,
-        transactions_root=hash_tree_root(payload.transactions),
+        transactions_htr=hash_tree_root(payload.transactions),
     )
 ```
 

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -179,8 +179,8 @@ class ExecutionPayloadHeader(Container):
     base_fee_per_gas: uint256
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
-    transactions_root: Root
-    withdrawals_root: Root  # [New in Capella]
+    transactions_htr: Root
+    withdrawals_htr: Root  # [New in Capella]
 ```
 
 #### `BeaconBlockBody`
@@ -432,8 +432,8 @@ def process_execution_payload(state: BeaconState, payload: ExecutionPayload, exe
         extra_data=payload.extra_data,
         base_fee_per_gas=payload.base_fee_per_gas,
         block_hash=payload.block_hash,
-        transactions_root=hash_tree_root(payload.transactions),
-        withdrawals_root=hash_tree_root(payload.withdrawals),  # [New in Capella]
+        transactions_htr=hash_tree_root(payload.transactions),
+        withdrawals_htr=hash_tree_root(payload.withdrawals),  # [New in Capella]
     )
 ```
 

--- a/specs/capella/fork.md
+++ b/specs/capella/fork.md
@@ -84,8 +84,8 @@ def upgrade_to_capella(pre: bellatrix.BeaconState) -> BeaconState:
         extra_data=pre.latest_execution_payload_header.extra_data,
         base_fee_per_gas=pre.latest_execution_payload_header.base_fee_per_gas,
         block_hash=pre.latest_execution_payload_header.block_hash,
-        transactions_root=pre.latest_execution_payload_header.transactions_root,
-        withdrawals_root=Root(),  # [New in Capella]
+        transactions_htr=pre.latest_execution_payload_header.transactions_htr,
+        withdrawals_htr=Root(),  # [New in Capella]
     )
     post = BeaconState(
         # Versioning

--- a/specs/capella/light-client/full-node.md
+++ b/specs/capella/light-client/full-node.md
@@ -52,13 +52,13 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
             extra_data=payload.extra_data,
             base_fee_per_gas=payload.base_fee_per_gas,
             block_hash=payload.block_hash,
-            transactions_root=hash_tree_root(payload.transactions),
-            withdrawals_root=hash_tree_root(payload.withdrawals),
+            transactions_htr=hash_tree_root(payload.transactions),
+            withdrawals_htr=hash_tree_root(payload.withdrawals),
         )
         execution_branch = compute_merkle_proof_for_block_body(block.message.body, EXECUTION_PAYLOAD_INDEX)
     else:
         # Note that during fork transitions, `finalized_header` may still point to earlier forks.
-        # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_root`),
+        # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_htr`),
         # it was not included in the corresponding light client data. To ensure compatibility
         # with legacy data going through `upgrade_lc_header_to_capella`, leave out execution data.
         execution_header = ExecutionPayloadHeader()

--- a/specs/eip4844/beacon-chain.md
+++ b/specs/eip4844/beacon-chain.md
@@ -135,8 +135,8 @@ class ExecutionPayloadHeader(Container):
     excess_data_gas: uint256  # [New in EIP-4844]
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
-    transactions_root: Root
-    withdrawals_root: Root
+    transactions_htr: Root
+    withdrawals_htr: Root
 ```
 
 ## Helper functions
@@ -232,8 +232,8 @@ def process_execution_payload(state: BeaconState, payload: ExecutionPayload, exe
         base_fee_per_gas=payload.base_fee_per_gas,
         excess_data_gas=payload.excess_data_gas,  # [New in EIP-4844]
         block_hash=payload.block_hash,
-        transactions_root=hash_tree_root(payload.transactions),
-        withdrawals_root=hash_tree_root(payload.withdrawals),
+        transactions_htr=hash_tree_root(payload.transactions),
+        withdrawals_htr=hash_tree_root(payload.withdrawals),
     )
 ```
 

--- a/specs/eip4844/fork.md
+++ b/specs/eip4844/fork.md
@@ -84,8 +84,8 @@ def upgrade_to_eip4844(pre: capella.BeaconState) -> BeaconState:
         base_fee_per_gas=pre.latest_execution_payload_header.base_fee_per_gas,
         excess_data_gas=uint256(0),  # [New in EIP-4844]
         block_hash=pre.latest_execution_payload_header.block_hash,
-        transactions_root=pre.latest_execution_payload_header.transactions_root,
-        withdrawals_root=pre.latest_execution_payload_header.withdrawals_root,
+        transactions_htr=pre.latest_execution_payload_header.transactions_htr,
+        withdrawals_htr=pre.latest_execution_payload_header.withdrawals_htr,
     )
     post = BeaconState(
         # Versioning

--- a/specs/eip4844/light-client/fork.md
+++ b/specs/eip4844/light-client/fork.md
@@ -39,8 +39,8 @@ def upgrade_lc_header_to_eip4844(pre: capella.LightClientHeader) -> LightClientH
             extra_data=pre.execution.extra_data,
             base_fee_per_gas=pre.execution.base_fee_per_gas,
             block_hash=pre.execution.block_hash,
-            transactions_root=pre.execution.transactions_root,
-            withdrawals_root=pre.execution.withdrawals_root,
+            transactions_htr=pre.execution.transactions_htr,
+            withdrawals_htr=pre.execution.withdrawals_htr,
         ),
         execution_branch=pre.execution_branch,
     )

--- a/specs/eip4844/light-client/full-node.md
+++ b/specs/eip4844/light-client/full-node.md
@@ -43,8 +43,8 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
             extra_data=payload.extra_data,
             base_fee_per_gas=payload.base_fee_per_gas,
             block_hash=payload.block_hash,
-            transactions_root=hash_tree_root(payload.transactions),
-            withdrawals_root=hash_tree_root(payload.withdrawals),
+            transactions_htr=hash_tree_root(payload.transactions),
+            withdrawals_htr=hash_tree_root(payload.withdrawals),
         )
 
         # [New in EIP4844]
@@ -54,7 +54,7 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
         execution_branch = compute_merkle_proof_for_block_body(block.message.body, EXECUTION_PAYLOAD_INDEX)
     else:
         # Note that during fork transitions, `finalized_header` may still point to earlier forks.
-        # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_root`),
+        # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_htr`),
         # it was not included in the corresponding light client data. To ensure compatibility
         # with legacy data going through `upgrade_lc_header_to_capella`, leave out execution data.
         execution_header = ExecutionPayloadHeader()

--- a/specs/eip4844/light-client/sync-protocol.md
+++ b/specs/eip4844/light-client/sync-protocol.md
@@ -52,8 +52,8 @@ def get_lc_execution_root(header: LightClientHeader) -> Root:
             extra_data=header.execution.extra_data,
             base_fee_per_gas=header.execution.base_fee_per_gas,
             block_hash=header.execution.block_hash,
-            transactions_root=header.execution.transactions_root,
-            withdrawals_root=header.execution.withdrawals_root,
+            transactions_htr=header.execution.transactions_htr,
+            withdrawals_htr=header.execution.withdrawals_htr,
         )
         return hash_tree_root(execution_header)
 

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -411,6 +411,6 @@ def process_execution_payload(state: BeaconState, block: BeaconBlock, execution_
             extra_data=payload.extra_data,
             base_fee_per_gas=payload.base_fee_per_gas,
             block_hash=payload.block_hash,
-            transactions_root=hash_tree_root(payload.transactions),
+            transactions_htr=hash_tree_root(payload.transactions),
         )
 ```

--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -273,7 +273,7 @@ def run_non_empty_transactions_test(spec, state):
     execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
-    assert state.latest_execution_payload_header.transactions_root == execution_payload.transactions.hash_tree_root()
+    assert state.latest_execution_payload_header.transactions_htr == execution_payload.transactions.hash_tree_root()
 
 
 @with_bellatrix_and_later
@@ -299,7 +299,7 @@ def run_zero_length_transaction_test(spec, state):
     execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
-    assert state.latest_execution_payload_header.transactions_root == execution_payload.transactions.hash_tree_root()
+    assert state.latest_execution_payload_header.transactions_htr == execution_payload.transactions.hash_tree_root()
 
 
 @with_bellatrix_and_later

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -22,10 +22,10 @@ def get_execution_payload_header(spec, execution_payload):
         extra_data=execution_payload.extra_data,
         base_fee_per_gas=execution_payload.base_fee_per_gas,
         block_hash=execution_payload.block_hash,
-        transactions_root=spec.hash_tree_root(execution_payload.transactions)
+        transactions_htr=spec.hash_tree_root(execution_payload.transactions)
     )
     if is_post_capella(spec):
-        payload_header.withdrawals_root = spec.hash_tree_root(execution_payload.withdrawals)
+        payload_header.withdrawals_htr = spec.hash_tree_root(execution_payload.withdrawals)
     if is_post_eip4844(spec):
         payload_header.excess_data_gas = execution_payload.excess_data_gas
     return payload_header

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -43,7 +43,7 @@ def get_sample_genesis_execution_payload_header(spec,
         gas_limit=30000000,
         base_fee_per_gas=1000000000,
         block_hash=eth1_block_hash,
-        transactions_root=spec.Root(b'\x56' * 32),
+        transactions_htr=spec.Root(b'\x56' * 32),
     )
 
     transactions_trie_root = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")


### PR DESCRIPTION
When using JSON-RPC to interact with execution-APIs such as `eth_getBlockByNumber` / `eth_getBlockByRoot`, the response contains a `transactionsRoot` representing the MPT root in EL block header. https://github.com/ethereum/execution-apis/blob/b7c5d3420e00648f456744d121ffbd929862924d/src/schemas/block.yaml#L35

When selecting JSON to interact with beacon-APIs such as `/eth/v1/beacon/light_client/updates`, the response contains a `transactions_root` representing the SSZ root in CL payload header.

This is confusing for clients accessing both CL and EL APIs, as "transactions root" has a different meaning depending on source. Furthermore, it leads to naming collisions when exploring potential designs that include both the MPT and SSZ roots in the EL block header.

This proposal renames the `transactions_root` and `withdrawals_root` in `ExecutionPayloadHeader` to `transactions_htr` and `withdrawals_htr` to distinguish their SSZ `hash_tree_root` basis from the MPT roots. This means, that, inside `ExecutionPayloadHeader`, and `_root` fields (the `receipts_root` and the `state_root`) refer to MPT roots, and any `_htr` fields (the `transactions_htr` and `withdrawals_htr`) are SSZ.

Risk analysis:

- Consensus, libp2p networking, and SSZ encoding are all unaffected.

- Engine API is unaffected (it doesn't exchange roots).

- The execution-APIs are used by popular applications, so changing the `transactionsRoot` name in the `eth_getBlockByXyz` endpoints would be a breaking change. Renaming the SSZ roots is less breaking.

- The beacon-APIs up through Bellatrix only expose `transactions_root` in the JSON version of `/eth/v2/debug/beacon/states/{state_id}`. However, practical implementations use the (unaffected) SSZ version of this endpoint, as it has a significantly more compact response.

- Capella extends the beacon-APIs light client REST endpoints with the CL `ExecutionPayloadHeader`. These APIs are not yet released.
  - `/eth/v1/beacon/light_client/bootstrap/{block_root}`
  - `/eth/v1/beacon/light_client/updates`
  - `/eth/v1/beacon/light_client/finality_update`
  - `/eth/v1/beacon/light_client/optimistic_update`
  - `/eth/v1/events?topics=light_client_finality_update`
  - `/eth/v1/events?topics=light_client_optimistic_update`