### PR TITLE
Whisk: don't mutate candidates during cooldown

### DIFF
--- a/specs/_features/whisk/beacon-chain.md
+++ b/specs/_features/whisk/beacon-chain.md
@@ -318,30 +318,25 @@ def get_shuffle_indices(randao_reveal: BLSSignature) -> Sequence[uint64]:
 
 ```python
 def process_shuffled_trackers(state: BeaconState, body: BeaconBlockBody) -> None:
-    # Check the shuffle proof
-    shuffle_indices = get_shuffle_indices(body.randao_reveal)
-    pre_shuffle_trackers = [state.whisk_candidate_trackers[i] for i in shuffle_indices]
-
     shuffle_epoch = get_current_epoch(state) % WHISK_EPOCHS_PER_SHUFFLING_PHASE
     if shuffle_epoch + WHISK_PROPOSER_SELECTION_GAP + 1 >= WHISK_EPOCHS_PER_SHUFFLING_PHASE:
         # Require trackers set to zero during cooldown
         assert body.whisk_post_shuffle_trackers == Vector[WhiskTracker, WHISK_VALIDATORS_PER_SHUFFLE]()
         assert body.whisk_shuffle_proof_M_commitment == BLSG1Point()
         assert body.whisk_shuffle_proof == WhiskShuffleProof()
-        post_shuffle_trackers = pre_shuffle_trackers
     else:
         # Require shuffled trackers during shuffle
+        shuffle_indices = get_shuffle_indices(body.randao_reveal)
+        pre_shuffle_trackers = [state.whisk_candidate_trackers[i] for i in shuffle_indices]
         assert IsValidWhiskShuffleProof(
             pre_shuffle_trackers,
             body.whisk_post_shuffle_trackers,
             body.whisk_shuffle_proof_M_commitment,
             body.whisk_shuffle_proof,
         )
-        post_shuffle_trackers = body.whisk_post_shuffle_trackers
-
-    # Shuffle candidate trackers
-    for i, shuffle_index in enumerate(shuffle_indices):
-        state.whisk_candidate_trackers[shuffle_index] = post_shuffle_trackers[i]
+        # Shuffle candidate trackers
+        for i, shuffle_index in enumerate(shuffle_indices):
+            state.whisk_candidate_trackers[shuffle_index] = body.whisk_post_shuffle_trackers[i]
 ```
 
 ```python


### PR DESCRIPTION
During cooldown phase, validators do not provide a secret shuffle. However, the spec still mutates the trackers with public randnomess. This appears to be unnecessary, since latter steps of the protocol depend on the cumulative randnomness of randao provided by each proposer during the cooldown phase. Each participant should have the same influence in the shuffle outcome with this PR or without.

If there's no security benefit in mutating candidate trackers during cooldown, let's not do so to reduce some cycles during block processing and state hashing 

CC: @asn-d6 