### PR TITLE
Reject Blobs Which Reference Already Finalized Parent Blocks

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -155,6 +155,7 @@ The following validations MUST pass before forwarding the `signed_blob_sidecar` 
 - _[IGNORE]_ The sidecar's block's parent (defined by `sidecar.block_parent_root`) has been seen (via both gossip and non-gossip sources) (a client MAY queue sidecars for processing once the parent block is retrieved).
 - _[REJECT]_ The sidecar's block's parent (defined by `sidecar.block_parent_root`) passes validation.
 - _[REJECT]_ The sidecar is from a higher slot than the sidecar's block's parent (defined by `sidecar.block_parent_root`).
+- _[REJECT]_ The current finalized_checkpoint is an ancestor of the sidecar's block's parent -- i.e. `get_checkpoint_block(store, sidecar.block_parent_root, store.finalized_checkpoint.epoch) == store.finalized_checkpoint.root`.
 - _[REJECT]_ The proposer signature, `signed_blob_sidecar.signature`, is valid as verified by `verify_blob_sidecar_signature`.
 - _[IGNORE]_ The sidecar is the only sidecar with valid signature received for the tuple `(sidecar.block_root, sidecar.index)`.
 - _[REJECT]_ The sidecar is proposed by the expected `proposer_index` for the block's slot in the context of the current shuffling (defined by `block_parent_root`/`slot`).


### PR DESCRIPTION
Currently we will allow blobs to reference parent blocks which are already finalized. This could allow malicious peers to perform DOS attacks by referencing a very old parent block. Due to the requirements for nodes to verify proposer shuffling for these blobs, you could have a malicous peer force a honest node to perform an excessive amount of epoch transitions to verify the shuffling for the proposer. In order to mitigate this we can simply add the same gossip validation condition that we have for beacon blocks for blobs:

```
[REJECT] The current finalized_checkpoint is an ancestor of block -- i.e. get_checkpoint_block(store, block.parent_root, store.finalized_checkpoint.epoch) == store.finalized_checkpoint.root
```

This was encountered when running an Antithesis experiment.