### PR TITLE
chore!: Renames `CELLS_PER_BLOB` to `CELLS_PER_EXT_BLOB`

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -147,7 +147,7 @@ def recover_matrix(cells_dict: Dict[Tuple[BlobIndex, CellID], Cell], blob_count:
         full_polynomial = recover_polynomial(cell_ids, cells_bytes)
         cells_from_full_polynomial = [
             full_polynomial[i * FIELD_ELEMENTS_PER_CELL:(i + 1) * FIELD_ELEMENTS_PER_CELL]
-            for i in range(CELLS_PER_BLOB)
+            for i in range(CELLS_PER_EXT_BLOB)
         ]
         extended_matrix.extend(cells_from_full_polynomial)
     return ExtendedMatrix(extended_matrix)

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -377,7 +377,7 @@ def compute_cells_and_proofs(blob: Blob) -> Tuple[
         Vector[Cell, CELLS_PER_EXT_BLOB],
         Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
     """
-    Compute all the cell proofs for one blob. This is an inefficient O(n^2) algorithm,
+    Compute all the cell proofs for an extended blob. This is an inefficient O(n^2) algorithm,
     for performant implementation the FK20 algorithm that runs in O(n log n) should be
     used instead.
 

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -403,7 +403,7 @@ def compute_cells_and_proofs(blob: Blob) -> Tuple[
 ```python
 def compute_cells(blob: Blob) -> Vector[Cell, CELLS_PER_EXT_BLOB]:
     """
-    Compute the cell data for a blob (without computing the proofs).
+    Compute the cell data for an extended blob (without computing the proofs).
 
     Public method.
     """

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/das/test_das.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/das/test_das.py
@@ -18,11 +18,11 @@ def test_compute_extended_matrix(spec):
     blob_count = 2
     input_blobs = [get_sample_blob(spec, rng=rng) for _ in range(blob_count)]
     extended_matrix = spec.compute_extended_matrix(input_blobs)
-    assert len(extended_matrix) == spec.CELLS_PER_BLOB * blob_count
+    assert len(extended_matrix) == spec.CELLS_PER_EXT_BLOB * blob_count
 
-    rows = [extended_matrix[i:(i + spec.CELLS_PER_BLOB)] for i in range(0, len(extended_matrix), spec.CELLS_PER_BLOB)]
+    rows = [extended_matrix[i:(i + spec.CELLS_PER_EXT_BLOB)] for i in range(0, len(extended_matrix), spec.CELLS_PER_EXT_BLOB)]
     assert len(rows) == blob_count
-    assert len(rows[0]) == spec.CELLS_PER_BLOB
+    assert len(rows[0]) == spec.CELLS_PER_EXT_BLOB
 
     for blob_index, row in enumerate(rows):
         extended_blob = []
@@ -40,7 +40,7 @@ def test_recover_matrix(spec):
     rng = random.Random(5566)
 
     # Number of samples we will be recovering from
-    N_SAMPLES = spec.CELLS_PER_BLOB // 2
+    N_SAMPLES = spec.CELLS_PER_EXT_BLOB // 2
 
     blob_count = 2
     cells_dict = {}
@@ -54,9 +54,9 @@ def test_recover_matrix(spec):
         cell_ids = []
         # First figure out just the indices of the cells
         for _ in range(N_SAMPLES):
-            cell_id = rng.randint(0, spec.CELLS_PER_BLOB - 1)
+            cell_id = rng.randint(0, spec.CELLS_PER_EXT_BLOB - 1)
             while cell_id in cell_ids:
-                cell_id = rng.randint(0, spec.CELLS_PER_BLOB - 1)
+                cell_id = rng.randint(0, spec.CELLS_PER_EXT_BLOB - 1)
             cell_ids.append(cell_id)
             cell = cells[cell_id]
             cells_dict[(blob_index, cell_id)] = cell

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/das/test_das.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/das/test_das.py
@@ -20,7 +20,8 @@ def test_compute_extended_matrix(spec):
     extended_matrix = spec.compute_extended_matrix(input_blobs)
     assert len(extended_matrix) == spec.CELLS_PER_EXT_BLOB * blob_count
 
-    rows = [extended_matrix[i:(i + spec.CELLS_PER_EXT_BLOB)] for i in range(0, len(extended_matrix), spec.CELLS_PER_EXT_BLOB)]
+    rows = [extended_matrix[i:(i + spec.CELLS_PER_EXT_BLOB)]
+            for i in range(0, len(extended_matrix), spec.CELLS_PER_EXT_BLOB)]
     assert len(rows) == blob_count
     assert len(rows[0]) == spec.CELLS_PER_EXT_BLOB
 

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -71,7 +71,7 @@ def test_recover_polynomial(spec):
     rng = random.Random(5566)
 
     # Number of samples we will be recovering from
-    N_SAMPLES = spec.CELLS_PER_BLOB // 2
+    N_SAMPLES = spec.CELLS_PER_EXT_BLOB // 2
 
     # Get the data we will be working with
     blob = get_sample_blob(spec)
@@ -86,9 +86,9 @@ def test_recover_polynomial(spec):
     cell_ids = []
     # First figure out just the indices of the cells
     for i in range(N_SAMPLES):
-        j = rng.randint(0, spec.CELLS_PER_BLOB - 1)
+        j = rng.randint(0, spec.CELLS_PER_EXT_BLOB - 1)
         while j in cell_ids:
-            j = rng.randint(0, spec.CELLS_PER_BLOB - 1)
+            j = rng.randint(0, spec.CELLS_PER_EXT_BLOB - 1)
         cell_ids.append(j)
     # Now the cells themselves
     known_cells_bytes = [cells_bytes[cell_id] for cell_id in cell_ids]


### PR DESCRIPTION
The name changing follows from its value -- it would be `CELLS_PER_BLOB` if we were doing `FIELD_ELEMENTS_PER_BLOB // FIELD_ELEMENTS_PER_CELL`