### PR TITLE
Specify when clients can serve block and sidecars in byRoot RPC methods

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -253,7 +253,7 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 No more than `MAX_REQUEST_BLOCKS_DENEB` may be requested at a time.
 
 *[Modified in Deneb:EIP4844]*
-Clients SHOULD consider including a block in the response as soon as it it passes the gossip validation rules.
+Clients SHOULD consider including a block in the response as soon as it passes the gossip validation rules.
 
 ##### BlobSidecarsByRoot v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -304,7 +304,7 @@ Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
 
 Clients SHOULD consider including a sidecar in the response as soon as it passes the gossip validation rules.
-Clients MUST NOT respond with sidecars that failed gossip vaildation.
+Clients MUST NOT respond with sidecars that failed gossip validation.
 Clients MUST NOT respond with sidecars related to blocks that failed `fork_choice.on_block`.
 
 ##### BlobSidecarsByRange v1

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -255,6 +255,9 @@ No more than `MAX_REQUEST_BLOCKS_DENEB` may be requested at a time.
 *[Modified in Deneb:EIP4844]*
 Clients SHOULD consider including a block in the response as soon as it passes the gossip validation rules.
 
+*[New in Deneb:EIP4844]*
+Clients MAY continue serving blocks after failed `fork_choice.on_block` if and only if the failure reason is due to missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block).
+
 ##### BlobSidecarsByRoot v1
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/1/`
@@ -306,7 +309,7 @@ Clients MAY limit the number of blocks and sidecars in the response.
 Clients SHOULD consider including a sidecar in the response as soon as it passes the gossip validation rules.
 Clients MUST NOT respond with sidecars that failed gossip validation.
 Clients MUST NOT respond with sidecars related to blocks that failed `fork_choice.on_block`.
-Clients MAY continue serving blocks\sidecars after failed `fork_choice.on_block` if and only if the failure reason is due to missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block).
+Clients MAY continue serving sidecars after failed `fork_choice.on_block` if and only if the failure reason is due to missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block).
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -256,7 +256,9 @@ No more than `MAX_REQUEST_BLOCKS_DENEB` may be requested at a time.
 Clients SHOULD include a block in the response as soon as it passes the gossip validation rules.
 
 *[New in Deneb:EIP4844]*
-Clients MAY continue serving blocks after failed `fork_choice.on_block` if and only if the failure reason is due to missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block).
+Clients SHOULD NOT include blocks for which one of the following conditions is met:
+- `state_transition(block)` fails.
+- the kzg proof of an available blob is invalid with respect to `blob_kzg_commitments` in the `block` (i.e. `verify_blob_kzg_proof_batch` fails on one or more known blobs).
 
 ##### BlobSidecarsByRoot v1
 
@@ -307,9 +309,9 @@ Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
 
 Clients SHOULD include a sidecar in the response as soon as it passes the gossip validation rules.
-Clients MUST NOT respond with sidecars that failed gossip validation.
-Clients MUST NOT respond with sidecars related to blocks that failed `fork_choice.on_block`.
-Clients MAY continue serving sidecars after failed `fork_choice.on_block` if and only if the failure reason is due to missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block).
+Clients SHOULD NOT include sidecars related to blocks for which one of the following conditions is met:
+- `state_transition(block)` fails.
+- the kzg proof of an available blob is invalid with respect to `blob_kzg_commitments` in the `block` (i.e. `verify_blob_kzg_proof_batch` fails on one or more known blobs).
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -304,7 +304,7 @@ Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
 
 Clients SHOULD include a sidecar in the response as soon as it passes the gossip validation rules.
-Clients MUST NOT respond with sidecars that fails gossip validation rules.
+Clients MUST NOT respond with sidecars that fail gossip validation rules.
 Clients SHOULD NOT respond with sidecars related to blocks that fail gossip validation rules.
 Clients SHOULD NOT include sidecars related to blocks that fail `state_transition(block)`.
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -252,6 +252,9 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 
 No more than `MAX_REQUEST_BLOCKS_DENEB` may be requested at a time.
 
+*[Modified in Deneb:EIP4844]*
+Clients SHOULD consider including a block in the response as soon as it it passes the gossip validation rules.
+
 ##### BlobSidecarsByRoot v1
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/1/`
@@ -299,6 +302,10 @@ Clients MUST support requesting sidecars since `minimum_request_epoch`, where `m
 
 Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
+
+Clients SHOULD consider including a sidecar in the response as soon as it passes the gossip validation rules.
+Clients MUST NOT respond with sidecars that failed gossip vaildation.
+Clients MUST NOT respond with sidecars related to blocks that failed `fork_choice.on_block`.
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -305,7 +305,7 @@ Clients MAY limit the number of blocks and sidecars in the response.
 
 Clients SHOULD include a sidecar in the response as soon as it passes the gossip validation rules.
 Clients MUST NOT respond with sidecars that fails gossip validation rules.
-Clients MUST NOT respond with sidecars related to blocks that fail gossip validation rules.
+Clients SHOULD NOT respond with sidecars related to blocks that fail gossip validation rules.
 Clients SHOULD NOT include sidecars related to blocks that fail `state_transition(block)`.
 
 ##### BlobSidecarsByRange v1

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -254,6 +254,7 @@ No more than `MAX_REQUEST_BLOCKS_DENEB` may be requested at a time.
 
 *[Modified in Deneb:EIP4844]*
 Clients SHOULD include a block in the response as soon as it passes the gossip validation rules.
+Clients SHOULD NOT respond with blocks that fail the beacon chain state transition.
 
 ##### BlobSidecarsByRoot v1
 
@@ -305,7 +306,7 @@ Clients MAY limit the number of blocks and sidecars in the response.
 
 Clients SHOULD include a sidecar in the response as soon as it passes the gossip validation rules.
 Clients SHOULD NOT respond with sidecars related to blocks that fail gossip validation rules.
-Clients SHOULD NOT include sidecars related to blocks that fail `state_transition(block)`.
+Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon chain state transition
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -253,7 +253,7 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 No more than `MAX_REQUEST_BLOCKS_DENEB` may be requested at a time.
 
 *[Modified in Deneb:EIP4844]*
-Clients SHOULD consider including a block in the response as soon as it passes the gossip validation rules.
+Clients SHOULD include a block in the response as soon as it passes the gossip validation rules.
 
 *[New in Deneb:EIP4844]*
 Clients MAY continue serving blocks after failed `fork_choice.on_block` if and only if the failure reason is due to missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block).

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -304,7 +304,6 @@ Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
 
 Clients SHOULD include a sidecar in the response as soon as it passes the gossip validation rules.
-Clients MUST NOT respond with sidecars that fail gossip validation rules.
 Clients SHOULD NOT respond with sidecars related to blocks that fail gossip validation rules.
 Clients SHOULD NOT include sidecars related to blocks that fail `state_transition(block)`.
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -306,7 +306,7 @@ Clients MUST support requesting sidecars since `minimum_request_epoch`, where `m
 Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
 
