### PR TITLE
Refactor `Makefile`: only list the spec names once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,10 @@ GENERATOR_VENVS = $(patsubst $(GENERATOR_DIR)/%, $(GENERATOR_DIR)/%venv, $(GENER
 # To check generator matching:
 #$(info $$GENERATOR_TARGETS is [${GENERATOR_TARGETS}])
 
-MARKDOWN_FILES = $(wildcard $(SPEC_DIR)/phase0/*.md) \
-                 $(wildcard $(SPEC_DIR)/altair/*.md) $(wildcard $(SPEC_DIR)/altair/**/*.md) \
-                 $(wildcard $(SPEC_DIR)/bellatrix/*.md) \
-                 $(wildcard $(SPEC_DIR)/capella/*.md) $(wildcard $(SPEC_DIR)/capella/**/*.md) \
-                 $(wildcard $(SPEC_DIR)/deneb/*.md) $(wildcard $(SPEC_DIR)/deneb/**/*.md) \
-                 $(wildcard $(SPEC_DIR)/_features/custody/*.md) \
-                 $(wildcard $(SPEC_DIR)/_features/das/*.md) \
-                 $(wildcard $(SPEC_DIR)/_features/sharding/*.md) \
+MARKDOWN_FILES = $(wildcard $(SPEC_DIR)/*/*.md) \
+                 $(wildcard $(SPEC_DIR)/*/*/*.md) \
+                 $(wildcard $(SPEC_DIR)/_features/*/*.md) \
+                 $(wildcard $(SPEC_DIR)/_features/*/*/*.md) \
                  $(wildcard $(SSZ_DIR)/*.md)
 
 ALL_EXECUTABLE_SPECS = phase0 altair bellatrix capella deneb


### PR DESCRIPTION
### Issue
Every time I added a new spec, I forget to add it to the linter and test coverage scope.

### How did I fix it

Add a list `ALL_EXECUTABLE_SPECS = phase0 altair bellatrix capella deneb`. So we only have to update this variable for future specs.

~~Note: we still have to manually update `MARKDOWN_FILES` content because the paths differ.~~