### PR TITLE
Extract sync committee period <-> slot helpers to common LC test module

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
@@ -28,6 +28,7 @@ from eth2spec.test.helpers.forks import (
     is_post_fork,
 )
 from eth2spec.test.helpers.light_client import (
+    compute_start_slot_at_next_sync_committee_period,
     get_sync_aggregate,
 )
 from eth2spec.test.helpers.state import (
@@ -279,15 +280,6 @@ def emit_upgrade_store(test, new_s_spec, phases=None):
             "checks": get_checks(test.s_spec, test.store),
         }
     })
-
-
-def compute_start_slot_at_sync_committee_period(spec, sync_committee_period):
-    return spec.compute_start_slot_at_epoch(sync_committee_period * spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
-
-
-def compute_start_slot_at_next_sync_committee_period(spec, state):
-    sync_committee_period = spec.compute_sync_committee_period_at_slot(state.slot)
-    return compute_start_slot_at_sync_committee_period(spec, sync_committee_period + 1)
 
 
 @with_light_client

--- a/tests/core/pyspec/eth2spec/test/helpers/light_client.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/light_client.py
@@ -8,6 +8,15 @@ from eth2spec.test.helpers.sync_committee import (
 from math import floor
 
 
+def compute_start_slot_at_sync_committee_period(spec, sync_committee_period):
+    return spec.compute_start_slot_at_epoch(sync_committee_period * spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
+
+
+def compute_start_slot_at_next_sync_committee_period(spec, state):
+    sync_committee_period = spec.compute_sync_committee_period_at_slot(state.slot)
+    return compute_start_slot_at_sync_committee_period(spec, sync_committee_period + 1)
+
+
 def get_sync_aggregate(spec, state, num_participants=None, signature_slot=None):
     # By default, the sync committee signs the previous slot
     if signature_slot is None:


### PR DESCRIPTION
The two functions `compute_start_slot_at_sync_committee_period` and `compute_start_slot_at_next_sync_committee_period` are currently only available during LC `test_sync`. Move them to the common LC test module so that they can be used from future tests as well.