### PR TITLE
Set `--bls-type` default value to `fastest`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/conftest.py
+++ b/tests/core/pyspec/eth2spec/test/conftest.py
@@ -44,7 +44,7 @@ def pytest_addoption(parser):
         help="bls-default: make tests that are not dependent on BLS run without BLS"
     )
     parser.addoption(
-        "--bls-type", action="store", type=str, default="py_ecc", choices=["py_ecc", "milagro", "arkworks", "fastest"],
+        "--bls-type", action="store", type=str, default="fastest", choices=["py_ecc", "milagro", "arkworks", "fastest"],
         help=(
             "bls-type: use specified BLS implementation;"
             "fastest: use milagro for signatures and arkworks for everything else (e.g. KZG)"


### PR DESCRIPTION
Fix leftover of #3521. Now running pytest with `fastest` BLS setting instead of pure `py_ecc` by default.
