### PR TITLE
clarify/fix things in blob requests

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -286,10 +286,7 @@ Requests sidecars by block root and index.
 The response is a list of `BlobSidecar` whose length is less than or equal to the number of requests.
 It may be less in the case that the responding peer is missing blocks or sidecars.
 
-The response is unsigned, i.e. `BlobSidecar`, as the signature of the beacon block proposer
-may not be available beyond the initial distribution via gossip.
-
-Before consuming the next response chunk, the response reader SHOULD verify the blob sidecar is well-formatted and correct w.r.t. the expected KZG commitments through `verify_blob_kzg_proof_batch`.
+Before consuming the next response chunk, the response reader SHOULD verify the blob sidecar is well-formatted, has valid inclusion proof, and is correct w.r.t. the expected KZG commitments through `verify_blob_kzg_proof`.
 
 No more than `MAX_REQUEST_BLOB_SIDECARS` may be requested at a time.
 
@@ -334,9 +331,7 @@ Response Content:
 
 Requests blob sidecars in the slot range `[start_slot, start_slot + count)`, leading up to the current head block as selected by fork choice.
 
-The response is unsigned, i.e. `BlobSidecarsByRange`, as the signature of the beacon block proposer may not be available beyond the initial distribution via gossip.
-
-Before consuming the next response chunk, the response reader SHOULD verify the blob sidecar is well-formatted and correct w.r.t. the expected KZG commitments through `verify_blob_kzg_proof_batch`.
+Before consuming the next response chunk, the response reader SHOULD verify the blob sidecar is well-formatted, has valid inclusion proof, and is correct w.r.t. the expected KZG commitments through `verify_blob_kzg_proof`.
 
 `BlobSidecarsByRange` is primarily used to sync blobs that may have been missed on gossip and to sync within the `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` window.
 


### PR DESCRIPTION
* Remove the (now incorrect) note about the blob signature
* add that a client SHOULD check the inclusion proof when doing consistency/validation checks 

I'm not sure we should put much more on validations here. Looking at the beaconblock sync methods (byRoot and byRange), we are very minimal on what conditions to perform and where (other than the actual block verificaitons which happen downstream in whatever pipeline the client chooses)

Open to feedback