### PR TITLE
Check correct fork version in LC sync protocol

### DIFF
--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -387,7 +387,8 @@ def validate_light_client_update(store: LightClientStore,
         pubkey for (bit, pubkey) in zip(sync_aggregate.sync_committee_bits, sync_committee.pubkeys)
         if bit
     ]
-    fork_version = compute_fork_version(compute_epoch_at_slot(update.signature_slot))
+    fork_version_slot = max(update.signature_slot, 1) - 1
+    fork_version = compute_fork_version(compute_epoch_at_slot(fork_version_slot))
     domain = compute_domain(DOMAIN_SYNC_COMMITTEE, fork_version, genesis_validators_root)
     signing_root = compute_signing_root(update.attested_header.beacon, domain)
     assert bls.FastAggregateVerify(participant_pubkeys, signing_root, sync_aggregate.sync_committee_signature)

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -387,7 +387,7 @@ def validate_light_client_update(store: LightClientStore,
         pubkey for (bit, pubkey) in zip(sync_aggregate.sync_committee_bits, sync_committee.pubkeys)
         if bit
     ]
-    fork_version_slot = max(update.signature_slot, 1) - 1
+    fork_version_slot = max(update.signature_slot, Slot(1)) - Slot(1)
     fork_version = compute_fork_version(compute_epoch_at_slot(fork_version_slot))
     domain = compute_domain(DOMAIN_SYNC_COMMITTEE, fork_version, genesis_validators_root)
     signing_root = compute_signing_root(update.attested_header.beacon, domain)

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_transition.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_transition.py
@@ -47,6 +47,7 @@ def _set_operations_by_dict(block, operation_dict):
 
 def _state_transition_and_sign_block_at_slot(spec,
                                              state,
+                                             sync_aggregate=None,
                                              operation_dict=None):
     """
     Cribbed from ``transition_unsigned_block`` helper
@@ -61,6 +62,8 @@ def _state_transition_and_sign_block_at_slot(spec,
     Thus use dict to pass operations.
     """
     block = build_empty_block(spec, state)
+    if sync_aggregate is not None:
+        block.body.sync_aggregate = sync_aggregate
 
     if operation_dict:
         _set_operations_by_dict(block, operation_dict)
@@ -141,7 +144,7 @@ def state_transition_across_slots_with_ignoring_proposers(spec,
             next_slot(spec, state)
 
 
-def do_fork(state, spec, post_spec, fork_epoch, with_block=True, operation_dict=None):
+def do_fork(state, spec, post_spec, fork_epoch, with_block=True, sync_aggregate=None, operation_dict=None):
     spec.process_slots(state, state.slot + 1)
 
     assert state.slot % spec.SLOTS_PER_EPOCH == 0
@@ -172,7 +175,12 @@ def do_fork(state, spec, post_spec, fork_epoch, with_block=True, operation_dict=
         assert state.fork.current_version == post_spec.config.DENEB_FORK_VERSION
 
     if with_block:
-        return state, _state_transition_and_sign_block_at_slot(post_spec, state, operation_dict=operation_dict)
+        return state, _state_transition_and_sign_block_at_slot(
+            post_spec,
+            state,
+            sync_aggregate=sync_aggregate,
+            operation_dict=operation_dict,
+        )
     else:
         return state, None
 

--- a/tests/core/pyspec/eth2spec/test/helpers/light_client.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/light_client.py
@@ -31,7 +31,7 @@ def get_sync_aggregate(spec, state, num_participants=None, signature_slot=None):
     sync_committee_signature = compute_aggregate_sync_committee_signature(
         spec,
         signature_state,
-        signature_slot,
+        max(signature_slot, 1) - 1,
         committee_indices[:num_participants],
     )
     sync_aggregate = spec.SyncAggregate(


### PR DESCRIPTION
- Sync committee is determined by signature_slot
- Signature fork version is determined by max(signature_slot, 1) - 1
- Attested block fork version can be anything < signature_slot

Old logic incorrectly derived signature fork version from signature_slot and did not subtract a slot. Extended tests to check this edge case.