### PR TITLE
Handle `integer_squareroot` bound case

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -178,7 +178,7 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value |
 | - | - |
-| `MAX_UINT_64` | `uint64(2**64 - 1)` |
+| `UINT64_MAX` | `uint64(2**64 - 1)` |
 | `GENESIS_SLOT` | `Slot(0)` |
 | `GENESIS_EPOCH` | `Epoch(0)` |
 | `FAR_FUTURE_EPOCH` | `Epoch(2**64 - 1)` |
@@ -600,7 +600,7 @@ def integer_squareroot(n: uint64) -> uint64:
     """
     Return the largest integer ``x`` such that ``x**2 <= n``.
     """
-    if n == MAX_UINT_64:
+    if n == UINT64_MAX:
         return uint64(4294967295)
     x = n
     y = (x + 1) // 2

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -178,6 +178,7 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value |
 | - | - |
+| `MAX_UINT_64` | `uint64(2**64 - 1)` |
 | `GENESIS_SLOT` | `Slot(0)` |
 | `GENESIS_EPOCH` | `Epoch(0)` |
 | `FAR_FUTURE_EPOCH` | `Epoch(2**64 - 1)` |
@@ -599,6 +600,8 @@ def integer_squareroot(n: uint64) -> uint64:
     """
     Return the largest integer ``x`` such that ``x**2 <= n``.
     """
+    if n == MAX_UINT_64:
+        return uint64(4294967295)
     x = n
     y = (x + 1) // 2
     while y < x:

--- a/tests/core/pyspec/eth2spec/test/helpers/constants.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/constants.py
@@ -89,4 +89,4 @@ ALL_PRESETS = (MINIMAL, MAINNET)
 #
 # Number
 #
-MAX_UINT_64 = 2**64 - 1
+UINT64_MAX = 2**64 - 1

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/math/test_integer_squareroot.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/math/test_integer_squareroot.py
@@ -1,0 +1,23 @@
+import random
+from math import isqrt
+from eth2spec.test.context import (
+    spec_test,
+    single_phase,
+    with_all_phases,
+)
+
+
+@with_all_phases
+@spec_test
+@single_phase
+def test_integer_squareroot(spec):
+    values = [0, 100, 2**64 - 2, 2**64 - 1]
+    for n in values:
+        uint64_n = spec.uint64(n)
+        assert spec.integer_squareroot(uint64_n) == isqrt(n)
+
+    rng = random.Random(5566)
+    for _ in range(10):
+        n = rng.randint(0, 2**64 - 1)
+        uint64_n = spec.uint64(n)
+        assert spec.integer_squareroot(uint64_n) == isqrt(n)

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/math/test_integer_squareroot.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/math/test_integer_squareroot.py
@@ -21,3 +21,9 @@ def test_integer_squareroot(spec):
         n = rng.randint(0, 2**64 - 1)
         uint64_n = spec.uint64(n)
         assert spec.integer_squareroot(uint64_n) == isqrt(n)
+
+    try:
+        spec.integer_squareroot(spec.uint64(2**64))
+        assert False
+    except ValueError:
+        pass

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/test_config_invariants.py
@@ -2,7 +2,7 @@ from eth2spec.test.context import (
     spec_state_test,
     with_all_phases,
 )
-from eth2spec.test.helpers.constants import MAX_UINT_64
+from eth2spec.test.helpers.constants import UINT64_MAX
 from eth2spec.test.helpers.forks import (
     is_post_altair, is_post_bellatrix,
 )
@@ -16,9 +16,9 @@ def check_bound(value, lower_bound, upper_bound):
 @with_all_phases
 @spec_state_test
 def test_validators(spec, state):
