### PR TITLE
Change `recover_polynomial` to `recover_all_cells`

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -135,7 +135,7 @@ def recover_matrix(cells_dict: Dict[Tuple[BlobIndex, CellID], Cell], blob_count:
     """
     Return the recovered ``ExtendedMatrix``.
 
-    This helper demonstrates how to apply ``recover_polynomial``.
+    This helper demonstrates how to apply ``recover_all_cells``.
     The data structure for storing cells is implementation-dependent.
     """
     extended_matrix = []
@@ -144,12 +144,8 @@ def recover_matrix(cells_dict: Dict[Tuple[BlobIndex, CellID], Cell], blob_count:
         cells = [cells_dict[(blob_index, cell_id)] for cell_id in cell_ids]
         cells_bytes = [[bls_field_to_bytes(element) for element in cell] for cell in cells]
 
-        full_polynomial = recover_polynomial(cell_ids, cells_bytes)
-        cells_from_full_polynomial = [
-            full_polynomial[i * FIELD_ELEMENTS_PER_CELL:(i + 1) * FIELD_ELEMENTS_PER_CELL]
-            for i in range(CELLS_PER_EXT_BLOB)
-        ]
-        extended_matrix.extend(cells_from_full_polynomial)
+        all_cells_for_row = recover_all_cells(cell_ids, cells_bytes)
+        extended_matrix.extend(all_cells_for_row)
     return ExtendedMatrix(extended_matrix)
 ```
 

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -45,7 +45,7 @@
   - [`construct_vanishing_polynomial`](#construct_vanishing_polynomial)
   - [`recover_shifted_data`](#recover_shifted_data)
   - [`recover_original_data`](#recover_original_data)
-  - [`recover_polynomial`](#recover_polynomial)
+  - [`recover_all_cells`](#recover_all_cells)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -596,14 +596,15 @@ def recover_original_data(eval_shifted_extended_evaluation: Sequence[BLSFieldEle
     return reconstructed_data
 ```
 
-### `recover_polynomial`
+### `recover_all_cells`
 
 ```python
-def recover_polynomial(cell_ids: Sequence[CellID],
-                       cells_bytes: Sequence[Vector[Bytes32, FIELD_ELEMENTS_PER_CELL]]) -> Polynomial:
+def recover_all_cells(cell_ids: Sequence[CellID],
+                      cells_bytes: Sequence[Vector[Bytes32, FIELD_ELEMENTS_PER_CELL]]) -> Sequence[Cell]:
     """
-    Recover original polynomial from FIELD_ELEMENTS_PER_EXT_BLOB evaluations, half of which can be missing. This
-    algorithm uses FFTs to recover cells faster than using Lagrange implementation, as can be seen here:
+    Recover all of the cells in the extended blob from FIELD_ELEMENTS_PER_EXT_BLOB evaluations, 
+    half of which can be missing.
+    This algorithm uses FFTs to recover cells faster than using Lagrange implementation, as can be seen here:
     https://ethresear.ch/t/reed-solomon-erasure-code-recovery-in-n-log-2-n-time-with-ffts/3039
 
     A faster version thanks to Qi Zhou can be found here:
@@ -646,5 +647,9 @@ def recover_polynomial(cell_ids: Sequence[CellID],
         end = (cell_id + 1) * FIELD_ELEMENTS_PER_CELL
         assert reconstructed_data[start:end] == cell
 
-    return reconstructed_data
+    reconstructed_data_as_cells = [
+        reconstructed_data[i * FIELD_ELEMENTS_PER_CELL:(i + 1) * FIELD_ELEMENTS_PER_CELL]
+        for i in range(CELLS_PER_EXT_BLOB)]
+
+    return reconstructed_data_as_cells
 ```

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -67,7 +67,7 @@ def test_verify_cell_proof_batch(spec):
 @with_eip7594_and_later
 @spec_test
 @single_phase
-def test_recover_polynomial(spec):
+def test_recover_all_cells(spec):
     rng = random.Random(5566)
 
     # Number of samples we will be recovering from
@@ -93,15 +93,15 @@ def test_recover_polynomial(spec):
     # Now the cells themselves
     known_cells_bytes = [cells_bytes[cell_id] for cell_id in cell_ids]
 
-    # Recover the data
-    recovered_data = spec.recover_polynomial(cell_ids, known_cells_bytes)
+    # Recover all of the cells
+    recovered_cells = spec.recover_all_cells(cell_ids, known_cells_bytes)
+    recovered_data = [x for xs in recovered_cells for x in xs]
 
     # Check that the original data match the non-extended portion of the recovered data
     assert original_polynomial == recovered_data[:len(recovered_data) // 2]
 
-    # Now flatten the cells and check that they match the entirety of the recovered data
-    flattened_cells = [x for xs in cells for x in xs]
-    assert flattened_cells == recovered_data
+    # Check that the recovered cells match the original cells
+    assert cells == recovered_data
 
 
 @with_eip7594_and_later

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -101,7 +101,7 @@ def test_recover_all_cells(spec):
     assert original_polynomial == recovered_data[:len(recovered_data) // 2]
 
     # Check that the recovered cells match the original cells
-    assert cells == recovered_data
+    assert cells == recovered_cells
 
 
 @with_eip7594_and_later


### PR DESCRIPTION
This fixes two abstraction leaks:

- The Polynomial type was being exposed to the user
- The caller was also grouping the returned polynomial into cell types, meaning that das_core.md needed to know about `FIELD_ELEMENTS_PER_CELL` and `CELLS_PER_EXT_BLOB` in `recover_matrix`.