### PR TITLE
Remove phase 0 from fork choice test generator

### DIFF
--- a/tests/generators/fork_choice/main.py
+++ b/tests/generators/fork_choice/main.py
@@ -1,5 +1,5 @@
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators, combine_mods
-from eth2spec.test.helpers.constants import PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB
+from eth2spec.test.helpers.constants import ALTAIR, BELLATRIX, CAPELLA, DENEB
 
 
 if __name__ == "__main__":

--- a/tests/generators/fork_choice/main.py
+++ b/tests/generators/fork_choice/main.py
@@ -3,15 +3,14 @@ from eth2spec.test.helpers.constants import PHASE0, ALTAIR, BELLATRIX, CAPELLA, 
 
 
 if __name__ == "__main__":
-    phase_0_mods = {key: 'eth2spec.test.phase0.fork_choice.test_' + key for key in [
+    # Note: Fork choice tests start from Altair - there are no fork choice test for phase 0 anymore
+    altair_mods = {key: 'eth2spec.test.phase0.fork_choice.test_' + key for key in [
         'get_head',
         'on_block',
         'ex_ante',
         'reorg',
         'withholding',
     ]}
-    # No additional Altair specific finality tests, yet.
-    altair_mods = phase_0_mods
 
     # For merge `on_merge_block` test kind added with `pow_block_N.ssz` files with several
     # PowBlock's which should be resolved by `get_pow_block(hash: Hash32) -> PowBlock` function
@@ -23,7 +22,6 @@ if __name__ == "__main__":
     deneb_mods = capella_mods  # No additional Capella specific fork choice tests
 
     all_mods = {
-        PHASE0: phase_0_mods,
         ALTAIR: altair_mods,
         BELLATRIX: bellatrix_mods,
         CAPELLA: capella_mods,


### PR DESCRIPTION
#3294 removes phase 0 from all fork choice tests, but test vector generators were still producing empty directories for these. This PR updates the test generator to not produce phase 0 fork choice test directories.