### PR TITLE
Add guard when `fill_prev_epoch` is `True` in epoch `0`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -280,7 +280,7 @@ def state_transition_with_full_block(spec,
             )
             for attestation in attestations:
                 block.body.attestations.append(attestation)
-    if fill_prev_epoch:
+    if fill_prev_epoch and state.slot >= spec.SLOTS_PER_EPOCH:
         slot_to_attest = state.slot - spec.SLOTS_PER_EPOCH + 1
         attestations = get_valid_attestation_at_slot(
             state,


### PR DESCRIPTION
`state_transition_with_full_block` takes two flags, `fill_cur_epoch` and `fill_prev_epoch`, to control what attestations to include into the new testing block.

While `fill_cur_epoch` uses `MIN_ATTESTATION_INCLUSION_DELAY` as the minimum slot before taking effect, `fill_prev_epoch` results in an annoying assert, requiring caller to work around the case of calling the function as usual at the start.

This adds a similar minimum slot `SLOTS_PER_EPOCH` for `fill_prev_epoch` before which the flag is ignored, same as for `fill_cur_epoch`.