### PR TITLE
Update ExecutionPayloadHeader changelog according to EIP4788

### DIFF
--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -166,6 +166,7 @@ class ExecutionPayloadHeader(Container):
     withdrawals_root: Root
     blob_gas_used: uint64  # [New in Deneb:EIP4844]
     excess_blob_gas: uint64  # [New in Deneb:EIP4844]
+    parent_beacon_block_root: Root  # [New in Deneb:EIP4788]
 ```
 
 ## Helper functions


### PR DESCRIPTION
[EIP4788](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4788.md#block-structure-and-validity) adds `parent_beacon_block_root` on the ExecutionPayloadHeader.