### PR TITLE
generators/kzg_4844: Add positive G1_POINT_AT_INFINITY test vectors

### DIFF
--- a/tests/generators/kzg_4844/main.py
+++ b/tests/generators/kzg_4844/main.py
@@ -222,8 +222,9 @@ def case03_verify_kzg_proof():
         commitment = spec.blob_to_kzg_commitment(blob)
         proof = spec.G1_POINT_AT_INFINITY
         assert not spec.verify_kzg_proof(commitment, z, y, proof)
+        prefix = 'verify_kzg_proof_case_incorrect_proof_point_at_infinity'
         identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
-        yield f'verify_kzg_proof_case_incorrect_proof_point_at_infinity_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
+        yield f'{prefix}_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'z': encode_hex(z),
@@ -240,8 +241,9 @@ def case03_verify_kzg_proof():
         commitment = spec.blob_to_kzg_commitment(blob)
         proof = spec.G1_POINT_AT_INFINITY
         assert spec.verify_kzg_proof(commitment, z, y, proof)
+        prefix = 'verify_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly'
         identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
-        yield f'verify_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
+        yield f'{prefix}_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'z': encode_hex(z),
@@ -259,8 +261,9 @@ def case03_verify_kzg_proof():
         proof = spec.G1_POINT_AT_INFINITY
         assert spec.verify_kzg_proof(commitment, z, y, proof)
         assert y == field_element_bytes(2)
+        prefix = 'verify_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly'
         identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
-        yield f'verify_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
+        yield f'{prefix}_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'z': encode_hex(z),
@@ -453,8 +456,6 @@ def case05_verify_blob_kzg_proof():
         },
         'output': True
     }
-
-
 
     # Edge case: Invalid blob
     for blob in INVALID_BLOBS:

--- a/tests/generators/kzg_4844/main.py
+++ b/tests/generators/kzg_4844/main.py
@@ -67,6 +67,7 @@ INVALID_G1_POINTS = [G1_INVALID_TOO_FEW_BYTES, G1_INVALID_TOO_MANY_BYTES,
                      G1_INVALID_P1_NOT_IN_G1, G1_INVALID_P1_NOT_ON_CURVE]
 
 BLOB_ALL_ZEROS = spec.Blob()
+BLOB_ALL_TWOS = spec.Blob(b''.join([field_element_bytes(2) for n in range(4096)]))
 BLOB_RANDOM_VALID1 = spec.Blob(b''.join([field_element_bytes(pow(2, n + 256, spec.BLS_MODULUS)) for n in range(4096)]))
 BLOB_RANDOM_VALID2 = spec.Blob(b''.join([field_element_bytes(pow(3, n + 256, spec.BLS_MODULUS)) for n in range(4096)]))
 BLOB_RANDOM_VALID3 = spec.Blob(b''.join([field_element_bytes(pow(5, n + 256, spec.BLS_MODULUS)) for n in range(4096)]))
