### PR TITLE
add note about not invalidating valid and available blocks

### DIFF
--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -47,6 +47,8 @@ Initially, verification requires every verifying actor to retrieve all matching 
 
 The block MUST NOT be considered valid until all valid `Blob`s have been downloaded. Blocks that have been previously validated as available SHOULD be considered available even if the associated `Blob`s have subsequently been pruned.
 
+*Note*: Extraneous or invalid Blobs received on the p2p network MUST NOT invalidate a block that is otherwise valid and available.
+
 ```python
 def is_data_available(beacon_block_root: Root, blob_kzg_commitments: Sequence[KZGCommitment]) -> bool:
     # `retrieve_blobs_and_proofs` is implementation and context dependent

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -93,10 +93,9 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # [New in Deneb:EIP4844]
     # Check if blob data is available
     # If not, this block MAY be queued and subsequently considered when blob data becomes available
-    assert is_data_available(hash_tree_root(block), block.body.blob_kzg_commitments)
-
     # *Note*: Extraneous or invalid Blobs (in addition to the expected/referenced valid blobs)
     # received on the p2p network MUST NOT invalidate a block that is otherwise valid and available
+    assert is_data_available(hash_tree_root(block), block.body.blob_kzg_commitments)
 
     # Check the block is valid and compute the post-state
     state = pre_state.copy()

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -47,7 +47,7 @@ Initially, verification requires every verifying actor to retrieve all matching 
 
 The block MUST NOT be considered valid until all valid `Blob`s have been downloaded. Blocks that have been previously validated as available SHOULD be considered available even if the associated `Blob`s have subsequently been pruned.
 
-*Note*: Extraneous or invalid Blobs received on the p2p network MUST NOT invalidate a block that is otherwise valid and available.
+*Note*: Extraneous or invalid Blobs (in addition to KZG expected/referenced valid blobs) received on the p2p network MUST NOT invalidate a block that is otherwise valid and available.
 
 ```python
 def is_data_available(beacon_block_root: Root, blob_kzg_commitments: Sequence[KZGCommitment]) -> bool:
@@ -94,6 +94,9 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Check if blob data is available
     # If not, this block MAY be queued and subsequently considered when blob data becomes available
     assert is_data_available(hash_tree_root(block), block.body.blob_kzg_commitments)
+
+    # *Note*: Extraneous or invalid Blobs (in addition to the expected/referenced valid blobs)
+    # received on the p2p network MUST NOT invalidate a block that is otherwise valid and available
 
     # Check the block is valid and compute the post-state
     state = pre_state.copy()


### PR DESCRIPTION
This came up on the call today as a path that is not entirely clear in the spec.

I think that this note is either appropriate here (before `is_data_available()`) or embedded as a comment in `on_block()` around the call to `is_data_available()`. Open to thoughts on how to make sure we are abundantly clear here.

