### PR TITLE
chore: Add is_zero check in g1_lincomb [DO NOT MERGE]

### DIFF
--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -279,6 +279,8 @@ def g1_lincomb(points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElemen
     assert len(points) == len(scalars)
     result = bls.Z1()
     for x, a in zip(points, scalars):
+        if a == 0:
+            continue
         result = bls.add(result, bls.multiply(bls.bytes48_to_G1(x), a))
     return KZGCommitment(bls.G1_to_bytes48(result))
 ```


### PR DESCRIPTION
This checks whether the scalar is zero and skips the multiply and add operation.