### PR TITLE
Add `data_gas_used` field to `ExecutionPayload`

### DIFF
--- a/specs/_features/eip6110/beacon-chain.md
+++ b/specs/_features/eip6110/beacon-chain.md
@@ -91,8 +91,8 @@ class ExecutionPayload(Container):
     block_hash: Hash32
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
-    excess_data_gas: uint256
     data_gas_used: uint256
+    excess_data_gas: uint256
     deposit_receipts: List[DepositReceipt, MAX_DEPOSIT_RECEIPTS_PER_PAYLOAD]  # [New in EIP6110]
 ```
 
@@ -117,8 +117,8 @@ class ExecutionPayloadHeader(Container):
     block_hash: Hash32
     transactions_root: Root
     withdrawals_root: Root
-    excess_data_gas: uint256
     data_gas_used: uint256
+    excess_data_gas: uint256
     deposit_receipts_root: Root  # [New in EIP6110]
 ```
 
@@ -270,8 +270,8 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
         block_hash=payload.block_hash,
         transactions_root=hash_tree_root(payload.transactions),
         withdrawals_root=hash_tree_root(payload.withdrawals),
-        excess_data_gas=payload.excess_data_gas,
         data_gas_used=payload.data_gas_used,
+        excess_data_gas=payload.excess_data_gas,
         deposit_receipts_root=hash_tree_root(payload.deposit_receipts),  # [New in EIP6110]
     )
 ```

--- a/specs/_features/eip6110/beacon-chain.md
+++ b/specs/_features/eip6110/beacon-chain.md
@@ -92,6 +92,7 @@ class ExecutionPayload(Container):
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
     excess_data_gas: uint256
+    data_gas_used: uint256
     deposit_receipts: List[DepositReceipt, MAX_DEPOSIT_RECEIPTS_PER_PAYLOAD]  # [New in EIP6110]
 ```
 
@@ -117,6 +118,7 @@ class ExecutionPayloadHeader(Container):
     transactions_root: Root
     withdrawals_root: Root
     excess_data_gas: uint256
+    data_gas_used: uint256
     deposit_receipts_root: Root  # [New in EIP6110]
 ```
 
@@ -269,6 +271,7 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
         transactions_root=hash_tree_root(payload.transactions),
         withdrawals_root=hash_tree_root(payload.withdrawals),
         excess_data_gas=payload.excess_data_gas,
+        data_gas_used=payload.data_gas_used,
         deposit_receipts_root=hash_tree_root(payload.deposit_receipts),  # [New in EIP6110]
     )
 ```

--- a/specs/_features/eip6110/fork.md
+++ b/specs/_features/eip6110/fork.md
@@ -88,8 +88,8 @@ def upgrade_to_eip6110(pre: deneb.BeaconState) -> BeaconState:
         block_hash=pre.latest_execution_payload_header.block_hash,
         transactions_root=pre.latest_execution_payload_header.transactions_root,
         withdrawals_root=pre.latest_execution_payload_header.withdrawals_root,
-        excess_data_gas=uint256(0),
         data_gas_used=uint256(0),
+        excess_data_gas=uint256(0),
         deposit_receipts_root=Root(),  # [New in EIP-6110]
     )
     post = BeaconState(

--- a/specs/_features/eip6110/fork.md
+++ b/specs/_features/eip6110/fork.md
@@ -89,6 +89,7 @@ def upgrade_to_eip6110(pre: deneb.BeaconState) -> BeaconState:
         transactions_root=pre.latest_execution_payload_header.transactions_root,
         withdrawals_root=pre.latest_execution_payload_header.withdrawals_root,
         excess_data_gas=uint256(0),
+        data_gas_used=uint256(0),
         deposit_receipts_root=Root(),  # [New in EIP-6110]
     )
     post = BeaconState(

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -126,8 +126,8 @@ class ExecutionPayload(Container):
     block_hash: Hash32  # Hash of execution block
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
-    excess_data_gas: uint256  # [New in Deneb]
     data_gas_used: uint256  # [New in Deneb]
+    excess_data_gas: uint256  # [New in Deneb]
 ```
 
 #### `ExecutionPayloadHeader`
@@ -151,8 +151,8 @@ class ExecutionPayloadHeader(Container):
     block_hash: Hash32  # Hash of execution block
     transactions_root: Root
     withdrawals_root: Root
-    excess_data_gas: uint256  # [New in Deneb]
     data_gas_used: uint256  # [New in Deneb]
+    excess_data_gas: uint256  # [New in Deneb]
 ```
 
 ## Helper functions
@@ -259,8 +259,8 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
         block_hash=payload.block_hash,
         transactions_root=hash_tree_root(payload.transactions),
         withdrawals_root=hash_tree_root(payload.withdrawals),
-        excess_data_gas=payload.excess_data_gas,  # [New in Deneb]
         data_gas_used=payload.data_gas_used,  # [New in Deneb]
+        excess_data_gas=payload.excess_data_gas,  # [New in Deneb]
     )
 ```
 

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -127,6 +127,7 @@ class ExecutionPayload(Container):
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
     excess_data_gas: uint256  # [New in Deneb]
+    data_gas_used: uint256  # [New in Deneb]
 ```
 
 #### `ExecutionPayloadHeader`
