### PR TITLE
Reject zero inputs in bls_modular_inverse()

### DIFF
--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -252,10 +252,11 @@ def compute_challenge(blob: Blob,
 ```python
 def bls_modular_inverse(x: BLSFieldElement) -> BLSFieldElement:
     """
-    Compute the modular inverse of x
-    i.e. return y such that x * y % BLS_MODULUS == 1 and return 0 for x == 0
+    Compute the modular inverse of x (for x != 0)
+    i.e. return y such that x * y % BLS_MODULUS == 1
     """
-    return BLSFieldElement(pow(x, -1, BLS_MODULUS)) if x != 0 else BLSFieldElement(0)
+    assert (int(x) % BLS_MODULUS) != 0
+    return BLSFieldElement(pow(x, -1, BLS_MODULUS))
 ```
 
 #### `div`

--- a/tests/core/pyspec/eth2spec/test/deneb/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -218,6 +218,29 @@ def test_verify_blob_kzg_proof_incorrect_proof(spec):
 @with_deneb_and_later
 @spec_test
 @single_phase
+def test_bls_modular_inverse(spec):
+    """
+    Verify computation of multiplicative inverse
+    """
+    rng = random.Random(5566)
+
+    # Should fail for x == 0
+    expect_assertion_error(lambda: spec.bls_modular_inverse(0))
+    expect_assertion_error(lambda: spec.bls_modular_inverse(spec.BLS_MODULUS))
+    expect_assertion_error(lambda: spec.bls_modular_inverse(2 * spec.BLS_MODULUS))
+
+    # Test a trivial inversion
+    assert 1 == int(spec.bls_modular_inverse(1))
+
+    # Test a random inversion
+    r = rng.randint(0, spec.BLS_MODULUS - 1)
+    r_inv = int(spec.bls_modular_inverse(r))
+    assert r * r_inv % BLS_MODULUS == 1
+
+
+@with_deneb_and_later
+@spec_test
+@single_phase
 def test_validate_kzg_g1_generator(spec):
     """
     Verify that `validate_kzg_g1` allows the generator G1


### PR DESCRIPTION
Zero doesn't have a multiplicative inverse and having bls_modular_inverse() return zero upon receiving zero was a convention.

We then noticed that implementing that convention in blst was not straightforward, so we decided to revisit it.

Given that there is no point in the spec where bls_modular_inverse() is called with zero as its input, and given that from a protocol point of view that convention doesn't make much sense, we decided to instead reject zero as inputs to bls_modular_inverse(). This PR makes it so.