### PR TITLE
chore: use py-arkworks's multi-exp method inside of `g1_lincomb` and `g2_lincomb`

### DIFF
--- a/pysetup/spec_builders/deneb.py
+++ b/pysetup/spec_builders/deneb.py
@@ -17,6 +17,7 @@ from eth2spec.capella import {preset_name} as capella
     def preparations(cls):
         return '''
 T = TypeVar('T')  # For generic function
+TPoint = TypeVar('TPoint')  # For generic function. G1 or G2 point.
 '''
 
     @classmethod

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -135,7 +135,7 @@ def g2_lincomb(points: Sequence[G2Point], scalars: Sequence[BLSFieldElement]) ->
     assert len(points) == len(scalars)
 
     if len(points) == 0:
-        return bls.Z2()
+        return bls.G2_to_bytes96(bls.Z2())
 
     points_g2 = []
     for point in points:

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -133,9 +133,10 @@ def g2_lincomb(points: Sequence[G2Point], scalars: Sequence[BLSFieldElement]) ->
     BLS multiscalar multiplication in G2. This function can be optimized using Pippenger's algorithm and variants.
     """
     assert len(points) == len(scalars)
-    result = bls.Z2()
-    for x, a in zip(points, scalars):
-        result = bls.add(result, bls.multiply(bls.bytes96_to_G2(x), a))
+    points_g2 = []
+    for point in points:
+        points_g2.append(bls.bytes96_to_G2(point))
+    result = bls.g2_multi_exp(points_g2, scalars)
     return Bytes96(bls.G2_to_bytes96(result))
 ```
 

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -133,9 +133,14 @@ def g2_lincomb(points: Sequence[G2Point], scalars: Sequence[BLSFieldElement]) ->
     BLS multiscalar multiplication in G2. This can be naively implemented using double-and-add.
     """
     assert len(points) == len(scalars)
+
+    if len(points) == 0:
+        return bls.Z2()
+
     points_g2 = []
     for point in points:
         points_g2.append(bls.bytes96_to_G2(point))
+
     result = bls.multi_exp(points_g2, scalars)
     return Bytes96(bls.G2_to_bytes96(result))
 ```

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -130,13 +130,13 @@ def coset_evals_to_cell(coset_evals: CosetEvals) -> Cell:
 ```python
 def g2_lincomb(points: Sequence[G2Point], scalars: Sequence[BLSFieldElement]) -> Bytes96:
     """
-    BLS multiscalar multiplication in G2. This function can be optimized using Pippenger's algorithm and variants.
+    BLS multiscalar multiplication in G2. This can be naively implemented using double-and-add.
     """
     assert len(points) == len(scalars)
     points_g2 = []
     for point in points:
         points_g2.append(bls.bytes96_to_G2(point))
-    result = bls.g2_multi_exp(points_g2, scalars)
+    result = bls.multi_exp(points_g2, scalars)
     return Bytes96(bls.G2_to_bytes96(result))
 ```
 

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -274,13 +274,13 @@ def div(x: BLSFieldElement, y: BLSFieldElement) -> BLSFieldElement:
 ```python
 def g1_lincomb(points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElement]) -> KZGCommitment:
     """
-    BLS multiscalar multiplication. This function can be optimized using Pippenger's algorithm and variants.
+    BLS multiscalar multiplication in G1. This can be naively implemented using double-and-add.
     """
     assert len(points) == len(scalars)
     points_g1 = []
     for point in points:
         points_g1.append(bls.bytes48_to_G1(point))
-    result = bls.g1_multi_exp(points_g1, scalars)
+    result = bls.multi_exp(points_g1, scalars)
     return KZGCommitment(bls.G1_to_bytes48(result))
 ```
 

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -279,7 +279,7 @@ def g1_lincomb(points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElemen
     assert len(points) == len(scalars)
 
     if len(points) == 0:
-        return bls.Z1()
+        return bls.G1_to_bytes48(bls.Z1())
 
     points_g1 = []
     for point in points:

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -18,6 +18,7 @@
     - [`reverse_bits`](#reverse_bits)
     - [`bit_reversal_permutation`](#bit_reversal_permutation)
   - [BLS12-381 helpers](#bls12-381-helpers)
+    - [`multi_exp`](#multi_exp)
     - [`hash_to_bls_field`](#hash_to_bls_field)
     - [`bytes_to_bls_field`](#bytes_to_bls_field)
     - [`bls_field_to_bytes`](#bls_field_to_bytes)
@@ -145,6 +146,18 @@ def bit_reversal_permutation(sequence: Sequence[T]) -> Sequence[T]:
 ```
 
 ### BLS12-381 helpers
