### PR TITLE
Change get_latest_attesting_balance() to get_weight()

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -18,7 +18,7 @@
     - [`get_current_slot`](#get_current_slot)
     - [`compute_slots_since_epoch_start`](#compute_slots_since_epoch_start)
     - [`get_ancestor`](#get_ancestor)
-    - [`get_latest_attesting_balance`](#get_latest_attesting_balance)
+    - [`get_weight`](#get_weight)
     - [`filter_block_tree`](#filter_block_tree)
     - [`get_filtered_block_tree`](#get_filtered_block_tree)
     - [`get_head`](#get_head)
@@ -174,10 +174,10 @@ def get_ancestor(store: Store, root: Root, slot: Slot) -> Root:
         return root
 ```
 
-#### `get_latest_attesting_balance`
+#### `get_weight`
 
 ```python
-def get_latest_attesting_balance(store: Store, root: Root) -> Gwei:
+def get_weight(store: Store, root: Root) -> Gwei:
     state = store.checkpoint_states[store.justified_checkpoint]
     active_indices = get_active_validator_indices(state, get_current_epoch(state))
     attestation_score = Gwei(sum(
@@ -197,7 +197,6 @@ def get_latest_attesting_balance(store: Store, root: Root) -> Gwei:
         committee_weight = get_total_active_balance(state) // SLOTS_PER_EPOCH
         proposer_score = (committee_weight * PROPOSER_SCORE_BOOST) // 100
     return attestation_score + proposer_score
-
 ```
 
 #### `filter_block_tree`
@@ -270,7 +269,7 @@ def get_head(store: Store) -> Root:
             return head
         # Sort by latest attesting balance with ties broken lexicographically
         # Ties broken by favoring block with lexicographically higher root
-        head = max(children, key=lambda root: (get_latest_attesting_balance(store, root), root))
+        head = max(children, key=lambda root: (get_weight(store, root), root))
 ```
 
 #### `should_update_justified_checkpoint`

--- a/tests/core/pyspec/eth2spec/test/helpers/optimistic_sync.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/optimistic_sync.py
@@ -177,7 +177,7 @@ def get_opt_head_block_root(spec, mega_store):
             return head
         # Sort by latest attesting balance with ties broken lexicographically
         # Ties broken by favoring block with lexicographically higher root
-        head = max(children, key=lambda root: (spec.get_latest_attesting_balance(store, root), root))
+        head = max(children, key=lambda root: (spec.get_weight(store, root), root))
 
 
 def is_invalidated(mega_store, block_root):

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
@@ -729,14 +729,14 @@ def test_proposer_boost(spec, state):
     on_tick_and_append_step(spec, store, time, test_steps)
     yield from add_block(spec, store, signed_block, test_steps)
     assert store.proposer_boost_root == spec.hash_tree_root(block)
-    assert spec.get_latest_attesting_balance(store, spec.hash_tree_root(block)) > 0
+    assert spec.get_weight(store, spec.hash_tree_root(block)) > 0
 
     # Ensure that boost is removed after slot is over
     time = (store.genesis_time + block.slot * spec.config.SECONDS_PER_SLOT +
             spec.config.SECONDS_PER_SLOT)
     on_tick_and_append_step(spec, store, time, test_steps)
     assert store.proposer_boost_root == spec.Root()
-    assert spec.get_latest_attesting_balance(store, spec.hash_tree_root(block)) == 0
+    assert spec.get_weight(store, spec.hash_tree_root(block)) == 0
 
     next_slots(spec, state, 3)
     block = build_empty_block_for_next_slot(spec, state)
@@ -747,14 +747,14 @@ def test_proposer_boost(spec, state):
     on_tick_and_append_step(spec, store, time, test_steps)
     yield from add_block(spec, store, signed_block, test_steps)
     assert store.proposer_boost_root == spec.hash_tree_root(block)
-    assert spec.get_latest_attesting_balance(store, spec.hash_tree_root(block)) > 0
+    assert spec.get_weight(store, spec.hash_tree_root(block)) > 0
 
     # Ensure that boost is removed after slot is over
     time = (store.genesis_time + block.slot * spec.config.SECONDS_PER_SLOT +
             spec.config.SECONDS_PER_SLOT)
     on_tick_and_append_step(spec, store, time, test_steps)
     assert store.proposer_boost_root == spec.Root()
-    assert spec.get_latest_attesting_balance(store, spec.hash_tree_root(block)) == 0
+    assert spec.get_weight(store, spec.hash_tree_root(block)) == 0
 
     test_steps.append({
         'checks': {


### PR DESCRIPTION
Proposal to rename `get_latest_attesting_balance()` in the fork choice to `get_weight()`.

I am trying to write about this function, and it's frustratingly difficult since the name "latest attesting balance" is quite ambiguous.

A few reasons:

  - "Weight" better reflects this quantity's role in the protocol. It chimes with the "heaviest" in GHOST.
  - Validators attest to a block directly, and only implicitly to its ancestors. This is the origin of the ambiguity - I want to distinguish between the direct latest attesting balance of a block (those validators who attested to that block), and the latest attesting balance in the sense of this function, which is the sum of all those direct latest attesting balances for all its descendants. It's all quite cumbersome. Calling the latter the block's weight would be much simpler.
  - Now that we have included proposer boost in the calculation, "latest attesting balance" is not really accurate any more.