### PR TITLE
Add "commitment" to test names for consistency

### DIFF
--- a/tests/generators/kzg_4844/main.py
+++ b/tests/generators/kzg_4844/main.py
@@ -708,7 +708,7 @@ def case06_verify_blob_kzg_proof_batch():
     # Edge case: Invalid commitment, too few bytes
     commitments_invalid_tooFewBytes = commitments[:3] + [commitments[3][:-1]] + commitments[4:]
     expect_exception(spec.verify_blob_kzg_proof_batch, VALID_BLOBS, commitments, commitments_invalid_tooFewBytes)
-    yield 'verify_blob_kzg_proof_batch_case_too_few_bytes', {
+    yield 'verify_blob_kzg_proof_batch_case_commitment_too_few_bytes', {
         'input': {
             'blobs': encode_hex_list(VALID_BLOBS),
             'commitments': encode_hex_list(commitments_invalid_tooFewBytes),
@@ -720,7 +720,7 @@ def case06_verify_blob_kzg_proof_batch():
     # Edge case: Invalid commitment, too many bytes
     commitments_invalid_tooManyBytes = commitments[:3] + [commitments[3] + b"\x00"] + commitments[4:]
     expect_exception(spec.verify_blob_kzg_proof_batch, VALID_BLOBS, commitments, commitments_invalid_tooManyBytes)
-    yield 'verify_blob_kzg_proof_batch_case_too_many_bytes', {
+    yield 'verify_blob_kzg_proof_batch_case_commitment_too_many_bytes', {
         'input': {
             'blobs': encode_hex_list(VALID_BLOBS),
             'commitments': encode_hex_list(commitments_invalid_tooManyBytes),


### PR DESCRIPTION
I just noticed that for `verify_blob_kzg_proof_batch` two of the test case names were missing context.

For consistency, these tests (too few bytes, too many bytes) should look like:

<img width="474" alt="image" src="https://user-images.githubusercontent.com/95511699/232878804-9fd6c785-d7db-422e-9cde-3af2b2324eff.png">

<img width="474" alt="image" src="https://user-images.githubusercontent.com/95511699/232878871-ab3756d9-d126-4877-9685-bec16476df7b.png">