-Clients SHOULD consider including a sidecar in the response as soon as it passes the gossip validation rules.
+Clients SHOULD include a sidecar in the response as soon as it passes the gossip validation rules.
 Clients MUST NOT respond with sidecars that failed gossip validation.
 Clients MUST NOT respond with sidecars related to blocks that failed `fork_choice.on_block`.
 Clients MAY continue serving sidecars after failed `fork_choice.on_block` if and only if the failure reason is due to missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block).

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -306,7 +306,7 @@ Clients MAY limit the number of blocks and sidecars in the response.
 Clients SHOULD consider including a sidecar in the response as soon as it passes the gossip validation rules.
 Clients MUST NOT respond with sidecars that failed gossip validation.
 Clients MUST NOT respond with sidecars related to blocks that failed `fork_choice.on_block`.
-Clients MAY continue serving blocks\sidecars after failed `fork_choice.on_block` only if the failure reason is due to `is_data_available` failing for missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block)."
+Clients MAY continue serving blocks\sidecars after failed `fork_choice.on_block` if and only if the failure reason is due to missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block).
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -306,6 +306,7 @@ Clients MAY limit the number of blocks and sidecars in the response.
 Clients SHOULD consider including a sidecar in the response as soon as it passes the gossip validation rules.
 Clients MUST NOT respond with sidecars that failed gossip validation.
 Clients MUST NOT respond with sidecars related to blocks that failed `fork_choice.on_block`.
+Clients MAY continue serving blocks\sidecars after failed `fork_choice.on_block` only if the failure reason is due to `is_data_available` failing for missing blobs. (i.e. some sidecars are missing but the available ones have been fully verified against the fully validated block)."
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -255,11 +255,6 @@ No more than `MAX_REQUEST_BLOCKS_DENEB` may be requested at a time.
 *[Modified in Deneb:EIP4844]*
 Clients SHOULD include a block in the response as soon as it passes the gossip validation rules.
 
