### PR TITLE
Update 4788 feature to send current slot

### DIFF
--- a/specs/_features/eip4788/beacon-chain.md
+++ b/specs/_features/eip4788/beacon-chain.md
@@ -44,6 +44,7 @@ class ExecutionPayload(Container):
     block_hash: Hash32  # Hash of execution block
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    excess_data_gas: uint256
     parent_beacon_block_root: Root # [New in EIP-4788]
 ```
 
@@ -68,5 +69,6 @@ class ExecutionPayloadHeader(Container):
     block_hash: Hash32  # Hash of execution block
     transactions_root: Root
     withdrawals_root: Root
+    excess_data_gas: uint256
     parent_beacon_block_root: Root # [New in EIP-4788]
 ```

--- a/specs/_features/eip4788/beacon-chain.md
+++ b/specs/_features/eip4788/beacon-chain.md
@@ -46,6 +46,7 @@ class ExecutionPayload(Container):
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
     excess_data_gas: uint256
     parent_beacon_block_root: Root # [New in EIP-4788]
+    current_slot: Slot             # [New in EIP-4788]
 ```
 
 #### `ExecutionPayloadHeader`
@@ -71,4 +72,5 @@ class ExecutionPayloadHeader(Container):
     withdrawals_root: Root
     excess_data_gas: uint256
     parent_beacon_block_root: Root # [New in EIP-4788]
+    current_slot: Slot             # [New in EIP-4788]
 ```

--- a/specs/_features/eip4788/validator.md
+++ b/specs/_features/eip4788/validator.md
@@ -93,6 +93,7 @@ def prepare_execution_payload(state: BeaconState,
         suggested_fee_recipient=suggested_fee_recipient,
         withdrawals=get_expected_withdrawals(state),
         parent_beacon_block_root=hash_tree_root(state.latest_block_header), # [New in EIP-4788]
+        current_slot=state.slot,                                            # [New in EIP-4788]
     )
     return execution_engine.notify_forkchoice_updated(
         head_block_hash=parent_hash,


### PR DESCRIPTION
This modification means the EL does not need to compute any slot numbers, which would require leaking the boundary between layers.