### PR TITLE
Whisk: assert zeroed values during selection gap

### DIFF
--- a/specs/_features/whisk/beacon-chain.md
+++ b/specs/_features/whisk/beacon-chain.md
@@ -322,7 +322,7 @@ def process_shuffled_trackers(state: BeaconState, body: BeaconBlockBody) -> None
 
     shuffle_epoch = get_current_epoch(state) % WHISK_EPOCHS_PER_SHUFFLING_PHASE
     if shuffle_epoch + WHISK_PROPOSER_SELECTION_GAP + 1 >= WHISK_EPOCHS_PER_SHUFFLING_PHASE:
-        # Require unchanged trackers during cooldown
+        # Require trackers set to zero during cooldown
         assert body.whisk_post_shuffle_trackers == Vector[WhiskTracker, WHISK_VALIDATORS_PER_SHUFFLE]()
         assert body.whisk_shuffle_proof_M_commitment == BLSG1Point()
         assert body.whisk_shuffle_proof == WhiskShuffleProof()


### PR DESCRIPTION
Whisk requires to not submit tracker shuffling during a selection gap. To have more deterministic block production the spec should assert `whisk_shuffle_proof_M_commitment` and `whisk_shuffle_proof` to be zero. It should also assert `whisk_post_shuffle_trackers` to be zero instead of `pre_shuffle_trackers`. Setting the values to `pre_shuffle_trackers` does not add any new information while increasing the number of non-zero bytes in the block increasing its compressed size.