-*[New in Deneb:EIP4844]*
-Clients SHOULD NOT include blocks for which one of the following conditions is met:
-- `state_transition(block)` fails.
-- the kzg proof of an available blob is invalid with respect to `blob_kzg_commitments` in the `block` (i.e. `verify_blob_kzg_proof_batch` fails on one or more known blobs).
-
 ##### BlobSidecarsByRoot v1
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/1/`
@@ -309,9 +304,9 @@ Clients MUST respond with at least one sidecar, if they have it.
 Clients MAY limit the number of blocks and sidecars in the response.
 
 Clients SHOULD include a sidecar in the response as soon as it passes the gossip validation rules.
-Clients SHOULD NOT include sidecars related to blocks for which one of the following conditions is met:
-- `state_transition(block)` fails.
-- the kzg proof of an available blob is invalid with respect to `blob_kzg_commitments` in the `block` (i.e. `verify_blob_kzg_proof_batch` fails on one or more known blobs).
+Clients MUST NOT respond with sidecars that fails gossip validation rules.
+Clients MUST NOT respond with sidecars related to blocks that fail gossip validation rules.
+Clients SHOULD NOT include sidecars related to blocks that fail `state_transition(block)`.
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -857,7 +857,7 @@ Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
 Clients CAN consider including a block in the response as soon as it it passes the gossip validation rules.
-Clients MUST NOT respond with blocks that failed gossip vaildation rules.
+Clients MUST NOT respond with blocks that failed gossip validation rules.
 Clients MUST NOT respond with blocks that failed `fork_choice.on_block`.
 
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -856,7 +856,7 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
-Clients CAN consider including a block in the response as soon as it it passes the gossip validation rules.
+Clients MAY consider including a block in the response as soon as it it passes the gossip validation rules.
 Clients MUST NOT respond with blocks that failed gossip validation rules.
 Clients MUST NOT respond with blocks that failed `fork_choice.on_block`.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -857,7 +857,7 @@ Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
 Clients MAY include a block in the response as soon as it passes the gossip validation rules.
-Clients SHOULD NOT respond with blocks that fail beacon chain state transition.
+Clients SHOULD NOT respond with blocks that fail the beacon chain state transition.
 
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -857,8 +857,8 @@ Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
 Clients MAY include a block in the response as soon as it passes the gossip validation rules.
-Clients MUST NOT respond with blocks that failed gossip validation rules.
-Clients MUST NOT respond with blocks that failed `fork_choice.on_block`.
+Clients MUST NOT respond with blocks that fail gossip validation rules.
+Clients SHOULD NOT include blocks that fail `state_transition(block)`.
 
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -856,7 +856,7 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
-Clients MAY consider including a block in the response as soon as it it passes the gossip validation rules.
+Clients MAY consider including a block in the response as soon as it passes the gossip validation rules.
 Clients MUST NOT respond with blocks that failed gossip validation rules.
 Clients MUST NOT respond with blocks that failed `fork_choice.on_block`.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -857,7 +857,6 @@ Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
 Clients MAY include a block in the response as soon as it passes the gossip validation rules.
-Clients MUST NOT respond with blocks that fail gossip validation rules.
 Clients SHOULD NOT respond with blocks that fail beacon chain state transition.
 
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -856,7 +856,7 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
-Clients MAY consider including a block in the response as soon as it passes the gossip validation rules.
+Clients MAY include a block in the response as soon as it passes the gossip validation rules.
 Clients MUST NOT respond with blocks that failed gossip validation rules.
 Clients MUST NOT respond with blocks that failed `fork_choice.on_block`.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -856,6 +856,10 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 Clients MUST respond with at least one block, if they have it.
 Clients MAY limit the number of blocks in the response.
 
+Clients CAN consider including a block in the response as soon as it it passes the gossip validation rules.
+Clients MUST NOT respond with blocks that failed gossip vaildation rules.
+Clients MUST NOT respond with blocks that failed `fork_choice.on_block`.
+
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 
 ##### Ping

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -858,7 +858,7 @@ Clients MAY limit the number of blocks in the response.
 
 Clients MAY include a block in the response as soon as it passes the gossip validation rules.
 Clients MUST NOT respond with blocks that fail gossip validation rules.
-Clients SHOULD NOT include blocks that fail `state_transition(block)`.
+Clients SHOULD NOT respond with blocks that fail beacon chain state transition.
 
 `/eth2/beacon_chain/req/beacon_blocks_by_root/1/` is deprecated. Clients MAY respond with an empty list during the deprecation transition period.
 


### PR DESCRIPTION
Based on conversation in #3547.

Allow clients to respond with blocks and blobs as soon as they pass gossip validation.

Two points of discussion I have in mind:

1. The idea is to have it a possibility (`MAY`) in `Phase0` but to be an encouraged (`SHOULD`) behaviour from `Deneb`. This to allow mixed client approach: some could add it from `Deneb` only, other could have it enabled for all forks.

2. The `MUST NOT` reenforce the obvious concept that clients must not respond with objects that they think are invalid. Problem is that we can fall in complications like "block import failed but due to data unavailability so block and sidecars i have so far are actually good and can be server".


fixes #3547 