### PR TITLE
specially mark EIP4844 changes

### DIFF
--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -41,16 +41,15 @@
 
 ## Introduction
 
-This upgrade adds blobs to the beacon chain as part of Deneb. This is an extension of the Capella upgrade.
-
-The blob transactions are packed into the execution payload by the EL/builder with their corresponding blobs being independently transmitted and are limited by `MAX_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB`. However the CL limit is independently defined by `MAX_BLOBS_PER_BLOCK`.
+Deneb is a consensus-layer upgrade containing a number of features. Including:
+* [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844): Shard Blob Transactions scale data-availability of Ethereum in a simple, forwards-compatible manner.
 
 ## Custom types
 
 | Name | SSZ equivalent | Description |
 | - | - | - |
-| `VersionedHash` | `Bytes32` | |
-| `BlobIndex` | `uint64` | |
+| `VersionedHash` | `Bytes32` | [New in Deneb:EIP4844] |
+| `BlobIndex` | `uint64` | [New in Deneb:EIP4844] |
 
 ## Constants
 
@@ -73,8 +72,11 @@ The blob transactions are packed into the execution payload by the EL/builder wi
 
 | Name | Value | Description |
 | - | - | - |
-| `MAX_BLOB_COMMITMENTS_PER_BLOCK` | `uint64(2**12)` (= 4096) | hardfork independent fixed theoretical limit same as `LIMIT_BLOBS_PER_TX` (see EIP 4844) |
-| `MAX_BLOBS_PER_BLOCK`            | `uint64(2**2)` (= 4)     | Maximum number of blobs in a single block limited by `MAX_BLOB_COMMITMENTS_PER_BLOCK` |
+| `MAX_BLOB_COMMITMENTS_PER_BLOCK` | `uint64(2**12)` (= 4096) | [New in Deneb:EIP4844] hardfork independent fixed theoretical limit same as `LIMIT_BLOBS_PER_TX` (see EIP 4844) |
+| `MAX_BLOBS_PER_BLOCK`            | `uint64(2**2)` (= 4)     | [New in Deneb:EIP4844] Maximum number of blobs in a single block limited by `MAX_BLOB_COMMITMENTS_PER_BLOCK` |
+
+*Note*: The blob transactions are packed into the execution payload by the EL/builder with their corresponding blobs being independently transmitted
+and are limited by `MAX_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB`. However the CL limit is independently defined by `MAX_BLOBS_PER_BLOCK`.
 
 ## Configuration
 
@@ -100,9 +102,9 @@ class BeaconBlockBody(Container):
     voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
     sync_aggregate: SyncAggregate
     # Execution
-    execution_payload: ExecutionPayload  # [Modified in Deneb]
+    execution_payload: ExecutionPayload  # [Modified in Deneb:EIP4844]
     bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
-    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]  # [New in Deneb]
+    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]  # [New in Deneb:EIP4844]
 ```
 
 #### `ExecutionPayload`
@@ -126,8 +128,8 @@ class ExecutionPayload(Container):
     block_hash: Hash32  # Hash of execution block
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
-    data_gas_used: uint64  # [New in Deneb]
-    excess_data_gas: uint64  # [New in Deneb]
+    data_gas_used: uint64  # [New in Deneb:EIP4844]
+    excess_data_gas: uint64  # [New in Deneb:EIP4844]
 ```
 
 #### `ExecutionPayloadHeader`
@@ -151,8 +153,8 @@ class ExecutionPayloadHeader(Container):
     block_hash: Hash32  # Hash of execution block
     transactions_root: Root
     withdrawals_root: Root
