### PR TITLE
[hotfix] Fix docs deploy script

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,5 +20,5 @@ jobs:
         with:
           key: ${{ github.ref }}
           path: .cache
-      - run: pip install -e .[docs]
+      - run: pip install mkdocs==1.4.2 mkdocs-material==9.1.5 mdx-truly-sane-lists==1.3 mkdocs-awesome-pages-plugin==2.8.0
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
### Issue

The merge of #3380 triggered a `master` branch error when deploying docs website:
https://github.com/ethereum/consensus-specs/actions/runs/5071294984/jobs/9107863566

```
Run pip install -e .[docs]
Obtaining file:///home/runner/work/consensus-specs/consensus-specs
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [34 lines of output]
      /opt/hostedtoolcache/Python/3.[11](https://github.com/ethereum/consensus-specs/actions/runs/5071294984/jobs/9107863566#step:6:12).3/x64/bin/python: No module named pip
      Traceback (most recent call last):
        File "<string>", line 26, in <module>
      ModuleNotFoundError: No module named 'ruamel'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line [13](https://github.com/ethereum/consensus-specs/actions/runs/5071294984/jobs/9107863566#step:6:14)2, in get_requires_for_build_editable
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-2fystufe/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 450, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-2fystufe/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-2fystufe/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-2fystufe/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 488, in run_setup
          self).run_setup(setup_script=setup_script)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-2fystufe/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 338, in run_setup
          exec(code, locals())
        File "<string>", line 28, in <module>
        File "<string>", line 22, in installPackage
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/subprocess.py", line 413, in check_call
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['/opt/hostedtoolcache/Python/3.11.3/x64/bin/python', '-m', 'pip', 'install', 'ruamel.yaml==0.[17](https://github.com/ethereum/consensus-specs/actions/runs/5071294984/jobs/9107863566#step:6:18).[21](https://github.com/ethereum/consensus-specs/actions/runs/5071294984/jobs/9107863566#step:6:22)']' returned non-zero exit status 1.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

Notice:  A new release of pip is available: [22](https://github.com/ethereum/consensus-specs/actions/runs/5071294984/jobs/9107863566#step:6:23).3.1 -> [23](https://github.com/ethereum/consensus-specs/actions/runs/5071294984/jobs/9107863566#step:6:24).1.2
Notice:  To update, run: pip install --upgrade pip
Error: Process completed with exit code 1.
```

We didn't update the relevant code at all recently. My guess is GitHub container updated or `pip` has been updated.

A quick fix is installing mkdocs modules directly without `setup.py`.

**Note: this PR is a minor hotfix, targeting on `master` branch directly before we cut a release.**