### PR TITLE
Minor comment on `ExecutionLayerWithdrawalRequest` 

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -229,7 +229,7 @@ class PendingPartialWithdrawal(Container):
 ```
 #### `ExecutionLayerWithdrawalRequest`
 
-*Note*: The container is new in EIP7251.
+*Note*: The container is new in EIP7251:EIP7002.
 
 ```python
 class ExecutionLayerWithdrawalRequest(Container):


### PR DESCRIPTION
Fix `ExecutionLayerWithdrawalRequest` container to also imply it's for EIP7002