### PR TITLE
Move and rework `include_attestation_from_previous_fork_with_new_range` test to a `transition` test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/deneb/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/sanity/test_blocks.py
@@ -2,25 +2,17 @@ import random
 
 from eth2spec.test.helpers.state import (
     state_transition_and_sign_block,
-    next_epoch_via_block,
-    transition_to,
 )
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
 from eth2spec.test.context import (
-    DENEB,
     spec_state_test,
-    spec_configured_state_test,
     with_deneb_and_later,
-    with_phases,
 )
 from eth2spec.test.helpers.execution_payload import (
     compute_el_block_hash,
     get_random_tx,
-)
-from eth2spec.test.helpers.attestations import (
-    get_valid_attestation,
 )
 from eth2spec.test.helpers.sharding import (
     get_sample_opaque_tx,
@@ -111,35 +103,3 @@ def test_invalid_exceed_max_blobs_per_block(spec, state):
 @spec_state_test
 def test_mix_blob_tx_and_non_blob_tx(spec, state):
     yield from run_block_with_blobs(spec, state, blob_count=1, tx_count=1, non_blob_tx_count=1)
-
-
-@with_phases([DENEB])
-@spec_configured_state_test({
-    'DENEB_FORK_EPOCH': 2,
-})
-def test_include_attestation_from_previous_fork_with_new_range(spec, state):
-    # Transition to the epoch prior to the fork epoch
-    next_epoch_via_block(spec, state)
-
-    # Generate an attestation for slot 0 of this epoch
-    attestation = get_valid_attestation(spec, state, signed=True)
-
-    # Transition to second to last slot in `DENEB_FORK_EPOCH`
-    next_epoch_via_block(spec, state)
-    current_epoch = spec.get_current_epoch(state)
-    assert current_epoch == spec.config.DENEB_FORK_EPOCH
-    penultimate_slot = spec.compute_start_slot_at_epoch(current_epoch + 1) - 2
-    transition_to(spec, state, penultimate_slot)
-
-    # Ensure the new state is in the increased EIP-7045 slot inclusion range
-    assert penultimate_slot - attestation.data.slot > spec.SLOTS_PER_EPOCH
-
-    block = build_empty_block_for_next_slot(spec, state)
-    block.body.attestations.append(attestation)
-
-    yield 'pre', state
-
-    signed_block = state_transition_and_sign_block(spec, state, block)
-
-    yield 'blocks', [signed_block]
-    yield 'post', state


### PR DESCRIPTION
Address https://github.com/ethereum/consensus-spec-tests/issues/35
Thank @ethDreamer for reporting it.

It's simpler to move this test case to `transition` tests instead of trying to make it stay in `sanity` block tests. The transition test case format has defined the `fork_epoch` so we don't need to apply `spec_configured_state_test` decorator and override the config there.
