### PR TITLE
Fix `compute_quotient_eval_within_domain` overflow

### DIFF
--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -459,7 +459,7 @@ def compute_quotient_eval_within_domain(z: BLSFieldElement,
         f_i = int(BLS_MODULUS) + int(polynomial[i]) - int(y) % BLS_MODULUS
         numerator = f_i * int(omega_i) % BLS_MODULUS
         denominator = int(z) * (int(BLS_MODULUS) + int(z) - int(omega_i)) % BLS_MODULUS
-        result += div(BLSFieldElement(numerator), BLSFieldElement(denominator))
+        result += int(div(BLSFieldElement(numerator), BLSFieldElement(denominator)))
 
     return BLSFieldElement(result % BLS_MODULUS)
 ```


### PR DESCRIPTION
Found in #3255

Test case:
```
cd tests/core/pyspec
pytest eth2spec/test/deneb/unittests/polynomial_commitments/test_polynomial_commitments.py::test_compute_kzg_proof_within_domain --preset=mainnet
```

`for i, z in enumerate(roots_of_unity_brp)` is 4096 iterations. My miserable laptop still couldn't run through this test case with the mainnet preset. 


