### PR TITLE
Electra:EIP-7002/7251: clarify pending partial withdrawals handling

### DIFF
--- a/presets/mainnet/electra.yaml
+++ b/presets/mainnet/electra.yaml
@@ -38,3 +38,8 @@ MAX_CONSOLIDATIONS: 1
 MAX_DEPOSIT_RECEIPTS_PER_PAYLOAD: 8192
 # 2**4 (= 16) withdrawal requests
 MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 16
+
+# Withdrawals processing
+# ---------------------------------------------------------------
+# 2**3 ( = 8) pending withdrawals
+MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 8

--- a/presets/minimal/electra.yaml
+++ b/presets/minimal/electra.yaml
@@ -38,3 +38,8 @@ MAX_CONSOLIDATIONS: 1
 MAX_DEPOSIT_RECEIPTS_PER_PAYLOAD: 4
 # [customized] 2**1 (= 2) withdrawal requests
 MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 2
+
+# Withdrawals processing
+# ---------------------------------------------------------------
+# 2**0 ( = 1) pending withdrawals
+MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 1

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -19,6 +19,7 @@
   - [State list lengths](#state-list-lengths)
   - [Max operations per block](#max-operations-per-block)
   - [Execution](#execution)
+  - [Withdrawals processing](#withdrawals-processing)
 - [Configuration](#configuration)
   - [Validator cycle](#validator-cycle)
 - [Containers](#containers)
@@ -173,6 +174,12 @@ The following values are (non-configurable) constants used throughout the specif
 | `MAX_ATTESTER_SLASHINGS_ELECTRA`   | `2**0` (= 1) | *[New in Electra:EIP7549]* |
 | `MAX_ATTESTATIONS_ELECTRA` | `2**3` (= 8) | *[New in Electra:EIP7549]* |
 | `MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD` | `uint64(2**4)` (= 16)| *[New in Electra:EIP7002]* Maximum number of execution layer withdrawal requests in each payload |
+
+### Withdrawals processing
+
+| Name | Value | Description |
+| - | - | - |
+| `MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP` | `uint64(2**3)` (= 8)| *[New in Electra:EIP7002]* Maximum number of pending partial withdrawals to process per payload |
 
 ## Configuration
 
@@ -881,7 +888,7 @@ def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], 
 
     # [New in Electra:EIP7251] Consume pending partial withdrawals
     for withdrawal in state.pending_partial_withdrawals:
-        if withdrawal.withdrawable_epoch > epoch or len(withdrawals) == MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD:
+        if withdrawal.withdrawable_epoch > epoch or len(withdrawals) == MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP:
             break
 
         validator = state.validators[withdrawal.index]

--- a/tests/core/pyspec/eth2spec/test/electra/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/electra/unittests/test_config_invariants.py
@@ -8,5 +8,8 @@ from eth2spec.test.context import (
 @with_electra_and_later
 @spec_test
 @single_phase
-def test_withdrawals(spec):
-    assert spec.MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD < spec.MAX_WITHDRAWALS_PER_PAYLOAD
+def test_processing_pending_partial_withdrawals(spec):
+    assert (
+        spec.MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+        < spec.MAX_WITHDRAWALS_PER_PAYLOAD
+    )


### PR DESCRIPTION
renames constant and adjust value so we get the intended behavior so that pending partial withdrawals (from EL) can't block processing CL withdrawals