### PR TITLE
`p2p-interface.md`: Add `quic` ENR entry.

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -959,7 +959,8 @@ The Ethereum Node Record (ENR) for an Ethereum consensus client MUST contain the
 The ENR MAY contain the following entries:
 
 -  An IPv4 address (`ip` field) and/or IPv6 address (`ip6` field).
--  A TCP port (`tcp` field) representing the local libp2p listening port.
+-  A TCP port (`tcp` field) representing the local libp2p TCP listening port.
+-  A QUIC port (`quic` field) representing the local libp2p QUIC (UDP) listening port.
 -  A UDP port (`udp` field) representing the local discv5 listening port.
 
 Specifications of these parameters can be found in the [ENR Specification](http://eips.ethereum.org/EIPS/eip-778).


### PR DESCRIPTION
This ENR entry seems already used by Lighthouse BN.
Exemple found on the Holesky network:

```
enr:-MS4QEyTlybz9KMHKN7pXHOvlD8Q1muUXN7mbeUCPjSyKOEYScKDpmkaxxuE8DOC-YlCIqweCQpEw8uLG4s4z0huDAEUh2F0dG5ldHOIAAAAAAAGAACEZXRoMpBprg6ZBQFwAP__________gmlkgnY0gmlwhIjzqrKEcXVpY4IjKYlzZWNwMjU2azGhA-tFvPZaDfibme3y3o9xderqssFhY1Pnjw6AwqwreQz7iHN5bmNuZXRzAIN0Y3CCIyiDdWRwgiMo
```

cc @michaelsproul 

![image](https://github.com/ethereum/consensus-specs/assets/4943830/032b8623-48af-4ca5-ba85-b1db1a710455)