@@ -79,7 +80,7 @@ BLOB_INVALID_CLOSE = spec.Blob(b''.join(
 BLOB_INVALID_LENGTH_PLUS_ONE = BLOB_RANDOM_VALID1 + b"\x00"
 BLOB_INVALID_LENGTH_MINUS_ONE = BLOB_RANDOM_VALID1[:-1]
 
-VALID_BLOBS = [BLOB_ALL_ZEROS, BLOB_RANDOM_VALID1, BLOB_RANDOM_VALID2,
+VALID_BLOBS = [BLOB_ALL_ZEROS, BLOB_ALL_TWOS, BLOB_RANDOM_VALID1, BLOB_RANDOM_VALID2,
                BLOB_RANDOM_VALID3, BLOB_ALL_MODULUS_MINUS_ONE, BLOB_ALMOST_ZERO]
 INVALID_BLOBS = [BLOB_INVALID, BLOB_INVALID_CLOSE, BLOB_INVALID_LENGTH_PLUS_ONE, BLOB_INVALID_LENGTH_MINUS_ONE]
 
@@ -216,19 +217,58 @@ def case03_verify_kzg_proof():
 
     # Incorrect `G1_POINT_AT_INFINITY` proof
     blob = BLOB_RANDOM_VALID1
-    _, y = spec.compute_kzg_proof(blob, z)
-    commitment = spec.blob_to_kzg_commitment(blob)
-    proof = spec.G1_POINT_AT_INFINITY
-    assert not spec.verify_kzg_proof(commitment, z, y, proof)
-    yield 'verify_kzg_proof_case_incorrect_proof_point_at_infinity', {
-        'input': {
-            'commitment': encode_hex(commitment),
-            'z': encode_hex(z),
-            'y': encode_hex(y),
-            'proof': encode_hex(proof),
-        },
-        'output': False
-    }
+    for z in VALID_FIELD_ELEMENTS:
+        _, y = spec.compute_kzg_proof(blob, z)
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.G1_POINT_AT_INFINITY
+        assert not spec.verify_kzg_proof(commitment, z, y, proof)
+        identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
+        yield f'verify_kzg_proof_case_incorrect_proof_point_at_infinity_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
+            'input': {
+                'commitment': encode_hex(commitment),
+                'z': encode_hex(z),
+                'y': encode_hex(y),
+                'proof': encode_hex(proof),
+            },
+            'output': False
+        }
+
+    # Correct `G1_POINT_AT_INFINITY` proof for zero poly
+    blob = BLOB_ALL_ZEROS
+    for z in VALID_FIELD_ELEMENTS:
+        _, y = spec.compute_kzg_proof(blob, z)
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.G1_POINT_AT_INFINITY
+        assert spec.verify_kzg_proof(commitment, z, y, proof)
+        identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
+        yield f'verify_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
+            'input': {
+                'commitment': encode_hex(commitment),
+                'z': encode_hex(z),
+                'y': encode_hex(y),
+                'proof': encode_hex(proof),
+            },
+            'output': True
+        }
+
+    # Correct `G1_POINT_AT_INFINITY` proof for poly of all twos
+    blob = BLOB_ALL_TWOS
+    for z in VALID_FIELD_ELEMENTS:
+        _, y = spec.compute_kzg_proof(blob, z)
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.G1_POINT_AT_INFINITY
+        assert spec.verify_kzg_proof(commitment, z, y, proof)
+        assert y == field_element_bytes(2)
+        identifier = f'{encode_hex(hash(blob))}_{encode_hex(z)}'
+        yield f'verify_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly_{(hash(bytes(identifier, "utf-8"))[:8]).hex()}', {
+            'input': {
+                'commitment': encode_hex(commitment),
+                'z': encode_hex(z),
+                'y': encode_hex(y),
+                'proof': encode_hex(proof),
+            },
+            'output': True
+        }
 
     # Edge case: Invalid commitment
     for commitment in INVALID_G1_POINTS:
@@ -383,6 +423,38 @@ def case05_verify_blob_kzg_proof():
         },
         'output': False
     }
+
+    # Correct `G1_POINT_AT_INFINITY` proof and commitment for zero poly
+    blob = BLOB_ALL_ZEROS
+    commitment = spec.blob_to_kzg_commitment(blob)
+    proof = spec.G1_POINT_AT_INFINITY
+    assert commitment == spec.G1_POINT_AT_INFINITY
+    assert spec.verify_blob_kzg_proof(blob, commitment, proof)
+    yield 'verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly', {
+        'input': {
+            'blob': encode_hex(blob),
+            'commitment': encode_hex(commitment),
+            'proof': encode_hex(proof),
+        },
+        'output': True
+    }
+
+    # Correct `G1_POINT_AT_INFINITY` proof for all twos poly
+    blob = BLOB_ALL_TWOS
+    commitment = spec.blob_to_kzg_commitment(blob)
+    proof = spec.G1_POINT_AT_INFINITY
+    assert commitment != spec.G1_POINT_AT_INFINITY
+    assert spec.verify_blob_kzg_proof(blob, commitment, proof)
+    yield 'verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly', {
+        'input': {
+            'blob': encode_hex(blob),
+            'commitment': encode_hex(commitment),
+            'proof': encode_hex(proof),
+        },
+        'output': True
+    }
+
+
 
     # Edge case: Invalid blob
     for blob in INVALID_BLOBS:


### PR DESCRIPTION
In a similar vein to https://github.com/ethereum/consensus-specs/pull/3507, this PR is adding some **valid** test vectors for valid edge-case blobs whose proof or commitment is the point at infinity.

In particular:
- Proof being the point at infinity is a valid case for when the blob is all zeroes. A blob being all zeroes is basically the zero polynomial -- its commitment will be the point at infinity and the corresponding proof will also be the point at infinity.
- A related edge case can happen for a blob full of twos (or any other constant number): A blob full of twos would correspond to the polynomial p(x) = 2 and it's corresponding KZG proof would be the point at infinity. It's corresponding commitment would be 2G (not the point at infinity).

As part of this commit, I also edited the `verify_kzg_proof_case_incorrect_proof_point_at_infinity()` test to loop over all valid field elements for the evaluation point (lmk if you want me to split it to another commit).

Also, I didn't modify the `verify_blob_kzg_proof_batch()` test vectors because the edge-case will be tested automatically by adding `BLOB_ALL_TWOS` to `VALID_BLOBS` and the test `verify_blob_kzg_proof_batch_case_*()`.

/cc @jtraglia 