### PR TITLE
[DRAFT] Generate Hive Test Fixtures

### DIFF
--- a/configs/hive.yaml
+++ b/configs/hive.yaml
@@ -1,0 +1,95 @@
+# Mainnet config
+
+# Extends the mainnet preset
+PRESET_BASE: 'mainnet'
+
+# Free-form short name of the network that this configuration applies to - known
+# canonical network names include:
+# * 'mainnet' - there can be only one
+# * 'prater' - testnet
+# Must match the regex: [a-z0-9\-]
+CONFIG_NAME: 'hive'
+
+# Transition
+# ---------------------------------------------------------------
+# Estimated on Sept 15, 2022
+TERMINAL_TOTAL_DIFFICULTY: 58750000000000000000000
+# By default, don't use these params
+TERMINAL_BLOCK_HASH: 0x0000000000000000000000000000000000000000000000000000000000000000
+TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: 18446744073709551615
+
+
+
+# Genesis
+# ---------------------------------------------------------------
+# `2**14` (= 16,384)
+MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384
+# Dec 1, 2020, 12pm UTC
+MIN_GENESIS_TIME: 1606824000
+# Mainnet initial fork version, recommend altering for testnets
+GENESIS_FORK_VERSION: 0x0000000a
+# 604800 seconds (7 days)
+GENESIS_DELAY: 604800
+
+
+# Forking
+# ---------------------------------------------------------------
+# Some forks are disabled for now:
+#  - These may be re-assigned to another fork-version later
+#  - Temporarily set to max uint64 value: 2**64 - 1
+
+# Altair
+ALTAIR_FORK_VERSION: 0x0100000a
+ALTAIR_FORK_EPOCH: 74240  # Oct 27, 2021, 10:56:23am UTC
+# Bellatrix
+BELLATRIX_FORK_VERSION: 0x0200000a
+BELLATRIX_FORK_EPOCH: 144896  # Sept 6, 2022, 11:34:47am UTC
+# Capella
+CAPELLA_FORK_VERSION: 0x0300000a
+CAPELLA_FORK_EPOCH: 194048  # April 12, 2023, 10:27:35pm UTC
+# Deneb
+DENEB_FORK_VERSION: 0x0400000a
+DENEB_FORK_EPOCH: 18446744073709551615
+
+
+
+
+# Time parameters
+# ---------------------------------------------------------------
+# 12 seconds
+SECONDS_PER_SLOT: 12
+# 14 (estimate from Eth1 mainnet)
+SECONDS_PER_ETH1_BLOCK: 14
+# 2**8 (= 256) epochs ~27 hours
+MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
+# 2**8 (= 256) epochs ~27 hours
+SHARD_COMMITTEE_PERIOD: 256
+# 2**11 (= 2,048) Eth1 blocks ~8 hours
+ETH1_FOLLOW_DISTANCE: 2048
+
+
+# Validator cycle
+# ---------------------------------------------------------------
+# 2**2 (= 4)
+INACTIVITY_SCORE_BIAS: 4
+# 2**4 (= 16)
+INACTIVITY_SCORE_RECOVERY_RATE: 16
+# 2**4 * 10**9 (= 16,000,000,000) Gwei
+EJECTION_BALANCE: 16000000000
+# 2**2 (= 4)
+MIN_PER_EPOCH_CHURN_LIMIT: 4
+# 2**16 (= 65,536)
+CHURN_LIMIT_QUOTIENT: 65536
+
+
+# Fork choice
+# ---------------------------------------------------------------
+# 40%
+PROPOSER_SCORE_BOOST: 40
+
+# Deposit contract
+# ---------------------------------------------------------------
+# Ethereum PoW Mainnet
+DEPOSIT_CHAIN_ID: 1
+DEPOSIT_NETWORK_ID: 1
+DEPOSIT_CONTRACT_ADDRESS: 0x00000000219ab540356cBB839Cbe05303d7705Fa

