### PR TITLE
remove: old warnings

### DIFF
--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -22,8 +22,6 @@ This document describes the process of the first upgrade of the beacon chain: th
 
 ## Configuration
 
-Warning: this configuration is not definitive.
-
 | Name | Value |
 | - | - |
 | `ALTAIR_FORK_VERSION` | `Version('0x01000000')` |

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -13,7 +13,6 @@ Altair adds new messages, topics and data to the Req-Resp, Gossip and Discovery 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Warning](#warning)
 - [Modifications in Altair](#modifications-in-altair)
   - [MetaData](#metadata)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
@@ -37,11 +36,6 @@ Altair adds new messages, topics and data to the Req-Resp, Gossip and Discovery 
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
-
-## Warning
-
-This document is currently illustrative for early Altair testnets and some parts are subject to change.
-Refer to the note in the [validator guide](./validator.md) for further details.
 
 ## Modifications in Altair
 

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -10,7 +10,6 @@ This is an accompanying document to [Altair -- The Beacon Chain](./beacon-chain.
 
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
-- [Warning](#warning)
 - [Constants](#constants)
   - [Misc](#misc)
 - [Containers](#containers)
@@ -62,10 +61,6 @@ Block proposers incorporate the (aggregated) sync committee signatures into each
 
 All terminology, constants, functions, and protocol mechanics defined in the [Altair -- The Beacon Chain](./beacon-chain.md) doc are requisite for this document and used throughout.
 Please see this document before continuing and use as a reference throughout.
-
-## Warning
-
-This document is currently illustrative for early Altair testnets and some parts are subject to change, especially pending implementation and profiling of Altair testnets.
 
 ## Constants
 

--- a/specs/bellatrix/fork.md
+++ b/specs/bellatrix/fork.md
@@ -22,8 +22,6 @@ This document describes the process of Bellatrix upgrade.
 
 ## Configuration
 
-Warning: this configuration is not definitive.
-
 | Name | Value |
 | - | - |
 | `BELLATRIX_FORK_VERSION` | `Version('0x02000000')` |

--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -12,7 +12,6 @@ Readers should understand the Phase 0 and Altair documents and use them as a bas
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-  - [Warning](#warning)
   - [Modifications in Bellatrix](#modifications-in-bellatrix)
     - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
       - [Topics and messages](#topics-and-messages)
@@ -32,11 +31,6 @@ Readers should understand the Phase 0 and Altair documents and use them as a bas
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
-
-## Warning
-
-This document is currently illustrative for early Bellatrix testnets and some parts are subject to change.
-Refer to the note in the [validator guide](./validator.md) for further details.
 
 ## Modifications in Bellatrix
 

--- a/specs/capella/fork.md
+++ b/specs/capella/fork.md
@@ -22,8 +22,6 @@ This document describes the process of the Capella upgrade.
 
 ## Configuration
 
-Warning: this configuration is not definitive.
-
 | Name | Value |
 | - | - |
 | `CAPELLA_FORK_VERSION` | `Version('0x03000000')` |


### PR DESCRIPTION
Reviewing the specs again today, I noticed some warnings can be removed. Mainly the old fork epoch numbers and networking