### PR TITLE
Align `seen_ttl` with attestation lifetime

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -245,7 +245,7 @@ The following gossipsub [parameters](https://github.com/libp2p/specs/blob/master
 - `fanout_ttl` (ttl for fanout maps for topics we are not subscribed to but have published to, seconds): 60
 - `mcache_len` (number of windows to retain full messages in cache for `IWANT` responses): 6
 - `mcache_gossip` (number of windows to gossip about): 3
-- `seen_ttl` (number of heartbeat intervals to retain message IDs): 550
+- `seen_ttl` (expiry time for cache of seen message ids, seconds): SECONDS_PER_SLOT * SLOTS_PER_EPOCH * 2
 
 *Note*: Gossipsub v1.1 introduces a number of
 [additional parameters](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#overview-of-new-parameters)


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/pull/3360 effectively extends the valid lifetime of an attestation/aggregate to 2 epochs - this means that an aggregate that was published at the beginning of a slot now is valid per the gossip rules up to 2 epochs later.

Then net effect of the above change is that peers are allowed to republish old aggregates and attestations and libp2p will not stop the spread with the settings we recommend - instead the messages will have to be stopped with the "attestation cover rule" or similar, even though they have been observed already.

Significant amounts of this kind of spam have been observed on the aggregate channel in particular leading to a 5x increase in aggregate traffic as some clients republish these old messages in spite of the "attestation cover rule" which should have stopped them - this simple change will provide an additional layer of protection against such bugs.