### PR TITLE
Modify compute_[blob_]kzg_proof to remove superfluous computations

### DIFF
--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -501,7 +501,7 @@ def compute_kzg_proof_impl(polynomial: Polynomial, z: BLSFieldElement) -> Tuple[
 #### `compute_blob_kzg_proof`
 
 ```python
-def compute_blob_kzg_proof(blob: Blob, commitment_bytes: Bytes32) -> KZGProof:
+def compute_blob_kzg_proof(blob: Blob, commitment_bytes: Bytes48) -> KZGProof:
     """
     Given a blob, return the KZG proof that is used to verify it against the commitment.
     This method does not verify that the commitment is correct with respect to `blob`.

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -510,7 +510,7 @@ def compute_blob_kzg_proof(blob: Blob, commitment_bytes: Bytes48) -> KZGProof:
     commitment = bytes_to_kzg_commitment(commitment_bytes)
     polynomial = blob_to_polynomial(blob)
     evaluation_challenge = compute_challenge(blob, commitment)
-    proof, y = compute_kzg_proof_impl(polynomial, evaluation_challenge)
+    proof, _ = compute_kzg_proof_impl(polynomial, evaluation_challenge)
     return proof
 ```
 

--- a/specs/deneb/validator.md
+++ b/specs/deneb/validator.md
@@ -96,7 +96,7 @@ def get_blob_sidecars(block: BeaconBlock, blobs: Sequence[Blob]) -> Sequence[Blo
             block_parent_root=block.parent_root,
             blob=blob,
             kzg_commitment=block.body.blob_kzg_commitments[index],
-            kzg_proof=compute_blob_kzg_proof(blob),
+            kzg_proof=compute_blob_kzg_proof(blob, block.body.blob_kzg_commitments[index]),
         )
         for index, blob in enumerate(blobs)
     ]

--- a/tests/core/pyspec/eth2spec/test/deneb/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -18,9 +18,8 @@ def test_verify_kzg_proof(spec, state):
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
     polynomial = spec.blob_to_polynomial(blob)
-    proof = spec.compute_kzg_proof_impl(polynomial, x)
+    proof, y = spec.compute_kzg_proof_impl(polynomial, x)
 
-    y = spec.evaluate_polynomial_in_evaluation_form(polynomial, x)
     assert spec.verify_kzg_proof_impl(commitment, x, y, proof)
 
 
@@ -103,7 +102,6 @@ def test_compute_kzg_proof_within_domain(spec, state):
     roots_of_unity_brp = spec.bit_reversal_permutation(spec.ROOTS_OF_UNITY)
 
     for i, z in enumerate(roots_of_unity_brp):
-        proof = spec.compute_kzg_proof_impl(polynomial, z)
+        proof, y = spec.compute_kzg_proof_impl(polynomial, z)
 
-        y = spec.evaluate_polynomial_in_evaluation_form(polynomial, z)
         assert spec.verify_kzg_proof_impl(commitment, z, y, proof)

--- a/tests/formats/kzg/compute_blob_kzg_proof.md
+++ b/tests/formats/kzg/compute_blob_kzg_proof.md
@@ -9,7 +9,7 @@ The test data is declared in a `data.yaml` file:
 ```yaml
 input:
   blob: Blob -- the data blob
-  commitment: Bytes32 -- the commitment to the blob
+  commitment: Bytes48 -- the commitment to the blob
 output: KZGProof -- The blob KZG proof
 ```
 

--- a/tests/formats/kzg/compute_blob_kzg_proof.md
+++ b/tests/formats/kzg/compute_blob_kzg_proof.md
@@ -9,10 +9,12 @@ The test data is declared in a `data.yaml` file:
 ```yaml
 input:
   blob: Blob -- the data blob
+  commitment: Bytes32 -- the commitment to the blob
 output: KZGProof -- The blob KZG proof
 ```
 
 - `blob` here is encoded as a string: hexadecimal encoding of `4096 * 32 = 131072` bytes, prefixed with `0x`.
+- `commitment` here is encoded as a string: hexadecimal encoding of `32` bytes, prefixed with `0x`.
 
 All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
 

--- a/tests/formats/kzg/compute_blob_kzg_proof.md
+++ b/tests/formats/kzg/compute_blob_kzg_proof.md
@@ -14,7 +14,7 @@ output: KZGProof -- The blob KZG proof
 ```
 
 - `blob` here is encoded as a string: hexadecimal encoding of `4096 * 32 = 131072` bytes, prefixed with `0x`.
-- `commitment` here is encoded as a string: hexadecimal encoding of `32` bytes, prefixed with `0x`.
+- `commitment` here is encoded as a string: hexadecimal encoding of `48` bytes, prefixed with `0x`.
 
 All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
 

--- a/tests/formats/kzg/compute_kzg_proof.md
+++ b/tests/formats/kzg/compute_kzg_proof.md
@@ -10,7 +10,7 @@ The test data is declared in a `data.yaml` file:
 input:
   blob: Blob -- the data blob representing a polynomial
   z: Bytes32 -- bytes encoding the BLS field element at which the polynomial should be evaluated
-output: Tuple[KZGProof, y] -- The KZG proof and the value y = f(z)
+output: Tuple[KZGProof, Bytes32] -- The KZG proof and the value y = f(z)
 ```
 
 - `blob` here is encoded as a string: hexadecimal encoding of `4096 * 32 = 131072` bytes, prefixed with `0x`.

