### PR TITLE
Fix CircleCI Python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
           path: tests/core/pyspec/test-reports
   test-eip6110:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.9
     working_directory: ~/specs-repo
     steps:
       - restore_cache:


### PR DESCRIPTION
This PR addresses the conflict between adding #3309 (EIP-6110 CI job) and #2964. CircleCI jobs should all be on Python3.9 env.