### PR TITLE
Check `assert time >= store.time` in fork-choice tests

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -623,6 +623,9 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
 
 ```python
 def on_tick(store: Store, time: uint64) -> None:
+    # Precondition
+    assert time >= store.time
+
     # If the ``store.time`` falls behind, while loop catches up slot by slot
     # to ensure that every previous slot is processed with ``on_tick_per_slot``
     tick_slot = (time - store.genesis_time) // SECONDS_PER_SLOT

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -623,9 +623,6 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
 
 ```python
 def on_tick(store: Store, time: uint64) -> None:
-    # Precondition
-    assert time >= store.time
-
     # If the ``store.time`` falls behind, while loop catches up slot by slot
     # to ensure that every previous slot is processed with ``on_tick_per_slot``
     tick_slot = (time - store.genesis_time) // SECONDS_PER_SLOT

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -60,8 +60,7 @@ def tick_and_add_block(spec, store, signed_block, test_steps, valid=True,
     block_time = pre_state.genesis_time + signed_block.message.slot * spec.config.SECONDS_PER_SLOT
     while store.time < block_time:
         time = pre_state.genesis_time + (spec.get_current_slot(store) + 1) * spec.config.SECONDS_PER_SLOT
-        if time > store.time:
-            on_tick_and_append_step(spec, store, time, test_steps)
+        on_tick_and_append_step(spec, store, time, test_steps)
 
     post_state = yield from add_block(
         spec, store, signed_block, test_steps,
@@ -146,10 +145,9 @@ def get_blobs_file_name(blobs=None, blobs_root=None):
 
 def on_tick_and_append_step(spec, store, time, test_steps):
     assert time >= store.time
-    if store.time < time:
-        spec.on_tick(store, time)
-        test_steps.append({'tick': int(time)})
-        output_store_checks(spec, store, test_steps)
+    spec.on_tick(store, time)
+    test_steps.append({'tick': int(time)})
+    output_store_checks(spec, store, test_steps)
 
 
 def run_on_block(spec, store, signed_block, valid=True):

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -60,7 +60,8 @@ def tick_and_add_block(spec, store, signed_block, test_steps, valid=True,
     block_time = pre_state.genesis_time + signed_block.message.slot * spec.config.SECONDS_PER_SLOT
     while store.time < block_time:
         time = pre_state.genesis_time + (spec.get_current_slot(store) + 1) * spec.config.SECONDS_PER_SLOT
-        on_tick_and_append_step(spec, store, time, test_steps)
+        if time > store.time:
+            on_tick_and_append_step(spec, store, time, test_steps)
 
     post_state = yield from add_block(
         spec, store, signed_block, test_steps,
@@ -144,6 +145,7 @@ def get_blobs_file_name(blobs=None, blobs_root=None):
 
 
 def on_tick_and_append_step(spec, store, time, test_steps):
+    assert time >= store.time
     if store.time < time:
         spec.on_tick(store, time)
         test_steps.append({'tick': int(time)})

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -144,9 +144,10 @@ def get_blobs_file_name(blobs=None, blobs_root=None):
 
 
 def on_tick_and_append_step(spec, store, time, test_steps):
-    spec.on_tick(store, time)
-    test_steps.append({'tick': int(time)})
-    output_store_checks(spec, store, test_steps)
+    if store.time < time:
+        spec.on_tick(store, time)
+        test_steps.append({'tick': int(time)})
+        output_store_checks(spec, store, test_steps)
 
 
 def run_on_block(spec, store, signed_block, valid=True):


### PR DESCRIPTION
To prevent other future bugs like #3548, this PR adds `assert time >= store.time` to `on_tick`.

Note that we have stated " `on_tick(store, time)` whenever `time > store.time` where `time` is the current Unix time" in fork choice specs. This PR is only to make it more explicit.

It will remove some extra `on_tick` steps from test vectors.