### PR TITLE
Fallback to MODE_SINGLE_PROCESS

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/settings.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/settings.py
@@ -5,7 +5,7 @@ import multiprocessing
 MODE_SINGLE_PROCESS = 'MODE_SINGLE_PROCESS'
 MODE_MULTIPROCESSING = 'MODE_MULTIPROCESSING'
 # Test generator mode
-GENERATOR_MODE = MODE_MULTIPROCESSING
+GENERATOR_MODE = MODE_SINGLE_PROCESS
 # Number of subprocesses when using MODE_MULTIPROCESSING
 NUM_PROCESS = multiprocessing.cpu_count() // 2 - 1
 


### PR DESCRIPTION
Due to #3385, fallback to use `MODE_SINGLE_PROCESS` by default.
