### PR TITLE
chore: Fixes and elaborates on comments for `compute_kzg_proof_multi`

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -313,7 +313,7 @@ def compute_kzg_proof_multi_impl(
     This is done by committing to the following quotient polynomial:  
     Q(X) = f(X) - r(X) / Z(X)
     Where:
-        - r(X) is the degree k-1 polynomial that agrees with f(x) at all `k` points
+        - r(X) is the degree `k-1` polynomial that agrees with f(x) at all `k` points
         - Z(X) is the degree `k` polynomial that evaluates to zero on all `k` points
     """
 

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -308,18 +308,26 @@ def compute_kzg_proof_multi_impl(
         polynomial_coeff: PolynomialCoeff,
         zs: Sequence[BLSFieldElement]) -> Tuple[KZGProof, Sequence[BLSFieldElement]]:
     """
-    Helper function that computes multi-evaluation KZG proofs.
+    Compute a KZG multi-evaluation proof for a set of `k` points.
+
+    This is done by committing to the following quotient polynomial:  
+    Q(X) = f(X) - r(X) / Z(X)
+    Where:
+        - r(X) is the degree k-1 polynomial that agrees with f(x) at all `k` points
+        - Z(X) is the degree `k` polynomial that evaluates to zero on all `k` points
     """
 
-    # For all x_i, compute p(x_i) - p(z)
+    # For all points, compute the evaluation of those points.
     ys = [evaluate_polynomialcoeff(polynomial_coeff, z) for z in zs]
+    # Compute r(X)
     interpolation_polynomial = interpolate_polynomialcoeff(zs, ys)
+    # Compute f(X) - r(X)
     polynomial_shifted = add_polynomialcoeff(polynomial_coeff, neg_polynomialcoeff(interpolation_polynomial))
 
-    # For all x_i, compute (x_i - z)
+    # Compute Z(X)
     denominator_poly = vanishing_polynomialcoeff(zs)
 
-    # Compute the quotient polynomial directly in evaluation form
+    # Compute the quotient polynomial directly in monomial form
     quotient_polynomial = divide_polynomialcoeff(polynomial_shifted, denominator_poly)
 
     return KZGProof(g1_lincomb(KZG_SETUP_G1_MONOMIAL[:len(quotient_polynomial)], quotient_polynomial)), ys

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -317,7 +317,7 @@ def compute_kzg_proof_multi_impl(
         - Z(X) is the degree `k` polynomial that evaluates to zero on all `k` points
     """
 
-    # For all points, compute the evaluation of those points.
+    # For all points, compute the evaluation of those points
     ys = [evaluate_polynomialcoeff(polynomial_coeff, z) for z in zs]
     # Compute r(X)
     interpolation_polynomial = interpolate_polynomialcoeff(zs, ys)


### PR DESCRIPTION
I fixed and fleshed out the comments a bit more for this function. 

- We were not computing the quotient polynomial in evaluation form. (We can't because it would cause a divide by zero error, with the current fft algorithm)