### PR TITLE
Whisk: fix boostraping induced missed slots - zero proof

### DIFF
--- a/specs/_features/whisk/beacon-chain.md
+++ b/specs/_features/whisk/beacon-chain.md
@@ -238,10 +238,10 @@ def process_epoch(state: BeaconState) -> None:
 ```python
 def process_whisk_opening_proof(state: BeaconState, block: BeaconBlock) -> None:
     tracker = state.whisk_proposer_trackers[state.slot % WHISK_PROPOSER_TRACKERS_COUNT]
-    if all(b == 0 for b in block.body.whisk_opening_proof[8:]):
+    if block.body.whisk_opening_proof == WhiskTrackerProof():
         # no proof signals tracker is created with insecure initial 'k'
-        nonce = bytes_to_uint64(block.body.whisk_opening_proof[:8])
-        assert tracker.k_r_G == tracker.r_G * get_initial_whisk_k(block.proposer_index, nonce)
+        k = get_initial_whisk_k(block.proposer_index, block.body.whisk_initial_k_nonce)
+        assert tracker.k_r_G == tracker.r_G * k
     else:
         k_commitment = state.whisk_k_commitments[block.proposer_index]
         assert IsValidWhiskOpeningProof(tracker, k_commitment, block.body.whisk_opening_proof)
@@ -298,6 +298,7 @@ class BeaconBlockBody(capella.BeaconBlockBody):
     bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
     # Whisk
     whisk_opening_proof: WhiskTrackerProof  # [New in Whisk]
+    whisk_initial_k_nonce: uint64
     whisk_post_shuffle_trackers: Vector[WhiskTracker, WHISK_VALIDATORS_PER_SHUFFLE]  # [New in Whisk]
     whisk_shuffle_proof: WhiskShuffleProof  # [New in Whisk]
     whisk_shuffle_proof_M_commitment: BLSG1Point  # [New in Whisk]

--- a/specs/_features/whisk/beacon-chain.md
+++ b/specs/_features/whisk/beacon-chain.md
@@ -239,6 +239,7 @@ def process_epoch(state: BeaconState) -> None:
 def process_whisk_opening_proof(state: BeaconState, block: BeaconBlock) -> None:
     tracker = state.whisk_proposer_trackers[state.slot % WHISK_PROPOSER_TRACKERS_COUNT]
     if block.body.whisk_opening_proof == WhiskTrackerProof():
+        # no proof signals tracker is created with insecure initial 'k'
         assert tracker.k_r_G == tracker.r_G * get_initial_whisk_k(block.proposer_index, 0)
     else:
         k_commitment = state.whisk_k_commitments[block.proposer_index]

--- a/specs/_features/whisk/beacon-chain.md
+++ b/specs/_features/whisk/beacon-chain.md
@@ -238,8 +238,11 @@ def process_epoch(state: BeaconState) -> None:
 ```python
 def process_whisk_opening_proof(state: BeaconState, block: BeaconBlock) -> None:
     tracker = state.whisk_proposer_trackers[state.slot % WHISK_PROPOSER_TRACKERS_COUNT]
-    k_commitment = state.whisk_k_commitments[block.proposer_index]
-    assert IsValidWhiskOpeningProof(tracker, k_commitment, block.body.whisk_opening_proof)
+    if block.body.whisk_opening_proof == WhiskTrackerProof():
+        assert tracker.k_r_G == tracker.r_G * get_initial_whisk_k(block.proposer_index, 0)
+    else:
+        k_commitment = state.whisk_k_commitments[block.proposer_index]
+        assert IsValidWhiskOpeningProof(tracker, k_commitment, block.body.whisk_opening_proof)
 ```
 
 Removed `assert block.proposer_index == get_beacon_proposer_index(state)` check in Whisk.

--- a/specs/_features/whisk/beacon-chain.md
+++ b/specs/_features/whisk/beacon-chain.md
@@ -238,9 +238,10 @@ def process_epoch(state: BeaconState) -> None:
 ```python
 def process_whisk_opening_proof(state: BeaconState, block: BeaconBlock) -> None:
     tracker = state.whisk_proposer_trackers[state.slot % WHISK_PROPOSER_TRACKERS_COUNT]
-    if block.body.whisk_opening_proof == WhiskTrackerProof():
+    if all(b == 0 for b in block.body.whisk_opening_proof[8:]):
         # no proof signals tracker is created with insecure initial 'k'
-        assert tracker.k_r_G == tracker.r_G * get_initial_whisk_k(block.proposer_index, 0)
+        nonce = bytes_to_uint64(block.body.whisk_opening_proof[:8])
+        assert tracker.k_r_G == tracker.r_G * get_initial_whisk_k(block.proposer_index, nonce)
     else:
         k_commitment = state.whisk_k_commitments[block.proposer_index]
         assert IsValidWhiskOpeningProof(tracker, k_commitment, block.body.whisk_opening_proof)


### PR DESCRIPTION
Whisk on its current spec will induce ~2% missed slot rate on the initial epochs after the fork, and over 12,000 cumulative missed slots during the first year post-fork. I've written this longer form doc that explains the cause of the issue, its likely-hood, and the patch to solve it.

https://hackmd.io/@dapplion/whisk_induced_missed_slots

![photo_2023-08-17_20-33-35](https://github.com/ethereum/consensus-specs/assets/35266934/aa567280-aa39-4120-af57-92c37f8c7ead)
