### PR TITLE
Whisk: complete TODO items in fork logic

### DIFF
--- a/specs/_features/whisk/beacon-chain.md
+++ b/specs/_features/whisk/beacon-chain.md
@@ -179,8 +179,11 @@ class BeaconState(Container):
 ```python
 def select_whisk_proposer_trackers(state: BeaconState, epoch: Epoch) -> None:
     # Select proposer trackers from candidate trackers
-    proposer_seed_epoch = max(epoch, WHISK_PROPOSER_SELECTION_GAP) - WHISK_PROPOSER_SELECTION_GAP
-    proposer_seed = get_seed(state, proposer_seed_epoch, DOMAIN_WHISK_PROPOSER_SELECTION)
+    proposer_seed = get_seed(
+        state,
+        Epoch(saturating_sub(epoch, WHISK_PROPOSER_SELECTION_GAP)),
+        DOMAIN_WHISK_PROPOSER_SELECTION
+    )
     for i in range(WHISK_PROPOSER_TRACKERS_COUNT):
         index = compute_shuffled_index(uint64(i), uint64(len(state.whisk_candidate_trackers)), proposer_seed)
         state.whisk_proposer_trackers[i] = state.whisk_candidate_trackers[index]

--- a/specs/_features/whisk/fork.md
+++ b/specs/_features/whisk/fork.md
@@ -115,8 +115,7 @@ def upgrade_to_whisk(pre: capella.BeaconState) -> BeaconState:
 
     # Do a candidate selection followed by a proposer selection so that we have proposers for the upcoming day
     # Use an old epoch when selecting candidates so that we don't get the same seed as in the next candidate selection
-    initial_candidate_gap = WHISK_PROPOSER_SELECTION_GAP + Epoch(1)
-    select_whisk_candidate_trackers(post, max(epoch, initial_candidate_gap) - initial_candidate_gap)
+    select_whisk_candidate_trackers(post, max(0, epoch - WHISK_PROPOSER_SELECTION_GAP - 1))
     select_whisk_proposer_trackers(post, epoch)
 
     # Do a final round of candidate selection.

--- a/specs/_features/whisk/fork.md
+++ b/specs/_features/whisk/fork.md
@@ -115,7 +115,7 @@ def upgrade_to_whisk(pre: capella.BeaconState) -> BeaconState:
 
     # Do a candidate selection followed by a proposer selection so that we have proposers for the upcoming day
     # Use an old epoch when selecting candidates so that we don't get the same seed as in the next candidate selection
-    select_whisk_candidate_trackers(post, max(0, epoch - WHISK_PROPOSER_SELECTION_GAP - 1))
+    select_whisk_candidate_trackers(post, Epoch(saturating_sub(epoch, WHISK_PROPOSER_SELECTION_GAP + 1)))
     select_whisk_proposer_trackers(post, epoch)
 
     # Do a final round of candidate selection.

--- a/specs/_features/whisk/fork.md
+++ b/specs/_features/whisk/fork.md
@@ -53,27 +53,13 @@ The upgrade occurs after the completion of the inner loop of `process_slots` tha
 This ensures that we drop right into the beginning of the shuffling phase but without `process_whisk_epoch()` triggering for this Whisk run. Hence we handle all the setup ourselves in `upgrade_to_whisk()` below.
 
 ```python
-def whisk_candidate_selection(state: BeaconState, epoch: Epoch) -> None:
-    # TODO
-    # pylint: disable=unused-argument
-    pass
-```
-
-```python
-def whisk_proposer_selection(state: BeaconState, epoch: Epoch) -> None:
-    # TODO
-    # pylint: disable=unused-argument
-    pass
-```
-
-```python
-def upgrade_to_whisk(pre: bellatrix.BeaconState) -> BeaconState:
+def upgrade_to_whisk(pre: capella.BeaconState) -> BeaconState:
     # Compute initial unsafe trackers for all validators
     ks = [get_initial_whisk_k(ValidatorIndex(validator_index), 0) for validator_index in range(len(pre.validators))]
     whisk_k_commitments = [get_k_commitment(k) for k in ks]
     whisk_trackers = [get_initial_tracker(k) for k in ks]
 
-    epoch = bellatrix.get_current_epoch(pre)
+    epoch = get_current_epoch(pre)
     post = BeaconState(
         # Versioning
         genesis_time=pre.genesis_time,
@@ -115,6 +101,11 @@ def upgrade_to_whisk(pre: bellatrix.BeaconState) -> BeaconState:
         next_sync_committee=pre.next_sync_committee,
         # Execution-layer
         latest_execution_payload_header=pre.latest_execution_payload_header,
+        # Withdrawals
+        next_withdrawal_index=pre.next_withdrawal_index,
+        next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
+        # Deep history valid from Capella onwards
+        historical_summaries=pre.historical_summaries,
         # Whisk
         whisk_proposer_trackers=[WhiskTracker() for _ in range(WHISK_PROPOSER_TRACKERS_COUNT)],  # [New in Whisk]
         whisk_candidate_trackers=[WhiskTracker() for _ in range(WHISK_CANDIDATE_TRACKERS_COUNT)],  # [New in Whisk]
@@ -124,12 +115,13 @@ def upgrade_to_whisk(pre: bellatrix.BeaconState) -> BeaconState:
 
     # Do a candidate selection followed by a proposer selection so that we have proposers for the upcoming day
     # Use an old epoch when selecting candidates so that we don't get the same seed as in the next candidate selection
-    whisk_candidate_selection(post, epoch - WHISK_PROPOSER_SELECTION_GAP - 1)
-    whisk_proposer_selection(post, epoch)
+    initial_candidate_gap = WHISK_PROPOSER_SELECTION_GAP + Epoch(1)
+    select_whisk_candidate_trackers(post, max(epoch, initial_candidate_gap) - initial_candidate_gap)
+    select_whisk_proposer_trackers(post, epoch)
 
     # Do a final round of candidate selection.
     # We need it so that we have something to shuffle over the upcoming shuffling phase.
-    whisk_candidate_selection(post, epoch)
+    select_whisk_candidate_trackers(post, epoch)
 
     return post
 ```

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -59,6 +59,7 @@
     - [`xor`](#xor)
     - [`uint_to_bytes`](#uint_to_bytes)
     - [`bytes_to_uint64`](#bytes_to_uint64)
+    - [`saturating_sub`](#saturating_sub)
   - [Crypto](#crypto)
     - [`hash`](#hash)
     - [`hash_tree_root`](#hash_tree_root)
@@ -628,6 +629,16 @@ def bytes_to_uint64(data: bytes) -> uint64:
     Return the integer deserialization of ``data`` interpreted as ``ENDIANNESS``-endian.
     """
     return uint64(int.from_bytes(data, ENDIANNESS))
+```
+
+#### `saturating_sub`
+
+```python
+def saturating_sub(a: int, b: int) -> int:
+    """
+    Computes a - b, saturating at numeric bounds.
+    """
+    return a - b if a > b else 0
 ```
 
 ### Crypto


### PR DESCRIPTION
Reuse `select_whisk_proposer_trackers` and `select_whisk_candidate_trackers` for the fork transition initial selection of trackers

Also add missing properties from capella state initialization