### PR TITLE
EIP-7251: Use MIN_ACTIVATION_BALANCE instead of MAX_EFFECTIVE_BALANCE

### DIFF
--- a/specs/_features/eip7251/beacon-chain.md
+++ b/specs/_features/eip7251/beacon-chain.md
@@ -454,9 +454,9 @@ def switch_to_compounding_validator(state: BeaconState, index: ValidatorIndex) -
 ```python
 def queue_excess_active_balance(state: BeaconState, index: ValidatorIndex) -> None:
     balance = state.balances[index]
-    if balance > MAX_EFFECTIVE_BALANCE:
-        excess_balance = balance - MAX_EFFECTIVE_BALANCE
-        state.balances[index] = balance - excess_balance
+    if balance > MIN_ACTIVATION_BALANCE:
+        excess_balance = balance - MIN_ACTIVATION_BALANCE
+        state.balances[index] = MIN_ACTIVATION_BALANCE
         state.pending_balance_deposits.append(
             PendingBalanceDeposit(index=index, amount=excess_balance)
         )


### PR DESCRIPTION
Sticks with two params for EIP-7251: `MIN_ACTIVATION_BALANCE` and `MAX_EFFECTIVE_BALANCE_EIP7251` by replacing `MAX_EFFECTIVE_BALANCE` with the former.

A slight change in `queue_excess_active_balance` arithmetics:  `state.balances[index] = balance - (balance - MIN_ACTIVATION_BALANCE)` simplified to `state.balances[index] = MIN_ACTIVATION_BALANCE`