### PR TITLE
Simplify commitee weight computation

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -194,10 +194,7 @@ def get_latest_attesting_balance(store: Store, root: Root) -> Gwei:
     proposer_score = Gwei(0)
     # Boost is applied if ``root`` is an ancestor of ``proposer_boost_root``
     if get_ancestor(store, store.proposer_boost_root, store.blocks[root].slot) == root:
-        num_validators = len(get_active_validator_indices(state, get_current_epoch(state)))
-        avg_balance = get_total_active_balance(state) // num_validators
-        committee_size = num_validators // SLOTS_PER_EPOCH
-        committee_weight = committee_size * avg_balance
+        committee_weight = get_total_active_balance(state) // SLOTS_PER_EPOCH
         proposer_score = (committee_weight * PROPOSER_SCORE_BOOST) // 100
     return attestation_score + proposer_score
 


### PR DESCRIPTION
Simplify unnecessary divisions since there is no possible overflow 