-    check_bound(spec.VALIDATOR_REGISTRY_LIMIT, 1, MAX_UINT_64)
-    check_bound(spec.MAX_COMMITTEES_PER_SLOT, 1, MAX_UINT_64)
-    check_bound(spec.TARGET_COMMITTEE_SIZE, 1, MAX_UINT_64)
+    check_bound(spec.VALIDATOR_REGISTRY_LIMIT, 1, UINT64_MAX)
+    check_bound(spec.MAX_COMMITTEES_PER_SLOT, 1, UINT64_MAX)
+    check_bound(spec.TARGET_COMMITTEE_SIZE, 1, UINT64_MAX)
 
     # Note: can be less if you assume stricters bounds on validator set based on total ETH supply
     maximum_validators_per_committee = (
@@ -30,24 +30,24 @@ def test_validators(spec, state):
     check_bound(spec.config.MIN_PER_EPOCH_CHURN_LIMIT, 1, spec.VALIDATOR_REGISTRY_LIMIT)
     check_bound(spec.config.CHURN_LIMIT_QUOTIENT, 1, spec.VALIDATOR_REGISTRY_LIMIT)
 
-    check_bound(spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, spec.TARGET_COMMITTEE_SIZE, MAX_UINT_64)
+    check_bound(spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, spec.TARGET_COMMITTEE_SIZE, UINT64_MAX)
 
 
 @with_all_phases
 @spec_state_test
 def test_balances(spec, state):
     assert spec.MAX_EFFECTIVE_BALANCE % spec.EFFECTIVE_BALANCE_INCREMENT == 0
-    check_bound(spec.MIN_DEPOSIT_AMOUNT, 1, MAX_UINT_64)
-    check_bound(spec.MAX_EFFECTIVE_BALANCE, spec.MIN_DEPOSIT_AMOUNT, MAX_UINT_64)
-    check_bound(spec.MAX_EFFECTIVE_BALANCE, spec.EFFECTIVE_BALANCE_INCREMENT, MAX_UINT_64)
+    check_bound(spec.MIN_DEPOSIT_AMOUNT, 1, UINT64_MAX)
+    check_bound(spec.MAX_EFFECTIVE_BALANCE, spec.MIN_DEPOSIT_AMOUNT, UINT64_MAX)
+    check_bound(spec.MAX_EFFECTIVE_BALANCE, spec.EFFECTIVE_BALANCE_INCREMENT, UINT64_MAX)
 
 
 @with_all_phases
 @spec_state_test
 def test_hysteresis_quotient(spec, state):
-    check_bound(spec.HYSTERESIS_QUOTIENT, 1, MAX_UINT_64)
+    check_bound(spec.HYSTERESIS_QUOTIENT, 1, UINT64_MAX)
     check_bound(spec.HYSTERESIS_DOWNWARD_MULTIPLIER, 1, spec.HYSTERESIS_QUOTIENT)
-    check_bound(spec.HYSTERESIS_UPWARD_MULTIPLIER, spec.HYSTERESIS_QUOTIENT, MAX_UINT_64)
+    check_bound(spec.HYSTERESIS_UPWARD_MULTIPLIER, spec.HYSTERESIS_QUOTIENT, UINT64_MAX)
 
 
 @with_all_phases
@@ -68,7 +68,7 @@ def test_time(spec, state):
     assert spec.SLOTS_PER_EPOCH <= spec.SLOTS_PER_HISTORICAL_ROOT
     assert spec.MIN_SEED_LOOKAHEAD < spec.MAX_SEED_LOOKAHEAD
     assert spec.SLOTS_PER_HISTORICAL_ROOT % spec.SLOTS_PER_EPOCH == 0
-    check_bound(spec.SLOTS_PER_HISTORICAL_ROOT, spec.SLOTS_PER_EPOCH, MAX_UINT_64)
+    check_bound(spec.SLOTS_PER_HISTORICAL_ROOT, spec.SLOTS_PER_EPOCH, UINT64_MAX)
     check_bound(spec.MIN_ATTESTATION_INCLUSION_DELAY, 1, spec.SLOTS_PER_EPOCH)
 
 


### PR DESCRIPTION
**Credits to the University of Manchester Bounded Model Checking (BMC) project team: Bruno Farias, Youcheng Sun, and Lucas C. Cordeiro for reporting this issue!** 🙏 💯 

This team is an [Ethereum Foundation ESP](https://esp.ethereum.foundation/applicants) "Bounded Model Checking for Verifying and Testing Ethereum Consensus Specifications (FY22-0751)" project grantee. They used [ESBMC model checker](https://github.com/esbmc/esbmc) to find this issue.

Also, thanks to Mate Soos and Justin Traglia (@jtraglia) for helping verify the issue! 🙌 

### tl;dr

It's a spec bug, but it's impossible to produce it in the current mainnet.

### Description

`integer_squareroot` raises ValueError exception when `n` is maxint of `uint64`, i.e., `2**64 - 1`.

However, we only use `integer_squareroot` in 
1. `integer_squareroot(total_balance)`
2. `integer_squareroot(SLOTS_PER_EPOCH)`

With the current Ether total supply + EIP-1559, it's unlikely to hit the overflow bound in a very long time. (🦇🔊)

That said, it should be fixed to return the expected value.

### How did I fix it

To make minimal changes in the spec, this fix returns the hardcoded edge case result. It's not pretty, but it's an easy patch. I believe there are better solutions, but I'm inclined not to change the existing code much.

Given that `2**64` should be overflow when computing total balance, I think we are not able to provide clean "state transition" test vectors for it. Perhaps we can have another new "math" category test vectors later.

p.s. I talked to all the CL client teams about it before opening this PR. :)
