### PR TITLE
Add transition test case of non-empty pre-state `historical_roots`

### DIFF
--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -294,7 +294,7 @@ def is_partially_withdrawable_validator(validator: Validator, balance: Gwei) -> 
 
 ### Epoch processing
 
-*Note*: The function `process_historical_summaries_update` replaces `process_historical_roots_update` in Bellatrix.
+*Note*: The function `process_historical_summaries_update` replaces `process_historical_roots_update` in Capella.
 
 ```python
 def process_epoch(state: BeaconState) -> None:

--- a/tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py
+++ b/tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py
@@ -425,11 +425,11 @@ def test_non_empty_historical_roots(state, fork_epoch, spec, post_spec, pre_tag,
     """
     Test with non-empty pre-state `state.historical_roots`.
 
-    Since Capella froze `historical_roots`, Capealla spec doesn't invoke `process_historical_roots_update` anymore.
+    Since Capella froze `historical_roots`, Capella spec doesn't invoke `process_historical_roots_update` anymore.
     Therefore, we need to fill in `historical_roots` with non-empty value.
     """
     # fill in historical_roots with non-empty values
-    pre_historical_roots = [b'\x56' * 32 for _ in range(spec.SLOTS_PER_HISTORICAL_ROOT)]
+    pre_historical_roots = [b'\x56' * 32]
     state.historical_roots = pre_historical_roots
 
     transition_until_fork(spec, state, fork_epoch)

--- a/tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py
+++ b/tests/core/pyspec/eth2spec/test/altair/transition/test_transition.py
@@ -418,3 +418,37 @@ def test_transition_with_no_attestations_until_after_fork(state, fork_epoch, spe
 
     yield "blocks", blocks
     yield "post", state
+
+
+@with_fork_metas([ForkMeta(pre_fork_name=pre, post_fork_name=post, fork_epoch=2) for pre, post in ALL_PRE_POST_FORKS])
+def test_non_empty_historical_roots(state, fork_epoch, spec, post_spec, pre_tag, post_tag):
+    """
+    Test with non-empty pre-state `state.historical_roots`.
+
+    Since Capella froze `historical_roots`, Capealla spec doesn't invoke `process_historical_roots_update` anymore.
+    Therefore, we need to fill in `historical_roots` with non-empty value.
+    """
+    # fill in historical_roots with non-empty values
+    pre_historical_roots = [b'\x56' * 32 for _ in range(spec.SLOTS_PER_HISTORICAL_ROOT)]
+    state.historical_roots = pre_historical_roots
+
+    transition_until_fork(spec, state, fork_epoch)
+    # check pre state
+    assert spec.get_current_epoch(state) < fork_epoch
+    assert len(state.historical_roots) > 0
+
+    yield "pre", state
+
+    # irregular state transition to handle fork:
+    blocks = []
+    state, block = do_fork(state, spec, post_spec, fork_epoch)
+    blocks.append(post_tag(block))
+
+    # continue regular state transition with new spec into next epoch
+    transition_to_next_epoch_and_append_blocks(post_spec, state, post_tag, blocks, only_last_block=True)
+
+    yield "blocks", blocks
+    yield "post", state
+
+    assert len(state.historical_roots) > 0
+    assert state.historical_roots == pre_historical_roots

--- a/tests/formats/transition/README.md
+++ b/tests/formats/transition/README.md
@@ -9,6 +9,8 @@ Clients should assume forks happen sequentially in the following manner:
 0. `phase0`
 1. `altair`
 2. `bellatrix`
+3. `capella`
+4. `deneb`
 
 For example, if a test case has `post_fork` of `altair`, the test consumer should assume the test begins in `phase0` and use that specification to process the initial state and any blocks up until the fork epoch. After the fork happens, the test consumer should use the specification according to the `altair` fork to process the remaining data.
 


### PR DESCRIPTION
### Issue

To cover https://github.com/prysmaticlabs/prysm/pull/13477 with this test case.

### Description
- Add fork transition test case of non-empty pre-state `historical_roots`
- [non-substantive] Update transition test format
- [non-substantive] Fix Capella spec comment typo