### PR TITLE
Add kzg_7594 test formats

### DIFF
--- a/tests/formats/kzg_7594/README.md
+++ b/tests/formats/kzg_7594/README.md
@@ -1,0 +1,13 @@
+# KZG tests for EIP-7594
+
+A test type for KZG libraries. Tests all the public interfaces that a KZG library is required to implement for EIP-7594, as defined in `polynomial-commitments-sampling.md`.
+
+We do not recommend rolling your own crypto or using an untested KZG library.
+
+The KZG test suite runner has the following handlers:
+
+- [`compute_cells`](./compute_cells.md)
+- [`compute_cells_and_proofs`](./compute_cells_and_proofs.md)
+- [`verify_cell_proof`](./verify_cell_proof.md)
+- [`verify_cell_proof_batch`](./verify_cell_proof_batch.md)
+- [`recover_all_cells`](./recover_all_cells.md)

--- a/tests/formats/kzg_7594/compute_cells.md
+++ b/tests/formats/kzg_7594/compute_cells.md
@@ -1,0 +1,22 @@
+# Test format: Compute cells
+
+Compute the cells for a given `blob`.
+
+## Test case format
+
+The test data is declared in a `data.yaml` file:
+
+```yaml
+input:
+  blob: Blob -- the data blob
+output: List[Cell] -- the cells
+```
+
+- `Blob` is a 131072-byte hexadecimal string, prefixed with `0x`.
+- `Cell` is a 2048-byte hexadecimal string, prefixed with `0x`.
+
+All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
+
+## Condition
+
+The `compute_cells` handler should compute the cells (chunks of an extended blob) for `blob`, and the result should match the expected `output`. If the blob is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element) it should error, i.e. the output should be `null`.

--- a/tests/formats/kzg_7594/compute_cells_and_proofs.md
+++ b/tests/formats/kzg_7594/compute_cells_and_proofs.md
@@ -1,0 +1,23 @@
+# Test format: Compute cells and proofs
+
+Compute the cells and cell KZG proofs for a given `blob`.
+
+## Test case format
+
+The test data is declared in a `data.yaml` file:
+
+```yaml
+input:
+  blob: Blob -- the data blob
+output: Tuple[List[Cell], List[KZGProof]] -- the cells and proofs
+```
+
+- `Blob` is a 131072-byte hexadecimal string, prefixed with `0x`.
+- `Cell` is a 2048-byte hexadecimal string, prefixed with `0x`.
+- `KZGProof` is a 48-byte hexadecimal string, prefixed with `0x`.
+
+All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
+
+## Condition
+
+The `compute_cells_and_proofs` handler should compute the cells (chunks of an extended blob) and cell KZG proofs for `blob`, and the result should match the expected `output`. If the blob is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element) it should error, i.e. the output should be `null`.

--- a/tests/formats/kzg_7594/recover_all_cells.md
+++ b/tests/formats/kzg_7594/recover_all_cells.md
@@ -1,0 +1,23 @@
+# Test format: Recover all cells
+
+Recover all cells given at least 50% of the original `cells`.
+
+## Test case format
+
+The test data is declared in a `data.yaml` file:
+
+```yaml
+input:
+  cell_ids: List[CellID] -- the cell identifier for each cell
+  cells: List[Cell] -- the partial collection of cells
+output: List[Cell] -- all cells, including recovered cells
+```
+
+- `CellID` is an unsigned 64-bit integer.
+- `Cell` is a 2048-byte hexadecimal string, prefixed with `0x`.
+
+All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
+
+## Condition
+
+The `recover_all_cells` handler should recover missing cells, and the result should match the expected `output`. If any cell is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element) or any `cell_id` is invalid (e.g. greater than the number of cells for an extended blob), it should error, i.e. the output should be `null`.

--- a/tests/formats/kzg_7594/verify_cell_proof.md
+++ b/tests/formats/kzg_7594/verify_cell_proof.md
@@ -1,0 +1,26 @@
+# Test format: Verify cell proof
+
+Use the cell KZG `proof` to verify that the KZG `commitment` for a given `cell` is correct.
+
+## Test case format
+
+The test data is declared in a `data.yaml` file:
+
+```yaml
+input:
+  commitment: Bytes48 -- the KZG commitment
+  cell_id: CellID -- the identifier for the cell
+  cell: Cell -- the cell
+  proof: Bytes48 -- the KZG proof for the cell
+output: bool -- true (correct proof) or false (incorrect proof)
+```
+
+- `Bytes48` is a 48-byte hexadecimal string, prefixed with `0x`.
+- `CellID` is an unsigned 64-bit integer.
+- `Cell` is a 2048-byte hexadecimal string, prefixed with `0x`.
+
+All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
+
+## Condition
+
+The `verify_cell_proof` handler should verify that `commitment` is a correct KZG commitment to `cell` by using the cell KZG proof `proof`, and the result should match the expected `output`. If the commitment or proof is invalid (e.g. not on the curve or not in the G1 subgroup of the BLS curve), `cell` is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element), or `cell_id` is invalid (e.g. greater than the number of cells for an extended blob), it should error, i.e. the output should be `null`.

--- a/tests/formats/kzg_7594/verify_cell_proof_batch.md
+++ b/tests/formats/kzg_7594/verify_cell_proof_batch.md
@@ -1,0 +1,28 @@
+# Test format: Verify cell proof batch
+
+Use the cell KZG `proofs` to verify that the KZG `row_commitments` for the given `cells` are correct.
+
+## Test case format
+
+The test data is declared in a `data.yaml` file:
+
+```yaml
+input:
+  row_commitments: List[Bytes48] -- the KZG commitments
+  row_indices: List[RowIndex] -- the commitment index for each cell
+  column_indices: List[ColumnIndex] -- the column index for each cell
+  cells: List[Cell] -- the cells
+  proofs: List[Bytes48] -- the KZG proof for each cell
+output: bool -- true (all proofs are correct) or false (some proofs incorrect)
+```
+
+- `Bytes48` is a 48-byte hexadecimal string, prefixed with `0x`.
+- `RowIndex` is an unsigned 64-bit integer.
+- `ColumnIndex` is an unsigned 64-bit integer.
+- `Cell` is a 2048-byte hexadecimal string, prefixed with `0x`.
+
+All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
+
+## Condition
+
+The `verify_cell_proof_batch` handler should verify that `row_commitments` are correct KZG commitments to `cells` by using the cell KZG proofs `proofs`, and the result should match the expected `output`. If any of the commitments or proofs are invalid (e.g. not on the curve or not in the G1 subgroup of the BLS curve), any cell is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element), or any `cell_id` is invalid (e.g. greater than the number of cells for an extended blob), it should error, i.e. the output should be `null`.


### PR DESCRIPTION
This PR adds test formats for EIP-7594 test vectors. See:

* https://github.com/ethereum/consensus-specs/pull/3693

Inspired by the KZG-4844 test formats.