### PR TITLE
Finalize deposit before applying it to a state

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1125,6 +1125,7 @@ def apply_deposit(state: BeaconState,
     else:
         # Increase balance by deposit amount
         index = ValidatorIndex(validator_pubkeys.index(pubkey))
+        increase_balance(state, index, amount)
         # Check if valid deposit switch to compounding credentials [New in Electra:EIP-7251]
         if (
             is_compounding_withdrawal_credential(withdrawal_credentials)

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -153,7 +153,7 @@ def upgrade_to_electra(pre: deneb.BeaconState) -> BeaconState:
         earliest_exit_epoch=earliest_exit_epoch,
         consolidation_balance_to_consume=get_consolidation_churn_limit(pre),
         earliest_consolidation_epoch=compute_activation_exit_epoch(get_current_epoch(pre)),
-        pending_balance_deposits=[],
+        pending_deposits=[],
         pending_partial_withdrawals=[],
         pending_consolidations=[],
     )


### PR DESCRIPTION
### Proposal
Extends `state.pending_balance_deposits` to keep the deposit data and an epoch when a deposit was processed by the consensus layer. The deposit is applied to the state only when that epoch gets finalized and if the activation churn has enough capacity.

### Analysis
* Reduces engineering complexity of EIP-6110 implementation as an index of a new validator is associated with the pubkey only after the deposit is finalized, so there is no need to support forks in `(pubkey, index)` cache implementation.
* Increases beacon state size as each entry of the deposits queue needs to hold 176 bytes of additional data (pubkey, withdrawal credentials and signature) which is a 12 times increase. For example, with `100_000` validators in the activation queue the pending deposits queue will consume ~18MB vs 1.5MB of just pending deposit balances.
* Rate limits signature verifications per epoch by the means of the activation queue, but moves all verification operations to the epoch processing.
* Requires top-ups to be finalized before they can be processed.
* Invalid deposits will waste churn. Considering a high cost of submitting an invalid deposit, the potential effect should be negligible.
* Makes no use for `validator.activation_aligibility_epoch` which can be repurposed in the future.