### PR TITLE
RLP-encoded blob transaction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -641,6 +641,7 @@ class DenebSpecBuilder(CapellaSpecBuilder):
     @classmethod
     def imports(cls, preset_name: str):
         return super().imports(preset_name) + f'''
+from eth2spec.utils.rlp import rlp, SignedBlobTransaction
 from eth2spec.capella import {preset_name} as capella
 '''
 
@@ -654,6 +655,11 @@ T = TypeVar('T')  # For generic function
     @classmethod
     def sundry_functions(cls) -> str:
         return super().sundry_functions() + '\n\n' + '''
+def get_blob_versioned_hashes(signed_blob_tx_rlp: bytes) -> Sequence[VersionedHash]:
+    decoded_tx = rlp.decode(signed_blob_tx_rlp, SignedBlobTransaction)
+    return [VersionedHash(x) for x in decoded_tx.blob_versioned_hashes]
+
+
 def retrieve_blobs_and_proofs(beacon_block_root: Root) -> PyUnion[Tuple[Blob, KZGProof], Tuple[str, str]]:
     # pylint: disable=unused-argument
     return ("TEST", "TEST")'''

--- a/tests/core/pyspec/eth2spec/utils/rlp.py
+++ b/tests/core/pyspec/eth2spec/utils/rlp.py
@@ -1,0 +1,55 @@
+import rlp
+from rlp.sedes import (
+    BigEndianInt,
+    Binary,
+    CountableList,
+    big_endian_int,
+    binary,
+)
+
+address = Binary.fixed_length(20, allow_empty=True)
+hash32 = Binary.fixed_length(32)
+int32 = BigEndianInt(32)
+
+
+class AccountAccesses(rlp.Serializable):
+    fields = [
+        ('account', address),
+        ('storage_keys', CountableList(hash32)),
+    ]
+
+
+class SignedBlobTransaction(rlp.Serializable):
+    fields = [
+        ('chain_id', big_endian_int),
+        ('nonce', big_endian_int),
+        ('max_priority_fee_per_gas', big_endian_int),
+        ('gas_limit', big_endian_int),
+        ('to', address),
+        ('value', big_endian_int),
+        ('data', binary),
+        ('access_list', CountableList(AccountAccesses)),
+        ('max_fee_per_gas', big_endian_int),
+        ('blob_versioned_hashes', CountableList(hash32)),
+        ('y_parity', big_endian_int),  # v
+        ('r', big_endian_int),
+        ('s', big_endian_int),
+    ]
+
+
+def get_sample_signed_blob_tx(blob_versioned_hashes):
+    return SignedBlobTransaction(
+        chain_id=0,
+        nonce=1,
+        max_priority_fee_per_gas=2,
+        gas_limit=55667788,
+        to=b'\x11' * 20,
+        value=123,
+        data=b'',
+        access_list=(AccountAccesses(account=b'\x22' * 20, storage_keys=[b'\x33' * 32]),),
+        max_fee_per_gas=1,
+        blob_versioned_hashes=blob_versioned_hashes,
+        y_parity=2,
+        r=3,
+        s=4,
+    )


### PR DESCRIPTION
To evaluate https://github.com/ethereum/EIPs/pull/6985 suggestion, this PR demonstrates the CL-side changes.

- **Fields are TBD**: Since I have some questions about the fields (https://github.com/ethereum/EIPs/pull/6985#discussion_r1185201301),  the RLP data in this PR is not as same as what https://github.com/ethereum/EIPs/pull/6985 proposed.
- **Complexity of the decode function**: Given RLP libraries are mature enough (according to EL devs), I think using existing RLP library may be safer than implementing an RLP offset parser in CL specs/clients. This PR extracts an abstract `get_blob_versioned_hashes` that implementers can use an RLP library to retrieve `blob_versioned_hashes`.

Declaration: I do not tend to this change. I just show what CL specs will be.