### PR TITLE
Upgrade `wheel`, `pip`, and `setuptools` with `make install_test`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,26 +36,26 @@ commands:
     steps:
       - restore_cached_venv:
           venv_name: v24-pyspec
-          reqs_checksum: cache-{{ checksum "setup.py" }}
+          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "requirements_preinstallation.txt" }}
   save_pyspec_cached_venv:
     description: Save a venv into a cache with pyspec keys"
     steps:
       - save_cached_venv:
           venv_name: v24-pyspec
-          reqs_checksum: cache-{{ checksum "setup.py" }}
+          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "requirements_preinstallation.txt" }}
           venv_path: ./venv
   restore_deposit_contract_tester_cached_venv:
     description: "Restore the venv from cache for the deposit contract tester"
     steps:
       - restore_cached_venv:
           venv_name: v23-deposit-contract-tester
-          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "solidity_deposit_contract/web3_tester/requirements.txt" }}
+          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "requirements_preinstallation.txt" }}-{{ checksum "solidity_deposit_contract/web3_tester/requirements.txt" }}
   save_deposit_contract_tester_cached_venv:
     description: "Save the venv to cache for later use of the deposit contract tester"
     steps:
       - save_cached_venv:
           venv_name: v23-deposit-contract-tester
-          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "solidity_deposit_contract/web3_tester/requirements.txt" }}
+          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "requirements_preinstallation.txt" }}-{{ checksum "solidity_deposit_contract/web3_tester/requirements.txt" }}
           venv_path: ./solidity_deposit_contract/web3_tester/venv
 jobs:
   checkout_specs:

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ pyspec:
 
 # installs the packages to run pyspec tests
 install_test:
-	python3 -m venv venv; . venv/bin/activate; python3 -m pip install -e .[lint]; python3 -m pip install -e .[test]
+	python3 -m venv venv; . venv/bin/activate; python3 -m pip install --upgrade wheel pip setuptools; python3 -m pip install -e .[lint]; python3 -m pip install -e .[test]
 
 # Testing against `minimal` or `mainnet` config by default
 test: pyspec

--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,15 @@ generate_tests: $(GENERATOR_TARGETS)
 pyspec:
 	python3 -m venv venv; . venv/bin/activate; python3 setup.py pyspecdev
 
+# check the setup tool requirements
+preinstallation:
+	python3 -m venv venv; . venv/bin/activate; \
+	python3 -m pip install -r requirements_preinstallation.txt
+
 # installs the packages to run pyspec tests
-install_test:
-	python3 -m venv venv; . venv/bin/activate; python3 -m pip install --upgrade wheel pip setuptools; python3 -m pip install -e .[lint]; python3 -m pip install -e .[test]
+install_test: preinstallation
+	python3 -m venv venv; . venv/bin/activate; \
+	python3 -m pip install -e .[lint]; python3 -m pip install -e .[test]
 
 # Testing against `minimal` or `mainnet` config by default
 test: pyspec

--- a/requirements_preinstallation.txt
+++ b/requirements_preinstallation.txt
@@ -1,0 +1,3 @@
+pip>=23.1.2
+wheel>=0.40.0
+setuptools>=68.0.0


### PR DESCRIPTION
In the process of debugging the CI failure in #3442. We're now updating to the latest versions of `wheel`, `pip`, and `setuptools` at the beginning of the `make install_test` command.