### PR TITLE
Slashable message propagation post-deneb

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -183,7 +183,8 @@ The following validations MUST pass before forwarding the `blob_sidecar` on the 
 - _[REJECT]_ The current finalized_checkpoint is an ancestor of the sidecar's block -- i.e. `get_checkpoint_block(store, block_header.parent_root, store.finalized_checkpoint.epoch) == store.finalized_checkpoint.root`.
 - _[REJECT]_ The sidecar's inclusion proof is valid as verified by `verify_blob_sidecar_inclusion_proof(blob_sidecar)`.
 - _[REJECT]_ The sidecar's blob is valid as verified by `verify_blob_kzg_proof(blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof)`.
-- _[IGNORE]_ The sidecar is the first sidecar for the tuple (block_header.slot, block_header.proposer_index, blob_sidecar.index) with valid header signature, sidecar inclusion proof, and kzg proof.
+- _[IGNORE]_ The sidecar is the first sidecar for the tuple (`hash_tree_root(block_header)`, blob_sidecar.index) with valid header signature, sidecar inclusion proof, and kzg proof.
+- _[IGNORE]_ The sidecar's `signed_block_header` is not slashable.
 - _[REJECT]_ The sidecar is proposed by the expected `proposer_index` for the block's slot in the context of the current shuffling (defined by `block_header.parent_root`/`block_header.slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling, the sidecar MAY be queued for later processing while proposers for the block's branch are calculated -- in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -333,6 +333,7 @@ The following validations MUST pass before forwarding the `signed_beacon_block` 
   i.e. validate that `signed_beacon_block.message.slot > compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)`
   (a client MAY choose to validate and store such blocks for additional purposes -- e.g. slashing detection, archive nodes, etc).
 - _[IGNORE]_ The block is the first block with valid signature received for the proposer for the slot, `signed_beacon_block.message.slot`.
+- _[IGNORE]_ The block is not slashable.
 - _[REJECT]_ The proposer signature, `signed_beacon_block.signature`, is valid with respect to the `proposer_index` pubkey.
 - _[IGNORE]_ The block's parent (defined by `block.parent_root`) has been seen
   (via both gossip and non-gossip sources)


### PR DESCRIPTION
The existing gossip rules mean we can propagate two (or more) slashable messages so long as they are not both blocks, or both sidecars of the same index. I don't think this is necessarily a bad thing in itself but I do think it makes things unnecessarily more complicated in implementation. 

This has implications in the block production endpoint for example: 

https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlockV2

According to existing rules, clients should return 202 and publish (if `broadcast_validation = gossip`) when receiving a message consisting of a block and a blob sidecar containing a slashable block header, even though this is immediately identifiable as slashable.

Related to this, the existing rules force clients to build caches tracking slashability not just across all block components (which clients must in slasher implementations and also to support `broadcast_validation = consensus_and_equivocation`), but also at lower levels of granularity (blob index and message type). For example we have to differentiate between the following scenarios when `signed_header_a` and `signed_header_b` are slashable:

##### Scenario 1
 Message 1: `(signed_header_a, blob_index_1)`
 Message 2, not propagated: `(signed_header_b, blob_index_1)`
 
 ##### Scenario 2
 Message 1: `(signed_header_a, blob_index_1)`
 Message 2, propagated: `(signed_header_b, blob_index_2)`

The suggestion here is to split the blob gossip rule related to slashability into two rules, one that's just about de-duplication, and one that's related to slashability more generally. And to add a general slashability rule to block gossip.