### PR TITLE
Incentivise timely electra fork with halting bomb

### DIFF
--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -102,6 +102,9 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     block_root = hash_tree_root(block)
     state_transition(state, signed_block, True)
 
+    if compute_timestamp_at_slot(block.slot) > 1735117200 and state.fork.current_version != ELECTRA_FORK_VERSION:
+        return
+
     # Add new block to the store
     store.blocks[block_root] = block
     # Add new state for this block to the store


### PR DESCRIPTION
Some core devs are rightfully concerned with the increasing scope of the Electra fork. The community has agreed that Electra will be a small fork delivered before EOY 2024. The difficulty bomb was a widely successful mechanism in the proof-of-work days to stimulate innovation. A halting mechanism achieves the same goal but it's simpler to implement and to reason about

This PR introduces a halting bomb that can be incorporated as a soft fork by clients at any time before the halting date. If the chain has not forked into Electra before the halting deadline no block can be incorporated in the fork-choice, effectively halting the chain