### PR TITLE
eip7549: flatten aggregate_bits

### DIFF
--- a/specs/_features/eip7549/p2p-interface.md
+++ b/specs/_features/eip7549/p2p-interface.md
@@ -36,19 +36,17 @@ The `beacon_aggregate_and_proof` and `beacon_attestation_{subnet_id}` topics are
 
 The following convenience variables are re-defined
 - `index = get_committee_indices(aggregate.committee_bits)[0]`
-- `aggregation_bits = aggregate.aggregation_bits[0]`
 
 The following validations are added:
-* [REJECT] `len(committee_indices) == len(aggregate.attestation_bits) == 1`, where `committee_indices = get_committee_indices(aggregate)`.
+* [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(aggregate)`.
 * [REJECT] `aggregate.data.index == 0`
 
 ###### `beacon_attestation_{subnet_id}`
 
 The following convenience variables are re-defined
 - `index = get_committee_indices(attestation.committee_bits)[0]`
-- `aggregation_bits = attestation.aggregation_bits[0]`
 
 The following validations are added:
-* [REJECT] `len(committee_indices) == len(attestation.attestation_bits) == 1`, where `committee_indices = get_committee_indices(attestation)`.
+* [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(attestation)`.
 * [REJECT] `attestation.data.index == 0`
 

--- a/specs/_features/eip7549/validator.md
+++ b/specs/_features/eip7549/validator.md
@@ -35,7 +35,11 @@ def compute_on_chain_aggregate(network_aggregates: List[Attestation]) -> Attesta
     aggregates = sorted(network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0])
 
     data = aggregates[0].data
-    aggregation_bits = [a.aggregation_bits[0] for a in aggregates]
+    aggregation_bits = Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]()
+    for a in aggregates:
+        for b in a.aggregation_bits:
+            aggregation_bits.append(b)
+
     signature = bls.Aggregate([a.signature for a in aggregates])
 
     committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
@@ -50,10 +54,8 @@ def compute_on_chain_aggregate(network_aggregates: List[Attestation]) -> Attesta
 #### Construct attestation
 
 - Set `attestation_data.index = 0`.
-- Let `aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where the bit of the index of the validator in the `committee` is set to `0b1`.
-- Set `attestation.aggregation_bits = [aggregation_bits]`, a list of length 1
-- Let `committee_bits` be a `Bitvector[MAX_COMMITTEES_PER_SLOT]`, where the bit at the index associated with the validator's committee is set to `0b1`
-- Set `attestation.committee_bits = committee_bits`
+- Let `attestation.aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where the bit of the index of the validator in the `committee` is set to `0b1`.
+- Let `attestation.committee_bits` be a `Bitvector[MAX_COMMITTEES_PER_SLOT]`, where the bit at the index associated with the validator's committee is set to `0b1`.
 
 *Note*: Calling `get_attesting_indices(state, attestation)` should return a list of length equal to 1, containing `validator_index`.
 
@@ -63,6 +65,5 @@ def compute_on_chain_aggregate(network_aggregates: List[Attestation]) -> Attesta
 
 - Set `attestation_data.index = 0`.
 - Let `aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where each bit set from each individual attestation is set to `0b1`.
-- Set `attestation.aggregation_bits = [aggregation_bits]`, a list of length 1
-- Set `attestation.committee_bits = committee_bits`, where `committee_bits` has the same value as in each individual attestation
+- Set `attestation.committee_bits = committee_bits`, where `committee_bits` has the same value as in each individual attestation.
 

--- a/specs/_features/eip7549/validator.md
+++ b/specs/_features/eip7549/validator.md
@@ -54,7 +54,7 @@ def compute_on_chain_aggregate(network_aggregates: List[Attestation]) -> Attesta
 #### Construct attestation
 
 - Set `attestation_data.index = 0`.
-- Let `attestation.aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where the bit of the index of the validator in the `committee` is set to `0b1`.
+- Let `attestation.aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]` of length `len(committee)`, where the bit of the index of the validator in the `committee` is set to `0b1`.
 - Let `attestation.committee_bits` be a `Bitvector[MAX_COMMITTEES_PER_SLOT]`, where the bit at the index associated with the validator's committee is set to `0b1`.
 
 *Note*: Calling `get_attesting_indices(state, attestation)` should return a list of length equal to 1, containing `validator_index`.
@@ -64,6 +64,6 @@ def compute_on_chain_aggregate(network_aggregates: List[Attestation]) -> Attesta
 #### Construct aggregate
 
 - Set `attestation_data.index = 0`.
-- Let `aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where each bit set from each individual attestation is set to `0b1`.
+- Let `aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]` of length `len(committee)`, where each bit set from each individual attestation is set to `0b1`.
 - Set `attestation.committee_bits = committee_bits`, where `committee_bits` has the same value as in each individual attestation.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -367,7 +367,7 @@ The following validations MUST pass before forwarding the `signed_aggregate_and_
 - _[REJECT]_ The aggregate attestation's epoch matches its target -- i.e. `aggregate.data.target.epoch ==
   compute_epoch_at_slot(aggregate.data.slot)`
 - _[REJECT]_ The number of aggregation bits matches the committee size -- i.e.
-  `len(aggregation_bits) == len(get_beacon_committee(state, aggregate.data.slot, aggregate.data.index))`.
+  `len(aggregation_bits) == len(get_beacon_committee(state, aggregate.data.slot, index))`.
 - _[REJECT]_ The aggregate attestation has participants --
   that is, `len(get_attesting_indices(state, aggregate)) >= 1`.
 - _[IGNORE]_ A valid aggregate attestation defined by `hash_tree_root(aggregate.data)` whose `aggregation_bits` is a non-strict superset has _not_ already been seen.


### PR DESCRIPTION
Replaces nested `attestation.aggregation_bits: List[Bitlist[]]` type with a flattened `Bitlist[]` by utilising concatenation and computing committee offsets on the fly as suggested in https://github.com/ethereum/consensus-specs/pull/3559#discussion_r1535298141

cc @arnetheduck 