### PR TITLE
Clarify `voluntary_exits` gossip topic after Capella

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -118,7 +118,7 @@ Topics follow the same specification as in prior upgrades.
 
 The `beacon_block` topic is modified to also support Deneb blocks and new topics are added per table below.
 
-The `voluntary_exit` topic is implicitly modified due to the lock-in use of `CAPELLA_FORK_VERSION` for this message signature validation for EIP-7044.
+The `voluntary_exit` topic is implicitly modified despite the lock-in use of `CAPELLA_FORK_VERSION` for this message signature validation for EIP-7044.
 
 The `beacon_aggregate_and_proof` and `beacon_attestation_{subnet_id}` topics are modified to support the gossip of attestations created in epoch `N` to be gossiped through the entire range of slots in epoch `N+1` rather than only through one epoch of slots for EIP-7045.
 


### PR DESCRIPTION
Could we change wording here a bit, please. "Due to" sounds close to 'because of" and is a bit confusing, because we use `CAPELLA_FORK` for the signature domain but we don't lock the topic, we change it like we always do on every new fork - update topics for all objects to be derived from the current fork.
Should fix #3638  