### PR TITLE
More readable and less complex process_inactivity_scores

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -611,11 +611,12 @@ def process_inactivity_updates(state: BeaconState) -> None:
     if get_current_epoch(state) == GENESIS_EPOCH:
         return
 
-    unslashed_validator_indicies = get_unslashed_participating_indices(state, TIMELY_TARGET_FLAG_INDEX, get_previous_epoch(state))
+    previous_epoch = get_previous_epoch(state)
+    matching_target_indices = get_unslashed_participating_indices(state, TIMELY_TARGET_FLAG_INDEX, previous_epoch)
 
     for index in get_eligible_validator_indices(state):
         # Increase the inactivity score of inactive validators
-        if index in unslashed_validator_indicies:
+        if index in matching_target_indices:
             state.inactivity_scores[index] -= min(1, state.inactivity_scores[index])
         else:
             state.inactivity_scores[index] += INACTIVITY_SCORE_BIAS

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -611,9 +611,10 @@ def process_inactivity_updates(state: BeaconState) -> None:
     if get_current_epoch(state) == GENESIS_EPOCH:
         return
 
+    unslashed_validator_indicies = get_unslashed_participating_indices(state, TIMELY_TARGET_FLAG_INDEX, get_previous_epoch(state))
     for index in get_eligible_validator_indices(state):
         # Increase the inactivity score of inactive validators
-        if index in get_unslashed_participating_indices(state, TIMELY_TARGET_FLAG_INDEX, get_previous_epoch(state)):
+        if index in unslashed_validator_indicies:
             state.inactivity_scores[index] -= min(1, state.inactivity_scores[index])
         else:
             state.inactivity_scores[index] += INACTIVITY_SCORE_BIAS

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -612,6 +612,7 @@ def process_inactivity_updates(state: BeaconState) -> None:
         return
 
     unslashed_validator_indicies = get_unslashed_participating_indices(state, TIMELY_TARGET_FLAG_INDEX, get_previous_epoch(state))
+
     for index in get_eligible_validator_indices(state):
         # Increase the inactivity score of inactive validators
         if index in unslashed_validator_indicies:


### PR DESCRIPTION
This PR does 2 things:
* make process_inactivity_scores more readable.
* Reduce algorithmic complexity from O(N^3) to O(N^2).

The algorithmic complexity part has been bothering me but feel free to ignore if deemed as non-important :).