### PR TITLE
Clarify minimum request epoch for serving the blobs by clients

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -239,7 +239,7 @@ No more than `MAX_REQUEST_BLOB_SIDECARS` may be requested at a time.
 The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `BlobSidecar` payload.
 
-Clients MUST support requesting sidecars since `minimum_request_epoch`, where `minimum_request_epoch = max(finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, DENEB_FORK_EPOCH)`. If any root in the request content references a block earlier than `minimum_request_epoch`, peers MAY respond with error code `3: ResourceUnavailable` or not include the blob sidecar in the response.
+Clients MUST support requesting sidecars since `minimum_request_epoch`, where `minimum_request_epoch = min(finalized_epoch, max(current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, DENEB_FORK_EPOCH))`. If any root in the request content references a block earlier than `minimum_request_epoch`, peers MAY respond with error code `3: ResourceUnavailable` or not include the blob sidecar in the response.
 
 Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.


### PR DESCRIPTION
I think the current formula for `minimum_request_epoch` for blobs will stall the clients in event of non finalization .

Depending upon various constants actual value, its possible that `max(finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, DENEB_FORK_EPOCH)` could endup > finalized_epoch,
and the clients which start off from the finalized (using checkpoint sync) will not get blobs to forward sync from finalized and will not meet the availability forkchoice checks sending them in limbo.

This PR makes sure that blobs from clients are always available from `finalized_epoch`