### PR TITLE
🐛 Fix redundant SSZ generic tests

### DIFF
--- a/tests/generators/ssz_generic/ssz_container.py
+++ b/tests/generators/ssz_generic/ssz_container.py
@@ -69,8 +69,9 @@ def valid_cases():
         for mode in [RandomizationMode.mode_zero, RandomizationMode.mode_max]:
             yield f'{name}_{mode.to_name()}', valid_test_case(lambda: container_case_fn(rng, mode, typ))
 
-        modes = [RandomizationMode.mode_random, RandomizationMode.mode_zero, RandomizationMode.mode_max]
-        if len(offsets) != 0:
+        if len(offsets) == 0:
+            modes = [RandomizationMode.mode_random, RandomizationMode.mode_zero, RandomizationMode.mode_max]
+        else:
             modes = list(RandomizationMode)
 
         for mode in modes:
@@ -80,12 +81,7 @@ def valid_cases():
         # Notes: Below is the second wave of iteration, and only the random mode is selected
         # for container without offset since ``RandomizationMode.mode_zero`` and ``RandomizationMode.mode_max``
         # are deterministic.
-        modes = [RandomizationMode.mode_random]
-        if len(offsets) != 0:
-            # Notes: ``RandomizationMode.mode_zero`` and ``RandomizationMode.mode_max`` are
-            # pseudo-random modes for containers that contains List of Bitlist
-            # (because the length of List and Bitlist are randoms).
-            modes = list(RandomizationMode)
+        modes = [RandomizationMode.mode_random] if len(offsets) != 0 else list(RandomizationMode)
         for mode in modes:
             for variation in range(10):
                 yield f'{name}_{mode.to_name()}_{variation}', \

--- a/tests/generators/ssz_generic/ssz_container.py
+++ b/tests/generators/ssz_generic/ssz_container.py
@@ -46,11 +46,11 @@ class BitsStruct(Container):
     E: Bitvector[8]
 
 
