### PR TITLE
Shift all fork choice tests to Altair & later

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_ex_ante.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_ex_ante.py
@@ -1,7 +1,7 @@
 from eth2spec.test.context import (
     MAINNET,
     spec_state_test,
-    with_all_phases,
+    with_altair_and_later,
     with_presets,
 )
 from eth2spec.test.helpers.attestations import (
@@ -31,7 +31,7 @@ def _apply_base_block_a(spec, state, store, test_steps):
     assert spec.get_head(store) == signed_block_a.message.hash_tree_root()
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_ex_ante_vanilla(spec, state):
     """
@@ -118,7 +118,7 @@ def _get_greater_than_proposer_boost_score(spec, store, state, proposer_boost_ro
     return proposer_score // base_effective_balance + 1
 
 
-@with_all_phases
+@with_altair_and_later
 @with_presets([MAINNET], reason="to create non-duplicate committee")
 @spec_state_test
 def test_ex_ante_attestations_is_greater_than_proposer_boost_with_boost(spec, state):
@@ -191,7 +191,7 @@ def test_ex_ante_attestations_is_greater_than_proposer_boost_with_boost(spec, st
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_ex_ante_sandwich_without_attestations(spec, state):
     """
@@ -254,7 +254,7 @@ def test_ex_ante_sandwich_without_attestations(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_ex_ante_sandwich_with_honest_attestation(spec, state):
     """
@@ -335,7 +335,7 @@ def test_ex_ante_sandwich_with_honest_attestation(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @with_presets([MAINNET], reason="to create non-duplicate committee")
 @spec_state_test
 def test_ex_ante_sandwich_with_boost_not_sufficient(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
@@ -2,7 +2,6 @@ import random
 
 from eth2spec.test.context import (
     spec_state_test,
-    with_all_phases,
     with_altair_and_later,
     with_presets,
 )
@@ -38,7 +37,7 @@ from eth2spec.test.helpers.state import (
 rng = random.Random(1001)
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_genesis(spec, state):
     test_steps = []
@@ -62,7 +61,7 @@ def test_genesis(spec, state):
         yield 'description', 'meta', f"Although it's not phase 0, we may use {spec.fork} spec to start testnets."
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_chain_no_attestations(spec, state):
     test_steps = []
@@ -91,7 +90,7 @@ def test_chain_no_attestations(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_split_tie_breaker_no_attestations(spec, state):
     test_steps = []
@@ -130,7 +129,7 @@ def test_split_tie_breaker_no_attestations(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_shorter_chain_but_heavier_weight(spec, state):
     test_steps = []
@@ -170,7 +169,7 @@ def test_shorter_chain_but_heavier_weight(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_filtered_block_tree(spec, state):
@@ -247,7 +246,7 @@ def test_filtered_block_tree(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_proposer_boost_correct_head(spec, state):
     test_steps = []
@@ -302,7 +301,7 @@ def test_proposer_boost_correct_head(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_discard_equivocations_on_attester_slashing(spec, state):
     test_steps = []
@@ -374,7 +373,7 @@ def test_discard_equivocations_on_attester_slashing(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_discard_equivocations_slashed_validator_censoring(spec, state):
@@ -636,7 +635,7 @@ We cannot generate a block that:
 The block being a descendant of store.justified_checkpoint.root is necessary because
 filter_block_tree descends the tree starting at store.justified_checkpoint.root
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_incorrect_finalized(spec, state):
     # Check that the store doesn't allow for a head block that has:

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
@@ -5,7 +5,6 @@ from eth2spec.utils.ssz.ssz_impl import hash_tree_root
 from eth2spec.test.context import (
     MINIMAL,
     spec_state_test,
-    with_all_phases,
     with_altair_and_later,
     with_presets
 )
@@ -47,7 +46,7 @@ def _drop_random_one_third(_slot, _index, indices):
     return rng.sample(sorted(indices), participant_count)
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_basic(spec, state):
     test_steps = []
@@ -77,7 +76,7 @@ def test_basic(spec, state):
     # TODO: add tests for justified_root and finalized_root
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_on_block_checkpoints(spec, state):
@@ -114,7 +113,7 @@ def test_on_block_checkpoints(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_on_block_future_block(spec, state):
     test_steps = []
@@ -135,7 +134,7 @@ def test_on_block_future_block(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_on_block_bad_parent_root(spec, state):
     test_steps = []
@@ -161,7 +160,7 @@ def test_on_block_bad_parent_root(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_on_block_before_finalized(spec, state):
@@ -193,7 +192,7 @@ def test_on_block_before_finalized(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_on_block_finalized_skip_slots(spec, state):
@@ -240,7 +239,7 @@ def test_on_block_finalized_skip_slots(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_on_block_finalized_skip_slots_not_in_skip_chain(spec, state):
@@ -287,7 +286,7 @@ def test_on_block_finalized_skip_slots_not_in_skip_chain(spec, state):
 
 
 """
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_new_finalized_slot_is_not_justified_checkpoint_ancestor(spec, state):
@@ -369,7 +368,7 @@ def test_new_finalized_slot_is_not_justified_checkpoint_ancestor(spec, state):
 """
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_new_finalized_slot_is_justified_checkpoint_ancestor(spec, state):
@@ -441,7 +440,7 @@ def test_new_finalized_slot_is_justified_checkpoint_ancestor(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_proposer_boost(spec, state):
     test_steps = []
@@ -500,7 +499,7 @@ def test_proposer_boost(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 def test_proposer_boost_root_same_slot_untimely_block(spec, state):
     test_steps = []
@@ -534,7 +533,7 @@ def test_proposer_boost_root_same_slot_untimely_block(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_justification_withholding(spec, state):
@@ -616,7 +615,7 @@ def test_justification_withholding(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_justification_withholding_reverse_order(spec, state):
@@ -693,7 +692,7 @@ def test_justification_withholding_reverse_order(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_justification_update_beginning_of_epoch(spec, state):
@@ -742,7 +741,7 @@ def test_justification_update_beginning_of_epoch(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_justification_update_end_of_epoch(spec, state):
@@ -792,7 +791,7 @@ def test_justification_update_end_of_epoch(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_incompatible_justification_update_start_of_epoch(spec, state):
@@ -868,7 +867,7 @@ def test_incompatible_justification_update_start_of_epoch(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_incompatible_justification_update_end_of_epoch(spec, state):
@@ -945,7 +944,7 @@ def test_incompatible_justification_update_end_of_epoch(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_justified_update_not_realized_finality(spec, state):
@@ -1018,7 +1017,7 @@ def test_justified_update_not_realized_finality(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_justified_update_monotonic(spec, state):
@@ -1097,7 +1096,7 @@ def test_justified_update_monotonic(spec, state):
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets([MINIMAL], reason="too slow")
 def test_justified_update_always_if_better(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_reorg.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_reorg.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
     spec_state_test,
-    with_all_phases,
+    with_altair_and_later,
     with_presets,
 )
 from eth2spec.test.helpers.constants import (
@@ -35,7 +35,7 @@ from eth2spec.test.helpers.state import (
 TESTING_PRESETS = [MINIMAL]
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets(TESTING_PRESETS, reason="too slow")
 def test_simple_attempted_reorg_without_enough_ffg_votes(spec, state):
@@ -250,7 +250,7 @@ def _run_delayed_justification(spec, state, attemped_reorg, is_justifying_previo
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets(TESTING_PRESETS, reason="too slow")
 def test_simple_attempted_reorg_delayed_justification_current_epoch(spec, state):
@@ -401,7 +401,7 @@ def _run_include_votes_of_another_empty_chain(spec, state, enough_ffg, is_justif
     yield 'steps', test_steps
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets(TESTING_PRESETS, reason="too slow")
 def test_include_votes_another_empty_chain_with_enough_ffg_votes_current_epoch(spec, state):
@@ -412,7 +412,7 @@ def test_include_votes_another_empty_chain_with_enough_ffg_votes_current_epoch(s
         spec, state, enough_ffg=True, is_justifying_previous_epoch=False)
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets(TESTING_PRESETS, reason="too slow")
 def test_include_votes_another_empty_chain_without_enough_ffg_votes_current_epoch(spec, state):
@@ -423,7 +423,7 @@ def test_include_votes_another_empty_chain_without_enough_ffg_votes_current_epoc
         spec, state, enough_ffg=False, is_justifying_previous_epoch=False)
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets(TESTING_PRESETS, reason="too slow")
 def test_delayed_justification_current_epoch(spec, state):
@@ -443,7 +443,7 @@ def test_delayed_justification_current_epoch(spec, state):
     yield from _run_delayed_justification(spec, state, attemped_reorg=False, is_justifying_previous_epoch=False)
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets(TESTING_PRESETS, reason="too slow")
 def test_delayed_justification_previous_epoch(spec, state):
@@ -460,7 +460,7 @@ def test_delayed_justification_previous_epoch(spec, state):
     yield from _run_delayed_justification(spec, state, attemped_reorg=False, is_justifying_previous_epoch=True)
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets(TESTING_PRESETS, reason="too slow")
 def test_simple_attempted_reorg_delayed_justification_previous_epoch(spec, state):
@@ -483,7 +483,7 @@ def test_simple_attempted_reorg_delayed_justification_previous_epoch(spec, state
     yield from _run_delayed_justification(spec, state, attemped_reorg=True, is_justifying_previous_epoch=True)
 
 
-@with_all_phases
+@with_altair_and_later
 @spec_state_test
 @with_presets(TESTING_PRESETS, reason="too slow")
 def test_include_votes_another_empty_chain_with_enough_ffg_votes_previous_epoch(spec, state):


### PR DESCRIPTION
#3290 changes [`on_tick`](https://github.com/ethereum/consensus-specs/blame/a0eb23f108802ce604d5184f403d7b9dce11e919/specs/phase0/fork-choice.md#L403) to update `Store` in a way that is not expected in Phase 0. When clients run test vectors, they have to resort to hacking their test runner to skip certain (all?) fork choice tests from Phase 0. 

 This PR moves all fork choice tests to Altair and later, removing the need for a hacky test runner.