### PR TITLE
EIP-7251: rename PartialWithdrawal field

### DIFF
--- a/specs/_features/eip7251/beacon-chain.md
+++ b/specs/_features/eip7251/beacon-chain.md
@@ -21,7 +21,7 @@
 - [Containers](#containers)
   - [New containers](#new-containers)
     - [New `PendingBalanceDeposit`](#new-pendingbalancedeposit)
-    - [New `PendingPartialWithdrawal`](#new-pendingPartialWithdrawal)
+    - [New `PendingPartialWithdrawal`](#new-pendingpartialwithdrawal)
     - [New `ExecutionLayerWithdrawRequest`](#new-executionlayerwithdrawrequest)
     - [New `Consolidation`](#new-consolidation)
     - [New `SignedConsolidation`](#new-signedconsolidation)

--- a/specs/_features/eip7251/beacon-chain.md
+++ b/specs/_features/eip7251/beacon-chain.md
@@ -21,7 +21,7 @@
 - [Containers](#containers)
   - [New containers](#new-containers)
     - [New `PendingBalanceDeposit`](#new-pendingbalancedeposit)
-    - [New `PartialWithdrawal`](#new-partialwithdrawal)
+    - [New `PendingPartialWithdrawal`](#new-pendingPartialWithdrawal)
     - [New `ExecutionLayerWithdrawRequest`](#new-executionlayerwithdrawrequest)
     - [New `Consolidation`](#new-consolidation)
     - [New `SignedConsolidation`](#new-signedconsolidation)
@@ -160,10 +160,10 @@ class PendingBalanceDeposit(Container):
     amount: Gwei
 ```
 
-#### New `PartialWithdrawal`
+#### New `PendingPartialWithdrawal`
 
 ```python
-class PartialWithdrawal(Container):
+class PendingPartialWithdrawal(Container):
     index: ValidatorIndex
     amount: Gwei
     withdrawable_epoch: Epoch
@@ -254,7 +254,7 @@ class BeaconState(Container):
     consolidation_balance_to_consume: Gwei  # [New in EIP-7251]
     earliest_consolidation_epoch: Epoch  # [New in EIP-7251]
     pending_balance_deposits: List[PendingBalanceDeposit, PENDING_BALANCE_DEPOSITS_LIMIT]  # [New in EIP-7251]
-    pending_partial_withdrawals: List[PartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]  # [New in EIP-7251]
+    pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]  # [New in EIP-7251]
     pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]  # [New in EIP-7251]
 ```
 
@@ -904,7 +904,7 @@ def process_execution_layer_withdraw_request(
         )
         exit_queue_epoch = compute_exit_epoch_and_update_churn(state, to_withdraw)
         withdrawable_epoch = Epoch(exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
-        state.pending_partial_withdrawals.append(PartialWithdrawal(
+        state.pending_partial_withdrawals.append(PendingPartialWithdrawal(
             index=index,
             amount=to_withdraw,
             withdrawable_epoch=withdrawable_epoch,

--- a/tests/core/pyspec/eth2spec/test/eip7251/block_processing/test_process_execution_layer_withdraw_request.py
+++ b/tests/core/pyspec/eth2spec/test/eip7251/block_processing/test_process_execution_layer_withdraw_request.py
@@ -154,7 +154,7 @@ def test_partial_withdrawal_queue_full(spec, state):
         amount=10 ** 9,
     )
 
-    partial_withdrawal = spec.PartialWithdrawal(index=0, amount=1, withdrawable_epoch=current_epoch)
+    partial_withdrawal = spec.PendingPartialWithdrawal(index=0, amount=1, withdrawable_epoch=current_epoch)
     state.pending_partial_withdrawals = [partial_withdrawal] * spec.PENDING_PARTIAL_WITHDRAWALS_LIMIT
     yield from run_execution_layer_withdraw_request_processing(
         spec, state, execution_layer_withdraw_request, success=False


### PR DESCRIPTION
Renamed the `PartialWithdrawal` field to be more consistent with the other added fields.