### PR TITLE
clarify point validation description

### DIFF
--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -62,7 +62,7 @@ Public functions MUST accept raw bytes as input and perform the required cryptog
 | `G1Point` | `Bytes48` | |
 | `G2Point` | `Bytes96` | |
 | `BLSFieldElement` | `uint256` | Validation: `x < BLS_MODULUS` |
-| `KZGCommitment` | `Bytes48` | Validation: Perform [BLS standard's](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.5) "KeyValidate" check but do allow the identity point |
+| `KZGCommitment` | `Bytes48` | Validation: Perform [BLS standard's](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.5) "KeyValidate" check but do allow the point at infinity |
 | `KZGProof` | `Bytes48` | Same as for `KZGCommitment` |
 | `Polynomial` | `Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | A polynomial in evaluation form |
 | `Blob` | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` | A basic data blob |


### PR DESCRIPTION
Use equivalent description for point validation that is clearer given the definition of `G1_POINT_AT_INFINITY` in this document

Existing term "identity point" requires more outside knowledge that readers may not necessarily have