@@ -151,6 +152,7 @@ class ExecutionPayloadHeader(Container):
     transactions_root: Root
     withdrawals_root: Root
     excess_data_gas: uint256  # [New in Deneb]
+    data_gas_used: uint256  # [New in Deneb]
 ```
 
 ## Helper functions
@@ -258,6 +260,7 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
         transactions_root=hash_tree_root(payload.transactions),
         withdrawals_root=hash_tree_root(payload.withdrawals),
         excess_data_gas=payload.excess_data_gas,  # [New in Deneb]
+        data_gas_used=payload.data_gas_used,  # [New in Deneb]
     )
 ```
 

--- a/specs/deneb/fork.md
+++ b/specs/deneb/fork.md
@@ -83,8 +83,8 @@ def upgrade_to_deneb(pre: capella.BeaconState) -> BeaconState:
         block_hash=pre.latest_execution_payload_header.block_hash,
         transactions_root=pre.latest_execution_payload_header.transactions_root,
         withdrawals_root=pre.latest_execution_payload_header.withdrawals_root,
-        excess_data_gas=uint256(0),  # [New in Deneb]
         data_gas_used=uint256(0),  # [New in Deneb]
+        excess_data_gas=uint256(0),  # [New in Deneb]
     )
     post = BeaconState(
         # Versioning

--- a/specs/deneb/fork.md
+++ b/specs/deneb/fork.md
@@ -84,6 +84,7 @@ def upgrade_to_deneb(pre: capella.BeaconState) -> BeaconState:
         transactions_root=pre.latest_execution_payload_header.transactions_root,
         withdrawals_root=pre.latest_execution_payload_header.withdrawals_root,
         excess_data_gas=uint256(0),  # [New in Deneb]
+        data_gas_used=uint256(0),  # [New in Deneb]
     )
     post = BeaconState(
         # Versioning

--- a/specs/deneb/light-client/fork.md
+++ b/specs/deneb/light-client/fork.md
@@ -42,6 +42,7 @@ def upgrade_lc_header_to_deneb(pre: capella.LightClientHeader) -> LightClientHea
             transactions_root=pre.execution.transactions_root,
             withdrawals_root=pre.execution.withdrawals_root,
             excess_data_gas=uint256(0),  # [New in Deneb]
+            data_gas_used=uint256(0),  # [New in Deneb]
         ),
         execution_branch=pre.execution_branch,
     )

--- a/specs/deneb/light-client/fork.md
+++ b/specs/deneb/light-client/fork.md
@@ -41,8 +41,8 @@ def upgrade_lc_header_to_deneb(pre: capella.LightClientHeader) -> LightClientHea
             block_hash=pre.execution.block_hash,
             transactions_root=pre.execution.transactions_root,
             withdrawals_root=pre.execution.withdrawals_root,
-            excess_data_gas=uint256(0),  # [New in Deneb]
             data_gas_used=uint256(0),  # [New in Deneb]
+            excess_data_gas=uint256(0),  # [New in Deneb]
         ),
         execution_branch=pre.execution_branch,
     )

--- a/specs/deneb/light-client/full-node.md
+++ b/specs/deneb/light-client/full-node.md
@@ -50,6 +50,7 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
         # [New in Deneb]
         if epoch >= DENEB_FORK_EPOCH:
             execution_header.excess_data_gas = payload.excess_data_gas
+            execution_header.data_gas_used = payload.data_gas_used
 
         execution_branch = compute_merkle_proof_for_block_body(block.message.body, EXECUTION_PAYLOAD_INDEX)
     else:

--- a/specs/deneb/light-client/full-node.md
+++ b/specs/deneb/light-client/full-node.md
@@ -49,8 +49,8 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
 
         # [New in Deneb]
         if epoch >= DENEB_FORK_EPOCH:
-            execution_header.excess_data_gas = payload.excess_data_gas
             execution_header.data_gas_used = payload.data_gas_used
+            execution_header.excess_data_gas = payload.excess_data_gas
 
         execution_branch = compute_merkle_proof_for_block_body(block.message.body, EXECUTION_PAYLOAD_INDEX)
     else:

--- a/specs/deneb/light-client/sync-protocol.md
+++ b/specs/deneb/light-client/sync-protocol.md
@@ -68,7 +68,7 @@ def is_valid_light_client_header(header: LightClientHeader) -> bool:
 
     # [New in Deneb]
     if epoch < DENEB_FORK_EPOCH:
-        if header.execution.excess_data_gas != uint256(0):
+        if header.execution.excess_data_gas != uint256(0) or header.execution.data_gas_used != uint256(0):
             return False
 
     if epoch < CAPELLA_FORK_EPOCH:

--- a/tests/core/pyspec/eth2spec/test/deneb/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/sanity/test_blocks.py
@@ -16,7 +16,7 @@ from eth2spec.test.helpers.sharding import (
 )
 
 
