### PR TITLE
Add comment about zero length case in batch verification

### DIFF
--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -566,7 +566,7 @@ def verify_blob_kzg_proof_batch(blobs: Sequence[Blob],
                                 proofs_bytes: Sequence[Bytes48]) -> bool:
     """
     Given a list of blobs and blob KZG proofs, verify that they correspond to the provided commitments.
-
+    Will return True if there are zero blobs/commitments/proofs.
     Public method.
     """
 


### PR DESCRIPTION
The team auditing c-kzg-4844 had this minor critique, which I agree with:

> I think it may be worth the extra clarifications in the specs on how the zero length case should be handled.

This PR adds a comment to the `verify_blob_kzg_proof_batch ` docstring about this.

Also, delete the blank line to be more in line with other docstrings. For example:

https://github.com/ethereum/consensus-specs/blob/fe9c1a8cbf0c2da8a4f349efdcd77dd7ac8445c4/specs/deneb/polynomial-commitments.md?plain=1#L445-L449

https://github.com/ethereum/consensus-specs/blob/fe9c1a8cbf0c2da8a4f349efdcd77dd7ac8445c4/specs/deneb/polynomial-commitments.md?plain=1#L358-L362