### PR TITLE
Rename `get_safe_execution_payload_hash` -> `*_block_hash`

### DIFF
--- a/fork_choice/safe-block.md
+++ b/fork_choice/safe-block.md
@@ -7,7 +7,7 @@
 
 - [Introduction](#introduction)
 - [`get_safe_beacon_block_root`](#get_safe_beacon_block_root)
-- [`get_safe_execution_payload_hash`](#get_safe_execution_payload_hash)
+- [`get_safe_execution_block_hash`](#get_safe_execution_block_hash)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -31,10 +31,10 @@ def get_safe_beacon_block_root(store: Store) -> Root:
 *Note*: Currently safe block algorithm simply returns `store.justified_checkpoint.root`
 and is meant to be improved in the future.
 
-## `get_safe_execution_payload_hash`
+## `get_safe_execution_block_hash`
 
 ```python
-def get_safe_execution_payload_hash(store: Store) -> Hash32:
+def get_safe_execution_block_hash(store: Store) -> Hash32:
     safe_block_root = get_safe_beacon_block_root(store)
     safe_block = store.blocks[safe_block_root]
 

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -75,7 +75,7 @@ As per EIP-3675, before a post-transition block is finalized, `notify_forkchoice
 ##### `safe_block_hash`
 
 The `safe_block_hash` parameter MUST be set to return value of
-[`get_safe_execution_payload_hash(store: Store)`](../../fork_choice/safe-block.md#get_safe_execution_payload_hash) function.
+[`get_safe_execution_block_hash(store: Store)`](../../fork_choice/safe-block.md#get_safe_execution_block_hash) function.
 
 ##### `should_override_forkchoice_update`
 

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -120,8 +120,8 @@ To obtain an execution payload, a block proposer building a block on top of a `s
 1. Set `payload_id = prepare_execution_payload(state, pow_chain, safe_block_hash, finalized_block_hash, suggested_fee_recipient, execution_engine)`, where:
     * `state` is the state object after applying `process_slots(state, slot)` transition to the resulting state of the parent block processing
     * `pow_chain` is a `Dict[Hash32, PowBlock]` dictionary that abstractly represents all blocks in the PoW chain with block hash as the dictionary key
-    * `safe_block_hash` is the return value of the `get_safe_execution_payload_hash(store: Store)` function call
-    * `finalized_block_hash` is the hash of the latest finalized execution payload (`Hash32()` if none yet finalized)
+    * `safe_block_hash` is the return value of the `get_safe_execution_block_hash(store: Store)` function call
+    * `finalized_block_hash` is the block hash of the latest finalized execution payload (`Hash32()` if none yet finalized)
     * `suggested_fee_recipient` is the value suggested to be used for the `fee_recipient` field of the execution payload
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -121,7 +121,7 @@ of return values. Here we add two values, the string `'pre'` and the initial sta
 ```
 
 The state contains the last block, which is necessary for building up the next block (every block needs to
-have the hash of the previous one in a blockchain).
+have the root of the previous one in a blockchain).
 
 ```python
     signed_block = state_transition_and_sign_block(spec, state, block)
@@ -291,8 +291,8 @@ not execute EVM programs or store user data. It exists to provide a secure sourc
 information about the latest verified block hash of the execution layer.
 
 For every slot a validator is randomly selected as the proposer. The proposer proposes a block
-for the current head of the consensus layer chain (built on the previous block). That block 
-includes the hash of the proposed new head of the execution layer.
+for the current head of the consensus layer chain (built on the previous block). That block
+includes the block hash of the proposed new head of the execution layer.
 
 For every slot there is also a randomly selected committee of validators that needs to vote whether
 the new consensus layer block is valid, which requires the proposed head of the execution chain to


### PR DESCRIPTION
The name `get_safe_execution_payload_hash` is misleading, as it returns the execution block hash. There is no concept of a payload hash. Rename the function, and also update some documentation for clarity.