### PR TITLE
EIP-7549: replace committee_bits with committee_indices

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -569,17 +569,17 @@ def get_pending_balance_to_withdraw(state: BeaconState, validator_index: Validat
 #### Modified `get_attesting_indices`
 
 ```python
-def get_attesting_indices(state: BeaconState, attestation: Attestation) -> Set[ValidatorIndex]:
+def get_attesting_indices(state: BeaconState, attestation: Attestation) -> List[ValidatorIndex]:
     """
     Return the set of attesting indices corresponding to ``aggregation_bits`` and ``committee_indices``.
     """
-    output: Set[ValidatorIndex] = set()
+    output: List[ValidatorIndex] = list()
     committee_offset = 0
     for index in attestation.committee_indices:
         committee = get_beacon_committee(state, attestation.data.slot, index)
-        committee_attesters = set(
+        committee_attesters = list(
             index for i, index in enumerate(committee) if attestation.aggregation_bits[committee_offset + i])
-        output = output.union(committee_attesters)
+        output += committee_attesters
 
         committee_offset += len(committee)
 

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -43,17 +43,17 @@ The derivation of the `message-id` remains stable.
 ##### `beacon_aggregate_and_proof`
 
 The following convenience variables are re-defined
-- `index = get_committee_indices(aggregate.committee_bits)[0]`
+- `index = aggregate.committee_indices[0]`
 
 The following validations are added:
-* [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(aggregate)`.
+* [REJECT] `len(attestation.committee_indices) == 1`
 * [REJECT] `aggregate.data.index == 0`
 
 ##### `beacon_attestation_{subnet_id}`
 
 The following convenience variables are re-defined
-- `index = get_committee_indices(attestation.committee_bits)[0]`
+- `index = attestation.committee_indices[0]`
 
 The following validations are added:
-* [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(attestation)`.
+* [REJECT] `len(attestation.committee_indices) == 1`
 * [REJECT] `attestation.data.index == 0`

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -47,26 +47,29 @@ Changed the max attester slashings size to `MAX_ATTESTER_SLASHINGS_ELECTRA`.
 Changed the max attestations size to `MAX_ATTESTATIONS_ELECTRA`.
 
 The network attestation aggregates contain only the assigned committee attestations.
-Attestation aggregates received by the block proposer from the committee aggregators with disjoint `committee_bits` sets and equal `AttestationData` SHOULD be consolidated into a single `Attestation` object.
+Attestation aggregates received by the block proposer from the committee aggregators with equal `AttestationData` SHOULD be consolidated into a single `Attestation` object.
 The proposer should run the following function to construct an on chain final aggregate form a list of network aggregates with equal `AttestationData`:
 
 ```python
 def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Attestation:
-    aggregates = sorted(network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0])
+    data = network_aggregates[0].data
+    for att in network_aggregates:
+        assert data == att.data
 
-    data = aggregates[0].data
     aggregation_bits = Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]()
-    for a in aggregates:
-        for b in a.aggregation_bits:
+    for att in network_aggregates:
+        for b in att.aggregation_bits:
             aggregation_bits.append(b)
 
-    signature = bls.Aggregate([a.signature for a in aggregates])
+    signature = bls.Aggregate([att.signature for att in network_aggregates])
+    committee_indices = [att.committee_indices[0] for att in network_aggregates]
 
-    committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
-    committee_flags = [(index in committee_indices) for index in range(0, MAX_COMMITTEES_PER_SLOT)]
-    committee_bits = Bitvector[MAX_COMMITTEES_PER_SLOT](committee_flags)
-
-    return Attestation(aggregation_bits, data, committee_bits, signature)
+    return Attestation(
+        aggregation_bits=aggregation_bits,
+        data=data,
+        committee_indices=committee_indices,
+        signature=signature,
+    )
 ```
 
 #### Deposits
@@ -124,7 +127,7 @@ def prepare_execution_payload(state: BeaconState,
 
 - Set `attestation_data.index = 0`.
 - Let `attestation.aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]` of length `len(committee)`, where the bit of the index of the validator in the `committee` is set to `0b1`.
-- Let `attestation.committee_bits` be a `Bitvector[MAX_COMMITTEES_PER_SLOT]`, where the bit at the index associated with the validator's committee is set to `0b1`.
+- Let `attestation.committee_indices` be a `List[CommitteeIndex, MAX_COMMITTEES_PER_SLOT]` of length `1` with the index associated with the validator's committee.
 
 *Note*: Calling `get_attesting_indices(state, attestation)` should return a list of length equal to 1, containing `validator_index`.
 
@@ -134,4 +137,4 @@ def prepare_execution_payload(state: BeaconState,
 
 - Set `attestation_data.index = 0`.
 - Let `aggregation_bits` be a `Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]` of length `len(committee)`, where each bit set from each individual attestation is set to `0b1`.
-- Set `attestation.committee_bits = committee_bits`, where `committee_bits` has the same value as in each individual attestation.
+- Set `attestation.committee_indices = committee_indices`, where `committee_indices` has the same value as in each individual attestation.


### PR DESCRIPTION
### Proposal
Replaces `committee_bits: Bitvector` which is introduced by [EIP-7549](https://eips.ethereum.org/EIPS/eip-7549) with `committee_indices: List[CommitteeIndex]`. It gives more flexibility to a block proposer in producing on chain aggregates out of network aggregates received from the wire.

Today a block can contain up to `MAX_ATTESTATIONS` aggregates with the same committee index. Since EIP-7549 reduces this parameter from `128` to `8` it leaves much less space for duplicates. This proposal attempts to relax this limitation. Accommodating for more duplicates might be helpful in the case of bad network conditions when there are many valuable aggregates with a slight overlap in the `aggregation_bits`.

### Analysis
This PR uses `CommitteeIndex(uint64)` type for a committee index which gives an overhead to the size of on chain aggregates. Using `uint8` instead might be an option to diminish the overhead.

![image](https://github.com/ethereum/consensus-specs/assets/1892772/305ed35b-7ff5-4549-8d3f-213726cb3e74)

### Todo
* [ ] Fix tests
