### PR TITLE
🐛 Potential side effects with multiprocessing mode 

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_from_tests/gen.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_from_tests/gen.py
@@ -10,6 +10,10 @@ from eth2spec.gen_helpers.gen_base import gen_runner
 from eth2spec.gen_helpers.gen_base.gen_typing import TestCase, TestProvider
 
 
+def generate_case_fn(tfn, generator_mode, phase, preset, bls_active):
+    return lambda: tfn(generator_mode=generator_mode, phase=phase, preset=preset, bls_active=bls_active)
+
+
 def generate_from_tests(runner_name: str, handler_name: str, src: Any,
                         fork_name: SpecForkName, preset_name: PresetBaseName,
                         bls_active: bool = True,
@@ -52,7 +56,7 @@ def generate_from_tests(runner_name: str, handler_name: str, src: Any,
             suite_name=getattr(tfn, 'suite_name', 'pyspec_tests'),
             case_name=case_name,
             # TODO: with_all_phases and other per-phase tooling, should be replaced with per-fork equivalent.
-            case_fn=lambda: tfn(generator_mode=True, phase=phase, preset=preset_name, bls_active=bls_active)
+            case_fn=generate_case_fn(tfn, generator_mode=True, phase=phase, preset=preset_name, bls_active=bls_active)
         )
 
 


### PR DESCRIPTION
@hwwhww said there was an issue when the multiprocessing mode was activated:

---
_For example, the 
`minimal/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_greater_than_proposer_boost_with_boost` test should NOT exist because we’ve added the decorator “`@with_presets([MAINNET], reason="to create non-duplicate committee”)`” (https://github.com/ethereum/consensus-specs/blob/48143056b9be031ec810912ffc3227f7443eccd9/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_ex_ante.py#L121-L124)_

    _But if you run `make gen_fork_choice` with `MODE_MULTIPROCESSING`, you will see both folders:_
```
mainnet/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_greater_than_proposer_boost_with_boost

minimal/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_greater_than_proposer_boost_with_boost
```
---

Its like the decorator `@with_presets([MAINNET], reason="to create non-duplicate committee")` was ignored. 

What I did was to only consider 2 tests in `eth2spec/test/phase0/fork_choice/test_ex_ante.py`: `test_ex_ante_attestations_is_greater_than_proposer_boost_with_boost` and `test_ex_ante_vanilla`. What I discovered is the fact that the `generate_test_vector` was running both time the test method of `test_ex_ante_vanilla`. From the below:

https://github.com/ethereum/consensus-specs/blob/8d6a40522c00d7f7ea25d841208342212e1e2367/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py#L233-L264

`test_ex_ante_attestations_is_greater_than_proposer_boost_with_boost` was the first test to be submitted in the list `all_test_case_params`, and when started the second iteration of `for tprov in test_providers:` then the item in `all_test_case_params` was modified: the value `all_test_case_params[0].test_case.case_fn()` runned the method `test_ex_ante_vanilla` and not anymore the method `test_ex_ante_attestations_is_greater_than_proposer_boost_with_boost` _(to test that, I changed both method, one raised a `AssertionError` and the other one a `ValueError`; and I runned `test_case.case_fn()` to check what was the error raised.)_

It seems that the method `generate_from_tests` in `eth2spec/gen_helpers/gen_from_tests/gen.py` have a side effect on the lambda function provided to `TestCase.case_fn` => like `tfn` was modified when the `TestCase` of `test_ex_ante_vanilla` was generated. **That's why the decorator seems to be ignored**.

Honestly I don't know why the lambda function is impacted, my opinion is that this succesion of `yield` may generates this side effect.

What I did to fix this was to generate the lambda function by another method outside the scope of `generate_from_tests` and it seems to work.