### PR TITLE
Add `test_proposer_in_committee_without_participation__zero_pre_balance`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/sync_committee.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/sync_committee.py
@@ -111,14 +111,21 @@ def validate_sync_committee_rewards(spec, pre_state, post_state, committee_indic
         assert post_state.balances[index] == (0 if balance < penalty else balance - penalty)
 
 
-def run_sync_committee_processing(spec, state, block, expect_exception=False, skip_reward_validation=False):
+def run_sync_committee_processing(spec, state, block, expect_exception=False, skip_reward_validation=False,
+                                  zero_balance_proposer_index=None):
     """
     Processes everything up to the sync committee work, then runs the sync committee work in isolation, and
     produces a pre-state and post-state (None if exception) specifically for sync-committee processing changes.
     """
-    pre_state = state.copy()
     # process up to the sync committee work
     call = run_block_processing_to(spec, state, block, 'process_sync_aggregate')
+
+    if zero_balance_proposer_index is not None:
+        pre_balance = 0
+        state.balances[zero_balance_proposer_index] = pre_balance
+
+    pre_state = state.copy()
+
     yield 'pre', state
     yield 'sync_aggregate', block.body.sync_aggregate
     if expect_exception:


### PR DESCRIPTION
Suggested by @dapplion, this is a spec test for proposer in sync committee with balance close to zero, and **doesn't participate**.

### Testing target

In [`process_sync_aggregate`](
https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#sync-aggregate-processing)

https://github.com/ethereum/consensus-specs/blob/2faa44b6b68997beb6a64654be2b345a4bb7b8a8/specs/altair/beacon-chain.md?plain=1#L549-L559

We have implemented a for-loop designed to go through the committee sequentially. It either increases or decreases the balances in the for-loop. The sequence in which these adjustments are applied is critical, as it significantly influences the final results.

### Test case description
In this test case, we have (1) proposer in sync committee, (2) only "the validator next to the proposer in committee" has participated.

The proposer balance should get decreased and hit the lower bound `0` first, and then, increased with proposer reward in the next iteration on the participant.

As expected, the result doesn't match our testing helper check (`validate_sync_committee_rewards`.

Note that since we use effective balance to seed the proposer, the best I can mock in the test is setting `state.balances[proposer_index]` but not setting `state.validators[proposer_index].effective_balance`.