### PR TITLE
update eip-7547 branch to latest design

### DIFF
--- a/specs/_features/eip7547/beacon-chain.md
+++ b/specs/_features/eip7547/beacon-chain.md
@@ -32,48 +32,119 @@ This is the beacon chain specification to add an inclusion list mechanism to all
 | Name | Value |
 | - | - |
 | `MAX_TRANSACTIONS_PER_INCLUSION_LIST` |  `uint64(2**4)` (= 16) |
-| `MAX_GAS_PER_INCLUSION_LIST` | `uint64(2**21)` (= 2,097,152) |
 
 ## Containers
 
-### New Containers
-
-#### `InclusionListSummaryEntry`
-
-```python
-class InclusionListSummaryEntry(Container):
-    address: ExecutionAddress
-    gas_limit: uint64
-```
-
-#### `InclusionListSummary`
-
-```python
-class InclusionListSummary(Container):
-    slot: Slot
-    proposer_index: ValidatorIndex
-    summary: List[InclusionListSummaryEntry, MAX_TRANSACTIONS_PER_INCLUSION_LIST]
-```
-
 ### Extended containers
 
-#### `BeaconBlockBody`
+#### `ExecutionPayload`
 
 ```python
-class BeaconBlockBody(Container):
-    randao_reveal: BLSSignature
-    eth1_data: Eth1Data  # Eth1 data vote
-    graffiti: Bytes32  # Arbitrary data
-    # Operations
-    proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-    attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-    attestations: List[Attestation, MAX_ATTESTATIONS]
-    deposits: List[Deposit, MAX_DEPOSITS]
-    voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
-    sync_aggregate: SyncAggregate
-    # Execution
-    execution_payload: ExecutionPayload  # [Modified in Deneb:EIP4844]
-    bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
-    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    inclusion_list_summary: InclusionListSummary  # [New in EIP7547]
+class ExecutionPayload(Container):
+    # Execution block header fields
+    parent_hash: Hash32
+    fee_recipient: ExecutionAddress  # 'beneficiary' in the yellow paper
+    state_root: Bytes32
+    receipts_root: Bytes32
+    logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+    prev_randao: Bytes32  # 'difficulty' in the yellow paper
+    block_number: uint64  # 'number' in the yellow paper
+    gas_limit: uint64
+    gas_used: uint64
+    timestamp: uint64
+    extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+    base_fee_per_gas: uint256
+    # Extra payload fields
+    block_hash: Hash32  # Hash of execution block
+    transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+    withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    blob_gas_used: uint64
+    excess_blob_gas: uint64 
+    previous_inclusion_list_summary: List[ExecutionAddress, MAX_TRANSACTIONS_PER_INCLUSION_LIST] # [New in EIP7547]
+    inclusion_list_summary_root: Root  # [New in EIP7547]
+```
+
+#### `ExecutionPayloadHeader`
+
+```python
+class ExecutionPayloadHeader(Container):
+    # Execution block header fields
+    parent_hash: Hash32
+    fee_recipient: ExecutionAddress
+    state_root: Bytes32
+    receipts_root: Bytes32
+    logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+    prev_randao: Bytes32
+    block_number: uint64
+    gas_limit: uint64
+    gas_used: uint64
+    timestamp: uint64
+    extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+    base_fee_per_gas: uint256
+    # Extra payload fields
+    block_hash: Hash32  # Hash of execution block
+    transactions_root: Root
+    withdrawals_root: Root
+    blob_gas_used: uint64
+    excess_blob_gas: uint64 
+    previous_inclusion_list_summary_root: Root # [New in EIP7547]
+    inclusion_list_summary_root: Root # [New in EIP7547]
+```
+
+
+### Block processing
+
+#### Execution payload
+
+##### Modified `process_execution_payload`
+
+```python
+def process_execution_payload(state: BeaconState, body: BeaconBlockBody, execution_engine: ExecutionEngine) -> None:
+    payload = body.execution_payload
+
+    # Verify consistency of the parent hash with respect to the previous execution payload header
+    assert payload.parent_hash == state.latest_execution_payload_header.block_hash
+    # Verify prev_randao
+    assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
+    # Verify timestamp
+    assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+    # [New in EIP7547] Verify inclusion list summary
+    previous_inclusion_list_summary_root = hash_tree_root(payload.previous_inclusion_list_summary)
+    assert previous_inclusion_list_summary_root == state.latest_execution_payload_header.inclusion_list_summary_root
+
+    # Verify commitments are under limit
+    assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
+
+    # Verify the execution payload is valid
+    versioned_hashes = [kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments]
+    assert execution_engine.verify_and_notify_new_payload(
+        NewPayloadRequest(
+            execution_payload=payload,
+            versioned_hashes=versioned_hashes,
+            parent_beacon_block_root=state.latest_block_header.parent_root,
+        )
+    )
+
+    # Cache execution payload header
+    state.latest_execution_payload_header = ExecutionPayloadHeader(
+        parent_hash=payload.parent_hash,
+        fee_recipient=payload.fee_recipient,
+        state_root=payload.state_root,
+        receipts_root=payload.receipts_root,
+        logs_bloom=payload.logs_bloom,
+        prev_randao=payload.prev_randao,
+        block_number=payload.block_number,
+        gas_limit=payload.gas_limit,
+        gas_used=payload.gas_used,
+        timestamp=payload.timestamp,
+        extra_data=payload.extra_data,
+        base_fee_per_gas=payload.base_fee_per_gas,
+        block_hash=payload.block_hash,
+        transactions_root=hash_tree_root(payload.transactions),
+        withdrawals_root=hash_tree_root(payload.withdrawals),
+        blob_gas_used=payload.blob_gas_used,
+        excess_blob_gas=payload.excess_blob_gas,
+        previous_inclusion_list_summary_root=previous_inclusion_list_summary_root # [New in EIP7547]
+        inclusion_list_summary_root=payload.inclusion_list_summary_root # [New in EIP7547]
+    )
 ```

