### PR TITLE
Deneb: Fix typo in type of KZG_SETUP_LAGRANGE

### DIFF
--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -105,7 +105,7 @@ but reusing the `mainnet` settings in public networks is a critical security req
 | `KZG_SETUP_G2_LENGTH` | `65` |
 | `KZG_SETUP_G1` | `Vector[G1Point, FIELD_ELEMENTS_PER_BLOB]`, contents TBD |
 | `KZG_SETUP_G2` | `Vector[G2Point, KZG_SETUP_G2_LENGTH]`, contents TBD |
-| `KZG_SETUP_LAGRANGE` | `Vector[KZGCommitment, FIELD_ELEMENTS_PER_BLOB]`, contents TBD |
+| `KZG_SETUP_LAGRANGE` | `Vector[G1Point, FIELD_ELEMENTS_PER_BLOB]`, contents TBD |
 
 ## Helper functions
 


### PR DESCRIPTION
The type of lagrange setup is the same as the type of the monomial setup; KZGCommitment is reserved for G1Points which were created by `g1_lincomb`