### PR TITLE
EIP-7549: Add EIP7549 aggregation logic in testing tool

### DIFF
--- a/tests/core/pyspec/eth2spec/test/bellatrix/fork_choice/test_should_override_forkchoice_update.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/fork_choice/test_should_override_forkchoice_update.py
@@ -7,7 +7,7 @@ from eth2spec.test.helpers.constants import (
     MINIMAL,
 )
 from eth2spec.test.helpers.attestations import (
-    get_valid_attestation_at_slot,
+    get_valid_attestations_at_slot,
 )
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
@@ -109,7 +109,7 @@ def test_should_override_forkchoice_update__true(spec, state):
     # Fill a slot with attestations to its parent
     block = build_empty_block_for_next_slot(spec, state)
     parent_block_slot = block.slot - 1
-    block.body.attestations = get_valid_attestation_at_slot(
+    block.body.attestations = get_valid_attestations_at_slot(
         state,
         spec,
         parent_block_slot,
@@ -135,7 +135,7 @@ def test_should_override_forkchoice_update__true(spec, state):
     # Add attestations to the parent block
     temp_state = state.copy()
     next_slot(spec, temp_state)
-    attestations = get_valid_attestation_at_slot(
+    attestations = get_valid_attestations_at_slot(
         temp_state,
         spec,
         slot_to_attest=temp_state.slot - 1,

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -272,7 +272,7 @@ def _aggregate_aggregation_bits_and_signatures(spec, state, slot, aggregate, att
 
 def get_valid_attestation_at_slot(state, spec, slot_to_attest, participation_fn=None, beacon_block_root=None):
     """
-    Return the aggregate attestation post EIP-7549. 
+    Return the aggregate attestation post EIP-7549.
     Note: this EIP supports dense packing of on-chain aggregates so we can just return a single `Attestation`.
     """
     assert is_post_eip7549(spec)

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -272,7 +272,8 @@ def _aggregate_aggregation_bits_and_signatures(spec, state, slot, aggregate, att
 
 def get_valid_attestation_at_slot(state, spec, slot_to_attest, participation_fn=None, beacon_block_root=None):
     """
-    Return the aggregate attestation
+    Return the aggregate attestation post EIP-7549. 
+    Note: this EIP supports dense packing of on-chain aggregates so we can just return a single `Attestation`.
     """
     assert is_post_eip7549(spec)
     attestations = list(get_valid_attestations_at_slot(

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_proposer_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_proposer_head.py
@@ -4,7 +4,7 @@ from eth2spec.test.context import (
     with_altair_and_later,
 )
 from eth2spec.test.helpers.attestations import (
-    get_valid_attestation_at_slot,
+    get_valid_attestations_at_slot,
 )
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
@@ -101,7 +101,7 @@ def test_basic_is_parent_root(spec, state):
     # Fill a slot with attestations to its parent
     block = build_empty_block_for_next_slot(spec, state)
     parent_block_slot = block.slot - 1
-    block.body.attestations = get_valid_attestation_at_slot(
+    block.body.attestations = get_valid_attestations_at_slot(
         state,
         spec,
         parent_block_slot,
@@ -128,7 +128,7 @@ def test_basic_is_parent_root(spec, state):
     slot = state.slot
 
     # Add attestations to the parent block
-    attestations = get_valid_attestation_at_slot(
+    attestations = get_valid_attestations_at_slot(
         state,
         spec,
         slot_to_attest=slot - 1,

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_reorg.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_reorg.py
@@ -9,7 +9,7 @@ from eth2spec.test.helpers.constants import (
 from eth2spec.test.helpers.attestations import (
     state_transition_with_full_block,
     get_valid_attestation,
-    get_valid_attestation_at_slot,
+    get_valid_attestations_at_slot,
 )
 from eth2spec.test.helpers.block import (
     build_empty_block,
@@ -218,7 +218,7 @@ def _run_delayed_justification(spec, state, attemped_reorg, is_justifying_previo
     # add attestations of y
     temp_state = state.copy()
     next_slot(spec, temp_state)
-    attestations_for_y = list(get_valid_attestation_at_slot(temp_state, spec, signed_block_y.message.slot))
+    attestations_for_y = list(get_valid_attestations_at_slot(temp_state, spec, signed_block_y.message.slot))
     current_time = temp_state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
     on_tick_and_append_step(spec, store, current_time, test_steps)
     yield from add_attestations(spec, store, attestations_for_y, test_steps)
@@ -345,10 +345,10 @@ def _run_include_votes_of_another_empty_chain(spec, state, enough_ffg, is_justif
     # create 2/3 votes for the empty chain
     attestations_for_y = []
     # target_is_current = not is_justifying_previous_epoch
-    attestations = list(get_valid_attestation_at_slot(state, spec, state_a.slot))
+    attestations = list(get_valid_attestations_at_slot(state, spec, state_a.slot))
     attestations_for_y.append(attestations)
     for state in states_of_empty_chain:
-        attestations = list(get_valid_attestation_at_slot(state, spec, state.slot))
+        attestations = list(get_valid_attestations_at_slot(state, spec, state.slot))
         attestations_for_y.append(attestations)
 
     state = state_a.copy()


### PR DESCRIPTION
As @mkalinin suggested (https://github.com/ethereum/consensus-specs/pull/3640#discussion_r1546390851), this PR adds EIP-7549 style aggregation strategy in testing tools.
