### PR TITLE
EIP-7251: Remove extra `queue_excess_active_balance` call

### DIFF
--- a/specs/_features/eip7251/fork.md
+++ b/specs/_features/eip7251/fork.md
@@ -129,7 +129,6 @@ def upgrade_to_eip7251(pre: deneb.BeaconState) -> BeaconState:
     )
 
     # Ensure early adopters of compounding credentials go through the activation churn
-    queue_excess_active_balance(post)
     for index, validator in enumerate(post.validators):
         if has_compounding_withdrawal_credential(validator):
             queue_excess_active_balance(post, index)


### PR DESCRIPTION
Probably a line in the fork upgrade that we forgot to delete during linting. 