### PR TITLE
Attnet revamp: Subnet backbone structure based on beacon nodes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -383,7 +383,7 @@ from typing import (
 
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root, copy, uint_to_bytes
 from eth2spec.utils.ssz.ssz_typing import (
-    View, boolean, Container, List, Vector, uint8, uint32, uint64,
+    View, boolean, Container, List, Vector, uint8, uint32, uint64, uint256,
     Bytes1, Bytes4, Bytes32, Bytes48, Bytes96, Bitlist)
 from eth2spec.utils.ssz.ssz_typing import Bitvector  # noqa: F401
 from eth2spec.utils import bls
@@ -551,7 +551,7 @@ class BellatrixSpecBuilder(AltairSpecBuilder):
         return super().imports(preset_name) + f'''
 from typing import Protocol
 from eth2spec.altair import {preset_name} as altair
-from eth2spec.utils.ssz.ssz_typing import Bytes8, Bytes20, ByteList, ByteVector, uint256
+from eth2spec.utils.ssz.ssz_typing import Bytes8, Bytes20, ByteList, ByteVector
 '''
 
     @classmethod

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -88,10 +88,11 @@ All terminology, constants, functions, and protocol mechanics defined in the [Ph
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
-| `TARGET_AGGREGATORS_PER_COMMITTEE` | `2**4` (= 16) | validators | |
-| `RANDOM_SUBNETS_PER_VALIDATOR` | `2**0` (= 1) | subnets | |
-| `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` | `2**8` (= 256) | epochs | ~27 hours |
+| `TARGET_AGGREGATORS_PER_COMMITTEE` | `2**4` (= 16) | validators |
+| `EPOCHS_PER_SUBNET_SUBSCRIPTION` | `2**8` (= 256) | epochs | ~27 hours |
 | `ATTESTATION_SUBNET_COUNT` | `64` | The number of attestation subnets used in the gossipsub protocol. |
+| `ATTESTATION_SUBNET_EXTRA_BITS` | 0 | The number of extra bits of a NodeId to use when mapping to a subscribed subnet |
+| `SUBNETS_PER_NODE` | 2 | The number of long-lived subnets a beacon node should be subscribed to. |
 
 ## Containers
 
@@ -606,15 +607,29 @@ def get_aggregate_and_proof_signature(state: BeaconState,
 
 ## Phase 0 attestation subnet stability
 
-Because Phase 0 does not have shards and thus does not have Shard Committees, there is no stable backbone to the attestation subnets (`beacon_attestation_{subnet_id}`). To provide this stability, each validator must:
+Because Phase 0 does not have shards and thus does not have Shard Committees, there is no stable backbone to the attestation subnets (`beacon_attestation_{subnet_id}`). To provide this stability, each beacon node should:
 
-* Randomly select and remain subscribed to `RANDOM_SUBNETS_PER_VALIDATOR` attestation subnets
-* Maintain advertisement of the randomly selected subnets in their node's ENR `attnets` entry by setting the randomly selected `subnet_id` bits to `True` (e.g. `ENR["attnets"][subnet_id] = True`) for all persistent attestation subnets
-* Set the lifetime of each random subscription to a random number of epochs between `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` and `2 * EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION]`. At the end of life for a subscription, select a new random subnet, update subnet subscriptions, and publish an updated ENR
+* Remain subscribed to `SUBNETS_PER_NODE` for `SUBNET_DURATION_IN_EPOCHS` epochs.
+* Maintain advertisement of the selected subnets in their node's ENR `attnets` entry by setting the selected `subnet_id` bits to `True` (e.g. `ENR["attnets"][subnet_id] = True`) for all persistent attestation subnets.
+* Select these subnets based on their node-id as specified by the following
+	`compute_subnets(node_id,epoch)` function.
 
-*Note*: Short lived beacon committee assignments should not be added in into the ENR `attnets` entry.
+```python
+ATTESTATION_SUBNET_PREFIX_BITS = ceil(log2(ATTESTATION_SUBNET_COUNT)) + ATTESTATION_SUBNET_EXTRA_BITS
 
-*Note*: When preparing for a hard fork, a validator must select and subscribe to random subnets of the future fork versioning at least `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` epochs in advance of the fork. These new subnets for the fork are maintained in addition to those for the current fork until the fork occurs. After the fork occurs, let the subnets from the previous fork reach the end of life with no replacements.
+def compute_subnet(node_id, epoch, index):
+	  node_id_prefix = node_id >> (256 - ATTESTATION_SUBNET_PREFIX_BITS)
+	  permutation_seed = hash(uint_to_bytes(epoch // SUBNET_DURATION_IN_EPOCHS))
+	  permutated_prefix = compute_shuffled_index(node_id_prefix, 1 << ATTESTATION_SUBNET_PREFIX_BITS, permutation_seed)
+	  return (permutated_prefix + index) % ATTESTATION_SUBNET_COUNT
+
+def compute_subnets(node_id, epoch):
+	  return [compute_subnet(node_id, epoch, idx) for idx in range(SUBNETS_PER_NODE)]
+```
+
+*Note*: Nodes should subscribe to new subnets and remain subscribed to old subnets for at least one epoch. Nodes should pick a random duration to unsubscribe from old subnets to smooth the transition on the exact epoch boundary of which the shuffling changes. 
+
+*Note*: When preparing for a hard fork, a validator must select and subscribe to subnets of the future fork versioning at least `EPOCHS_PER_SUBNET_SUBSCRIPTION` epochs in advance of the fork. These new subnets for the fork are maintained in addition to those for the current fork until the fork occurs. After the fork occurs, let the subnets from the previous fork reach the end of life with no replacements.
 
 ## How to avoid slashing
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -94,7 +94,6 @@ All terminology, constants, functions, and protocol mechanics defined in the [Ph
 | `ATTESTATION_SUBNET_EXTRA_BITS` | `0` | The number of extra bits of a NodeId to use when mapping to a subscribed subnet |
 | `SUBNETS_PER_NODE` | `2` | The number of long-lived subnets a beacon node should be subscribed to. |
 | `ATTESTATION_SUBNET_PREFIX_BITS` | `(ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS)` | |
-| `SUBNET_DURATION_IN_EPOCHS` | `2` | |
 
 ## Containers
 
@@ -611,14 +610,14 @@ def get_aggregate_and_proof_signature(state: BeaconState,
 
 Because Phase 0 does not have shards and thus does not have Shard Committees, there is no stable backbone to the attestation subnets (`beacon_attestation_{subnet_id}`). To provide this stability, each beacon node should:
 
-* Remain subscribed to `SUBNETS_PER_NODE` for `SUBNET_DURATION_IN_EPOCHS` epochs.
+* Remain subscribed to `SUBNETS_PER_NODE` for `EPOCHS_PER_SUBNET_SUBSCRIPTION` epochs.
 * Maintain advertisement of the selected subnets in their node's ENR `attnets` entry by setting the selected `subnet_id` bits to `True` (e.g. `ENR["attnets"][subnet_id] = True`) for all persistent attestation subnets.
 * Select these subnets based on their node-id as specified by the following `compute_subnets(node_id,epoch)` function.
 
 ```python
 def compute_subnet(node_id: int, epoch: Epoch, index: int) -> int:
     node_id_prefix = node_id >> (256 - ATTESTATION_SUBNET_PREFIX_BITS)
-    permutation_seed = hash(uint_to_bytes(epoch // SUBNET_DURATION_IN_EPOCHS))
+    permutation_seed = hash(uint_to_bytes(epoch // EPOCHS_PER_SUBNET_SUBSCRIPTION))
     permutated_prefix = compute_shuffled_index(node_id_prefix, 1 << ATTESTATION_SUBNET_PREFIX_BITS, permutation_seed)
     return (permutated_prefix + index) % ATTESTATION_SUBNET_COUNT
 ```

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -612,7 +612,7 @@ Because Phase 0 does not have shards and thus does not have Shard Committees, th
 
 * Remain subscribed to `SUBNETS_PER_NODE` for `EPOCHS_PER_SUBNET_SUBSCRIPTION` epochs.
 * Maintain advertisement of the selected subnets in their node's ENR `attnets` entry by setting the selected `subnet_id` bits to `True` (e.g. `ENR["attnets"][subnet_id] = True`) for all persistent attestation subnets.
-* Select these subnets based on their node-id as specified by the following `compute_subscribed_subnets(node_id,epoch)` function.
+* Select these subnets based on their node-id as specified by the following `compute_subscribed_subnets(node_id, epoch)` function.
 
 ```python
 def compute_subscribed_subnet(node_id: int, epoch: Epoch, index: int) -> int:
@@ -629,7 +629,7 @@ def compute_subscribed_subnet(node_id: int, epoch: Epoch, index: int) -> int:
 
 ```python
 def compute_subscribed_subnets(node_id: int, epoch: Epoch) -> Sequence[int]:
-    return [compute_subscribed_subnet(node_id, epoch, idx) for idx in range(SUBNETS_PER_NODE)]
+    return [compute_subscribed_subnet(node_id, epoch, index) for index in range(SUBNETS_PER_NODE)]
 ```
 
 *Note*: When preparing for a hard fork, a validator must select and subscribe to subnets of the future fork versioning at least `EPOCHS_PER_SUBNET_SUBSCRIPTION` epochs in advance of the fork. These new subnets for the fork are maintained in addition to those for the current fork until the fork occurs. After the fork occurs, let the subnets from the previous fork reach the end of life with no replacements.

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -616,10 +616,14 @@ Because Phase 0 does not have shards and thus does not have Shard Committees, th
 
 ```python
 def compute_subscribed_subnet(node_id: int, epoch: Epoch, index: int) -> int:
-    node_id_prefix = node_id >> (256 - ATTESTATION_SUBNET_PREFIX_BITS)
+    node_id_prefix = node_id >> (256 - int(ATTESTATION_SUBNET_PREFIX_BITS))
     node_offset = node_id % EPOCHS_PER_SUBNET_SUBSCRIPTION
-    permutation_seed = hash(uint_to_bytes((epoch + node_offset) // EPOCHS_PER_SUBNET_SUBSCRIPTION))
-    permutated_prefix = compute_shuffled_index(node_id_prefix, 1 << ATTESTATION_SUBNET_PREFIX_BITS, permutation_seed)
+    permutation_seed = hash(uint_to_bytes(uint64((epoch + node_offset) // EPOCHS_PER_SUBNET_SUBSCRIPTION)))
+    permutated_prefix = compute_shuffled_index(
+        node_id_prefix,
+        1 << int(ATTESTATION_SUBNET_PREFIX_BITS),
+        permutation_seed,
+    )
     return (permutated_prefix + index) % ATTESTATION_SUBNET_COUNT
 ```
 

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/test_config_invariants.py
@@ -76,6 +76,8 @@ def test_time(spec, state):
 @spec_state_test
 def test_networking(spec, state):
     assert spec.SUBNETS_PER_NODE <= spec.ATTESTATION_SUBNET_COUNT
+    node_id_length = spec.NodeID(1).type_byte_length()  # in bytes
+    assert node_id_length * 8 == spec.NODE_ID_BITS  # in bits
 
 
 @with_all_phases

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/test_config_invariants.py
@@ -75,7 +75,7 @@ def test_time(spec, state):
 @with_all_phases
 @spec_state_test
 def test_networking(spec, state):
-    assert spec.RANDOM_SUBNETS_PER_VALIDATOR <= spec.ATTESTATION_SUBNET_COUNT
+    assert spec.SUBNETS_PER_NODE <= spec.ATTESTATION_SUBNET_COUNT
 
 
 @with_all_phases

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
@@ -1,6 +1,12 @@
+import random
+
 from eth2spec.test.context import (
+    single_phase,
     spec_state_test,
-    always_bls, with_phases, with_all_phases,
+    spec_test,
+    always_bls,
+    with_phases,
+    with_all_phases,
 )
 from eth2spec.test.helpers.constants import PHASE0
 from eth2spec.test.helpers.attestations import build_attestation_data, get_valid_attestation
@@ -476,3 +482,34 @@ def test_get_aggregate_and_proof_signature(spec, state):
         privkey=privkey,
         pubkey=pubkey,
     )
+
+
+def run_compute_subscribed_subnets_arguments(spec, rng=random.Random(1111)):
+    node_id = rng.randint(0, 2**40 - 1)  # try VALIDATOR_REGISTRY_LIMIT
+    epoch = rng.randint(0, 2**64 - 1)
+    subnets = spec.compute_subscribed_subnets(node_id, epoch)
+    assert len(subnets) == spec.SUBNETS_PER_NODE
+
+
+@with_all_phases
+@spec_test
+@single_phase
+def test_compute_subscribed_subnets_random_1(spec):
+    rng = random.Random(1111)
+    run_compute_subscribed_subnets_arguments(spec, rng)
+
+
+@with_all_phases
+@spec_test
+@single_phase
+def test_compute_subscribed_subnets_random_2(spec):
+    rng = random.Random(2222)
+    run_compute_subscribed_subnets_arguments(spec, rng)
+
+
+@with_all_phases
+@spec_test
+@single_phase
+def test_compute_subscribed_subnets_random_3(spec):
+    rng = random.Random(3333)
+    run_compute_subscribed_subnets_arguments(spec, rng)


### PR DESCRIPTION
***This is in a "LAST CALL" state., with the intention of merging on May 4 if no further issues emerge.***

*Note, this will be merged without the downscoring option to ensure that it can be rolled out iteratively across clients. Options to downscore if not on appropriate peer-id attnets will be added at a subsequent hard fork*

## Overview

This PR is for #2749 

The issue discussion highlights the main motivations for this change. The fundamental premise is that there currently is no way to enforce validators to subscribe to long-lived subnets, we may be oversubscribed to subnets and this results in significant bandwidth use. 

The proposed solution is to get beacon nodes to subscribe to long-lived subnets based on their node-id (can think peer-id). Some benefits of this are:
- Enforceable (a peer-id should now be subscribed to a pre-determined subnet, if not we can penalize)
- Tune bandwidth use at a network level by the `SUBNETS_PER_NODE` parameter
- Node operators running more validators are no longer directly penalized (in bandwidth use) for running more validators. A node operator running >=64 validators does not have to process every single attestation (defeating the purpose of the subnets). Equivalently, we distribute load to all beacon nodes. Everyone on the network participates a little bit by subscribing to a subnet. This would also mean the desire to connect to any individual node is higher and there is not a fight to connect to nodes that subscribe to the most subnets. I imagine this would improve peer connectivity. 
- We would no longer need the `attnet` field in the ENR (improving validator privacy) and in the future potentially remove the `metadata` RPC method if a similar approach can be found for the sync committee subnets. 
- Discovery searches can be optimized. As a node-id's initial prefix is fixed to a specific subnet. Discovery queries can target all nodes on a subnet via finding closest nodes to a known subnet prefix (i.e, nodes are no longer scattered randomly in the DHT, they are now segregated into groups based on the number of subnets).  
- Improve peer management as new nodes connecting can be assessed for subnet subscription before establishing a full connection (based on their peer-id). 
- Is fully backwards compatible during a transition period - A mixture of nodes/clients can implement this without penalty (keeping the attnet field for predetermined subnets). After a hard-fork we can make it a strict requirement, then remove the attnet field etc. 
- The update can be gradual. As clients adopt this and as users update their clients we can observe the effect on the network. If adverse effects start to occur we can adjust `SUBNETS_PER_NODE` to counter issues.

Some downsides are:
- Beacon nodes that currently have no validators attached will have a slightly increased bandwidth usage as they must now subscribe to `SUBNETS_PER_NODE` subnets.
- It isn't entirely certain how the backbone subnet structure looks for all networks, we likely reduce the number of nodes subscribed to long-lived subnets in total. It's uncertain how this plays out on mainnet. If misconfigured, the network could start seeing participation drops due to attestations being missed due to lack of finding peers subscribed to required subnets.
- The new approach specifies an exact epoch on which node-id shuffle to a new subnet. This can create a large churn of nodes and this transition period could cause turbulence as nodes rotate subnet subscriptions.
- Currently, a node can get away with connecting to a small number of peers (i.e those that are subscribed to the most subnets) to get a full subnet coverage. After this change, nodes will need a decent peer count to get a full coverage of subnets to avoid discovery queries.
- It is known in advance which node-ids will be subscribing to which subnets, which could lead to some additional forms of DOS vectors.
- There could be sybil attacks by setting node-ids to specific values to hijack subnets (however this is not a new vector as it can already be achieved in the current implementation by setting ENR values). 


### Useful statistics

I ran though the DHT to get an idea of subnet peer density and what it would look like after this change. 

I measured 4.2k nodes on mainnet. 
- 45% (1915)  beacon nodes are not subscribed to any long-lived subnets (i.e they claim to have no attached validators)
- 7% (316) beacon nodes were subscribed to 64 or more subnets (claimed more than 64 attached validators, or are running --subscribe-all-subnets). 

There are currently around 500 nodes per subnet. That is, if you search for a specific subnet, there should be around 500 distinct nodes to connect to (many nodes can subscribe to more than 1 subnet)

This change (with `SUBNETS_PER_NODE` ==2 ) would reduce the density just under 200 nodes per subnet. 

This would increase the total number of nodes subscribed to subnets from 2.3k to the full 4.2k (as all nodes now need to subscribe) and I'd expect it to be easier to find connections to peers on subnets. 

If we were to go with `SUBNETS_PER_NODE` ==1 there would be just under 100 nodes per subnet. 

I've opted for 2 just to be conservative. 

### Additional Notes

I've currently kept `ATTESTATION_SUBNET_EXTRA_BITS` at 0 to avoid complexity in the initial stages to see how discovery functions and debugging (but we can set this to higher now or later). 

I've left most of the current logic around the `attnets` field as is, as this should be kept for the transitional period. I've not touched the sync subnets. 

Personally, I'm in favour of this and am keen to push this along. However as always am open to feedback/suggestions and everyone's thoughts on whether we should actually do this.