-def run_block_with_blobs(spec, state, blob_count, excess_data_gas=1, valid=True):
+def run_block_with_blobs(spec, state, blob_count, excess_data_gas=1, data_gas_used=1, valid=True):
     yield 'pre', state
 
     block = build_empty_block_for_next_slot(spec, state)
@@ -24,6 +24,7 @@ def run_block_with_blobs(spec, state, blob_count, excess_data_gas=1, valid=True)
     block.body.blob_kzg_commitments = blob_kzg_commitments
     block.body.execution_payload.transactions = [opaque_tx]
     block.body.execution_payload.excess_data_gas = excess_data_gas
+    block.body.execution_payload.data_gas_used = data_gas_used
     block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
 
     if valid:

--- a/tests/core/pyspec/eth2spec/test/deneb/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/sanity/test_blocks.py
@@ -16,15 +16,15 @@ from eth2spec.test.helpers.sharding import (
 )
 
 
-def run_block_with_blobs(spec, state, blob_count, excess_data_gas=1, data_gas_used=1, valid=True):
+def run_block_with_blobs(spec, state, blob_count, data_gas_used=1, excess_data_gas=1, valid=True):
     yield 'pre', state
 
     block = build_empty_block_for_next_slot(spec, state)
     opaque_tx, _, blob_kzg_commitments, _ = get_sample_opaque_tx(spec, blob_count=blob_count)
     block.body.blob_kzg_commitments = blob_kzg_commitments
     block.body.execution_payload.transactions = [opaque_tx]
-    block.body.execution_payload.excess_data_gas = excess_data_gas
     block.body.execution_payload.data_gas_used = data_gas_used
+    block.body.execution_payload.excess_data_gas = excess_data_gas
     block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
 
     if valid:

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -32,6 +32,7 @@ def get_execution_payload_header(spec, execution_payload):
         payload_header.withdrawals_root = spec.hash_tree_root(execution_payload.withdrawals)
     if is_post_deneb(spec):
         payload_header.excess_data_gas = execution_payload.excess_data_gas
+        payload_header.data_gas_used = execution_payload.data_gas_used
     if is_post_eip6110(spec):
         payload_header.deposit_receipts_root = spec.hash_tree_root(execution_payload.deposit_receipts)
     return payload_header
@@ -99,6 +100,7 @@ def compute_el_header_block_hash(spec,
     if is_post_deneb(spec):
         # excess_data_gas
         execution_payload_header_rlp.append((big_endian_int, payload_header.excess_data_gas))
+        execution_payload_header_rlp.append((big_endian_int, payload_header.data_gas_used))
     if is_post_eip6110(spec):
         # deposit_receipts_root
         assert deposit_receipts_trie_root is not None
@@ -202,6 +204,7 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
         payload.withdrawals = spec.get_expected_withdrawals(state)
     if is_post_deneb(spec):
         payload.excess_data_gas = 0
+        payload.data_gas_used = 0
     if is_post_eip6110(spec):
         # just to be clear
         payload.deposit_receipts = []

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -31,8 +31,8 @@ def get_execution_payload_header(spec, execution_payload):
     if is_post_capella(spec):
         payload_header.withdrawals_root = spec.hash_tree_root(execution_payload.withdrawals)
     if is_post_deneb(spec):
-        payload_header.excess_data_gas = execution_payload.excess_data_gas
         payload_header.data_gas_used = execution_payload.data_gas_used
+        payload_header.excess_data_gas = execution_payload.excess_data_gas
     if is_post_eip6110(spec):
         payload_header.deposit_receipts_root = spec.hash_tree_root(execution_payload.deposit_receipts)
     return payload_header
@@ -99,8 +99,8 @@ def compute_el_header_block_hash(spec,
         execution_payload_header_rlp.append((Binary(32, 32), withdrawals_trie_root))
     if is_post_deneb(spec):
         # excess_data_gas
-        execution_payload_header_rlp.append((big_endian_int, payload_header.excess_data_gas))
         execution_payload_header_rlp.append((big_endian_int, payload_header.data_gas_used))
+        execution_payload_header_rlp.append((big_endian_int, payload_header.excess_data_gas))
     if is_post_eip6110(spec):
         # deposit_receipts_root
         assert deposit_receipts_trie_root is not None
@@ -203,8 +203,8 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
     if is_post_capella(spec):
         payload.withdrawals = spec.get_expected_withdrawals(state)
     if is_post_deneb(spec):
-        payload.excess_data_gas = 0
         payload.data_gas_used = 0
+        payload.excess_data_gas = 0
     if is_post_eip6110(spec):
         # just to be clear
         payload.deposit_receipts = []


### PR DESCRIPTION
Due to the recent EIP-4844 update: https://github.com/ethereum/EIPs/pull/7062, the CL side also has to add `data_gas_used` field to `ExecutionPayload`.

I intentionally didn't update EIP6110 light client specs because they are expected to be deleted in #3389.

@djrtwo 
In the EIP-4844 call today (https://github.com/ethereum/pm/issues/782) we tend to agree to include this change to devnet-6. That means we'd better publish a new spec release this week. :rage1:

