### PR TITLE
chore: try synthetic division when computing the quotient polynomial

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -263,15 +263,15 @@ def divide_by_linear_factors(polynomial: PolynomialCoeff, roots: Sequence[BLSFie
     assert len(polynomial) > len(roots)
 
     polynomial = list(reversed(polynomial))
-    quotient = [polynomial[0]]
     for root in roots:
+        quotient = [polynomial[0]]
         neg_root = BLS_MODULUS - root
         for i in range(1, len(polynomial)):
             new_coefficient = ((int(quotient[-1]) * int(neg_root)) + int(polynomial[i])) % BLS_MODULUS
             quotient.append(new_coefficient)
         # Pop off the remainder term
         _ = quotient.pop()
-        polynomial = quotient
+        polynomial = quotient.copy()
     
     quotient.reverse()
     

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -26,6 +26,7 @@
     - [`neg_polynomialcoeff`](#neg_polynomialcoeff)
     - [`multiply_polynomialcoeff`](#multiply_polynomialcoeff)
     - [`divide_polynomialcoeff`](#divide_polynomialcoeff)
+    - [`synthetic_division`](#synthetic_division)
     - [`shift_polynomialcoeff`](#shift_polynomialcoeff)
     - [`interpolate_polynomialcoeff`](#interpolate_polynomialcoeff)
     - [`vanishing_polynomialcoeff`](#vanishing_polynomialcoeff)

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -269,9 +269,9 @@ def divide_by_linear_factors(polynomial: PolynomialCoeff, roots: Sequence[BLSFie
         for i in range(1, len(polynomial)):
             new_coefficient = ((int(quotient[-1]) * int(neg_root)) + int(polynomial[i])) % BLS_MODULUS
             quotient.append(new_coefficient)
-    
         # Pop off the remainder term
         _ = quotient.pop()
+        polynomial = quotient
     
     quotient.reverse()
     

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -251,6 +251,28 @@ def divide_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> Polynomial
     return [x % BLS_MODULUS for x in o]
 ```
 
+#### `synthetic_division`
+
+```python
+def synthetic_division(polynomial: PolynomialCoeff, root: BLSFieldElement) -> PolynomialCoeff:
+    """
+    Polynomial division between a polynomial and a linear factor
+    """
+    polynomial = list(reversed(polynomial))
+    quotient = [polynomial[0]]
+    
+    for i in range(1, len(polynomial)):
+        new_coefficient = quotient[-1] * root + polynomial[i]
+        quotient.append(new_coefficient)
+    
+    # Pop off the remainder term
+    _ = quotient.pop()
+    
+    quotient.reverse()
+    
+    return quotient
+```
+
 #### `shift_polynomialcoeff`
 
 ```python
@@ -345,11 +367,9 @@ def compute_kzg_proof_multi_impl(
     # For all points, compute the evaluation of those points
     ys = [evaluate_polynomialcoeff(polynomial_coeff, z) for z in zs]
 
-    # Compute Z(X)
-    denominator_poly = vanishing_polynomialcoeff(zs)
-
-    # Compute the quotient polynomial directly in monomial form
-    quotient_polynomial = divide_polynomialcoeff(polynomial_coeff, denominator_poly)
+    quotient_polynomial = polynomial_coeff
+    for z in zs:
+        quotient_polynomial = synthetic_division(quotient_polynomial, -z)
 
     return KZGProof(g1_lincomb(KZG_SETUP_G1_MONOMIAL[:len(quotient_polynomial)], quotient_polynomial)), ys
 ```

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -267,7 +267,7 @@ def divide_by_linear_factors(polynomial: PolynomialCoeff, roots: Sequence[BLSFie
     for root in roots:
         neg_root = BLS_MODULUS - root
         for i in range(1, len(polynomial)):
-            new_coefficient = ((quotient[-1] * neg_root) % BLS_MODULUS + polynomial[i]) % BLS_MODULUS
+            new_coefficient = ((int(quotient[-1]) * int(neg_root)) + int(polynomial[i])) % BLS_MODULUS
             quotient.append(new_coefficient)
     
         # Pop off the remainder term

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -271,7 +271,7 @@ def divide_by_linear_factors(polynomial: PolynomialCoeff, roots: Sequence[BLSFie
             quotient.append(new_coefficient)
         # Pop off the remainder term
         _ = quotient.pop()
-        polynomial = quotient.copy()
+        polynomial = quotient
     
     quotient.reverse()
     

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -267,7 +267,7 @@ def divide_by_linear_factors(polynomial: PolynomialCoeff, roots: Sequence[BLSFie
     for root in roots:
         neg_root = BLS_MODULUS - root
         for i in range(1, len(polynomial)):
-            new_coefficient = (quotient[-1] * neg_root + polynomial[i]) % BLS_MODULUS
+            new_coefficient = ((quotient[-1] * neg_root) % BLS_MODULUS + polynomial[i]) % BLS_MODULUS
             quotient.append(new_coefficient)
     
         # Pop off the remainder term


### PR DESCRIPTION
This removes the need to compute the vanishing polynomial and then perform polynomial long division, by using synthetic division.