### PR TITLE
EIP-7549 Clarify network vs on chain aggregation

### DIFF
--- a/specs/_features/eip7549/validator.md
+++ b/specs/_features/eip7549/validator.md
@@ -26,7 +26,28 @@
 
 ##### Attestations
 
-Attestations received from aggregators with disjoint `committee_bits` sets and equal `AttestationData` SHOULD be consolidated into a single `Attestation` object.
+The network attestation aggregates contain only the assigned committee attestations.
+Attestation aggregates received by the block proposer from the committee aggregators with disjoint `committee_bits` sets and equal `AttestationData` SHOULD be consolidated into a single `Attestation` object.
+The proposer should run the following function to construct an on chain final aggregate form a list of network aggregates with equal `AttestationData`:
+
+```python
+def compute_on_chain_aggregate(network_aggregates: List[Attestation]) -> Attestation:
+    
+    aggregates = sorted(network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0])
+    
+    data = aggregates[0].data
+    aggregation_bits = [a.aggregation_bits[0] for a in aggregates]
+    signature = bls.Aggregate([a.signature for a in aggregates])
+    
+    committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
+    committee_flags = [(index in committee_indices) for index in range(0, MAX_COMMITTEES_PER_SLOT)]        
+    committee_bits = Bitvector[MAX_COMMITTEES_PER_SLOT](committee_flags)
+
+    return Attestation(aggregation_bits=aggregation_bits,
+                       data=data,
+                       committee_bits=committee_bits,
+                       signature=signature)
+```
 
 ### Attesting
 

--- a/specs/_features/eip7549/validator.md
+++ b/specs/_features/eip7549/validator.md
@@ -32,21 +32,17 @@ The proposer should run the following function to construct an on chain final ag
 
 ```python
 def compute_on_chain_aggregate(network_aggregates: List[Attestation]) -> Attestation:
-    
     aggregates = sorted(network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0])
-    
+
     data = aggregates[0].data
     aggregation_bits = [a.aggregation_bits[0] for a in aggregates]
     signature = bls.Aggregate([a.signature for a in aggregates])
-    
+
     committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
     committee_flags = [(index in committee_indices) for index in range(0, MAX_COMMITTEES_PER_SLOT)]        
     committee_bits = Bitvector[MAX_COMMITTEES_PER_SLOT](committee_flags)
 
-    return Attestation(aggregation_bits=aggregation_bits,
-                       data=data,
-                       committee_bits=committee_bits,
-                       signature=signature)
+    return Attestation(aggregation_bits, data, committee_bits, signature)
 ```
 
 ### Attesting


### PR DESCRIPTION
I'd like to suggest clarifying the different aggregation levels introduced in #3559: network vs on chain aggregation. IMO it's worth clearly mentioning the "final" aggregation which must be performed by the block proposer since it's the only new step compared to the previous aggregation logic. More details can be found in [this note](https://hackmd.io/@mehdi-aouadi/ry79J5ona)
Inspired by @mkalinin 's [note](https://hackmd.io/@n0ble/eip7549_onchain_aggregates#Block-proposal)