-    data_gas_used: uint64  # [New in Deneb]
-    excess_data_gas: uint64  # [New in Deneb]
+    data_gas_used: uint64  # [New in Deneb:EIP4844]
+    excess_data_gas: uint64  # [New in Deneb:EIP4844]
 ```
 
 ## Helper functions
@@ -205,7 +207,7 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
     if not self.is_valid_block_hash(new_payload_request.execution_payload):
         return False
 
-    # [New in Deneb]
+    # [New in Deneb:EIP4844]
     if not self.is_valid_versioned_hashes(new_payload_request):
         return False
 
@@ -232,11 +234,11 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
     # Verify timestamp
     assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
 
-    # [New in Deneb] Verify commitments are under limit
+    # [New in Deneb:EIP4844] Verify commitments are under limit
     assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
 
     # Verify the execution payload is valid
-    # [Modified in Deneb] Pass `versioned_hashes` to Execution Engine
+    # [Modified in Deneb:EIP4844] Pass `versioned_hashes` to Execution Engine
     versioned_hashes = [kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments]
     assert execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(execution_payload=payload, versioned_hashes=versioned_hashes)
@@ -259,8 +261,8 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
         block_hash=payload.block_hash,
         transactions_root=hash_tree_root(payload.transactions),
         withdrawals_root=hash_tree_root(payload.withdrawals),
-        data_gas_used=payload.data_gas_used,  # [New in Deneb]
-        excess_data_gas=payload.excess_data_gas,  # [New in Deneb]
+        data_gas_used=payload.data_gas_used,  # [New in Deneb:EIP4844]
+        excess_data_gas=payload.excess_data_gas,  # [New in Deneb:EIP4844]
     )
 ```
 

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -48,8 +48,8 @@ Deneb is a consensus-layer upgrade containing a number of features. Including:
 
 | Name | SSZ equivalent | Description |
 | - | - | - |
-| `VersionedHash` | `Bytes32` | [New in Deneb:EIP4844] |
-| `BlobIndex` | `uint64` | [New in Deneb:EIP4844] |
+| `VersionedHash` | `Bytes32` | *[New in Deneb:EIP4844]* |
+| `BlobIndex` | `uint64` | *[New in Deneb:EIP4844]* |
 
 ## Constants
 
@@ -72,8 +72,8 @@ Deneb is a consensus-layer upgrade containing a number of features. Including:
 
 | Name | Value | Description |
 | - | - | - |
-| `MAX_BLOB_COMMITMENTS_PER_BLOCK` | `uint64(2**12)` (= 4096) | [New in Deneb:EIP4844] hardfork independent fixed theoretical limit same as `LIMIT_BLOBS_PER_TX` (see EIP 4844) |
-| `MAX_BLOBS_PER_BLOCK`            | `uint64(2**2)` (= 4)     | [New in Deneb:EIP4844] Maximum number of blobs in a single block limited by `MAX_BLOB_COMMITMENTS_PER_BLOCK` |
+| `MAX_BLOB_COMMITMENTS_PER_BLOCK` | `uint64(2**12)` (= 4096) | *[New in Deneb:EIP4844]* hardfork independent fixed theoretical limit same as `LIMIT_BLOBS_PER_TX` (see EIP 4844) |
+| `MAX_BLOBS_PER_BLOCK`            | `uint64(2**2)` (= 4)     | *[New in Deneb:EIP4844]* Maximum number of blobs in a single block limited by `MAX_BLOB_COMMITMENTS_PER_BLOCK` |
 
 *Note*: The blob transactions are packed into the execution payload by the EL/builder with their corresponding blobs being independently transmitted
 and are limited by `MAX_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB`. However the CL limit is independently defined by `MAX_BLOBS_PER_BLOCK`.

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -25,7 +25,7 @@ This is the modification of the fork choice accompanying the Deneb upgrade.
 
 #### `is_data_available`
 
-[New in Deneb:EIP4844]
+*[New in Deneb:EIP4844]*
 
 The implementation of `is_data_available` will become more sophisticated during later scaling upgrades.
 Initially, verification requires every verifying actor to retrieve all matching `Blob`s and `KZGProof`s, and validate them with `verify_blob_kzg_proof_batch`.

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -25,6 +25,8 @@ This is the modification of the fork choice accompanying the Deneb upgrade.
 
 #### `is_data_available`
 
