### PR TITLE
Specify blobs by root condition if there's equivocating blobs

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -292,6 +292,10 @@ Clients MUST support requesting sidecars since `minimum_request_epoch`, where `m
 Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
 
+In the event of equivocating blobs, clients MUST serve only blobs with matching KZG commitments if they have seen the block.
+
+If clients have not seen the block, they MUST serve the first valid blobs they encounter.
+
 ##### BlobSidecarsByRange v1
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/1/`


### PR DESCRIPTION
h/t to @realbigsean for the [comment](https://github.com/ethereum/consensus-specs/issues/3527#issuecomment-1777332137)

This PR introduces an explicit condition for handling blob responses by root in cases of blob equivocation. Ensures clients adhere to specified behavior for serving blobs with matching KZG commitments or the first valid blobs they encounter, depending on whether the block has been seen.

Notes: 
- I'm not convinced the second must is truly necessary. Open for feedback 
- An alternate solution is to add the kzg commitment to the RPC request
- An alternate solution specify that clients MUST NOT serve blobs until the corresponding block has been fully validated. (This slows down the overall blob propagation speed)