### PR TITLE
Allow slashable messages to propagate via gossip until slashing

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -309,7 +309,7 @@ The following validations MUST pass before forwarding the `signed_beacon_block` 
 - _[IGNORE]_ The block is from a slot greater than the latest finalized slot --
   i.e. validate that `signed_beacon_block.message.slot > compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)`
   (a client MAY choose to validate and store such blocks for additional purposes -- e.g. slashing detection, archive nodes, etc).
-- _[IGNORE]_ The block is the first block with valid signature received for the proposer for the slot, `signed_beacon_block.message.slot`.
+- _[IGNORE]_ A valid slashing message has been observed for the proposer.
 - _[REJECT]_ The proposer signature, `signed_beacon_block.signature`, is valid with respect to the `proposer_index` pubkey.
 - _[IGNORE]_ The block's parent (defined by `block.parent_root`) has been seen
   (via both gossip and non-gossip sources)
@@ -417,8 +417,7 @@ The following validations MUST pass before forwarding the `attestation` on the s
   that is, it has exactly one participating validator (`len([bit for bit in attestation.aggregation_bits if bit]) == 1`, i.e. exactly 1 bit is set).
 - _[REJECT]_ The number of aggregation bits matches the committee size -- i.e.
   `len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot, data.index))`.
-- _[IGNORE]_ There has been no other valid attestation seen on an attestation subnet
-  that has an identical `attestation.data.target.epoch` and participating validator index.
+- _[IGNORE]_ A valid slashing message has been observed for the validator.
 - _[REJECT]_ The signature of `attestation` is valid.
 - _[IGNORE]_ The block being voted for (`attestation.data.beacon_block_root`) has been seen
   (via both gossip and non-gossip sources)


### PR DESCRIPTION
When a validator signs multiple blocks / attestations, they may get slashed. However, current gossip rules actually prevent such messages from propagating through the gossip network due to "first message" validity conditions:

> [IGNORE] The block is the first block with valid signature received
for the proposer for the slot, signed_beacon_block.message.slot.

https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#beacon_block

Using block as example, this enables the proposer to send one block to some participants, the other block to the other participants and potentially create a temporarily split network where only "border" nodes see both: the IGNORE rule will prevent the propagation of either of the two blocks throughout the network and thus potentially prevent them from reaching slashers.

Further, the block will also be dropped at the libp2p gossipsub level - `IGNORE` messages are added to the gossipsub "seen" list which keeps track of hashes of messages seen (so they are dropped if seen more than once), but they are not added to the message cache which enables the secondary IHAVE/IWANT distribution mechanism of gossipsub.

Thus, the only way to observe the duplicate of a block is to observe a follow-up (such as an attestation, aggregate or child) and try to download it via `ByRoot`, hoping that a neighbour has seen it which is unlikely - this slow recovery mechanism _may_ cause short-term disruptions in the network as peers strive to recover while more blocks get built on top of either of the two blocks or their parents.

It's important to note that the `seen_ttl` setting of gossipsub already ensures that we don't propagate *the same* message more than once - ie it's already not possible to spam the network by repeating an identical message over and over.

This change only covers slashable conditions - the "first-message" condition still applies to messages that don't carry slashing conditions (ie aggregates, sync committee messages etc) - for those, we hope that validators are honest in signing only one but should they choose to sign more than one, they cannot be used to DoS the network.

This rule also allows nodes to *replace* a block / attestation with a slashing message and propagate the slashing message instead of the offender and thus effectively represents a very similar IGNORE condition, albeit with more teeth.