### PR TITLE
Ensure make lint resolves to the right pylint and mypy versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,8 @@ codespell:
 lint: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
 	flake8  --config $(LINTER_CONFIG_FILE) ./eth2spec \
-	&& pylint --rcfile $(LINTER_CONFIG_FILE) $(PYLINT_SCOPE) \
-	&& mypy --config-file $(LINTER_CONFIG_FILE) $(MYPY_SCOPE)
+	&& python -m pylint --rcfile $(LINTER_CONFIG_FILE) $(PYLINT_SCOPE) \
+	&& python -m mypy --config-file $(LINTER_CONFIG_FILE) $(MYPY_SCOPE)
 
 lint_generators: pyspec
 	. venv/bin/activate; cd $(TEST_GENERATORS_DIR); \


### PR DESCRIPTION
At least in my local desktop environment, running `pylint` and `mypy` directly as binary resolves to the host version causing inconsistencies.

In my local experience and from https://stackoverflow.com/questions/51373063/pip3-bad-interpreter-no-such-file-or-directory running the module through the python binary ensures resolving the right module.

Without this PR I can't recreate the results of  `make lint` from CI in my local env