### PR TITLE
Remove extra tick

### DIFF
--- a/tests/core/pyspec/eth2spec/test/bellatrix/fork_choice/test_should_override_forkchoice_update.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/fork_choice/test_should_override_forkchoice_update.py
@@ -135,8 +135,6 @@ def test_should_override_forkchoice_update__true(spec, state):
     # Add attestations to the parent block
     temp_state = state.copy()
     next_slot(spec, temp_state)
-    current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time + 1
-    on_tick_and_append_step(spec, store, current_time, test_steps)
     attestations = get_valid_attestation_at_slot(
         temp_state,
         spec,

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_proposer_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_proposer_head.py
@@ -128,8 +128,6 @@ def test_basic_is_parent_root(spec, state):
     slot = state.slot
 
     # Add attestations to the parent block
-    current_time = slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
     attestations = get_valid_attestation_at_slot(
         state,
         spec,


### PR DESCRIPTION
Thank @rolfyone for reporting it!

https://media.githubusercontent.com/media/ethereum/consensus-spec-tests/master/tests/mainnet/bellatrix/fork_choice/should_override_forkchoice_update/pyspec_tests/should_override_forkchoice_update__true/steps.yaml

There is a tick `1573` **after**  tick `1576`, which should be impossible.

Another further bug-free fix is to add the precondition `assert time > store.time` in `on_tick` function, given that we have stated " `on_tick(store, time)` whenever `time > store.time` where `time` is the current Unix time". I'll open another PR for it.