### PR TITLE
Introduce UINT64_MAX_SQRT

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -179,6 +179,7 @@ The following values are (non-configurable) constants used throughout the specif
 | Name | Value |
 | - | - |
 | `UINT64_MAX` | `uint64(2**64 - 1)` |
+| `UINT64_MAX_SQRT` | `uint64(4294967295)` |
 | `GENESIS_SLOT` | `Slot(0)` |
 | `GENESIS_EPOCH` | `Epoch(0)` |
 | `FAR_FUTURE_EPOCH` | `Epoch(2**64 - 1)` |
@@ -601,7 +602,7 @@ def integer_squareroot(n: uint64) -> uint64:
     Return the largest integer ``x`` such that ``x**2 <= n``.
     """
     if n == UINT64_MAX:
-        return uint64(4294967295)
+        return UINT64_MAX_SQRT
     x = n
     y = (x + 1) // 2
     while y < x:


### PR DESCRIPTION
Replaces the magic number introduced in https://github.com/ethereum/consensus-specs/pull/3600 with the corresponding constant