### PR TITLE
Move `SUBNETS_PER_NODE` from Constants to Configuration

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -94,3 +94,8 @@ PROPOSER_SCORE_BOOST: 40
 DEPOSIT_CHAIN_ID: 1
 DEPOSIT_NETWORK_ID: 1
 DEPOSIT_CONTRACT_ADDRESS: 0x00000000219ab540356cBB839Cbe05303d7705Fa
+
+
+# Validator guide
+# ---------------------------------------------------------------
+SUBNETS_PER_NODE: 2

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -95,3 +95,8 @@ DEPOSIT_CHAIN_ID: 5
 DEPOSIT_NETWORK_ID: 5
 # Configured on a per testnet basis
 DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
+
+
+# Validator guide
+# ---------------------------------------------------------------
+SUBNETS_PER_NODE: 2

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -13,6 +13,8 @@ This is an accompanying document to [Phase 0 -- The Beacon Chain](./beacon-chain
 - [Custom types](#custom-types)
 - [Constants](#constants)
   - [Misc](#misc)
+- [Configuration](#configuration)
+  - [Misc](#misc-1)
 - [Containers](#containers)
   - [`Eth1Block`](#eth1block)
   - [`AggregateAndProof`](#aggregateandproof)
@@ -102,9 +104,16 @@ We define the following Python custom types for type hinting and readability:
 | `EPOCHS_PER_SUBNET_SUBSCRIPTION` | `2**8` (= 256) | epochs | ~27 hours |
 | `ATTESTATION_SUBNET_COUNT` | `64` | The number of attestation subnets used in the gossipsub protocol. |
 | `ATTESTATION_SUBNET_EXTRA_BITS` | `0` | The number of extra bits of a NodeId to use when mapping to a subscribed subnet |
-| `SUBNETS_PER_NODE` | `2` | The number of long-lived subnets a beacon node should be subscribed to. |
 | `ATTESTATION_SUBNET_PREFIX_BITS` | `(ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS)` | |
 | `NODE_ID_BITS` | `256` | The bit length of uint256 is 256 |
+
+## Configuration
+
+### Misc
+
+| Name | Value | Unit | Duration |
+| - | - | :-: | :-: |
+| `SUBNETS_PER_NODE` | `2` | The number of long-lived subnets a beacon node should be subscribed to. |
 
 ## Containers
 

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/test_config_invariants.py
@@ -75,7 +75,7 @@ def test_time(spec, state):
 @with_all_phases
 @spec_state_test
 def test_networking(spec, state):
-    assert spec.SUBNETS_PER_NODE <= spec.ATTESTATION_SUBNET_COUNT
+    assert spec.config.SUBNETS_PER_NODE <= spec.ATTESTATION_SUBNET_COUNT
     node_id_length = spec.NodeID(1).type_byte_length()  # in bytes
     assert node_id_length * 8 == spec.NODE_ID_BITS  # in bits
 

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
@@ -488,7 +488,7 @@ def run_compute_subscribed_subnets_arguments(spec, rng=random.Random(1111)):
     node_id = rng.randint(0, 2**40 - 1)  # try VALIDATOR_REGISTRY_LIMIT
     epoch = rng.randint(0, 2**64 - 1)
     subnets = spec.compute_subscribed_subnets(node_id, epoch)
-    assert len(subnets) == spec.SUBNETS_PER_NODE
+    assert len(subnets) == spec.config.SUBNETS_PER_NODE
 
 
 @with_all_phases


### PR DESCRIPTION
Per https://github.com/ethereum/consensus-specs/pull/3312#issuecomment-1548973273,

This PR moves `SUBNETS_PER_NODE` from "Constants" to "Configuration".

/cc @AgeManning 