--- a/tests/formats/kzg/compute_kzg_proof.md
+++ b/tests/formats/kzg/compute_kzg_proof.md
@@ -10,14 +10,15 @@ The test data is declared in a `data.yaml` file:
 input:
   blob: Blob -- the data blob representing a polynomial
   z: Bytes32 -- bytes encoding the BLS field element at which the polynomial should be evaluated
-output: KZGProof -- The KZG proof
+output: Tuple[KZGProof, y] -- The KZG proof and the value y = f(z)
 ```
 
 - `blob` here is encoded as a string: hexadecimal encoding of `4096 * 32 = 131072` bytes, prefixed with `0x`.
 - `z` here is encoded as a string: hexadecimal encoding of `32` bytes representing a little endian encoded field element, prefixed with `0x`.
+- `y` here is encoded as a string: hexadecimal encoding of `32` bytes representing a little endian encoded field element, prefixed with `0x`.
 
 All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
 
 ## Condition
 
-The `compute_kzg_proof` handler should compute the KZG proof for evaluating the polynomial represented by `blob` at `z`, and the result should match the expected `output`. If the blob is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element) or `z` is not a valid BLS field element, it should error, i.e. the output should be `null`.
+The `compute_kzg_proof` handler should compute the KZG proof as well as the value `y` for evaluating the polynomial represented by `blob` at `z`, and the result should match the expected `output`. If the blob is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element) or `z` is not a valid BLS field element, it should error, i.e. the output should be `null`.

--- a/tests/generators/kzg_4844/main.py
+++ b/tests/generators/kzg_4844/main.py
@@ -115,14 +115,14 @@ def case02_compute_kzg_proof():
     # Valid cases
     for blob in VALID_BLOBS:
         for z in VALID_ZS:
-            proof = spec.compute_kzg_proof(blob, z)
+            proof, y = spec.compute_kzg_proof(blob, z)
             identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
             yield f'compute_kzg_proof_case_valid_blob_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
                 'input': {
                     'blob': encode_hex(blob),
                     'z': encode_hex(z),
                 },
-                'output': encode_hex(proof)
+                'output': (encode_hex(proof), encode_hex(y))
             }
 
     # Edge case: Invalid blobs
@@ -156,9 +156,8 @@ def case03_verify_kzg_proof():
     # Valid cases
     for blob in VALID_BLOBS:
         for z in VALID_ZS:
-            proof = spec.compute_kzg_proof(blob, z)
+            proof, y = spec.compute_kzg_proof(blob, z)
             commitment = spec.blob_to_kzg_commitment(blob)
-            y = evaluate_blob_at(blob, z)
             assert spec.verify_kzg_proof(commitment, z, y, proof)
             identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
             yield f'verify_kzg_proof_case_correct_proof_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
@@ -174,9 +173,9 @@ def case03_verify_kzg_proof():
     # Incorrect proofs
     for blob in VALID_BLOBS:
         for z in VALID_ZS:
-            proof = bls_add_one(spec.compute_kzg_proof(blob, z))
+            proof_orig, y = spec.compute_kzg_proof(blob, z)
+            proof = bls_add_one(proof_orig)
             commitment = spec.blob_to_kzg_commitment(blob)
-            y = evaluate_blob_at(blob, z)
             assert not spec.verify_kzg_proof(commitment, z, y, proof)
             identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
             yield f'verify_kzg_proof_case_incorrect_proof_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
@@ -192,9 +191,8 @@ def case03_verify_kzg_proof():
     # Edge case: Invalid z
     for z in INVALID_ZS:
         blob, validz = VALID_BLOBS[4], VALID_ZS[1]
-        proof = spec.compute_kzg_proof(blob, validz)
+        proof, y = spec.compute_kzg_proof(blob, validz)
         commitment = spec.blob_to_kzg_commitment(blob)
-        y = VALID_ZS[3]
         expect_exception(spec.verify_kzg_proof, commitment, z, y, proof)
         identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
         yield f'verify_kzg_proof_case_invalid_z_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
@@ -209,7 +207,7 @@ def case03_verify_kzg_proof():
 
     # Edge case: Invalid y
     blob, z = VALID_BLOBS[1], VALID_ZS[1]
-    proof = spec.compute_kzg_proof(blob, z)
+    proof, _ = spec.compute_kzg_proof(blob, z)
     commitment = spec.blob_to_kzg_commitment(blob)
     y = INVALID_ZS[0]
     expect_exception(spec.verify_kzg_proof, commitment, z, y, proof)
@@ -257,9 +255,8 @@ def case03_verify_kzg_proof():
 
     # Edge case: Invalid commitment, not in G1
     blob, z = VALID_BLOBS[4], VALID_ZS[3]
-    proof = spec.compute_kzg_proof(blob, z)
+    proof, y = spec.compute_kzg_proof(blob, z)
     commitment = P1_NOT_IN_G1
-    y = VALID_ZS[2]
     expect_exception(spec.verify_kzg_proof, commitment, z, y, proof)
     yield 'verify_kzg_proof_case_commitment_not_in_G1', {
         'input': {
@@ -273,9 +270,8 @@ def case03_verify_kzg_proof():
 
     # Edge case: Invalid commitment, not on curve
     blob, z = VALID_BLOBS[1], VALID_ZS[4]
-    proof = spec.compute_kzg_proof(blob, z)
+    proof, y = spec.compute_kzg_proof(blob, z)
     commitment = P1_NOT_ON_CURVE
-    y = VALID_ZS[3]
     expect_exception(spec.verify_kzg_proof, commitment, z, y, proof)
     yield 'verify_kzg_proof_case_commitment_not_on_curve', {
         'input': {
@@ -291,32 +287,62 @@ def case03_verify_kzg_proof():
 def case04_compute_blob_kzg_proof():
     # Valid cases
     for blob in VALID_BLOBS:
-        proof = spec.compute_blob_kzg_proof(blob)
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.compute_blob_kzg_proof(blob, commitment)
         identifier = f'{encode_hex(hash(blob))}'
         yield f'compute_blob_kzg_proof_case_valid_blob_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
             'input': {
                 'blob': encode_hex(blob),
+                'commitment': encode_hex(commitment),
             },
             'output': encode_hex(proof)
         }
 
     # Edge case: Invalid blob
     for blob in INVALID_BLOBS:
-        expect_exception(spec.compute_blob_kzg_proof, blob)
+        commitment = G1
+        expect_exception(spec.compute_blob_kzg_proof, blob, commitment)
         identifier = f'{encode_hex(hash(blob))}'
         yield f'compute_blob_kzg_proof_case_invalid_blob_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
             'input': {
                 'blob': encode_hex(blob),
+                'commitment': encode_hex(commitment),
             },
             'output': None
         }
+
+    # Edge case: Invalid commitment, not in G1
+    commitment = P1_NOT_IN_G1
+    blob = VALID_BLOBS[1]
+    expect_exception(spec.compute_blob_kzg_proof, blob, commitment)
+    identifier = f'{encode_hex(hash(blob))}'
+    yield 'compute_blob_kzg_proof_case_invalid_commitment_not_in_G1', {
+        'input': {
+            'blob': encode_hex(blob),
+            'commitment': encode_hex(commitment),
+        },
+        'output': None
+    }
+
+    # Edge case: Invalid commitment, not on curve
+    commitment = P1_NOT_ON_CURVE
+    blob = VALID_BLOBS[1]
+    expect_exception(spec.compute_blob_kzg_proof, blob, commitment)
+    identifier = f'{encode_hex(hash(blob))}'
+    yield 'compute_blob_kzg_proof_case_invalid_commitment_not_on_curve', {
+        'input': {
+            'blob': encode_hex(blob),
+            'commitment': encode_hex(commitment),
+        },
+        'output': None
+    }
 
 
 def case05_verify_blob_kzg_proof():
     # Valid cases
     for blob in VALID_BLOBS:
-        proof = spec.compute_blob_kzg_proof(blob)
         commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.compute_blob_kzg_proof(blob, commitment)
         assert spec.verify_blob_kzg_proof(blob, commitment, proof)
         identifier = f'{encode_hex(hash(blob))}'
         yield f'verify_blob_kzg_proof_case_correct_proof_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
@@ -330,8 +356,8 @@ def case05_verify_blob_kzg_proof():
 
     # Incorrect proofs
     for blob in VALID_BLOBS:
-        proof = bls_add_one(spec.compute_blob_kzg_proof(blob))
         commitment = spec.blob_to_kzg_commitment(blob)
+        proof = bls_add_one(spec.compute_blob_kzg_proof(blob, commitment))
         assert not spec.verify_blob_kzg_proof(blob, commitment, proof)
         identifier = f'{encode_hex(hash(blob))}'
         yield f'verify_blob_kzg_proof_case_incorrect_proof_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
@@ -420,8 +446,8 @@ def case06_verify_blob_kzg_proof_batch():
     proofs = []
     commitments = []
     for blob in VALID_BLOBS:
-        proofs.append(spec.compute_blob_kzg_proof(blob))
         commitments.append(spec.blob_to_kzg_commitment(blob))
+        proofs.append(spec.compute_blob_kzg_proof(blob, commitments[-1]))
 
     for i in range(len(proofs)):
         assert spec.verify_blob_kzg_proof_batch(VALID_BLOBS[:i], commitments[:i], proofs[:i])


### PR DESCRIPTION
This introduces two changes to `polynomial_commitments.md`:

1. Change `compute_blob_kzg_proof()` to take the commitment as a parameter. This is because otherwise, the commitment will usually be computed twice, once inside and once outside the function.
2. Change `compute_kzg_proof()` to return the `y` value (the evaluation point), with a similar reasoning.