--- a/tests/core/pyspec/eth2spec/test/capella/api/test_api.py
+++ b/tests/core/pyspec/eth2spec/test/capella/api/test_api.py
@@ -1,0 +1,71 @@
+from eth2spec.test.helpers.hive import StateID, VerifyBeaconStateV2
+from eth2spec.test.context import (
+    with_capella_and_later,
+    spec_state_test,
+    hive_state,
+)
+from eth2spec.test.helpers.state import (
+    state_transition_and_sign_block,
+    next_slot,
+)
+from eth2spec.test.helpers.block import (
+    build_empty_block_for_next_slot,
+)
+from eth2spec.test.helpers.withdrawals import (
+    prepare_expected_withdrawals,
+)
+
+
+def _perform_valid_withdrawal(spec, state):
+    fully_withdrawable_indices, partial_withdrawals_indices = prepare_expected_withdrawals(
+        spec, state, num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 2,
+        num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 2)
+
+    next_slot(spec, state)
+    pre_next_withdrawal_index = state.next_withdrawal_index
+
+    expected_withdrawals = spec.get_expected_withdrawals(state)
+
+    pre_state = state.copy()
+
+    # Block 1
+    block = build_empty_block_for_next_slot(spec, state)
+    signed_block_1 = state_transition_and_sign_block(spec, state, block)
+
+    withdrawn_indices = [withdrawal.validator_index for withdrawal in expected_withdrawals]
+    fully_withdrawable_indices = list(set(fully_withdrawable_indices).difference(set(withdrawn_indices)))
+    partial_withdrawals_indices = list(set(partial_withdrawals_indices).difference(set(withdrawn_indices)))
+    assert state.next_withdrawal_index == pre_next_withdrawal_index + spec.MAX_WITHDRAWALS_PER_PAYLOAD
+
+    withdrawn_indices = [withdrawal.validator_index for withdrawal in expected_withdrawals]
+    fully_withdrawable_indices = list(set(fully_withdrawable_indices).difference(set(withdrawn_indices)))
+    partial_withdrawals_indices = list(set(partial_withdrawals_indices).difference(set(withdrawn_indices)))
+    assert state.next_withdrawal_index == pre_next_withdrawal_index + spec.MAX_WITHDRAWALS_PER_PAYLOAD
+
+    return pre_state, signed_block_1, pre_next_withdrawal_index
+
+
+@with_capella_and_later
+@spec_state_test
+@hive_state
+def test_debug_beacon_state_v2(spec, state):
+    _, signed_block_1, pre_next_withdrawal_index = (_perform_valid_withdrawal(spec, state))
+
+    # Block 2
+    block = build_empty_block_for_next_slot(spec, state)
+    signed_block_2 = state_transition_and_sign_block(spec, state, block)
+
+    assert state.next_withdrawal_index == pre_next_withdrawal_index + spec.MAX_WITHDRAWALS_PER_PAYLOAD * 2
+    yield 'blocks', [signed_block_1, signed_block_2]
+    yield 'post', state
+
+    yield 'hive', [
+        (
+            VerifyBeaconStateV2(id=StateID.Head()).
+            state_root(signed_block_2.message.state_root)
+        ),
+        (
+            VerifyBeaconStateV2(id=StateID.Slot(signed_block_2.message.slot)).
+            state_root(signed_block_2.message.state_root)
+        ),
+    ]

--- a/tests/core/pyspec/eth2spec/test/helpers/constants.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/constants.py
@@ -50,8 +50,9 @@ AFTER_DENEB_PRE_POST_FORKS = AFTER_DENEB_UPGRADES.items()
 #
 MAINNET = PresetBaseName('mainnet')
 MINIMAL = PresetBaseName('minimal')
+HIVE = PresetBaseName('hive')
 
-ALL_PRESETS = (MINIMAL, MAINNET)
+ALL_PRESETS = (MINIMAL, MAINNET, HIVE)
 
 
 #

--- a/tests/core/pyspec/eth2spec/test/helpers/hive.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/hive.py
@@ -1,0 +1,48 @@
+from ruamel.yaml import YAML
+from dataclasses import dataclass, field
+from typing import Dict
+yaml = YAML()
+
+
+class StateID(str):
+
+    @classmethod
+    def Root(cls, root):
+        return cls(f"root:{root.hex()}")
+
+    @classmethod
+    def Slot(cls, slot):
+        return cls(f"slot:{slot}")
+
+    @classmethod
+    def Head(cls):
+        return cls("head")
+
+    @classmethod
+    def Genesis(cls):
+        return cls("genesis")
+
+    @classmethod
+    def Finalized(cls):
+        return cls("finalized")
+
+    @classmethod
+    def Justified(cls):
+        return cls("justified")
+
+
+@dataclass(kw_only=True)
+class VerifyBeaconStateV2:
+    method: str = "BeaconStateV2"
+    id: StateID
+    fields: Dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.id = str(self.id)
+
+    def state_root(self, state_root):
+        self.fields["state_root"] = state_root.hex()
+        return self
+
+
+yaml.register_class(VerifyBeaconStateV2)

--- a/tests/formats/api/README.md
+++ b/tests/formats/api/README.md
@@ -1,0 +1,7 @@
+# Sanity tests
+
+The aim of the sanity tests is to set a base-line on what really needs to pass, i.e. the essentials.
+
+There are two handlers, documented individually:
+- [`slots`](./slots.md): transitions of one or more slots (and epoch transitions within)
+- [`blocks`](./blocks.md): transitions triggered by one or more blocks

