### PR TITLE
Update lru-dict package to latest stable release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1284,7 +1284,7 @@ setup(
         "remerkleable==0.1.27",
         "trie==2.0.2",
         RUAMEL_YAML_VERSION,
-        "lru-dict==1.1.8",
+        "lru-dict==1.2.0",
         MARKO_VERSION,
         "py_arkworks_bls12381==0.3.4",
         "curdleproofs @ git+https://github.com/nalinbhardwaj/curdleproofs.pie@master#egg=curdleproofs&subdirectory=curdleproofs",


### PR DESCRIPTION
lru-dict build fails when building under clang version 16 (https://github.com/amitdev/lru-dict/commit/6badf6376d12a2e0498f67bbc7d5c0332b96a4d7). This bumps the version to the latest stable release.

Tested on MacOS M2 and Ubuntu Jammy x86-64.