### PR TITLE
Delete `eip6110_mods` from light client testgen

### DIFF
--- a/tests/generators/light_client/main.py
+++ b/tests/generators/light_client/main.py
@@ -1,4 +1,4 @@
-from eth2spec.test.helpers.constants import ALTAIR, BELLATRIX, CAPELLA, DENEB, EIP6110
+from eth2spec.test.helpers.constants import ALTAIR, BELLATRIX, CAPELLA, DENEB
 from eth2spec.gen_helpers.gen_from_tests.gen import combine_mods, run_state_test_generators
 
 

--- a/tests/generators/light_client/main.py
+++ b/tests/generators/light_client/main.py
@@ -15,14 +15,12 @@ if __name__ == "__main__":
     ]}
     capella_mods = combine_mods(_new_capella_mods, bellatrix_mods)
     deneb_mods = capella_mods
-    eip6110_mods = deneb_mods
 
     all_mods = {
         ALTAIR: altair_mods,
         BELLATRIX: bellatrix_mods,
         CAPELLA: capella_mods,
         DENEB: deneb_mods,
-        EIP6110: eip6110_mods,
     }
 
     run_state_test_generators(runner_name="light_client", all_mods=all_mods)


### PR DESCRIPTION
leftover of #3389

delete the useless `eip6110_mods` from light client testgen.