### PR TITLE
Remove is_valid_block_hash change in Deneb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -742,9 +742,7 @@ class NoopExecutionEngine(ExecutionEngine):
         # pylint: disable=unused-argument
         raise NotImplementedError("no default block production")
 
-    def is_valid_block_hash(self: ExecutionEngine,
-                            execution_payload: ExecutionPayload,
-                            parent_beacon_block_root: Root) -> bool:
+    def is_valid_block_hash(self: ExecutionEngine, execution_payload: ExecutionPayload) -> bool:
         return True
 
     def is_valid_versioned_hashes(self: ExecutionEngine, new_payload_request: NewPayloadRequest) -> bool:

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -31,7 +31,6 @@
     - [Request data](#request-data)
       - [Modified `NewPayloadRequest`](#modified-newpayloadrequest)
     - [Engine APIs](#engine-apis)
-      - [`is_valid_block_hash`](#is_valid_block_hash)
       - [`is_valid_versioned_hashes`](#is_valid_versioned_hashes)
       - [Modified `notify_new_payload`](#modified-notify_new_payload)
       - [Modified `verify_and_notify_new_payload`](#modified-verify_and_notify_new_payload)
@@ -229,20 +228,6 @@ class NewPayloadRequest(object):
 
 #### Engine APIs
 
-##### `is_valid_block_hash`
-
-*Note*: The function `is_valid_block_hash` is modified to include the additional `parent_beacon_block_root` parameter for EIP-4788.
-
-```python
-def is_valid_block_hash(self: ExecutionEngine,
-                        execution_payload: ExecutionPayload,
-                        parent_beacon_block_root: Root) -> bool:
-    """
-    Return ``True`` if and only if ``execution_payload.block_hash`` is computed correctly.
-    """
-    ...
-```
-
 ##### `is_valid_versioned_hashes`
 
 ```python
@@ -279,8 +264,7 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
     execution_payload = new_payload_request.execution_payload
     parent_beacon_block_root = new_payload_request.parent_beacon_block_root
 
-    # [Modified in Deneb:EIP4788]
-    if not self.is_valid_block_hash(execution_payload, parent_beacon_block_root):
+    if not self.is_valid_block_hash(execution_payload):
         return False
 
     # [New in Deneb:EIP4844]


### PR DESCRIPTION
Since `is_valid_block_hash` is used in consensus-specs only for describing what `verify_and_notify_new_payload` does, `is_valid_block_hash` does not really exist in the clients.

`is_valid_block_hash` shouldn't accept `parent_beacon_block_root`, since it has nothing to do with them.

`verify_and_notify_new_payload` accepts `parent_beacon_block_root` and corresponds to [engine_newPayloadV3](https://github.com/ethereum/execution-apis/pull/420/files#diff-556d0544d517a1fe1242173c7d23c7cb5f3153bad5eeec9293865df9eefd349aR79-R89), but `is_valid_block_hash` doesn't have to do the same.