### PR TITLE
Lock doctoc version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
       - checkout
       - run:
           name: Check table of contents
-          command: sudo npm install -g doctoc@2 && make check_toc
+          command: sudo npm install -g doctoc@2.2.0 && make check_toc
   codespell:
     docker:
       - image: circleci/python:3.9

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commitRef || env.DEFAULT_BRANCH }}
       - name: Check table of contents
-        run: sudo npm install -g doctoc@2 && make check_toc
+        run: sudo npm install -g doctoc@2.2.0 && make check_toc
 
   codespell:
    runs-on: self-hosted


### PR DESCRIPTION
each CI run installs latest 2.x.x doctoc version, which currently is 2.2.1 https://www.npmjs.com/package/doctoc?activeTab=versions. 

Note that version 2.2.1 does not even exist in Github, where latest master is still at 2.2.0. So I picked that version, there's no acknowledgment anywhere of what 2.2.1 is fixing.

A non-locked version may break CI unexpectedly if the maintainer pushes a non-semver version