-def container_case_fn(rng: Random, mode: RandomizationMode, typ: Type[View]):
+def container_case_fn(rng: Random, mode: RandomizationMode, typ: Type[View], chaos: bool=False):
     return get_random_ssz_object(rng, typ,
                                  max_bytes_length=2000,
                                  max_list_length=2000,
-                                 mode=mode, chaos=False)
+                                 mode=mode, chaos=chaos)
 
 
 PRESET_CONTAINERS: Dict[str, Tuple[Type[View], Sequence[int]]] = {
@@ -79,7 +79,7 @@ def valid_cases():
                       valid_test_case(lambda: container_case_fn(rng, mode, typ))
             for variation in range(3):
                 yield f'{name}_{mode.to_name()}_chaos_{variation}', \
-                      valid_test_case(lambda: container_case_fn(rng, mode, typ))
+                      valid_test_case(lambda: container_case_fn(rng, mode, typ, chaos=True))
 
 
 def mod_offset(b: bytes, offset_index: int, change: Callable[[int], int]):

--- a/tests/generators/ssz_generic/ssz_container.py
+++ b/tests/generators/ssz_generic/ssz_container.py
@@ -71,9 +71,8 @@ def valid_cases():
 
         modes = [RandomizationMode.mode_random, RandomizationMode.mode_zero, RandomizationMode.mode_max]
         if len(offsets) != 0:
-            modes.extend([RandomizationMode.mode_nil_count,
-                          RandomizationMode.mode_one_count,
-                          RandomizationMode.mode_max_count])
+            modes = list(RandomizationMode)
+
         for mode in modes:
             for variation in range(3):
                 yield f'{name}_{mode.to_name()}_chaos_{variation}', \
@@ -86,11 +85,7 @@ def valid_cases():
             # Notes: ``RandomizationMode.mode_zero`` and ``RandomizationMode.mode_max`` are
             # pseudo-random modes for containers that contains List of Bitlist
             # (because the length of List and Bitlist are randoms).
-            modes.extend([RandomizationMode.mode_nil_count,
-                          RandomizationMode.mode_one_count,
-                          RandomizationMode.mode_max_count,
-                          RandomizationMode.mode_zero,
-                          RandomizationMode.mode_max])
+            modes = list(RandomizationMode)
         for mode in modes:
             for variation in range(10):
                 yield f'{name}_{mode.to_name()}_{variation}', \

--- a/tests/generators/ssz_generic/ssz_container.py
+++ b/tests/generators/ssz_generic/ssz_container.py
@@ -81,7 +81,7 @@ def valid_cases():
         # Notes: Below is the second wave of iteration, and only the random mode is selected
         # for container without offset since ``RandomizationMode.mode_zero`` and ``RandomizationMode.mode_max``
         # are deterministic.
-        modes = [RandomizationMode.mode_random] if len(offsets) != 0 else list(RandomizationMode)
+        modes = [RandomizationMode.mode_random] if len(offsets) == 0 else list(RandomizationMode)
         for mode in modes:
             for variation in range(10):
                 yield f'{name}_{mode.to_name()}_{variation}', \

--- a/tests/generators/ssz_generic/ssz_container.py
+++ b/tests/generators/ssz_generic/ssz_container.py
@@ -68,12 +68,16 @@ def valid_cases():
     for (name, (typ, offsets)) in PRESET_CONTAINERS.items():
         for mode in [RandomizationMode.mode_zero, RandomizationMode.mode_max]:
             yield f'{name}_{mode.to_name()}', valid_test_case(lambda: container_case_fn(rng, mode, typ))
-        random_modes = [RandomizationMode.mode_random, RandomizationMode.mode_zero, RandomizationMode.mode_max]
+        modes = [RandomizationMode.mode_random]
         if len(offsets) != 0:
-            random_modes.extend([RandomizationMode.mode_nil_count,
-                                 RandomizationMode.mode_one_count,
-                                 RandomizationMode.mode_max_count])
-        for mode in random_modes:
+            # Notes: ``RandomizationMode.mode_zero`` and ``RandomizationMode.mode_max`` are
+            # pseudo-random modes here because the length of List and Bitlist  are randoms.
+            modes.extend([RandomizationMode.mode_nil_count,
+                          RandomizationMode.mode_one_count,
+                          RandomizationMode.mode_max_count,
+                          RandomizationMode.mode_zero,
+                          RandomizationMode.mode_max])
+        for mode in modes:
             for variation in range(10):
                 yield f'{name}_{mode.to_name()}_{variation}', \
                       valid_test_case(lambda: container_case_fn(rng, mode, typ))

--- a/tests/generators/ssz_generic/ssz_container.py
+++ b/tests/generators/ssz_generic/ssz_container.py
@@ -68,10 +68,24 @@ def valid_cases():
     for (name, (typ, offsets)) in PRESET_CONTAINERS.items():
         for mode in [RandomizationMode.mode_zero, RandomizationMode.mode_max]:
             yield f'{name}_{mode.to_name()}', valid_test_case(lambda: container_case_fn(rng, mode, typ))
+
+        modes = [RandomizationMode.mode_random, RandomizationMode.mode_zero, RandomizationMode.mode_max]
+        if len(offsets) != 0:
+            modes.extend([RandomizationMode.mode_nil_count,
+                          RandomizationMode.mode_one_count,
+                          RandomizationMode.mode_max_count])
+        for mode in modes:
+            for variation in range(3):
+                yield f'{name}_{mode.to_name()}_chaos_{variation}', \
+                      valid_test_case(lambda: container_case_fn(rng, mode, typ, chaos=True))
+        # Notes: Below is the second wave of iteration, and only the random mode is selected
+        # for container without offset since ``RandomizationMode.mode_zero`` and ``RandomizationMode.mode_max``
+        # are deterministic.
         modes = [RandomizationMode.mode_random]
         if len(offsets) != 0:
             # Notes: ``RandomizationMode.mode_zero`` and ``RandomizationMode.mode_max`` are
-            # pseudo-random modes here because the length of List and Bitlist  are randoms.
+            # pseudo-random modes for containers that contains List of Bitlist
+            # (because the length of List and Bitlist are randoms).
             modes.extend([RandomizationMode.mode_nil_count,
                           RandomizationMode.mode_one_count,
                           RandomizationMode.mode_max_count,
@@ -81,9 +95,6 @@ def valid_cases():
             for variation in range(10):
                 yield f'{name}_{mode.to_name()}_{variation}', \
                       valid_test_case(lambda: container_case_fn(rng, mode, typ))
-            for variation in range(3):
-                yield f'{name}_{mode.to_name()}_chaos_{variation}', \
-                      valid_test_case(lambda: container_case_fn(rng, mode, typ, chaos=True))
 
 
 def mod_offset(b: bytes, offset_index: int, change: Callable[[int], int]):

--- a/tests/generators/ssz_generic/ssz_uints.py
+++ b/tests/generators/ssz_generic/ssz_uints.py
@@ -9,7 +9,7 @@ def uint_case_fn(rng: Random, mode: RandomizationMode, typ: Type[BasicView]):
     return get_random_ssz_object(rng, typ,
                                  max_bytes_length=typ.type_byte_length(),
                                  max_list_length=1,
-                                 mode=mode, chaos=False)
+                                 mode=mode, chaos=True)
 
 
 UINT_TYPES = [uint8, uint16, uint32, uint64, uint128, uint256]

--- a/tests/generators/ssz_generic/ssz_uints.py
+++ b/tests/generators/ssz_generic/ssz_uints.py
@@ -23,10 +23,10 @@ def valid_cases():
         yield f'uint_{byte_len * 8}_last_byte_empty', \
               valid_test_case(lambda: uint_type((2 ** ((byte_len - 1) * 8)) - 1))
         for variation in range(5):
-            yield f'uint_{byte_len * 8}_{mode.to_name()}_{variation}',\
+            yield f'uint_{byte_len * 8}_{mode.to_name()}_{variation}', \
                 valid_test_case(lambda: uint_case_fn(rng, mode, uint_type))
         for mode in [RandomizationMode.mode_zero, RandomizationMode.mode_max]:
-            yield f'uint_{byte_len * 8}_{mode.to_name()}',\
+            yield f'uint_{byte_len * 8}_{mode.to_name()}', \
                 valid_test_case(lambda: uint_case_fn(rng, mode, uint_type))
 
 

--- a/tests/generators/ssz_generic/ssz_uints.py
+++ b/tests/generators/ssz_generic/ssz_uints.py
@@ -18,13 +18,16 @@ UINT_TYPES = [uint8, uint16, uint32, uint64, uint128, uint256]
 def valid_cases():
     rng = Random(1234)
     for uint_type in UINT_TYPES:
+        mode = RandomizationMode.mode_random
         byte_len = uint_type.type_byte_length()
         yield f'uint_{byte_len * 8}_last_byte_empty', \
               valid_test_case(lambda: uint_type((2 ** ((byte_len - 1) * 8)) - 1))
         for variation in range(5):
-            for mode in [RandomizationMode.mode_random, RandomizationMode.mode_zero, RandomizationMode.mode_max]:
-                yield f'uint_{byte_len * 8}_{mode.to_name()}_{variation}', \
-                      valid_test_case(lambda: uint_case_fn(rng, mode, uint_type))
+            yield f'uint_{byte_len * 8}_{mode.to_name()}_{variation}',\
+                valid_test_case(lambda: uint_case_fn(rng, mode, uint_type))
+        for mode in [RandomizationMode.mode_zero, RandomizationMode.mode_max]:
+            yield f'uint_{byte_len * 8}_{mode.to_name()}',\
+                valid_test_case(lambda: uint_case_fn(rng, mode, uint_type))
 
 
 def invalid_cases():

--- a/tests/generators/ssz_generic/ssz_uints.py
+++ b/tests/generators/ssz_generic/ssz_uints.py
@@ -9,7 +9,7 @@ def uint_case_fn(rng: Random, mode: RandomizationMode, typ: Type[BasicView]):
     return get_random_ssz_object(rng, typ,
                                  max_bytes_length=typ.type_byte_length(),
                                  max_list_length=1,
-                                 mode=mode, chaos=True)
+                                 mode=mode, chaos=False)
 
 
 UINT_TYPES = [uint8, uint16, uint32, uint64, uint128, uint256]


### PR DESCRIPTION
(answer for #3343)

Hi @hwwhww,

Indeed there is indeed an issue with the randomisation for ssz_uints generator tests. That's because the parameter `chaos` is set to False. Do you aggree ?
If yes, then I will look for others SSZ generator tests.

What we have with `chaos=False` as the result of `valid_test_case(lambda: uint_case_fn(rng, mode, uint_type)`:

```python
uint_128_max_0
('value', 'data', '340282366920938463463374607431768211455')
('serialized', 'ssz', b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff')
('root', 'meta', '0xffffffffffffffffffffffffffffffff00000000000000000000000000000000')

uint_128_max_1
('value', 'data', '340282366920938463463374607431768211455')
('serialized', 'ssz', b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff')
('root', 'meta', '0xffffffffffffffffffffffffffffffff00000000000000000000000000000000')

uint_128_max_2
('value', 'data', '340282366920938463463374607431768211455')
('serialized', 'ssz', b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff')
('root', 'meta', '0xffffffffffffffffffffffffffffffff00000000000000000000000000000000')

uint_128_max_3
('value', 'data', '340282366920938463463374607431768211455')
('serialized', 'ssz', b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff')
('root', 'meta', '0xffffffffffffffffffffffffffffffff00000000000000000000000000000000')

uint_128_max_4
('value', 'data', '340282366920938463463374607431768211455')
('serialized', 'ssz', b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff')
('root', 'meta', '0xffffffffffffffffffffffffffffffff00000000000000000000000000000000')
```

and then with `chaos=True`:

```python
uint_128_max_0
('value', 'data', '260819946861870522707874081917815893340')
('serialized', 'ssz', b'\\-n\xb1\xc6\xf9|\x15\xed/2\x196\x188\xc4')
('root', 'meta', '0x5c2d6eb1c6f97c15ed2f3219361838c400000000000000000000000000000000')

uint_128_max_1
('value', 'data', '0')
('serialized', 'ssz', b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
('root', 'meta', '0x0000000000000000000000000000000000000000000000000000000000000000')

uint_128_max_2
('value', 'data', '5390216476892074497654328433555238240')
('serialized', 'ssz', b'`m\xe3\x07\xa7\x99\x97\xfcH\x02\xed\xc90\x1e\x0e\x04')
('root', 'meta', '0x606de307a79997fc4802edc9301e0e0400000000000000000000000000000000')

uint_128_max_3
('value', 'data', '157737201232106561970225729579745501179')
('serialized', 'ssz', b'\xfb_\x8f\x9fM\x8a\xf7{\xfd\x18\xa6\x9du\x14\xabv')
('root', 'meta', '0xfb5f8f9f4d8af77bfd18a69d7514ab7600000000000000000000000000000000')

uint_128_max_4
('value', 'data', '287657197159586928699800364455062079299')
('serialized', 'ssz', b'C\x07\xdf.\xb0\x0b\xa2\xb6\x12+J\x1d\xcf\xc2h\xd8')
('root', 'meta', '0x4307df2eb00ba2b6122b4a1dcfc268d800000000000000000000000000000000')
```

I think it makes more sense with the chaos.