### PR TITLE
change MAY to MUST for bbr request with step greater than 1

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -743,7 +743,7 @@ For example, requesting blocks starting at `start_slot=2` and `count=4` would re
 In cases where a slot is empty for a given slot number, no block is returned.
 For example, if slot 4 were empty in the previous example, the returned array would contain `[2, 3, 5]`.
 
-`step` is deprecated and must be set to 1. Clients may respond with a single block if a larger step is returned during the deprecation transition period.
+`step` is deprecated and must be set to 1. Clients MUST respond with a single block if a larger step is returned during the deprecation transition period.
 
 `/eth2/beacon_chain/req/beacon_blocks_by_range/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 


### PR DESCRIPTION
This PR seeks to clarify how clients handle BBR requests when the deprecated step parameter is greater than 1. See [2856](https://github.com/ethereum/consensus-specs/pull/2856)