### PR TITLE
Add upper epoch churn limit

### DIFF
--- a/specs/_features/limit_churn/beacon_chain.md
+++ b/specs/_features/limit_churn/beacon_chain.md
@@ -1,0 +1,52 @@
+Limit churn -- The Beacon Chain
+
+## Table of contents
+
+<!-- TOC -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Configuration](#configuration)
+  - [Validator cycle](#validator-cycle)
+- [Helper functions](#helper-functions)
+  - [Beacon state accessors](#beacon-state-accessors)
+    - [modified `get_validator_churn_limit`](#modified-get_validator_churn_limit)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+## Introduction
+
+This is the beacon chain specification to limit the max churn value, motivated to limit the validator active set growth rate.
+
+*Note:* This specification is built upon [Capella](../../capella/beacon_chain.md) and is under active development.
+
+## Configuration
+
+### Validator cycle
+
+| Name | Value |
+| - | - |
+| `MAX_PER_EPOCH_CHURN_LIMIT` | `uint64(12)` (= 12) |
+
+## Helper functions
+
+### Beacon state accessors
+
+#### modified `get_validator_churn_limit`
+
+```python
+def get_validator_churn_limit(state: BeaconState) -> uint64:
+    """
+    Return the validator churn limit for the current epoch.
+    """
+    active_validator_indices = get_active_validator_indices(state, get_current_epoch(state))
+    return min(
+      MAX_PER_EPOCH_CHURN_LIMIT,
+      max(
+        MIN_PER_EPOCH_CHURN_LIMIT,
+        uint64(len(active_validator_indices)) // CHURN_LIMIT_QUOTIENT
+      )
+    )
+```


### PR DESCRIPTION
This proposal limits beacon chain active index growth rate. Huge active validator set sizes make future roadmap upgrades more difficult. While this proposal does not address the root cause of growth, it "buys time" for proper solutions that may be delivered many months into the future.

**Projected fork schedule**
- D fork: EOY 2023
- E fork: mid 2024

Proposals such as [MaxEB](https://ethresear.ch/t/increase-the-max-effective-balance-a-modest-proposal/15801) can land on the E fork at the latest. By then beacon chain size could have reached > 2M active indexes.

![churn_limit](https://github.com/ethereum/consensus-specs/assets/35266934/a69c9b09-eec1-4b4c-8647-fe1d18c32664)

_chart source https://app.noteable.io/f/d0a86d09-bb88-4e47-96e8-e3a6e6f29183/Churn-limit.ipynb_

This change should be very easy to implement in consensus clients. Due to the exponential behaviour of the churn, there's an incentive to include this proposal in the first available fork.

This proposal is introduced with 12 as a starting value, which is higher than today's churn and which may cause a regression in the epoch churn when activated.

**Epoch churn regression**

 The spec as is can handle an epoch churn decrease of > 1.

For exits, the highest exit epoch with the previous churn is the starting point for the new churn:
 
 ```python
def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
    ...
    exit_queue_epoch = max(exit_epochs + [compute_activation_exit_epoch(get_current_epoch(state))])
    exit_queue_churn = len([v for v in state.validators if v.exit_epoch == exit_queue_epoch])
    # After the transition exit_queue_churn maybe >> than get_validator_churn_limit(state) without causing issues
    if exit_queue_churn >= get_validator_churn_limit(state):
        exit_queue_epoch += Epoch(1)
``` 

For activations less validators are sliced from the activation queue

```python
def process_registry_updates(state: BeaconState) -> None:
    ...
    # Dequeued validators for activation up to churn limit
    for index in activation_queue[:get_validator_churn_limit(state)]:
        validator = state.validators[index]
        validator.activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
```