+
+
+#### `multi_exp`
+
+This function performs a multi-scalar multiplication between `points` and `integers`. `points` can either be in G1 or G2.
+
+```python
+def multi_exp(points: PyUnion[Sequence[G1Point], Sequence[G2Point]],
+              integers: Sequence[uint64]) -> PyUnion[Sequence[G1Point], Sequence[G2Point]]:
+    # pylint: disable=unused-argument
+    ...
+```
 
 #### `hash_to_bls_field`
 

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -277,9 +277,14 @@ def g1_lincomb(points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElemen
     BLS multiscalar multiplication in G1. This can be naively implemented using double-and-add.
     """
     assert len(points) == len(scalars)
+
+    if len(points) == 0:
+        return bls.Z1()
+
     points_g1 = []
     for point in points:
         points_g1.append(bls.bytes48_to_G1(point))
+
     result = bls.multi_exp(points_g1, scalars)
     return KZGCommitment(bls.G1_to_bytes48(result))
 ```

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -153,8 +153,8 @@ def bit_reversal_permutation(sequence: Sequence[T]) -> Sequence[T]:
 This function performs a multi-scalar multiplication between `points` and `integers`. `points` can either be in G1 or G2.
 
 ```python
-def multi_exp(points: PyUnion[Sequence[G1Point], Sequence[G2Point]],
-              integers: Sequence[uint64]) -> PyUnion[Sequence[G1Point], Sequence[G2Point]]:
+def multi_exp(points: Sequence[TPoint],
+              integers: Sequence[uint64]) -> Sequence[TPoint]:
     # pylint: disable=unused-argument
     ...
 ```

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -280,7 +280,7 @@ def g1_lincomb(points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElemen
     points_g1 = []
     for point in points:
         points_g1.append(bls.bytes48_to_G1(point))
-    result = bls.g1_multi_exp(points_g1,scalars)
+    result = bls.g1_multi_exp(points_g1, scalars)
     return KZGCommitment(bls.G1_to_bytes48(result))
 ```
 

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -277,9 +277,10 @@ def g1_lincomb(points: Sequence[KZGCommitment], scalars: Sequence[BLSFieldElemen
     BLS multiscalar multiplication. This function can be optimized using Pippenger's algorithm and variants.
     """
     assert len(points) == len(scalars)
-    result = bls.Z1()
-    for x, a in zip(points, scalars):
-        result = bls.add(result, bls.multiply(bls.bytes48_to_G1(x), a))
+    points_g1 = []
+    for point in points:
+        points_g1.append(bls.bytes48_to_G1(point))
+    result = bls.g1_multi_exp(points_g1,scalars)
     return KZGCommitment(bls.G1_to_bytes48(result))
 ```
 

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -224,6 +224,23 @@ def multiply(point, scalar):
         return point * scalar
     return py_ecc_mul(point, scalar)
 
+def g1_multi_exp(points, integers):
+    """
+    Performs a multi-scalar multiplication between
+    `points` and `scalars`.
+    `point` should be in G1
+    """
+    assert(len(points) == len(integers))
+    if bls == arkworks_bls or bls == fastest_bls:
+        scalars = []
+        for integer in integers:
+            int_as_bytes = integer.to_bytes(32, 'little')
+            scalars.append(arkworks_Scalar.from_le_bytes(int_as_bytes))
+        return arkworks_G1.multiexp_unchecked(points, scalars)
+    result = Z1()
+    for point,scalar in points.zip(scalars):
+        result = add(result, multiply(point, scalar))
+    return result
 
 def neg(point):
     """

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -251,7 +251,7 @@ def multi_exp(points, integers):
         else:
             raise Exception("Invalid point type")
 
-    result = Z1()
+    result = None
     if isinstance(points[0], py_ecc_G1):
         result = Z1()
     elif isinstance(points[0], py_ecc_G2):

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -238,6 +238,8 @@ def multi_exp(points, integers):
             int_as_bytes = integer.to_bytes(32, 'little')
             scalars.append(arkworks_Scalar.from_le_bytes(int_as_bytes))
 
+        if len(points) == 0:
+            return Z1()
         # Check if we need to perform a G1 or G2 multiexp
         if isinstance(points[0], arkworks_G1):
             return arkworks_G1.multiexp_unchecked(points, scalars)

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -229,7 +229,7 @@ def multi_exp(points, integers):
     """
     Performs a multi-scalar multiplication between
     `points` and `scalars`.
-    `point` should be in G2
+    `points` can either be in G1 or G2
     """
     if bls == arkworks_bls or bls == fastest_bls:
         # Convert integers into arkworks Scalars

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -243,7 +243,7 @@ def g1_multi_exp(points, integers):
     return result
 
 
-# TODO: Duplicated code for now
+# TODO: Duplicated code for now (we can use type-checking to avoid duplication)
 def g2_multi_exp(points, integers):
     """
     Performs a multi-scalar multiplication between

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -230,9 +230,12 @@ def multi_exp(points, integers):
     Performs a multi-scalar multiplication between
     `points` and `scalars`.
     `points` can either be in G1 or G2.
-
-    Note: This method assumes that there is at least one point.
     """
+    # Since this method accepts either G1 or G2, we need to know
+    # the type of the point to return. Hence, we need at least one point.
+    if not points or not integers:
+        raise Exception("Cannot call multi_exp with zero points or zero integers")
+
     if bls == arkworks_bls or bls == fastest_bls:
         # Convert integers into arkworks Scalars
         scalars = []

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -228,7 +228,7 @@ def multiply(point, scalar):
 def multi_exp(points, integers):
     """
     Performs a multi-scalar multiplication between
-    `points` and `scalars`.
+    `points` and `integers`.
     `points` can either be in G1 or G2.
     """
     # Since this method accepts either G1 or G2, we need to know

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -229,7 +229,9 @@ def multi_exp(points, integers):
     """
     Performs a multi-scalar multiplication between
     `points` and `scalars`.
-    `points` can either be in G1 or G2
+    `points` can either be in G1 or G2.
+
+    Note: This method assumes that there is at least one point.
     """
     if bls == arkworks_bls or bls == fastest_bls:
         # Convert integers into arkworks Scalars
@@ -238,8 +240,6 @@ def multi_exp(points, integers):
             int_as_bytes = integer.to_bytes(32, 'little')
             scalars.append(arkworks_Scalar.from_le_bytes(int_as_bytes))
 
-        if len(points) == 0:
-            return Z1()
         # Check if we need to perform a G1 or G2 multiexp
         if isinstance(points[0], arkworks_G1):
             return arkworks_G1.multiexp_unchecked(points, scalars)
@@ -248,7 +248,14 @@ def multi_exp(points, integers):
         else:
             raise Exception("Invalid point type")
 
-    result = Z2()
+    result = Z1()
+    if isinstance(points[0], py_ecc_G1):
+        result = Z1()
+    elif isinstance(points[0], py_ecc_G2):
+        result = Z2()
+    else:
+        raise Exception("Invalid point type")
+
     for point, scalar in points.zip(integers):
         result = add(result, multiply(point, scalar))
     return result

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -224,13 +224,13 @@ def multiply(point, scalar):
         return point * scalar
     return py_ecc_mul(point, scalar)
 
+
 def g1_multi_exp(points, integers):
     """
     Performs a multi-scalar multiplication between
     `points` and `scalars`.
     `point` should be in G1
     """
-    assert(len(points) == len(integers))
     if bls == arkworks_bls or bls == fastest_bls:
         scalars = []
         for integer in integers:
@@ -238,9 +238,29 @@ def g1_multi_exp(points, integers):
             scalars.append(arkworks_Scalar.from_le_bytes(int_as_bytes))
         return arkworks_G1.multiexp_unchecked(points, scalars)
     result = Z1()
-    for point,scalar in points.zip(scalars):
+    for point, scalar in points.zip(integers):
         result = add(result, multiply(point, scalar))
     return result
+
+
+# TODO: Duplicated code for now
+def g2_multi_exp(points, integers):
+    """
+    Performs a multi-scalar multiplication between
+    `points` and `scalars`.
+    `point` should be in G2
+    """
+    if bls == arkworks_bls or bls == fastest_bls:
+        scalars = []
+        for integer in integers:
+            int_as_bytes = integer.to_bytes(32, 'little')
+            scalars.append(arkworks_Scalar.from_le_bytes(int_as_bytes))
+        return arkworks_G2.multiexp_unchecked(points, scalars)
+    result = Z2()
+    for point, scalar in points.zip(integers):
+        result = add(result, multiply(point, scalar))
+    return result
+
 
 def neg(point):
     """


### PR DESCRIPTION
Motivation for this PR is to reduce CI times. Switch from double-and-add to the bucket method.