### PR TITLE
 WIP: Add parent_slot to block, attestation, elsewhere 

### DIFF
--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -97,7 +97,23 @@ class BeaconBlockBody(Container):
     execution_payload: ExecutionPayload  # [Modified in Deneb]
     bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
     blob_kzg_commitments: List[KZGCommitment, MAX_BLOBS_PER_BLOCK]  # [New in Deneb]
+    parent_slot: Slot # New in deneb
 ```
+
+#### `AttestationData2`
+
+```python
+class AttestationData2(Container):
+    slot: Slot
+    index: CommitteeIndex
+    # LMD GHOST vote
+    beacon_block_root: Root
+    # FFG vote
+    source: Checkpoint
+    target_block_root: Root
+    beacon_block_slot: Slot  # Slot of the beacon_block_root
+```
+
 
 #### `ExecutionPayload`
 


### PR DESCRIPTION
A recurring problem of validating blocks and attestations is that the
slot of a given block root is unknown until the block itself has been
downloaded.

This is problematic because clients, when seeing an unknown block root,
must start looking for it with neighbours not knowing that the block is
already obsolete.

For example, when receiving a block or attestation with a *recent* slot
but unknown parent/block, clients must attempt to reconstruct the given
history - if the history has been orphaned (due to finalization), this
is not possible to do, but clients still waste resources and security
margin on the attempt, including quarantine spots (where blocks are held
while the parent is being resolved) and bandwidth.

An important note is that such histories are valid on the network in
general: for example, a client that is syncing may not yet have seen the
history that finalizes a block and may therefore choose to build on it,
thinking that it's the most recent head, even though the network
globally has progressed and orphaned it - such a history cannot be
discarded trivially.

Adding slot information resolves this problem - this PR shows
conceptually what the changes could look like.

`Attestation` in particular is currently redundantly encoded - because
attestations take up significant bandwidth on the network, the PR takes
care not to increase the size of the object.

This is a WIP PR to show conceptually what the change could look like - it currently builds on top of https://github.com/ethereum/consensus-specs/pull/3244, the interesting commit being https://github.com/ethereum/consensus-specs/commit/e838be5207fd172ef7beecab0c0375fe74d67139