+[New in Deneb:EIP4844]
+
 The implementation of `is_data_available` will become more sophisticated during later scaling upgrades.
 Initially, verification requires every verifying actor to retrieve all matching `Blob`s and `KZGProof`s, and validate them with `verify_blob_kzg_proof_batch`.
 
@@ -76,7 +78,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     )
     assert store.finalized_checkpoint.root == finalized_checkpoint_block
 
-    # [New in Deneb]
+    # [New in Deneb:EIP4844]
     # Check if blob data is available
     # If not, this block MAY be queued and subsequently considered when blob data becomes available
     assert is_data_available(hash_tree_root(block), block.body.blob_kzg_commitments)

--- a/specs/deneb/fork.md
+++ b/specs/deneb/fork.md
@@ -83,8 +83,8 @@ def upgrade_to_deneb(pre: capella.BeaconState) -> BeaconState:
         block_hash=pre.latest_execution_payload_header.block_hash,
         transactions_root=pre.latest_execution_payload_header.transactions_root,
         withdrawals_root=pre.latest_execution_payload_header.withdrawals_root,
-        data_gas_used=uint64(0),  # [New in Deneb]
-        excess_data_gas=uint64(0),  # [New in Deneb]
+        data_gas_used=uint64(0),  # [New in Deneb:EIP4844]
+        excess_data_gas=uint64(0),  # [New in Deneb:EIP4844]
     )
     post = BeaconState(
         # Versioning
@@ -126,7 +126,7 @@ def upgrade_to_deneb(pre: capella.BeaconState) -> BeaconState:
         current_sync_committee=pre.current_sync_committee,
         next_sync_committee=pre.next_sync_committee,
         # Execution-layer
-        latest_execution_payload_header=latest_execution_payload_header,  # [Modified in Deneb]
+        latest_execution_payload_header=latest_execution_payload_header,  # [Modified in Deneb:EIP4844]
         # Withdrawals
         next_withdrawal_index=pre.next_withdrawal_index,
         next_withdrawal_validator_index=pre.next_withdrawal_validator_index,

--- a/specs/deneb/light-client/fork.md
+++ b/specs/deneb/light-client/fork.md
@@ -41,8 +41,8 @@ def upgrade_lc_header_to_deneb(pre: capella.LightClientHeader) -> LightClientHea
             block_hash=pre.execution.block_hash,
             transactions_root=pre.execution.transactions_root,
             withdrawals_root=pre.execution.withdrawals_root,
-            data_gas_used=uint64(0),  # [New in Deneb]
-            excess_data_gas=uint64(0),  # [New in Deneb]
+            data_gas_used=uint64(0),  # [New in Deneb:EIP4844]
+            excess_data_gas=uint64(0),  # [New in Deneb:EIP4844]
         ),
         execution_branch=pre.execution_branch,
     )

--- a/specs/deneb/light-client/full-node.md
+++ b/specs/deneb/light-client/full-node.md
@@ -47,7 +47,7 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
             withdrawals_root=hash_tree_root(payload.withdrawals),
         )
 
-        # [New in Deneb]
+        # [New in Deneb:EIP4844]
         if epoch >= DENEB_FORK_EPOCH:
             execution_header.data_gas_used = payload.data_gas_used
             execution_header.excess_data_gas = payload.excess_data_gas

--- a/specs/deneb/light-client/sync-protocol.md
+++ b/specs/deneb/light-client/sync-protocol.md
@@ -66,7 +66,7 @@ def get_lc_execution_root(header: LightClientHeader) -> Root:
 def is_valid_light_client_header(header: LightClientHeader) -> bool:
     epoch = compute_epoch_at_slot(header.beacon.slot)
 
