### PR TITLE
Add fork type clarifications for light client headers while constructing light client data

### DIFF
--- a/specs/capella/light-client/full-node.md
+++ b/specs/capella/light-client/full-node.md
@@ -93,8 +93,8 @@ Full nodes SHOULD continue deriving the `LightClientUpdate` for each sync commit
 Full nodes SHOULD continue deriving the `LightClientFinalityUpdate` as per the altair specs but with the modified or upgraded `attested_header` and `finalized_header` with the following considerations:
 
 - Both `attested_header` and `finalized_header` are of the same fork types as `LightClientFinalityUpdate` and might need upgradation to bundle as update.
-- Above implies that the first update of capella MIGHT have both `attested_header` and `finalized_header` upgraded (if capella hardfork coincides with a finalization event) as they might belong to pre-capella epochs. Post this `finalized_header` will beed upgradation till a new finalization occurs in capella.
-- Over the wire, the fork infomation of transmitted data might be available (like fork `version` in beacon-apis or fork `context` in req/resp or fork gossip `topics` )
+- Above implies that the first update of capella MIGHT have both `attested_header` and `finalized_header` upgraded (if capella hardfork coincides with a finalization event) as they might belong to pre-capella epochs. Post this `finalized_header` will be upgradation till a new finalization occurs in capella.
+- Over the wire, the fork information of transmitted data might be available (like fork `version` in beacon-apis or fork `context` in req/resp or fork gossip `topics` )
  - However `LightClientFinalityUpdate`'s base fork can be assumed belonging to `attested_header`'s slot and can be used to store data without loss of information.
 
 ### `create_light_client_optimistic_update`
@@ -102,5 +102,5 @@ Full nodes SHOULD continue deriving the `LightClientFinalityUpdate` as per the a
 Full nodes should continue providing the `LightClientOptimisticUpdate` as per the altair specs but with the modified or upgraded `attested_header` with following considerations:
 
 - `attested_header` is to be constructed/upgraded of the same fork type as `LightClientOptimisticUpdate` and WILL need upgradation on the first update of the capella hardfork as the header will belong to a previous epoch.
-- Over the wire, the fork infomation of transmitted data might be available (like fork `version` in beacon-apis or fork `context` in req/resp or fork gossip `topics` )
+- Over the wire, the fork information of transmitted data might be available (like fork `version` in beacon-apis or fork `context` in req/resp or fork gossip `topics` )
 - However `LightClientFinalityUpdate`'s base fork can be assumed belonging to `attested_header`'s slot and can be used to store data without loss of information.

--- a/specs/capella/light-client/full-node.md
+++ b/specs/capella/light-client/full-node.md
@@ -76,3 +76,31 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
         execution_branch=execution_branch,
     )
 ```
+
+## Deriving light client data
+
+### `create_light_client_update`
+
+Full nodes SHOULD continue deriving the `LightClientUpdate` for each sync committee period as per the altair specs but with the modified or upgraded `attested_header` and `finalized_header` with the following considerations:
+
+- Both `attested_header` and `finalized_header` are of the same fork types as `LightClientUpdate` and might need upgradation to bundle as update.
+- Above implies that the first update of capella MIGHT have both `attested_header` and `finalized_header` upgraded (if capella hardfork coincides with a new period) as they might belong to pre-capella epochs. Post this `finalized_header` will need upgradation till a new finalization occurs in capella.
+- Over the wire, the fork information of transmitted data might be available (like fork `version` in beacon-apis or fork `context` in req/resp or fork gossip `topics`)
+- However `LightClientUpdate`'s base fork can be assumed belonging to `attested_header`'s slot and can be used to store data without loss of information.
+
+### `create_light_client_finality_update`
+
+Full nodes SHOULD continue deriving the `LightClientFinalityUpdate` as per the altair specs but with the modified or upgraded `attested_header` and `finalized_header` with the following considerations:
+
+- Both `attested_header` and `finalized_header` are of the same fork types as `LightClientFinalityUpdate` and might need upgradation to bundle as update.
+- Above implies that the first update of capella MIGHT have both `attested_header` and `finalized_header` upgraded (if capella hardfork coincides with a finalization event) as they might belong to pre-capella epochs. Post this `finalized_header` will beed upgradation till a new finalization occurs in capella.
+- Over the wire, the fork infomation of transmitted data might be available (like fork `version` in beacon-apis or fork `context` in req/resp or fork gossip `topics` )
+ - However `LightClientFinalityUpdate`'s base fork can be assumed belonging to `attested_header`'s slot and can be used to store data without loss of information.
+
+### `create_light_client_optimistic_update`
+
+Full nodes should continue providing the `LightClientOptimisticUpdate` as per the altair specs but with the modified or upgraded `attested_header` with following considerations:
+
+- `attested_header` is to be constructed/upgraded of the same fork type as `LightClientOptimisticUpdate` and WILL need upgradation on the first update of the capella hardfork as the header will belong to a previous epoch.
+- Over the wire, the fork infomation of transmitted data might be available (like fork `version` in beacon-apis or fork `context` in req/resp or fork gossip `topics` )
+- However `LightClientFinalityUpdate`'s base fork can be assumed belonging to `attested_header`'s slot and can be used to store data without loss of information.

--- a/specs/deneb/light-client/full-node.md
+++ b/specs/deneb/light-client/full-node.md
@@ -72,3 +72,18 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
         execution_branch=execution_branch,
     )
 ```
+
+## Deriving light client data
+
+### `create_light_client_update`
+
+Full nodes SHOULD continue deriving `LightClientUpdate` best update for each sync committee period as per the capella specs but with the modified or upgraded `attested_header` and `finalized_header` with the similar fork considerations as of capella specs.
+
+
+### `create_light_client_finality_update`
+
+Full nodes SHOULD continue deriving the `LightClientFinalityUpdate` as per the capella specs but with the modified or upgraded `attested_header` and `finalized_header` with the similar fork considerations as of capella specs.
+
+### `create_light_client_optimistic_update`
+
+Full nodes should continue providing the `LightClientOptimisticUpdate` as per the capella specs but with the modified or upgraded `attested_header` with the similar fork considerations as of capella specs.


### PR DESCRIPTION
Since there could be some confusion wile constructing the light client data especially at fork boundaries, this PR attempts to add some clarifications which were discussed in the R&D discord light client channel with @etan-status and others.