### PR TITLE
Rename new list of bits field to aggregation_bits_list

### DIFF
--- a/specs/_features/eip7549/beacon-chain.md
+++ b/specs/_features/eip7549/beacon-chain.md
@@ -44,7 +44,7 @@ This is the beacon chain specification to move the attestation committee index o
 
 ```python
 class Attestation(Container):
-    aggregation_bits: List[Bitlist[MAX_VALIDATORS_PER_COMMITTEE], MAX_COMMITTEES_PER_SLOT]  # [Modified in EIP7549]
+    aggregation_bits_list: List[Bitlist[MAX_VALIDATORS_PER_COMMITTEE], MAX_COMMITTEES_PER_SLOT]  # [Modified in EIP7549]
     data: AttestationData
     committee_bits: Bitvector[MAX_COMMITTEES_PER_SLOT]  # [New in EIP7549]
     signature: BLSSignature
@@ -78,13 +78,13 @@ def get_committee_indices(commitee_bits: Bitvector) -> List[CommitteeIndex]:
 ```python
 def get_attesting_indices(state: BeaconState, attestation: Attestation) -> Set[ValidatorIndex]:
     """
-    Return the set of attesting indices corresponding to ``aggregation_bits`` and ``committee_bits``.
+    Return the set of attesting indices corresponding to ``aggregation_bits_list`` and ``committee_bits``.
     """
 
     output = set()
     committee_indices = get_committee_indices(attestation.committee_bits)
     for index in committee_indices:
-        attesting_bits = attestation.aggregation_bits[index]
+        attesting_bits = attestation.aggregation_bits_list[index]
         committee = get_beacon_committee(state, attestation.data.slot, index)
         committee_attesters = set(index for i, index in enumerate(committee) if attesting_bits[i])
         output = output.union(committee_attesters)
@@ -106,11 +106,11 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     # [Modified in EIP7549]
     assert data.index == 0
     committee_indices = get_committee_indices(attestation.committee_bits)
-    assert len(committee_indices) == len(attestation.aggregation_bits)
+    assert len(committee_indices) == len(attestation.aggregation_bits_list)
     for index in committee_indices:
         assert index < get_committee_count_per_slot(state, data.target.epoch)
         committee = get_beacon_committee(state, data.slot, index)
-        assert len(attestation.aggregation_bits[index]) == len(committee)
+        assert len(attestation.aggregation_bits_list[index]) == len(committee)
 
     # Participation flag indices
     participation_flag_indices = get_attestation_participation_flag_indices(state, data, state.slot - data.slot)

--- a/specs/_features/eip7549/p2p-interface.md
+++ b/specs/_features/eip7549/p2p-interface.md
@@ -36,11 +36,11 @@ The `beacon_aggregate_and_proof` and `beacon_attestation_{subnet_id}` topics are
 
 The following convenience variables are re-defined
 - `index = get_committee_indices(aggregate.committee_bits)[0]`
-- `aggregation_bits = aggregate.aggregation_bits[0]`
+- `aggregation_bits = aggregate.aggregation_bits_list[0]`
 
 The following validations are added:
-* [REJECT] `len(committee_indices) == len(aggregate.attestation_bits) == 1`, where `committee_indices = get_committee_indices(aggregate)`.
-* [REJECT] `aggregate.data.index == 0`
+* [REJECT] Bits list contains a single committee -- i.e. `len(committee_indices) == len(aggregate.attestation_bits_list) == 1`, where `committee_indices = get_committee_indices(aggregate)`.
+* [REJECT] Legacy index is zero -- i.e. `aggregate.data.index == 0`
 
 ###### `beacon_attestation_{subnet_id}`
 
@@ -49,6 +49,6 @@ The following convenience variables are re-defined
 - `aggregation_bits = attestation.aggregation_bits[0]`
 
 The following validations are added:
-* [REJECT] `len(committee_indices) == len(attestation.attestation_bits) == 1`, where `committee_indices = get_committee_indices(attestation)`.
-* [REJECT] `attestation.data.index == 0`
+* [REJECT] Bits list contains a single committee -- i.e. `len(committee_indices) == len(attestation.attestation_bits_list) == 1`, where `committee_indices = get_committee_indices(attestation)`.
+* [REJECT] Legacy index is zero -- i.e. `attestation.data.index == 0`
 

--- a/specs/_features/eip7549/validator.md
+++ b/specs/_features/eip7549/validator.md
@@ -34,7 +34,7 @@ Attestations received from aggregators with disjoint `committee_bits` sets and e
 
 - Set `attestation_data.index = 0`.
 - Let `aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where the bit of the index of the validator in the `committee` is set to `0b1`.
-- Set `attestation.aggregation_bits = [aggregation_bits]`, a list of length 1
+- Set `attestation.aggregation_bits_list = [aggregation_bits]`, a list of length 1
 - Let `committee_bits` be a `Bitvector[MAX_COMMITTEES_PER_SLOT]`, where the bit at the index associated with the validator's committee is set to `0b1`
 - Set `attestation.committee_bits = committee_bits`
 
@@ -46,6 +46,6 @@ Attestations received from aggregators with disjoint `committee_bits` sets and e
 
 - Set `attestation_data.index = 0`.
 - Let `aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where each bit set from each individual attestation is set to `0b1`.
-- Set `attestation.aggregation_bits = [aggregation_bits]`, a list of length 1
+- Set `attestation.aggregation_bits_list = [aggregation_bits]`, a list of length 1
 - Set `attestation.committee_bits = committee_bits`, where `committee_bits` has the same value as in each individual attestation
 


### PR DESCRIPTION
EIP-7549 changes the bits type inside the attestation from a `Bitlist` to a `List[Bitlist]`. To make the change more clear, we should rename `aggregation_bits` to `aggregation_bits_list`. Then in internal routines, variables with name `aggregation_bits` are `Bitlist` types.

h/t to @hwwhww for the suggestion