-    # [New in Deneb]
+    # [New in Deneb:EIP4844]
     if epoch < DENEB_FORK_EPOCH:
         if header.execution.data_gas_used != uint64(0) or header.execution.excess_data_gas != uint64(0):
             return False

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -50,7 +50,7 @@ The specification of these changes continues in the same format as the network s
 
 #### `BlobSidecar`
 
-[New in Deneb:EIP4844]
+*[New in Deneb:EIP4844]*
 
 ```python
 class BlobSidecar(Container):
@@ -66,7 +66,7 @@ class BlobSidecar(Container):
 
 #### `SignedBlobSidecar`
 
-[New in Deneb:EIP4844]
+*[New in Deneb:EIP4844]*
 
 ```python
 class SignedBlobSidecar(Container):
@@ -76,7 +76,7 @@ class SignedBlobSidecar(Container):
 
 #### `BlobIdentifier`
 
-[New in Deneb:EIP4844]
+*[New in Deneb:EIP4844]*
 
 ```python
 class BlobIdentifier(Container):
@@ -130,7 +130,7 @@ New validation:
 
 ###### `blob_sidecar_{subnet_id}`
 
-[New in Deneb:EIP4844]
+*[New in Deneb:EIP4844]*
 
 This topic is used to propagate signed blob sidecars, where each blob index maps to some `subnet_id`.
 
@@ -199,7 +199,7 @@ No more than `MAX_REQUEST_BLOCKS_DENEB` may be requested at a time.
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/1/`
 
-[New in Deneb:EIP4844]
+*[New in Deneb:EIP4844]*
 
 The `<context-bytes>` field is calculated as `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 
@@ -248,7 +248,7 @@ Clients MAY limit the number of blocks and sidecars in the response.
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/1/`
 
-[New in Deneb:EIP4844]
+*[New in Deneb:EIP4844]*
 
 The `<context-bytes>` field is calculated as `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -50,6 +50,8 @@ The specification of these changes continues in the same format as the network s
 
 #### `BlobSidecar`
 
+[New in Deneb:EIP4844]
+
 ```python
 class BlobSidecar(Container):
     block_root: Root
@@ -64,6 +66,8 @@ class BlobSidecar(Container):
 
 #### `SignedBlobSidecar`
 
+[New in Deneb:EIP4844]
+
 ```python
 class SignedBlobSidecar(Container):
     message: BlobSidecar
@@ -71,6 +75,8 @@ class SignedBlobSidecar(Container):
 ```
 
 #### `BlobIdentifier`