--- a/specs/_features/eip7547/beacon-chain.md
+++ b/specs/_features/eip7547/beacon-chain.md
@@ -17,7 +17,6 @@
   - [Extended containers](#extended-containers)
     - [`ExecutionPayload`](#executionpayload)
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
-    - [`BeaconBlockBody`](#beaconblockbody)
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
   - [Block processing](#block-processing)
     - [Execution payload](#execution-payload)

--- a/specs/_features/eip7547/beacon-chain.md
+++ b/specs/_features/eip7547/beacon-chain.md
@@ -122,31 +122,8 @@ class ExecutionPayloadHeader(Container):
     withdrawals_root: Root
     blob_gas_used: uint64
     excess_blob_gas: uint64
-    inclusion_list_summary_root: Root  # [New in EIP4547]
-    inclusion_list_exclusions_root: Root  # [New in EIP4547]
-```
-
-#### `BeaconBlockBody`
-
-Note: `BeaconBlock` and `SignedBeaconBlock` types are updated indirectly.
-
-```python
-class BeaconBlockBody(Container):
-    randao_reveal: BLSSignature
-    eth1_data: Eth1Data  # Eth1 data vote
-    graffiti: Bytes32  # Arbitrary data
-    # Operations
-    proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-    attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-    attestations: List[Attestation, MAX_ATTESTATIONS]
-    deposits: List[Deposit, MAX_DEPOSITS]
-    voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
-    sync_aggregate: SyncAggregate
-    # Execution
-    execution_payload: ExecutionPayload
-    bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
-    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    inclusion_list_summary: SignedInclusionListSummary  # [New in EIP4547]
+    inclusion_list_summary_root: Root  # [New in EIP7547]
+    inclusion_list_exclusions_root: Root  # [New in EIP7547]
 ```
 
 ## Beacon chain state transition function
@@ -204,7 +181,7 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
         withdrawals_root=hash_tree_root(payload.withdrawals),
         blob_gas_used=payload.blob_gas_used,
         excess_blob_gas=payload.excess_blob_gas,
-        inclusion_list_summary_root=hash_tree_root(payload.inclusion_list_summary),  # [New in EIP4547]
-        inclusion_list_exclusions_root=hash_tree_root(payload.inclusion_list_exclusions),  # [New in EIP4547]
+        inclusion_list_summary_root=hash_tree_root(payload.inclusion_list_summary),  # [New in EIP7547]
+        inclusion_list_exclusions_root=hash_tree_root(payload.inclusion_list_exclusions),  # [New in EIP7547]
     )
 ```

--- a/specs/_features/eip7547/beacon-chain.md
+++ b/specs/_features/eip7547/beacon-chain.md
@@ -74,6 +74,6 @@ class BeaconBlockBody(Container):
     # Execution
     execution_payload: ExecutionPayload  # [Modified in Deneb:EIP4844]
     bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
-    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]  # [New in Deneb:EIP4844]
+    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     inclusion_list_summary: InclusionListSummary  # [New in EIP7547]
 ```

--- a/specs/_features/eip7547/fork-choice.md
+++ b/specs/_features/eip7547/fork-choice.md
@@ -6,24 +6,14 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
-- [Presets](#presets)
-  - [Time parameters](#time-parameters)
-- [Containers](#containers)
-    - [`InclusionList`](#inclusionlist)
+- [Preset](#preset)
+  - [Execution](#execution)
 - [Protocols](#protocols)
   - [`ExecutionEngine`](#executionengine)
     - [Request data](#request-data)
       - [Extended `PayloadAttributes`](#extended-payloadattributes)
-      - [New `NewInclusionListRequest`](#new-newinclusionlistrequest)
     - [Engine APIs](#engine-apis)
       - [Extended `notify_forkchoice_updated`](#extended-notify_forkchoice_updated)
-      - [New `notify_new_inclusion_list`](#new-notify_new_inclusion_list)
-- [Helpers](#helpers)
-  - [`verify_inclusion_list_summary_signature`](#verify_inclusion_list_summary_signature)
-  - [`verify_inclusion_list`](#verify_inclusion_list)
-  - [`is_inclusion_list_available`](#is_inclusion_list_available)
-- [Updated fork-choice handlers](#updated-fork-choice-handlers)
-  - [`on_block`](#on_block)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -32,23 +22,13 @@
 
 This is the modification of the fork choice accompanying the EIP7547 upgrade.
 
-## Presets
+## Preset
 
-### Time parameters
+### Execution
 
-| Name | Value | Unit | Duration |
-| - | - | :-: | :-: |
-| `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS` | `uint64(2)` | slots | 24 seconds |
-
-## Containers
-
-#### `InclusionList`
-
-```python
-class InclusionList(Container):
-    summary: SignedInclusionListSummary
-    transactions: List[Transaction, MAX_TRANSACTIONS_PER_INCLUSION_LIST]
-```
+| Name | Value |
+| - | - |
+| `MAX_TRANSACTIONS_PER_INCLUSION_LIST` |  `uint64(2**4)` (= 16) |
 
 ## Protocols
 
@@ -68,17 +48,7 @@ class PayloadAttributes(object):
     suggested_fee_recipient: ExecutionAddress
     withdrawals: Sequence[Withdrawal]
     parent_beacon_block_root: Root
-    inclusion_list_summary: List[InclusionListSummaryEntry, MAX_TRANSACTIONS_PER_INCLUSION_LIST]  # [New in EIP7547]
-```
-
-##### New `NewInclusionListRequest`
-
-```python
-@dataclass
-class NewInclusionListRequest(object):
-    inclusion_list: List[Transaction, MAX_TRANSACTIONS_PER_INCLUSION_LIST]
-    summary: List[InclusionListSummaryEntry, MAX_TRANSACTIONS_PER_INCLUSION_LIST]
-    parent_block_hash: Hash32
+    inclusion_list_transactions: List[Transaction, MAX_TRANSACTIONS_PER_INCLUSION_LIST]  # [New in EIP7547]
 ```
 
 #### Engine APIs
@@ -87,155 +57,3 @@ class NewInclusionListRequest(object):
 
 The only change made is to the `PayloadAttributes` container with the extended `PayloadAttributes`.
 Otherwise, `notify_forkchoice_updated` inherits all prior functionality.
-
-##### New `notify_new_inclusion_list`
-
-```python
-def notify_new_inclusion_list(self: ExecutionEngine,
-                              inclusion_list_request: NewInclusionListRequest) -> bool:
-    """
-    Return ``True`` if and only if the transactions in the inclusion list can be successfully executed
-    starting from the execution state corresponding to the `parent_block_hash` in the inclusion list
-    summary. The execution engine also checks that the total gas limit is less or equal that
-    ``MAX_GAS_PER_INCLUSION_LIST``, and the transactions in the list of transactions correspond
-    to the signed summary
-    """
-    ...
-```
-
-## Helpers
-
-### `verify_inclusion_list_summary_signature`
-
-```python
-def verify_inclusion_list_summary_signature(state: BeaconState, signed_summary: SignedInclusionListSummary) -> bool:
-    # TODO: do we need a new domain?
-    summary = signed_summary.message
-    signing_root = compute_signing_root(summary, get_domain(state, DOMAIN_BEACON_PROPOSER))
-    proposer = state.validators[summary.proposer_index]
-    return bls.Verify(proposer.pubkey, signing_root, signed_summary.signature)
-```
-
-### `verify_inclusion_list`
-
-```python
-def verify_inclusion_list(state: BeaconState, block: BeaconBlock,
-                          inclusion_list: InclusionList, execution_engine: ExecutionEngine) -> bool:
-    """
-    Returns true if the inclusion list is valid. 
-    """
-    # Check that the inclusion list corresponds to the block proposer
-    signed_summary = inclusion_list.summary
-    proposer_index = signed_summary.message.proposer_index
-    assert block.proposer_index == proposer_index
-
-    # Check that the signature is correct
-    assert verify_inclusion_list_summary_signature(state, signed_summary)
-
-    # TODO: These checks will also be performed by the EL surely so we can probably remove them from here.
-    # Check the summary and transaction list lengths
-    summary = signed_summary.message.summary
-    assert len(summary) <= MAX_TRANSACTIONS_PER_INCLUSION_LIST
-    assert len(inclusion_list.transactions) == len(summary)
-
-    # TODO: These checks will also be performed by the EL surely so we can probably remove them from here.
-    # Check that the total gas limit is bounded
-    total_gas_limit = sum(entry.gas_limit for entry in summary)
-    assert total_gas_limit <= MAX_GAS_PER_INCLUSION_LIST
-
-    # Check that the inclusion list is valid
-    return execution_engine.notify_new_inclusion_list(NewInclusionListRequest(
-        inclusion_list=inclusion_list.transactions, 
-        summary=inclusion_list.summary.message.summary,
-        parent_block_hash=state.latest_execution_payload_header.block_hash,
-    ))
-```
-
-### `is_inclusion_list_available`
-
-```python
-def is_inclusion_list_available(state: BeaconState, block: BeaconBlock) -> bool:
-    """
-    Returns whether one inclusion list for the corresponding block was seen in full and has been validated. 
-    `retrieve_inclusion_list` is implementation and context dependent
-    It returns one inclusion list that was broadcasted during the given slot by the given proposer. 
-
-    Note: the p2p network does not guarantee sidecar retrieval outside of
-    `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS`
-    """
-    # Verify the inclusion list
-    inclusion_list = retrieve_inclusion_list(block.slot, block.proposer_index)
-    return verify_inclusion_list(state, block, inclusion_list, EXECUTION_ENGINE)
-```
-
-## Updated fork-choice handlers
-
-### `on_block`
-
-*Note*: The only modification is the addition of the inclusion list availability check.
-
-```python
-def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
-    """
-    Run ``on_block`` upon receiving a new block.
-    """
-    block = signed_block.message
-    # Parent block must be known
-    assert block.parent_root in store.block_states
-    # Make a copy of the state to avoid mutability issues
-    pre_state = copy(store.block_states[block.parent_root])
-    # Blocks cannot be in the future. If they are, their consideration must be delayed until they are in the past.
-    assert get_current_slot(store) >= block.slot
-
-    # Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
-    finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
-    assert block.slot > finalized_slot
-    # Check block is a descendant of the finalized block at the checkpoint finalized slot
-    finalized_checkpoint_block = get_checkpoint_block(
-        store,
-        block.parent_root,
-        store.finalized_checkpoint.epoch,
-    )
-    assert store.finalized_checkpoint.root == finalized_checkpoint_block
-
-    # Check if blob data is available
-    # If not, this block MAY be queued and subsequently considered when blob data becomes available
-    # *Note*: Extraneous or invalid Blobs (in addition to the expected/referenced valid blobs)
-    # received on the p2p network MUST NOT invalidate a block that is otherwise valid and available
-    assert is_data_available(hash_tree_root(block), block.body.blob_kzg_commitments)
-
-    # Check the block is valid and compute the post-state
-    state = pre_state.copy()
-
-    # [New in EIP7547]
-    # Check if there is a valid inclusion list. 
-    # This check is performed only if the block's slot is within the visibility window
-    # If not, this block MAY be queued and subsequently considered when a valid inclusion list becomes available
-    if block.slot + MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS >= get_current_slot(store):
-        assert is_inclusion_list_available(state, block)
-
-    block_root = hash_tree_root(block)
-    state_transition(state, signed_block, True)
-
-    # Add new block to the store
-    store.blocks[block_root] = block
-    # Add new state for this block to the store
-    store.block_states[block_root] = state
-
-    # Add block timeliness to the store
-    time_into_slot = (store.time - store.genesis_time) % SECONDS_PER_SLOT
-    is_before_attesting_interval = time_into_slot < SECONDS_PER_SLOT // INTERVALS_PER_SLOT
-    is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
-    store.block_timeliness[hash_tree_root(block)] = is_timely
-
-    # Add proposer score boost if the block is timely and not conflicting with an existing block
-    is_first_block = store.proposer_boost_root == Root()
-    if is_timely and is_first_block:
-        store.proposer_boost_root = hash_tree_root(block)
-
-    # Update checkpoints in store if necessary
-    update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)
-
-    # Eagerly compute unrealized justification and finality.
-    compute_pulled_up_tip(store, block_root)
-```

--- a/specs/_features/eip7547/fork.md
+++ b/specs/_features/eip7547/fork.md
@@ -59,8 +59,6 @@ def compute_fork_version(epoch: Epoch) -> Version:
 
 ### Fork trigger
 
-EIP7547 does not need a hard fork. We only add this fork doc for compiling this new feature in pyspec.
-
 For now, we assume the condition will be triggered at epoch `EIP7547_FORK_EPOCH`.
 
 Note that for the pure EIP7547 networks, we don't apply `upgrade_to_EIP7547` since it starts with EIP7547 version logic.

--- a/specs/_features/eip7547/p2p-networking.md
+++ b/specs/_features/eip7547/p2p-networking.md
@@ -3,13 +3,16 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [EIP-7547 -- Networking](#eip-7547----networking)
-  - [Table of contents](#table-of-contents)
+  - [Preset](#preset)
+    - [Execution](#execution)
+  - [Containers](#containers)
+    - [New Containers](#new-containers)
+      - [`BeaconBlockAndInclusionList`](#beaconblockandinclusionlist)
   - [Modifications in EIP7547](#modifications-in-eip7547)
-    - [Preset](#preset)
     - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
       - [Topics and messages](#topics-and-messages)
         - [Global topics](#global-topics)
-          - [`inclusion_list`](#inclusion_list)
+          - [`beacon_block`](#beacon_block)
       - [Transitioning the gossip](#transitioning-the-gossip)
   - [Design rationale](#design-rationale)
   - [Why is it proposer may send multiple inclusion lists? Why not just one per slot?](#why-is-it-proposer-may-send-multiple-inclusion-lists-why-not-just-one-per-slot)
@@ -22,18 +25,28 @@ This document contains the consensus-layer networking specification for EIP-7547
 
 The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite.
 
-## Table of contents
+## Preset
 
+### Execution
+
+| Name | Value |
+| - | - |
+| `MAX_TRANSACTIONS_PER_INCLUSION_LIST` |  `uint64(2**4)` (= 16) |
+
+## Containers
+
+### New Containers
+
+#### `BeaconBlockAndInclusionList`
+
+```python
+class SignedBeaconBlockAndInclusionList(Container):
+    signed_block: SignedBeaconBlock
+    signed_summary: SignedInclusionListSummary
+    transactions: transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+```
 
 ## Modifications in EIP7547
-
-### Preset
-
-*[New in EIP7547]*
-
-| Name                                     | Value                             | Description                                                         |
-|------------------------------------------|-----------------------------------|---------------------------------------------------------------------|
-| `MIN_SLOTS_FOR_INCLUSION_LIST_REQUEST`   | `uint64(1)` |  |
 
 ### The gossip domain: gossipsub
 
@@ -43,39 +56,21 @@ Some gossip meshes are upgraded in the fork for EIP7547 to support upgraded type
 
 Topics follow the same specification as in prior upgrades.
 
-The `beacon_block` topic is modified to also support block with signed execution header and new topics are added per table below.
-
-The specification around the creation, validation, and dissemination of messages has not changed from the Deneb document unless explicitly noted here.
-
 The derivation of the `message-id` remains stable.
-
-The new topics along with the type of the `data` field of a gossipsub message are given in this table:
-
-| Name                          | Message Type                                         |
-|-------------------------------|------------------------------------------------------|
-| `inclusion_list`              | `InclusionList` [New in EIP7547]                     |
 
 ##### Global topics
 
-EIP7547 introduces new global topics for the inclusion list.
+###### `beacon_block`
 
-###### `inclusion_list`
+The *type* of the payload of this topic changes to the (modified) `BeaconBlockAndInclusionList`.
 
-This topic is used to propagate inclusion list.
+New validation:
 
-The following validations MUST pass before forwarding the `inclusion_list` on the network, assuming the alias `signed_summary = inclusion_list.summary`, `summary = signed_summary.message`:
+The following validations MUST pass before forwarding the `beacon_block` on the network.
 
-- _[IGNORE]_ The inclusion list is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
-  i.e. validate that `inclusion_list.slot <= current_slot`
-  (a client MAY queue future blocks for processing at the appropriate slot).
-- _[IGNORE]_ The inclusion list is not older than min slots for inclusion list request --
-  i.e. validate that `inclusion_list.slot >= current_slot - MIN_SLOTS_FOR_INCLUSION_LIST_REQUEST`
-  (a client MAY queue future blocks for processing at the appropriate slot).
-- _[IGNORE]_ The inclusion list is the first inclusion list with valid signature received for the proposer for the slot, `inclusion_list.slot`.
-  (a client MAY gossip multiple inclusion list from the same validator for the same slot).
-- _[REJECT]_ The inclusion list transactions `inclusion_list.transactions` length is within upperbound `MAX_TRANSACTIONS_PER_INCLUSION_LIST`.
-- _[REJECT]_ The inclusion list summary has the same length of transactions `len(summary.summary) == len(inclusion_list.transactions)`.
-- _[REJECT]_ The summary signature, `signed_summary.signature`, is valid with respect to the `proposer_index` pubkey.
+- _[REJECT]_ The inclusion list transactions `beacon_block.transactions` length is within upperbound `MAX_TRANSACTIONS_PER_INCLUSION_LIST`.
+- _[REJECT]_ The inclusion list summary has the same length of transactions `len(beacon_block.signed_summary) == len(beacon_block.transactions)`.
+- _[REJECT]_ The summary signature, `beacon_block.signed_sumary.signature`, is valid with respect to the `proposer_index` pubkey.
 - _[REJECT]_ The summary is proposed by the expected proposer_index for the summary's slot in the context of the current shuffling (defined by parent_root/slot). If the proposer_index cannot immediately be verified against the expected shuffling, the inclusion list MAY be queued for later processing while proposers for the summary's branch are calculated -- in such a case do not REJECT, instead IGNORE this message.
 
 #### Transitioning the gossip

--- a/specs/_features/eip7547/p2p-networking.md
+++ b/specs/_features/eip7547/p2p-networking.md
@@ -37,7 +37,7 @@ The specification of these changes continues in the same format as the network s
 
 ### The gossip domain: gossipsub
 
-Some gossip meshes are upgraded in the fork of ePBS to support upgraded types.
+Some gossip meshes are upgraded in the fork for EIP7547 to support upgraded types.
 
 #### Topics and messages
 
@@ -45,7 +45,7 @@ Topics follow the same specification as in prior upgrades.
 
 The `beacon_block` topic is modified to also support block with signed execution header and new topics are added per table below.
 
-The specification around the creation, validation, and dissemination of messages has not changed from the Capella document unless explicitly noted here.
+The specification around the creation, validation, and dissemination of messages has not changed from the Deneb document unless explicitly noted here.
 
 The derivation of the `message-id` remains stable.
 
@@ -57,7 +57,7 @@ The new topics along with the type of the `data` field of a gossipsub message ar
 
 ##### Global topics
 
-ePBS introduces new global topics for execution header, execution payload, payload attestation and inclusion list.
+EIP7547 introduces new global topics for the inclusion list.
 
 ###### `inclusion_list`
 
@@ -87,6 +87,4 @@ details on how to handle transitioning gossip topics for this upgrade.
 
 ## Why is it proposer may send multiple inclusion lists? Why not just one per slot?
 
-Proposers may submit multiple inclusion lists, providing validators with plausible deniability and eliminating a data availability attack route. 
-This concept stems from the "no free lunch IL design" which lets proposers send multiple ILs. The idea is that since only one IL is eventually chosen from many, 
-its content can't be relied upon for data availability due to the presence of multiple options.
+Proposers may submit multiple inclusion lists, providing validators with plausible deniability and eliminating a data availability attack route. This concept stems from the "no free lunch IL design" which lets proposers send multiple ILs. The idea is that since only one IL is eventually chosen from many, thus its contents can't be relied upon for data availability.

--- a/specs/_features/eip7547/p2p-networking.md
+++ b/specs/_features/eip7547/p2p-networking.md
@@ -70,7 +70,7 @@ The following validations MUST pass before forwarding the `beacon_block` on the 
 
 - _[REJECT]_ The inclusion list transactions `beacon_block.transactions` length is within upperbound `MAX_TRANSACTIONS_PER_INCLUSION_LIST`.
 - _[REJECT]_ The inclusion list summary has the same length of transactions `len(beacon_block.signed_summary) == len(beacon_block.transactions)`.
-- _[REJECT]_ The summary signature, `beacon_block.signed_sumary.signature`, is valid with respect to the `proposer_index` pubkey.
+- _[REJECT]_ The summary signature, `beacon_block.signed_summary.signature`, is valid with respect to the `proposer_index` pubkey.
 - _[REJECT]_ The summary is proposed by the expected proposer_index for the summary's slot in the context of the current shuffling (defined by parent_root/slot). If the proposer_index cannot immediately be verified against the expected shuffling, the inclusion list MAY be queued for later processing while proposers for the summary's branch are calculated -- in such a case do not REJECT, instead IGNORE this message.
 
 #### Transitioning the gossip

--- a/specs/_features/eip7547/validator.md
+++ b/specs/_features/eip7547/validator.md
@@ -74,10 +74,11 @@ All validator responsibilities remain unchanged other than those noted below.
 
 ### Inclusion list proposal
 
-EIP7547 introduces forward inclusion list. The detail design is described in this [post](https://ethresear.ch/t/no-free-lunch-a-new-inclusion-list-design/16389)
+EIP7547 introduces forward inclusion list. The detail design is described in this [post](https://ethresear.ch/t/no-free-lunch-a-new-inclusion-list-design/16389).
+
 Proposer must construct and broadcast `InclusionList` alongside `SignedBeaconBlock`.
-- Proposer for slot `N` submits `SignedBeaconBlock` and in parallel submits `InclusionList` to be included at the beginning of slot `N+1` builder.
-- Within `InclusionList`, `Transactions` are list of transactions that the proposer wants to include at the beginning of slot `N+1` builder.
+- Proposer for slot `N` submits `SignedBeaconBlock` and in parallel broadcast `InclusionList` to be included at the beginning of slot `N+1`.
+- Within `InclusionList`, `Transactions` are list of transactions that the proposer wants to include at the beginning of slot `N+1`.
 - Within `inclusionList`, `Summaries` are lists consisting on addresses sending those transactions and their gas limits. The summaries are signed by the proposer `N`.
 - Proposer may  send many of these pairs that aren't committed to its beacon block so no double proposing slashing is involved.
 
@@ -85,10 +86,10 @@ Proposer must construct and broadcast `InclusionList` alongside `SignedBeaconBlo
 
 To obtain an inclusion list, a block proposer building a block on top of a `state` must take the following actions:
 
-1. Check if the previous slot is skipped. If `state.latest_execution_payload_header.time_stamp` is from previous slot.
+1. Check if the previous slot is skipped. If `state.latest_execution_payload_header.timestamp` is from previous slot.
     * If it's skipped, the proposer should not propose an inclusion list. It can ignore rest of the steps.
 
-2. Retrieve inclusion list from execution layer by calling `get_execution_inclusion_list`.
+2. Retrieve `inclusion_list_response: GetInclusionListResponse` from execution layer by calling `ExecutionEngine.get_execution_inclusion_list(parent_block_hash)`.
 
 3. Call `build_inclusion_list` to build `InclusionList`.
 

--- a/specs/_features/eip7547/validator.md
+++ b/specs/_features/eip7547/validator.md
@@ -86,12 +86,9 @@ Proposer must construct and broadcast `InclusionList` alongside `SignedBeaconBlo
 
 To obtain an inclusion list, a block proposer building a block on top of a `state` must take the following actions:
 
-1. Check if the previous slot is skipped. If `state.latest_execution_payload_header.timestamp` is from previous slot.
-    * If it's skipped, the proposer should not propose an inclusion list. It can ignore rest of the steps.
+1. Retrieve `inclusion_list_response: GetInclusionListResponse` from execution layer by calling `ExecutionEngine.get_execution_inclusion_list(parent_block_hash)`.
 
-2. Retrieve `inclusion_list_response: GetInclusionListResponse` from execution layer by calling `ExecutionEngine.get_execution_inclusion_list(parent_block_hash)`.
-
-3. Call `build_inclusion_list` to build `InclusionList`.
+2. Call `build_inclusion_list` to build `InclusionList`.
 
 ```python
 def build_inclusion_list(state: BeaconState, inclusion_list_response: GetInclusionListResponse,

--- a/specs/_features/eip7547/validator.md
+++ b/specs/_features/eip7547/validator.md
@@ -77,10 +77,10 @@ All validator responsibilities remain unchanged other than those noted below.
 EIP7547 introduces forward inclusion list. The detail design is described in this [post](https://ethresear.ch/t/no-free-lunch-a-new-inclusion-list-design/16389).
 
 Proposer must construct and broadcast `InclusionList` alongside `SignedBeaconBlock`.
-- Proposer for slot `N` submits `SignedBeaconBlock` and in parallel broadcast `InclusionList` to be included at the beginning of slot `N+1`.
-- Within `InclusionList`, `Transactions` are list of transactions that the proposer wants to include at the beginning of slot `N+1`.
+- Proposer for slot `N` submits `SignedBeaconBlock` and in parallel broadcast `InclusionList` to be included at slot `N+1`.
+- Within `InclusionList`, `Transactions` are list of transactions that the proposer wants to include in slot `N+1`.
 - Within `inclusionList`, `Summaries` are lists consisting on addresses sending those transactions and their gas limits. The summaries are signed by the proposer `N`.
-- Proposer may  send many of these pairs that aren't committed to its beacon block so no double proposing slashing is involved.
+- Proposer may send many of these pairs that aren't committed to its beacon block so no double proposing slashing is involved.
 
 #### Constructing the inclusion list
 
@@ -113,7 +113,7 @@ def get_inclusion_list_summary_signature(state: BeaconState,
 
 #### Broadcast inclusion list
 
-Finally, the proposer broadcasts `inclusion_list` to the inclusion list subnet, the `inclusion_list` pubsub topic.
+Finally, the proposer broadcasts `inclusion_list` along with the `SignedBeaconBlock` on the `beacon_block` pubsub topic.
 
 ### Block and sidecar proposal
 


### PR DESCRIPTION
main features:
- IL gossiped in a sidecar
- as a consequence, no commitment to the summary in the beacon block, to avoid the possibility of split views (valid IL received but doesn't match the block, while others have received the correct IL)
- ExecutionPayload contains `previous_inclusion_list_summary`, including the proposer signature, and the Beacon State has `previous_proposer_index`, so the CL can check that the summary included by the EL is indeed one signed by the previous proposer
- removed 'MAX_GAS_PER_INCLUSION_LIST'. This is a concern of the EL


TODO: 
- update fork-choice.md and validator.md. Include domain for signing the IL sidecar
- decide the right place to update `state.previous_proposer_index`
- decide whether to stick with the IL sidecar or with the beacon block
- decide if we want to avoid having the signature on the summary be in the EL block, which doesn't have any use for it. Just needs to be checked by the CL, the EL block only needs the summary to verify its satisfaction.
