### PR TITLE
chore: Make List Copy explicit in `divide_polynomialcoeff`

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -214,7 +214,6 @@ def divide_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> Polynomial
     """
     Long polynomial division for two coefficient form polynomials ``a`` and ``b``
     """
-    a = [x for x in a]
     o = []
     apos = len(a) - 1
     bpos = len(b) - 1

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -214,6 +214,7 @@ def divide_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> Polynomial
     """
     Long polynomial division for two coefficient form polynomials ``a`` and ``b``
     """
+    a = a.copy()  # Make a copy since `a` is passed by reference
     o = []
     apos = len(a) - 1
     bpos = len(b) - 1


### PR DESCRIPTION
Pulled this out of #3697 so that #3697 is primarily adding type casts