### PR TITLE
Move is_previous_epoch_justified

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -11,8 +11,8 @@
   - [Configuration](#configuration)
   - [Helpers](#helpers)
     - [`LatestMessage`](#latestmessage)
-  - [`is_previous_epoch_justified`](#is_previous_epoch_justified)
     - [`Store`](#store)
+    - [`is_previous_epoch_justified`](#is_previous_epoch_justified)
     - [`get_forkchoice_store`](#get_forkchoice_store)
     - [`get_slots_since_genesis`](#get_slots_since_genesis)
     - [`get_current_slot`](#get_current_slot)
@@ -92,17 +92,6 @@ class LatestMessage(object):
     root: Root
 ```
 
-
-### `is_previous_epoch_justified`
-
-```python
-def is_previous_epoch_justified(store: Store) -> bool:
-    current_slot = get_current_slot(store)
-    current_epoch = compute_epoch_at_slot(current_slot)
-    return store.justified_checkpoint.epoch + 1 == current_epoch
-```
-
-
 #### `Store`
 
 The `Store` is responsible for tracking information required for the fork choice algorithm. The important fields being tracked are described below:
@@ -128,6 +117,15 @@ class Store(object):
     checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
     latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
     unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
+```
+
+#### `is_previous_epoch_justified`
+
+```python
+def is_previous_epoch_justified(store: Store) -> bool:
+    current_slot = get_current_slot(store)
+    current_epoch = compute_epoch_at_slot(current_slot)
+    return store.justified_checkpoint.epoch + 1 == current_epoch
 ```
 
 #### `get_forkchoice_store`


### PR DESCRIPTION
The `is_previous_epoch_justified` function heading is at the wrong indent level, and the function definition could be better placed to be more consistent with the usual spec layout. So I moved it.