### PR TITLE
Move parent_beacon_block_root in execution payload and update verification

### DIFF
--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -138,7 +138,7 @@ class ExecutionPayload(Container):
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
     data_gas_used: uint64  # [New in Deneb:EIP4844]
     excess_data_gas: uint64  # [New in Deneb:EIP4844]
-    parent_beacon_block_root: Bytes32  # [New in Deneb:EIP4844]
+    parent_beacon_block_root: Bytes32  # [New in Deneb:EIP4788]
 ```
 
 #### `ExecutionPayloadHeader`
@@ -164,7 +164,7 @@ class ExecutionPayloadHeader(Container):
     withdrawals_root: Root
     data_gas_used: uint64  # [New in Deneb:EIP4844]
     excess_data_gas: uint64  # [New in Deneb:EIP4844]
-    parent_beacon_block_root: Bytes32  # [New in Deneb:EIP4844]
+    parent_beacon_block_root: Bytes32  # [New in Deneb:EIP4788]
 ```
 
 ## Helper functions


### PR DESCRIPTION
Want to propose a simplification which allows execution block to be reconstructed entirely based on execution payload
 - add `parent_beacon_block_root` to execution payload since its already part of execution header 
 -   corresponding change for execution aps - https://github.com/ethereum/execution-apis/pull/441 

Till `4788` addition execution payload (from beacon bloc) had one to one correspondence with execution block and hence was possible to construct execution block with payload (and relatively straight forward debugging). However the payload from beacon bloc directly can't be used without massaging with parent

Ethereumjs has utility methods to construct block from execution payload

TODO
-   if this change is acceptable to community then can update any other post deneb references 