--- a/tests/formats/api/blocks.md
+++ b/tests/formats/api/blocks.md
@@ -1,0 +1,41 @@
+# Beacon API testing
+
+Sanity tests to cover a series of one or more blocks being processed, aiming to cover common changes.
+
+## Test case format
+
+### `hive.yaml`
+
+TBD.
+
+
+### `meta.yaml`
+
+```yaml
+description: string            -- Optional. Description of test case, purely for debugging purposes.
+bls_setting: int               -- see general test-format spec.
+reveal_deadlines_setting: int  -- see general test-format spec.
+blocks_count: int              -- the number of blocks processed in this test.
+```
+
+
+### `genesis.ssz_snappy`
+
+An SSZ-snappy encoded `BeaconState` of the Beacon chain genesis.
+
+
+### `blocks_<index>.ssz_snappy`
+
+A series of files, with `<index>` in range `[0, blocks_count)`. Blocks need to be processed in order,
+ following the main transition function (i.e. process slot and epoch transitions in between blocks as normal)
+
+Each file is a SSZ-snappy encoded `SignedBeaconBlock`.
+
+### `post.ssz_snappy`
+
+An SSZ-snappy encoded `BeaconState`, the state after applying the block transitions.
+
+
+## Condition
+
+The beacon API verifications have to match the expected result after the post-state has been applied.

--- a/tests/generators/api/README.md
+++ b/tests/generators/api/README.md
@@ -1,0 +1,8 @@
+# Beacon API tests
+
+Beacon API tests, which need to be run using `beacon/api` hive simulator.
+
+Information on the format of the tests can be found in the [api test formats documentation](../../formats/api/README.md).
+
+ 
+

--- a/tests/generators/api/main.py
+++ b/tests/generators/api/main.py
@@ -1,0 +1,38 @@
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB
+from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators, combine_mods
+
+
+if __name__ == "__main__":
+    phase_0_mods = {key: 'eth2spec.test.phase0.api.test_' + key for key in [
+        # 'api', TODO
+    ]}
+
+    _new_altair_mods = {key: 'eth2spec.test.altair.api.test_' + key for key in [
+        # 'api', TODO
+    ]}
+    altair_mods = combine_mods(_new_altair_mods, phase_0_mods)
+
+    _new_bellatrix_mods = {key: 'eth2spec.test.bellatrix.api.test_' + key for key in [
+        # 'api', TODO
+    ]}
+    bellatrix_mods = combine_mods(_new_bellatrix_mods, altair_mods)
+
+    _new_capella_mods = {key: 'eth2spec.test.capella.api.test_' + key for key in [
+        'api',
+    ]}
+    capella_mods = combine_mods(_new_capella_mods, bellatrix_mods)
+
+    _new_deneb_mods = {key: 'eth2spec.test.deneb.api.test_' + key for key in [
+        # 'api', TODO
+    ]}
+    deneb_mods = combine_mods(_new_deneb_mods, capella_mods)
+
+    all_mods = {
+        PHASE0: phase_0_mods,
+        ALTAIR: altair_mods,
+        BELLATRIX: bellatrix_mods,
+        CAPELLA: capella_mods,
+        DENEB: deneb_mods,
+    }
+
+    run_state_test_generators(runner_name="api", all_mods=all_mods)

--- a/tests/generators/api/requirements.txt
+++ b/tests/generators/api/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=4.4
+../../../[generator]


### PR DESCRIPTION
Introduces a new generator type, `api`, that can be used to produce hive test fixtures.

The fixtures specify a post state file that is used by hive as checkpoint sync start point for the consensus client.

The produced tests contain a `hive.yaml` file that lists a series of verifications/actions that hive must perform after the client is started. At the moment, only a single Beacon API verification is supported, but this list of actions can be expanded to perform P2P tasks.

The config file `configs/hive.yaml` is introduced, and its only purpose is to change the fork versions in order for the clients to accept the configuration files (otherwise the consensus client (prysm) fails with "cannot add config with conflicting fork version schedule").

Decorator `hive_state` is also introduced and performs two tasks:
- Changes the state's genesis time from zero to `MIN_GENESIS_TIME` in order for clients to accept the genesis state and post state as checkpoint sync, otherwise client (prysm) fails with "panic: zero genesis time".
- Yields the start state as `genesis.ssz_snappy`, which is then used by hive to configure the consensus client

`setup.py` was also modified in order to set `PRESET_BASE` in the resulting python module to the actual value found in the config yaml file (it was previously forced to the preset name value).

Open questions:
- The new preset file `configs/hive.yaml` should only be used to generate tests in the `api` generator, but I'm not sure how to put a limit to this.

Requires https://github.com/ethereum/hive/pull/784 to run the fixtures.