### PR TITLE
Whisk: use public key as initial commitment

### DIFF
--- a/specs/_features/whisk/fork.md
+++ b/specs/_features/whisk/fork.md
@@ -54,10 +54,9 @@ This ensures that we drop right into the beginning of the shuffling phase but wi
 
 ```python
 def upgrade_to_whisk(pre: capella.BeaconState) -> BeaconState:
-    # Compute initial unsafe trackers for all validators
-    ks = [get_initial_whisk_k(ValidatorIndex(validator_index), 0) for validator_index in range(len(pre.validators))]
-    whisk_k_commitments = [get_k_commitment(k) for k in ks]
-    whisk_trackers = [get_initial_tracker(k) for k in ks]
+    # Assign initial unsafe trackers for all validators
+    whisk_k_commitments = [get_k_commitment(validator.pubkey) for validator in pre.validators]
+    whisk_trackers = [validator.pubkey for validator in pre.validators]
 
     epoch = get_current_epoch(pre)
     post = BeaconState(


### PR DESCRIPTION
Current whisk spec forces validators into doing hundreds of thousands of G1 multiplications per slot and validating keypair. This is due to the non-determinism of `get_unique_whisk_k` and the need for a bootstrapping phase.

Instead we can use each validator public key as the unsafe `k_G` commitment. Since it is already guaranteed to be unique it removes the need for an unbounded function like `get_unique_whisk_k`.

This post explains in detail the considerations of the issue https://hackmd.io/@dapplion/expensive_duty_discovery