### PR TITLE
EIP-7251: Reclaim Activation Epochs Lost at Fork

### DIFF
--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -168,8 +168,20 @@ def upgrade_to_electra(pre: deneb.BeaconState) -> BeaconState:
         index
     ))
 
-    for index in pre_activation:
-        queue_entire_balance_and_reset_validator(post, ValidatorIndex(index))
+   activation_churn_limit = get_validator_activation_churn_limit(post)
+   adjusted_validators = 0
+   adjusted_epoch = get_current_epoch(post) - 1
+   for i, index in enumerate(pre_activation):
+       if i >= activation_churn_limit * 4
+           break
+       if post.validators[index].activation_eligibility_epoch > post.finalized_checkpoint.epoch
+           break
+       post.validators[index].activation_eligibility_epoch =
+           adjusted_epoch + (i // activation_churn_limit)
+       adjusted_validators += 1
+
+   for index in pre_activation[adjusted_validators:]:
+       queue_entire_balance_and_reset_validator(post, ValidatorIndex(index))
 
     # Ensure early adopters of compounding credentials go through the activation churn
     for index, validator in enumerate(post.validators):


### PR DESCRIPTION
When the electra fork happens, we move all the pre-activation validators into the `pending_balance_deposits()` to ensure they don't get put right into the validator set without queuing. We lose (by my math) 4 epochs worth of validator activations by doing this. This PR attempts to reclaim these lost epochs.

For more info, see [this comment](https://github.com/ethereum/consensus-specs/pull/3659#issuecomment-2048264808) I left on the original PR:

* https://github.com/ethereum/consensus-specs/pull/3659