### PR TITLE
Pin `curdleproofs==0.1.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -519,6 +519,6 @@ setup(
         "lru-dict==1.2.0",
         MARKO_VERSION,
         "py_arkworks_bls12381==0.3.4",
-        "curdleproofs @ git+https://github.com/nalinbhardwaj/curdleproofs.pie@805d06785b6ff35fde7148762277dd1ae678beeb#egg=curdleproofs&subdirectory=curdleproofs",
+        "curdleproofs==0.1.1",
     ]
 )


### PR DESCRIPTION
There is an error when installing `curdleproofs @ git+https://github.com/nalinbhardwaj/curdleproofs.pie@805d06785b6ff35fde7148762277dd1ae678beeb#egg=curdleproofs&subdirectory=curdleproofs`. As #3442 now uses `curdleproofs==0.1.1`, this PR tries to fix the error by cherry-picking it.

### Error message
```
Collecting merlin@ git+https://github.com/nalinbhardwaj/curdleproofs.pie@master#subdirectory=merlin (from curdleproofs@ git+https://github.com/nalinbhardwaj/curdleproofs.pie@805d06785b6ff35fde7148762277dd1ae678beeb#egg=curdleproofs&subdirectory=curdleproofs->eth2spec==1.4.0b1)
  Cloning https://github.com/nalinbhardwaj/curdleproofs.pie (to revision master) to /private/var/folders/zf/7y9f1tzn2y33y9601hsthq_40000gn/T/pip-install-yksz7cbi/merlin_90a81755e3e2483fa812ed6966e65973
  Running command git clone --filter=blob:none --quiet https://github.com/nalinbhardwaj/curdleproofs.pie /private/var/folders/zf/7y9f1tzn2y33y9601hsthq_40000gn/T/pip-install-yksz7cbi/merlin_90a81755e3e2483fa812ed6966e65973
  Resolved https://github.com/nalinbhardwaj/curdleproofs.pie to commit c36a47b38f6248ed12ad2bb193cbfd008d489a64
ERROR: merlin@ git+https://github.com/nalinbhardwaj/curdleproofs.pie@master#subdirectory=merlin from git+https://github.com/nalinbhardwaj/curdleproofs.pie@master#subdirectory=merlin (from curdleproofs@ git+https://github.com/nalinbhardwaj/curdleproofs.pie@805d06785b6ff35fde7148762277dd1ae678beeb#egg=curdleproofs&subdirectory=curdleproofs->eth2spec==1.4.0b1) does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
make: *** [install_test] Error 1

```