+
+[New in Deneb:EIP4844]
 
 ```python
 class BlobIdentifier(Container):
@@ -107,7 +113,7 @@ The new topics along with the type of the `data` field of a gossipsub message ar
 
 | Name | Message Type |
 | - | - |
-| `blob_sidecar_{subnet_id}` | `SignedBlobSidecar` (new) |
+| `blob_sidecar_{subnet_id}` | `SignedBlobSidecar` [New in Deneb:EIP4844] |
 
 ##### Global topics
 
@@ -123,6 +129,8 @@ New validation:
   i.e. validate that `len(body.signed_beacon_block.message.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK`
 
 ###### `blob_sidecar_{subnet_id}`
+
+[New in Deneb:EIP4844]
 
 This topic is used to propagate signed blob sidecars, where each blob index maps to some `subnet_id`.
 
@@ -191,7 +199,7 @@ No more than `MAX_REQUEST_BLOCKS_DENEB` may be requested at a time.
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/1/`
 
-New in deneb.
+[New in Deneb:EIP4844]
 
 The `<context-bytes>` field is calculated as `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 
@@ -240,7 +248,7 @@ Clients MAY limit the number of blocks and sidecars in the response.
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/1/`
 
-New in deneb.
+[New in Deneb:EIP4844]
 
 The `<context-bytes>` field is calculated as `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -336,7 +336,7 @@ def evaluate_polynomial_in_evaluation_form(polynomial: Polynomial,
 
 ### KZG
 
-KZG core functions. These are also defined in Deneb execution specs.
+KZG core functions. These are also defined in Deneb execution specs for EIP-4844.
 
 #### `blob_to_kzg_commitment`
 

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -49,7 +49,7 @@
 
 ## Introduction
 
-This document specifies basic polynomial operations and KZG polynomial commitment operations as they are needed for the Deneb specification. The implementations are not optimized for performance, but readability. All practical implementations should optimize the polynomial operations.
+This document specifies basic polynomial operations and KZG polynomial commitment operations that are essential for the implementation of the EIP-4844 feature in the Deneb specification. The implementations are not optimized for performance, but readability. All practical implementations should optimize the polynomial operations.
 
 Functions flagged as "Public method" MUST be provided by the underlying KZG library as public functions. All other functions are private functions used internally by the KZG library.
 
@@ -336,7 +336,7 @@ def evaluate_polynomial_in_evaluation_form(polynomial: Polynomial,
 
 ### KZG
 
-KZG core functions. These are also defined in Deneb execution specs for EIP-4844.
+KZG core functions. These are also defined in Deneb execution specs.
 
 #### `blob_to_kzg_commitment`
 

--- a/specs/deneb/validator.md
+++ b/specs/deneb/validator.md
@@ -46,11 +46,13 @@ Please see related Beacon Chain doc before continuing and use them as a referenc
 
 | Name | Value | Unit |
 | - | - | :-: |
-| `BLOB_SIDECAR_SUBNET_COUNT` | `4` | The number of blob sidecar subnets used in the gossipsub protocol. |
+| `BLOB_SIDECAR_SUBNET_COUNT` | `4` | *[New in Deneb:EIP4844]* The number of blob sidecar subnets used in the gossipsub protocol. |
 
 ## Helpers
 
 ### `BlobsBundle`
+
+*[New in Deneb:EIP4844]*
 
 ```python
 @dataclass
@@ -67,7 +69,7 @@ class BlobsBundle(object):
 class GetPayloadResponse(object):
     execution_payload: ExecutionPayload
     block_value: uint256
-    blobs_bundle: BlobsBundle
+    blobs_bundle: BlobsBundle  # [New in Deneb:EIP4844]
 ```
 
 ## Protocol
@@ -98,7 +100,7 @@ All validator responsibilities remain unchanged other than those noted below.
 
 ##### Blob KZG commitments
 
-[New in Deneb:EIP4844]
+*[New in Deneb:EIP4844]*
 
 1. After retrieving the execution payload from the execution engine as specified in Capella,
 use the `payload_id` to retrieve `blobs`, `blob_kzg_commitments`, and `blob_kzg_proofs`
@@ -106,6 +108,8 @@ via `get_payload(payload_id).blobs_bundle`.
 2. Set `block.body.blob_kzg_commitments = blob_kzg_commitments`.
 
 #### Constructing the `SignedBlobSidecar`s
+
+*[New in Deneb:EIP4844]*
 
 To construct a `SignedBlobSidecar`, a `signed_blob_sidecar` is defined with the necessary context for block and sidecar proposal.
 

--- a/specs/deneb/validator.md
+++ b/specs/deneb/validator.md
@@ -98,6 +98,8 @@ All validator responsibilities remain unchanged other than those noted below.
 
 ##### Blob KZG commitments
 
+[New in Deneb:EIP4844]
+
 1. After retrieving the execution payload from the execution engine as specified in Capella,
 use the `payload_id` to retrieve `blobs`, `blob_kzg_commitments`, and `blob_kzg_proofs`
 via `get_payload(payload_id).blobs_bundle`.


### PR DESCRIPTION
We are planning to include additional features (#3182) in the Deneb fork. This PR modifies the previous "[New in Deneb]" comment to "[New in Deneb:EIP4844]", allowing us to differentiate the sources once we integrate these new features.

Usine the notation `EIP4844` rather than `EIP-4844` because it's the form we use for feature spec *constant*, and it's shorter.