### PR TITLE
EIP-7594: Use FIELD_ELEMENTS_PER_EXT_BLOB in NUMBER_OF_COLUMNS

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -54,7 +54,7 @@ We define the following Python custom types for type hinting and readability:
 
 | Name | Value | Description |
 | - | - | - |
-| `NUMBER_OF_COLUMNS` | `uint64((FIELD_ELEMENTS_PER_BLOB * 2) // FIELD_ELEMENTS_PER_CELL)` (= 128) | Number of columns in the extended data matrix. |
+| `NUMBER_OF_COLUMNS` | `uint64(FIELD_ELEMENTS_PER_EXT_BLOB // FIELD_ELEMENTS_PER_CELL)` (= 128) | Number of columns in the extended data matrix. |
 
 ### Networking
 

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_config_invariants.py
@@ -10,7 +10,7 @@ from eth2spec.test.context import (
 @single_phase
 def test_invariants(spec):
     assert spec.FIELD_ELEMENTS_PER_BLOB % spec.FIELD_ELEMENTS_PER_CELL == 0
-    assert spec.FIELD_ELEMENTS_PER_BLOB * 2 % spec.config.NUMBER_OF_COLUMNS == 0
+    assert spec.FIELD_ELEMENTS_PER_EXT_BLOB % spec.config.NUMBER_OF_COLUMNS == 0
     assert spec.SAMPLES_PER_SLOT <= spec.config.NUMBER_OF_COLUMNS
     assert spec.CUSTODY_REQUIREMENT <= spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT
     assert spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT <= spec.config.NUMBER_OF_COLUMNS


### PR DESCRIPTION
We can replace `2 * FIELD_ELEMENTS_PER_BLOB` with `FIELD_ELEMENTS_PER_EXT_BLOB` here.