### PR TITLE
fix MAX_REQUEST_BLOBS_SIDECARS typo

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -183,7 +183,7 @@ Request Content:
 
 ```
 (
-  List[BlobIdentifier, MAX_REQUEST_BLOBS_SIDECARS * MAX_BLOBS_PER_BLOCK]
+  List[BlobIdentifier, MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK]
 )
 ```
 
@@ -191,7 +191,7 @@ Response Content:
 
 ```
 (
-  List[BlobSidecar, MAX_REQUEST_BLOBS_SIDECARS * MAX_BLOBS_PER_BLOCK]
+  List[BlobSidecar, MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK]
 )
 ```
 
@@ -202,7 +202,7 @@ It may be less in the case that the responding peer is missing blocks or sidecar
 The response is unsigned, i.e. `BlobSidecar`, as the signature of the beacon block proposer
 may not be available beyond the initial distribution via gossip.
 
-No more than `MAX_REQUEST_BLOBS_SIDECARS * MAX_BLOBS_PER_BLOCK` may be requested at a time.
+No more than `MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK` may be requested at a time.
 
 `BlobSidecarsByRoot` is primarily used to recover recent blobs (e.g. when receiving a block with a transaction whose corresponding blob is missing).
 


### PR DESCRIPTION
There is a small typo in the p2p spec -
`MAX_REQUEST_BLOBS_SIDECARS` should be spelled
`MAX_REQUEST_BLOB_SIDECARS`.