### PR TITLE
Add sentences about order of ByRoot responses

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -300,6 +300,8 @@ Clients MUST support requesting sidecars since `minimum_request_epoch`, where `m
 Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
 
+Clients MUST respond with blob sidecars they have in the order they were requested.
+
 ##### BlobSidecarsByRange v1
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/1/`

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -302,6 +302,8 @@ Clients MAY limit the number of blocks and sidecars in the response.
 
 Clients SHOULD respond with blob sidecars they have in the order they were requested.
 
+Clients MAY reject requests with duplicate roots.
+
 ##### BlobSidecarsByRange v1
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/1/`

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -300,7 +300,7 @@ Clients MUST support requesting sidecars since `minimum_request_epoch`, where `m
 Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
 
-Clients MUST respond with blob sidecars they have in the order they were requested.
+Clients SHOULD respond with blob sidecars they have in the order they were requested.
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -858,6 +858,8 @@ Clients MAY limit the number of blocks in the response.
 
 Clients SHOULD respond with blocks they have in the order they were requested.
 
+Clients MAY reject requests with duplicate roots.
+
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 
 ##### Ping

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -856,6 +856,8 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
+Clients MUST respond with blocks they have in the order they were requested.
+
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 
 ##### Ping

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -856,7 +856,7 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
-Clients MUST respond with blocks they have in the order they were requested.
+Clients SHOULD respond with blocks they have in the order they were requested.
 
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 


### PR DESCRIPTION
I noticed that `BlocksByRoot` and `BlobSidecarsByRoot` do not mention anything about order of responses. This PR adds a sentence to each section which states responses must be sent in the order they were requested.

Here's where the `ByRange` sections state this:

https://github.com/ethereum/consensus-specs/blob/36f0bb0ed62b463947fda97f42f8ddebc9565587/specs/phase0/p2p-interface.md?plain=1#L804

https://github.com/ethereum/consensus-specs/blob/36f0bb0ed62b463947fda97f42f8ddebc9565587/specs/deneb/p2p-interface.md?plain=1#L365