### PR TITLE
Add `GetPayloadResponse` dataclass for `get_payload` API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -588,7 +588,7 @@ class NoopExecutionEngine(ExecutionEngine):
                                   payload_attributes: Optional[PayloadAttributes]) -> Optional[PayloadId]:
         pass
 
-    def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> ExecutionPayload:
+    def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> GetPayloadResponse:
         # pylint: disable=unused-argument
         raise NotImplementedError("no default block production")
 

--- a/specs/_features/eip4788/validator.md
+++ b/specs/_features/eip4788/validator.md
@@ -13,7 +13,7 @@
 - [Helpers](#helpers)
 - [Protocols](#protocols)
   - [`ExecutionEngine`](#executionengine)
-    - [`get_payload`](#get_payload)
+    - [Modified `get_payload`](#modified-get_payload)
 - [Beacon chain responsibilities](#beacon-chain-responsibilities)
   - [Block proposal](#block-proposal)
     - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
@@ -40,7 +40,7 @@ Please see related Beacon Chain doc before continuing and use them as a referenc
 
 ### `ExecutionEngine`
 
-#### `get_payload`
+#### Modified `get_payload`
 
 `get_payload` returns the upgraded EIP-4788 `ExecutionPayload` type.
 

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -9,6 +9,7 @@
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
 - [Helpers](#helpers)
+  - [`GetPayloadResponse`](#getpayloadresponse)
   - [`get_pow_block_at_terminal_total_difficulty`](#get_pow_block_at_terminal_total_difficulty)
   - [`get_terminal_pow_block`](#get_terminal_pow_block)
 - [Protocols](#protocols)
@@ -35,6 +36,14 @@ All terminology, constants, functions, and protocol mechanics defined in the upd
 Please see related Beacon Chain doc before continuing and use them as a reference throughout.
 
 ## Helpers
+
+### `GetPayloadResponse`
+
+```python
+@dataclass
+class GetPayloadResponse(object):
+    execution_payload: ExecutionPayload
+```
 
 ### `get_pow_block_at_terminal_total_difficulty`
 
@@ -83,13 +92,13 @@ The Engine API may be used to implement it with an external execution engine.
 
 #### `get_payload`
 
-Given the `payload_id`, `get_payload` returns the most recent version of the execution payload that
-has been built since the corresponding call to `notify_forkchoice_updated` method.
+Given the `payload_id`, `get_payload` returns `GetPayloadResponse` with the most recent version of
+the execution payload that has been built since the corresponding call to `notify_forkchoice_updated` method.
 
 ```python
-def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> ExecutionPayload:
+def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> GetPayloadResponse:
     """
-    Return ``execution_payload`` object.
+    Return ``GetPayloadResponse`` object.
     """
     ...
 ```
@@ -162,7 +171,7 @@ def get_execution_payload(payload_id: Optional[PayloadId], execution_engine: Exe
         # Pre-merge, empty payload
         return ExecutionPayload()
     else:
-        return execution_engine.get_payload(payload_id)
+        return execution_engine.get_payload(payload_id).execution_payload
 ```
 
 *Note*: It is recommended for a validator to call `prepare_execution_payload` as soon as input parameters become known,

--- a/specs/capella/validator.md
+++ b/specs/capella/validator.md
@@ -11,9 +11,10 @@
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
 - [Helpers](#helpers)
+  - [Modified `GetPayloadResponse`](#modified-getpayloadresponse)
 - [Protocols](#protocols)
   - [`ExecutionEngine`](#executionengine)
-    - [`get_payload`](#get_payload)
+    - [Modified `get_payload`](#modified-get_payload)
 - [Beacon chain responsibilities](#beacon-chain-responsibilities)
   - [Block proposal](#block-proposal)
     - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
@@ -39,11 +40,20 @@ Please see related Beacon Chain doc before continuing and use them as a referenc
 
 ## Helpers
 
+### Modified `GetPayloadResponse`
+
+```python
+@dataclass
+class GetPayloadResponse(object):
+    execution_payload: ExecutionPayload
+    block_value: uint256
+```
+
 ## Protocols
 
 ### `ExecutionEngine`
 
-#### `get_payload`
+#### Modified `get_payload`
 
 `get_payload` returns the upgraded Capella `ExecutionPayload` type.
 

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -114,8 +114,8 @@ Optional step for optimistic sync tests.
 
 This step sets the [`payloadStatus`](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#PayloadStatusV1)
 value that Execution Layer client mock returns in responses to the following Engine API calls:
-* [`engine_newPayloadV1(payload)`](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_newpayloadv1) if `payload.blockHash == payload_info.block_hash`
-* [`engine_forkchoiceUpdatedV1(forkchoiceState, ...)`](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_forkchoiceupdatedv1) if `forkchoiceState.headBlockHash == payload_info.block_hash`
+* [`engine_newPayloadV1(payload)`](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_newpayloadv1) if `payload.blockHash == payload_info.block_hash`
+* [`engine_forkchoiceUpdatedV1(forkchoiceState, ...)`](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_forkchoiceupdatedv1) if `forkchoiceState.headBlockHash == payload_info.block_hash`
 
 *Note:* Status of a payload must be *initialized* via `on_payload_info` before the corresponding `on_block` execution step.
 


### PR DESCRIPTION
The stub `get_blobs_and_kzg_commitments` API was cleaned up by Engine API changes (https://github.com/ethereum/execution-apis/pull/402). Now [`engine_getPayloadV3`](https://github.com/ethereum/execution-apis/blob/3e481a23b5b5478aef87305a6c1d70ddb8eda9f1/src/engine/experimental/blob-extension.md#engine_getpayloadv3) returns multiple fields include [`blobsBundle`](https://github.com/ethereum/execution-apis/blob/3e481a23b5b5478aef87305a6c1d70ddb8eda9f1/src/engine/experimental/blob-extension.md#blobsbundlev1).

For CL specs, changing the function signature means we have to deal with backward compatibility. IMO it is easier to define a `GetPayloadResponse` dataclass for different versions.

This PR adds `GetPayloadResponse` and `BlobsBundle` dataclasses that reflect the Engine API changes.
 
