### PR TITLE
macOS support for running individual generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,8 @@ define run_generator
 	cd $(GENERATOR_DIR)/$(1); \
 	if ! test -d venv; then python3 -m venv venv; fi; \
 	. venv/bin/activate; \
-	pip3 install -r requirements.txt; \
+	pip3 install setuptools wheel; \
+	pip3 install --no-use-pep517 -r requirements.txt; \
 	python3 main.py -o $(CURRENT_DIR)/$(TEST_VECTOR_DIR); \
 	echo "generator $(1) finished"
 endef
@@ -244,5 +245,5 @@ build_docs: copy_docs
 	mkdocs build
 
 serve_docs:
-	. venv/bin/activate; 
+	. venv/bin/activate;
 	mkdocs serve


### PR DESCRIPTION
The workarounds in `setup.py` to install `ruamel.yaml` and `marko` don't work when starting from a clean build, e.g.:

```sh
make clean
git clean -dfx
make preinstallation
make install_test
make pyspec
make -j gen_fork_choice
```

This results in error:

```
generator fork_choice started
Processing /consensus-specs
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [30 lines of output]
      /consensus-specs/tests/generators/fork_choice/venv/bin/python3.11: No module named pip
      Traceback (most recent call last):
        File "<string>", line 45, in <module>
      ModuleNotFoundError: No module named 'ruamel'
```

Adding `--no-use-pep517` disables some environment isolation for `pip`, and makes this work once more on macOS. `--no-use-pep517` requires prior installation of `setuptools` and `wheel`.

```
% sw_vers
ProductName:      macOS
ProductVersion:   14.2.1
BuildVersion:     23C71
```