### PR TITLE
Optimization: reduce `len()` calls in `add_polynomialcoeff`

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -156,7 +156,9 @@ def add_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> PolynomialCoe
     Sum the coefficient form polynomials ``a`` and ``b``.
     """
     a, b = (a, b) if len(a) >= len(b) else (b, a)
-    return [(a[i] + (b[i] if i < len(b) else 0)) % BLS_MODULUS for i in range(len(a))]
+    length_a = len(a)
+    length_b = len(b)
+    return [(a[i] + (b[i] if i < length_b else 0)) % BLS_MODULUS for i in range(length_a)]
 ```
 
 #### `neg_polynomialcoeff`


### PR DESCRIPTION
## Description

I made some profiles on the DAS test case `test_verify_cell_proof`, which includes a `compute_cells_and_proofs` call and two `verify_cell_proof` calls. It turns out `len()` is somewhat expensive if we call it 400M times.

For the sake of tidiness and readability, We intentionally didn't have such optimization in spec writing. However, this one seems gain great performance improvement with only two extra lines.

## Before
![](https://storage.googleapis.com/ethereum-hackmd/upload_0aa638531ad948c82d8c52ae8c8d9acb.png)

* Speed: in 356.67s (0:05:56)


## After reducing the `len()` calls in `add_polynomialcoeff`

This minor optimization here use temporary variables to keep the `len(a)` and `len(b)` results: 
```python
def add_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> PolynomialCoeff:
    """
    Sum the coefficient form polynomials ``a`` and ``b``.
    """
    a, b = (a, b) if len(a) >= len(b) else (b, a)
    length_a = len(a)
    length_b = len(b)
    return [(a[i] + (b[i] if i < length_b else 0)) % BLS_MODULUS for i in range(length_a)]
```

![](https://storage.googleapis.com/ethereum-hackmd/upload_e8febdf3625e3bec4112a2a95b56eabb.png)

* Speed: in 234.21s (0:03:54)

It reduced ~35% time of this case.


