### PR TITLE
EIP-7594: Replace "proofs" with "kzg_proofs" in function names

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -175,7 +175,7 @@ def get_data_column_sidecars(signed_block: SignedBeaconBlock,
         block.body,
         get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments'),
     )
-    cells_and_proofs = [compute_cells_and_proofs(blob) for blob in blobs]
+    cells_and_proofs = [compute_cells_and_kzg_proofs(blob) for blob in blobs]
     blob_count = len(blobs)
     cells = [cells_and_proofs[i][0] for i in range(blob_count)]
     proofs = [cells_and_proofs[i][1] for i in range(blob_count)]

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -74,7 +74,7 @@ def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
     row_ids = [RowIndex(i) for i in range(len(sidecar.column))]
 
     # KZG batch verifies that the cells match the corresponding commitments and proofs
-    return verify_cell_proof_batch(
+    return verify_cell_kzg_proof_batch(
         row_commitments=sidecar.kzg_commitments,
         row_indices=row_ids,  # all rows
         column_indices=[sidecar.index],

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -37,7 +37,7 @@
     - [`coset_for_cell`](#coset_for_cell)
 - [Cells](#cells-1)
   - [Cell computation](#cell-computation)
-    - [`compute_cells_and_proofs`](#compute_cells_and_proofs)
+    - [`compute_cells_and_kzg_proofs`](#compute_cells_and_kzg_proofs)
     - [`compute_cells`](#compute_cells)
   - [Cell verification](#cell-verification)
     - [`verify_cell_kzg_proof`](#verify_cell_kzg_proof)
@@ -419,10 +419,10 @@ def coset_for_cell(cell_id: CellID) -> Coset:
 
 ### Cell computation
 
-#### `compute_cells_and_proofs`
+#### `compute_cells_and_kzg_proofs`
 
 ```python
-def compute_cells_and_proofs(blob: Blob) -> Tuple[
+def compute_cells_and_kzg_proofs(blob: Blob) -> Tuple[
         Vector[Cell, CELLS_PER_EXT_BLOB],
         Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
     """

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -480,9 +480,9 @@ def compute_cells(blob: Blob) -> Vector[Cell, CELLS_PER_EXT_BLOB]:
 
 ```python
 def verify_cell_kzg_proof(commitment_bytes: Bytes48,
-                      cell_id: CellID,
-                      cell: Cell,
-                      proof_bytes: Bytes48) -> bool:
+                          cell_id: CellID,
+                          cell: Cell,
+                          proof_bytes: Bytes48) -> bool:
     """
     Check a cell proof
 
@@ -506,10 +506,10 @@ def verify_cell_kzg_proof(commitment_bytes: Bytes48,
 
 ```python
 def verify_cell_kzg_proof_batch(row_commitments_bytes: Sequence[Bytes48],
-                            row_indices: Sequence[RowIndex],
-                            column_indices: Sequence[ColumnIndex],
-                            cells: Sequence[Cell],
-                            proofs_bytes: Sequence[Bytes48]) -> bool:
+                                row_indices: Sequence[RowIndex],
+                                column_indices: Sequence[ColumnIndex],
+                                cells: Sequence[Cell],
+                                proofs_bytes: Sequence[Bytes48]) -> bool:
     """
     Verify a set of cells, given their corresponding proofs and their coordinates (row_id, column_id) in the blob
     matrix. The list of all commitments is also provided in row_commitments_bytes.

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -40,8 +40,8 @@
     - [`compute_cells_and_proofs`](#compute_cells_and_proofs)
     - [`compute_cells`](#compute_cells)
   - [Cell verification](#cell-verification)
-    - [`verify_cell_proof`](#verify_cell_proof)
-    - [`verify_cell_proof_batch`](#verify_cell_proof_batch)
+    - [`verify_cell_kzg_proof`](#verify_cell_kzg_proof)
+    - [`verify_cell_kzg_proof_batch`](#verify_cell_kzg_proof_batch)
 - [Reconstruction](#reconstruction)
   - [`construct_vanishing_polynomial`](#construct_vanishing_polynomial)
   - [`recover_shifted_data`](#recover_shifted_data)
@@ -476,10 +476,10 @@ def compute_cells(blob: Blob) -> Vector[Cell, CELLS_PER_EXT_BLOB]:
 
 ### Cell verification
 
-#### `verify_cell_proof`
+#### `verify_cell_kzg_proof`
 
 ```python
-def verify_cell_proof(commitment_bytes: Bytes48,
+def verify_cell_kzg_proof(commitment_bytes: Bytes48,
                       cell_id: CellID,
                       cell: Cell,
                       proof_bytes: Bytes48) -> bool:
@@ -502,10 +502,10 @@ def verify_cell_proof(commitment_bytes: Bytes48,
         bytes_to_kzg_proof(proof_bytes))
 ```
 
-#### `verify_cell_proof_batch`
+#### `verify_cell_kzg_proof_batch`
 
 ```python
-def verify_cell_proof_batch(row_commitments_bytes: Sequence[Bytes48],
+def verify_cell_kzg_proof_batch(row_commitments_bytes: Sequence[Bytes48],
                             row_indices: Sequence[RowIndex],
                             column_indices: Sequence[ColumnIndex],
                             cells: Sequence[Cell],

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -34,7 +34,7 @@ def test_fft(spec):
 def test_verify_cell_kzg_proof(spec):
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
-    cells, proofs = spec.compute_cells_and_proofs(blob)
+    cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
 
     cell_id = 0
     assert spec.verify_cell_kzg_proof(commitment, cell_id, cells[cell_id], proofs[cell_id])
@@ -48,7 +48,7 @@ def test_verify_cell_kzg_proof(spec):
 def test_verify_cell_kzg_proof_batch(spec):
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
-    cells, proofs = spec.compute_cells_and_proofs(blob)
+    cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
 
     assert len(cells) == len(proofs)
 

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -31,28 +31,28 @@ def test_fft(spec):
 @with_eip7594_and_later
 @spec_test
 @single_phase
-def test_verify_cell_proof(spec):
+def test_verify_cell_kzg_proof(spec):
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
     cells, proofs = spec.compute_cells_and_proofs(blob)
 
     cell_id = 0
-    assert spec.verify_cell_proof(commitment, cell_id, cells[cell_id], proofs[cell_id])
+    assert spec.verify_cell_kzg_proof(commitment, cell_id, cells[cell_id], proofs[cell_id])
     cell_id = 1
-    assert spec.verify_cell_proof(commitment, cell_id, cells[cell_id], proofs[cell_id])
+    assert spec.verify_cell_kzg_proof(commitment, cell_id, cells[cell_id], proofs[cell_id])
 
 
 @with_eip7594_and_later
 @spec_test
 @single_phase
-def test_verify_cell_proof_batch(spec):
+def test_verify_cell_kzg_proof_batch(spec):
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
     cells, proofs = spec.compute_cells_and_proofs(blob)
 
     assert len(cells) == len(proofs)
 
-    assert spec.verify_cell_proof_batch(
+    assert spec.verify_cell_kzg_proof_batch(
         row_commitments_bytes=[commitment],
         row_indices=[0, 0],
         column_indices=[0, 4],

--- a/tests/core/pyspec/eth2spec/test/utils/kzg_tests.py
+++ b/tests/core/pyspec/eth2spec/test/utils/kzg_tests.py
@@ -152,4 +152,4 @@ INVALID_INDIVIDUAL_CELL_BYTES = [CELL_ALL_MAX_VALUE, CELL_ONE_INVALID_FIELD, CEL
 
 # Cells & Proofs
 
-VALID_CELLS_AND_PROOFS = []  # Saved in case02_compute_cells_and_proofs
+VALID_CELLS_AND_PROOFS = []  # Saved in case02_compute_cells_and_kzg_proofs

--- a/tests/formats/kzg_7594/README.md
+++ b/tests/formats/kzg_7594/README.md
@@ -7,7 +7,7 @@ We do not recommend rolling your own crypto or using an untested KZG library.
 The KZG test suite runner has the following handlers:
 
 - [`compute_cells`](./compute_cells.md)
-- [`compute_cells_and_proofs`](./compute_cells_and_proofs.md)
+- [`compute_cells_and_kzg_proofs`](./compute_cells_and_kzg_proofs.md)
 - [`verify_cell_kzg_proof`](./verify_cell_kzg_proof.md)
 - [`verify_cell_kzg_proof_batch`](./verify_cell_kzg_proof_batch.md)
 - [`recover_all_cells`](./recover_all_cells.md)

--- a/tests/formats/kzg_7594/README.md
+++ b/tests/formats/kzg_7594/README.md
@@ -8,6 +8,6 @@ The KZG test suite runner has the following handlers:
 
 - [`compute_cells`](./compute_cells.md)
 - [`compute_cells_and_proofs`](./compute_cells_and_proofs.md)
-- [`verify_cell_proof`](./verify_cell_proof.md)
-- [`verify_cell_proof_batch`](./verify_cell_proof_batch.md)
+- [`verify_cell_kzg_proof`](./verify_cell_kzg_proof.md)
+- [`verify_cell_kzg_proof_batch`](./verify_cell_kzg_proof_batch.md)
 - [`recover_all_cells`](./recover_all_cells.md)

--- a/tests/formats/kzg_7594/compute_cells_and_kzg_proofs.md
+++ b/tests/formats/kzg_7594/compute_cells_and_kzg_proofs.md
@@ -1,4 +1,4 @@
-# Test format: Compute cells and proofs
+# Test format: Compute cells and KZG proofs
 
 Compute the cells and cell KZG proofs for a given `blob`.
 
@@ -20,4 +20,4 @@ All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `
 
 ## Condition
 
-The `compute_cells_and_proofs` handler should compute the cells (chunks of an extended blob) and cell KZG proofs for `blob`, and the result should match the expected `output`. If the blob is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element) it should error, i.e. the output should be `null`.
+The `compute_cells_and_kzg_proofs` handler should compute the cells (chunks of an extended blob) and cell KZG proofs for `blob`, and the result should match the expected `output`. If the blob is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element) it should error, i.e. the output should be `null`.

--- a/tests/formats/kzg_7594/verify_cell_kzg_proof.md
+++ b/tests/formats/kzg_7594/verify_cell_kzg_proof.md
@@ -1,4 +1,4 @@
-# Test format: Verify cell proof
+# Test format: Verify cell KZG proof
 
 Use the cell KZG `proof` to verify that the KZG `commitment` for a given `cell` is correct.
 
@@ -23,4 +23,4 @@ All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `
 
 ## Condition
 
-The `verify_cell_proof` handler should verify that `commitment` is a correct KZG commitment to `cell` by using the cell KZG proof `proof`, and the result should match the expected `output`. If the commitment or proof is invalid (e.g. not on the curve or not in the G1 subgroup of the BLS curve), `cell` is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element), or `cell_id` is invalid (e.g. greater than the number of cells for an extended blob), it should error, i.e. the output should be `null`.
+The `verify_cell_kzg_proof` handler should verify that `commitment` is a correct KZG commitment to `cell` by using the cell KZG proof `proof`, and the result should match the expected `output`. If the commitment or proof is invalid (e.g. not on the curve or not in the G1 subgroup of the BLS curve), `cell` is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element), or `cell_id` is invalid (e.g. greater than the number of cells for an extended blob), it should error, i.e. the output should be `null`.

--- a/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md
+++ b/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md
@@ -1,4 +1,4 @@
-# Test format: Verify cell proof batch
+# Test format: Verify cell KZG proof batch
 
 Use the cell KZG `proofs` to verify that the KZG `row_commitments` for the given `cells` are correct.
 
@@ -25,4 +25,4 @@ All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `
 
 ## Condition
 
-The `verify_cell_proof_batch` handler should verify that `row_commitments` are correct KZG commitments to `cells` by using the cell KZG proofs `proofs`, and the result should match the expected `output`. If any of the commitments or proofs are invalid (e.g. not on the curve or not in the G1 subgroup of the BLS curve), any cell is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element), or any `cell_id` is invalid (e.g. greater than the number of cells for an extended blob), it should error, i.e. the output should be `null`.
+The `verify_cell_kzg_proof_batch` handler should verify that `row_commitments` are correct KZG commitments to `cells` by using the cell KZG proofs `proofs`, and the result should match the expected `output`. If any of the commitments or proofs are invalid (e.g. not on the curve or not in the G1 subgroup of the BLS curve), any cell is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element), or any `cell_id` is invalid (e.g. greater than the number of cells for an extended blob), it should error, i.e. the output should be `null`.

--- a/tests/generators/kzg_7594/main.py
+++ b/tests/generators/kzg_7594/main.py
@@ -90,10 +90,10 @@ def case02_compute_cells_and_proofs():
 
 
 ###############################################################################
-# Test cases for verify_cell_proof
+# Test cases for verify_cell_kzg_proof
 ###############################################################################
 
-def case03_verify_cell_proof():
+def case03_verify_cell_kzg_proof():
     # Valid cases
     for i in range(len(VALID_BLOBS)):
         cells, proofs = VALID_CELLS_AND_PROOFS[i]
@@ -101,9 +101,9 @@ def case03_verify_cell_proof():
         cell_id = (2 ** i - 1) % spec.CELLS_PER_EXT_BLOB
         cell = cells[cell_id]
         proof = proofs[cell_id]
-        assert spec.verify_cell_proof(commitment, cell_id, cell, proof)
+        assert spec.verify_cell_kzg_proof(commitment, cell_id, cell, proof)
         identifier = make_id(commitment, cell_id, cell, proof)
-        yield f'verify_cell_proof_case_valid_{identifier}', {
+        yield f'verify_cell_kzg_proof_case_valid_{identifier}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'cell_id': cell_id,
@@ -120,9 +120,9 @@ def case03_verify_cell_proof():
         cell_id = 99 % spec.CELLS_PER_EXT_BLOB
         cell = cells[cell_id]
         proof = proofs[cell_id]
-        assert not spec.verify_cell_proof(commitment, cell_id, cell, proof)
+        assert not spec.verify_cell_kzg_proof(commitment, cell_id, cell, proof)
         identifier = make_id(commitment, cell_id, cell, proof)
-        yield f'verify_cell_proof_case_incorrect_commitment_{identifier}', {
+        yield f'verify_cell_kzg_proof_case_incorrect_commitment_{identifier}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'cell_id': cell_id,
@@ -139,9 +139,9 @@ def case03_verify_cell_proof():
         cells, proofs = VALID_CELLS_AND_PROOFS[i]
         cell = VALID_INDIVIDUAL_RANDOM_CELL_BYTES[i]
         proof = proofs[cell_id]
-        assert not spec.verify_cell_proof(commitment, cell_id, cell, proof)
+        assert not spec.verify_cell_kzg_proof(commitment, cell_id, cell, proof)
         identifier = make_id(commitment, cell_id, cell, proof)
-        yield f'verify_cell_proof_case_incorrect_cell_{identifier}', {
+        yield f'verify_cell_kzg_proof_case_incorrect_cell_{identifier}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'cell_id': cell_id,
@@ -158,9 +158,9 @@ def case03_verify_cell_proof():
         cells, proofs = VALID_CELLS_AND_PROOFS[i]
         cell = cells[cell_id]
         proof = bls_add_one(proofs[cell_id])
-        assert not spec.verify_cell_proof(commitment, cell_id, cell, proof)
+        assert not spec.verify_cell_kzg_proof(commitment, cell_id, cell, proof)
         identifier = make_id(commitment, cell_id, cell, proof)
-        yield f'verify_cell_proof_case_incorrect_proof_{identifier}', {
+        yield f'verify_cell_kzg_proof_case_incorrect_proof_{identifier}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'cell_id': cell_id,
@@ -176,9 +176,9 @@ def case03_verify_cell_proof():
         cell_id = 81 % spec.CELLS_PER_EXT_BLOB
         cell = cells[cell_id]
         proof = proofs[cell_id]
-        expect_exception(spec.verify_cell_proof, commitment, cell_id, cell, proof)
+        expect_exception(spec.verify_cell_kzg_proof, commitment, cell_id, cell, proof)
         identifier = make_id(commitment, cell_id, cell, proof)
-        yield f'verify_cell_proof_case_invalid_commitment_{identifier}', {
+        yield f'verify_cell_kzg_proof_case_invalid_commitment_{identifier}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'cell_id': cell_id,
@@ -194,9 +194,9 @@ def case03_verify_cell_proof():
         commitment = VALID_COMMITMENTS[1]
         cell = cells[0]
         proof = proofs[0]
-        expect_exception(spec.verify_cell_proof, commitment, cell_id, cell, proof)
+        expect_exception(spec.verify_cell_kzg_proof, commitment, cell_id, cell, proof)
         identifier = make_id(commitment, cell_id, cell, proof)
-        yield f'verify_cell_proof_case_invalid_cell_id_{identifier}', {
+        yield f'verify_cell_kzg_proof_case_invalid_cell_id_{identifier}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'cell_id': cell_id,
@@ -212,9 +212,9 @@ def case03_verify_cell_proof():
         commitment = VALID_COMMITMENTS[2]
         cells, proofs = VALID_CELLS_AND_PROOFS[2]
         proof = proofs[cell_id]
-        expect_exception(spec.verify_cell_proof, commitment, cell_id, cell, proof)
+        expect_exception(spec.verify_cell_kzg_proof, commitment, cell_id, cell, proof)
         identifier = make_id(commitment, cell_id, cell, proof)
-        yield f'verify_cell_proof_case_invalid_cell_{identifier}', {
+        yield f'verify_cell_kzg_proof_case_invalid_cell_{identifier}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'cell_id': cell_id,
@@ -230,9 +230,9 @@ def case03_verify_cell_proof():
         commitment = VALID_COMMITMENTS[3]
         cell_id = 36 % spec.CELLS_PER_EXT_BLOB
         cell = cells[cell_id]
-        expect_exception(spec.verify_cell_proof, commitment, cell_id, cell, proof)
+        expect_exception(spec.verify_cell_kzg_proof, commitment, cell_id, cell, proof)
         identifier = make_id(commitment, cell_id, cell, proof)
-        yield f'verify_cell_proof_case_invalid_proof_{identifier}', {
+        yield f'verify_cell_kzg_proof_case_invalid_proof_{identifier}', {
             'input': {
                 'commitment': encode_hex(commitment),
                 'cell_id': cell_id,
@@ -244,19 +244,19 @@ def case03_verify_cell_proof():
 
 
 ###############################################################################
-# Test cases for verify_cell_proof_batch
+# Test cases for verify_cell_kzg_proof_batch
 ###############################################################################
 
-def case04_verify_cell_proof_batch():
+def case04_verify_cell_kzg_proof_batch():
     # Valid cases
     for i in range(len(VALID_BLOBS)):
         cells, proofs = VALID_CELLS_AND_PROOFS[i]
         row_commitments = [VALID_COMMITMENTS[i]]
         row_indices = [0] * spec.CELLS_PER_EXT_BLOB
         column_indices = list(range(spec.CELLS_PER_EXT_BLOB))
-        assert spec.verify_cell_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
+        assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
         identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_proof_batch_case_valid_{identifier}', {
+        yield f'verify_cell_kzg_proof_batch_case_valid_{identifier}', {
             'input': {
                 'row_commitments': encode_hex_list(row_commitments),
                 'row_indices': row_indices,
@@ -269,9 +269,9 @@ def case04_verify_cell_proof_batch():
 
     # Valid: zero cells
     cells, row_commitments, row_indices, column_indices, proofs = [], [], [], [], []
-    assert spec.verify_cell_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
+    assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
     identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_proof_batch_case_valid_zero_cells_{identifier}', {
+    yield f'verify_cell_kzg_proof_batch_case_valid_zero_cells_{identifier}', {
         'input': {
             'row_commitments': encode_hex_list(row_commitments),
             'row_indices': row_indices,
@@ -290,9 +290,9 @@ def case04_verify_cell_proof_batch():
     column_indices = [0, 0]
     cells = [cells0[0], cells1[0]]
     proofs = [proofs0[0], proofs1[0]]
-    assert spec.verify_cell_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
+    assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
     identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_proof_batch_case_valid_multiple_blobs_{identifier}', {
+    yield f'verify_cell_kzg_proof_batch_case_valid_multiple_blobs_{identifier}', {
         'input': {
             'row_commitments': encode_hex_list(row_commitments),
             'row_indices': row_indices,
@@ -310,9 +310,9 @@ def case04_verify_cell_proof_batch():
     row_commitments = VALID_COMMITMENTS
     row_indices = [2] * len(cells)
     column_indices = list(range(len(cells)))
-    assert spec.verify_cell_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
+    assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
     identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_proof_batch_case_valid_unused_row_commitments_{identifier}', {
+    yield f'verify_cell_kzg_proof_batch_case_valid_unused_row_commitments_{identifier}', {
         'input': {
             'row_commitments': encode_hex_list(row_commitments),
             'row_indices': row_indices,
@@ -330,9 +330,9 @@ def case04_verify_cell_proof_batch():
     column_indices = [0] * num_duplicates
     cells = [VALID_CELLS_AND_PROOFS[3][0][0]] * num_duplicates
     proofs = [VALID_CELLS_AND_PROOFS[3][1][0]] * num_duplicates
-    assert spec.verify_cell_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
+    assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
     identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_proof_batch_case_valid_same_cell_multiple_times_{identifier}', {
+    yield f'verify_cell_kzg_proof_batch_case_valid_same_cell_multiple_times_{identifier}', {
         'input': {
             'row_commitments': encode_hex_list(row_commitments),
             'row_indices': row_indices,
@@ -350,9 +350,9 @@ def case04_verify_cell_proof_batch():
     row_commitments = [bls_add_one(VALID_COMMITMENTS[5])]
     row_indices = [0] * len(cells)
     column_indices = list(range(len(cells)))
-    assert not spec.verify_cell_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
+    assert not spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
     identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_proof_batch_case_incorrect_row_commitment_{identifier}', {
+    yield f'verify_cell_kzg_proof_batch_case_incorrect_row_commitment_{identifier}', {
         'input': {
             'row_commitments': encode_hex_list(row_commitments),
             'row_indices': row_indices,
@@ -371,9 +371,9 @@ def case04_verify_cell_proof_batch():
     column_indices = list(range(len(cells)))
     # Change last cell so it's wrong
     cells[-1] = CELL_RANDOM_VALID2
-    assert not spec.verify_cell_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
+    assert not spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
     identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_proof_batch_case_incorrect_cell_{identifier}', {
+    yield f'verify_cell_kzg_proof_batch_case_incorrect_cell_{identifier}', {
         'input': {
             'row_commitments': encode_hex_list(row_commitments),
             'row_indices': row_indices,
@@ -392,9 +392,9 @@ def case04_verify_cell_proof_batch():
     column_indices = list(range(len(cells)))
     # Change last proof so it's wrong
     proofs[-1] = bls_add_one(proofs[-1])
-    assert not spec.verify_cell_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
+    assert not spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
     identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_proof_batch_case_incorrect_proof_{identifier}', {
+    yield f'verify_cell_kzg_proof_batch_case_incorrect_proof_{identifier}', {
         'input': {
             'row_commitments': encode_hex_list(row_commitments),
             'row_indices': row_indices,
@@ -413,9 +413,9 @@ def case04_verify_cell_proof_batch():
         row_commitments = [commitment]
         row_indices = [0] * len(cells)
         column_indices = list(range(len(cells)))
-        expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
         identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_proof_batch_case_invalid_row_commitment_{identifier}', {
+        yield f'verify_cell_kzg_proof_batch_case_invalid_row_commitment_{identifier}', {
             'input': {
                 'row_commitments': encode_hex_list(row_commitments),
                 'row_indices': row_indices,
@@ -434,9 +434,9 @@ def case04_verify_cell_proof_batch():
     # Set first row index to an invalid value
     row_indices[0] = 1
     column_indices = list(range(len(cells)))
-    expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+    expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
     identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_proof_batch_case_invalid_row_index_{identifier}', {
+    yield f'verify_cell_kzg_proof_batch_case_invalid_row_index_{identifier}', {
         'input': {
             'row_commitments': encode_hex_list(row_commitments),
             'row_indices': row_indices,
@@ -455,9 +455,9 @@ def case04_verify_cell_proof_batch():
     column_indices = list(range(len(cells)))
     # Set first column index to an invalid value
     column_indices[0] = spec.CELLS_PER_EXT_BLOB
-    expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+    expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
     identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_proof_batch_case_invalid_column_index_{identifier}', {
+    yield f'verify_cell_kzg_proof_batch_case_invalid_column_index_{identifier}', {
         'input': {
             'row_commitments': encode_hex_list(row_commitments),
             'row_indices': row_indices,
@@ -477,9 +477,9 @@ def case04_verify_cell_proof_batch():
         column_indices = list(range(len(cells)))
         # Set first cell to the invalid cell
         cells[0] = cell
-        expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
         identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_proof_batch_case_invalid_cell_{identifier}', {
+        yield f'verify_cell_kzg_proof_batch_case_invalid_cell_{identifier}', {
             'input': {
                 'row_commitments': encode_hex_list(row_commitments),
                 'row_indices': row_indices,
@@ -499,9 +499,9 @@ def case04_verify_cell_proof_batch():
         column_indices = list(range(len(cells)))
         # Set first proof to the invalid proof
         proofs[0] = proof
-        expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
         identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_proof_batch_case_invalid_proof_{identifier}', {
+        yield f'verify_cell_kzg_proof_batch_case_invalid_proof_{identifier}', {
             'input': {
                 'row_commitments': encode_hex_list(row_commitments),
                 'row_indices': row_indices,
@@ -519,9 +519,9 @@ def case04_verify_cell_proof_batch():
         row_commitments = []
         row_indices = [0] * len(cells)
         column_indices = list(range(len(cells)))
-        expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
         identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_proof_batch_case_invalid_missing_row_commitment_{identifier}', {
+        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_row_commitment_{identifier}', {
             'input': {
                 'row_commitments': encode_hex_list(row_commitments),
                 'row_indices': row_indices,
@@ -539,9 +539,9 @@ def case04_verify_cell_proof_batch():
         # Leave off one of the row indices
         row_indices = [0] * (len(cells) - 1)
         column_indices = list(range(len(cells)))
-        expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
         identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_proof_batch_case_invalid_missing_row_index_{identifier}', {
+        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_row_index_{identifier}', {
             'input': {
                 'row_commitments': encode_hex_list(row_commitments),
                 'row_indices': row_indices,
@@ -559,9 +559,9 @@ def case04_verify_cell_proof_batch():
         row_indices = [0] * len(cells)
         # Leave off one of the column indices
         column_indices = list(range(len(cells) - 1))
-        expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
         identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_proof_batch_case_invalid_missing_column_index_{identifier}', {
+        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_column_index_{identifier}', {
             'input': {
                 'row_commitments': encode_hex_list(row_commitments),
                 'row_indices': row_indices,
@@ -580,9 +580,9 @@ def case04_verify_cell_proof_batch():
         column_indices = list(range(len(cells)))
         # Remove the last proof
         cells = cells[:-1]
-        expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
         identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_proof_batch_case_invalid_missing_cell_{identifier}', {
+        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_cell_{identifier}', {
             'input': {
                 'row_commitments': encode_hex_list(row_commitments),
                 'row_indices': row_indices,
@@ -601,9 +601,9 @@ def case04_verify_cell_proof_batch():
         column_indices = list(range(len(cells)))
         # Remove the last proof
         proofs = proofs[:-1]
-        expect_exception(spec.verify_cell_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
         identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_proof_batch_case_invalid_missing_proof_{identifier}', {
+        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_proof_{identifier}', {
             'input': {
                 'row_commitments': encode_hex_list(row_commitments),
                 'row_indices': row_indices,
@@ -831,7 +831,7 @@ if __name__ == "__main__":
         # EIP-7594
         create_provider(EIP7594, 'compute_cells', case01_compute_cells),
         create_provider(EIP7594, 'compute_cells_and_proofs', case02_compute_cells_and_proofs),
-        create_provider(EIP7594, 'verify_cell_proof', case03_verify_cell_proof),
-        create_provider(EIP7594, 'verify_cell_proof_batch', case04_verify_cell_proof_batch),
+        create_provider(EIP7594, 'verify_cell_kzg_proof', case03_verify_cell_kzg_proof),
+        create_provider(EIP7594, 'verify_cell_kzg_proof_batch', case04_verify_cell_kzg_proof_batch),
         create_provider(EIP7594, 'recover_all_cells', case05_recover_all_cells),
     ])

--- a/tests/generators/kzg_7594/main.py
+++ b/tests/generators/kzg_7594/main.py
@@ -60,17 +60,17 @@ def case01_compute_cells():
 
 
 ###############################################################################
-# Test cases for compute_cells_and_proofs
+# Test cases for compute_cells_and_kzg_proofs
 ###############################################################################
 
-def case02_compute_cells_and_proofs():
+def case02_compute_cells_and_kzg_proofs():
     # Valid cases
     for blob in VALID_BLOBS:
-        cells, proofs = spec.compute_cells_and_proofs(blob)
+        cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
         # Save cells & proofs here to save on time.
         VALID_CELLS_AND_PROOFS.append((cells, proofs))
         identifier = make_id(blob)
-        yield f'compute_cells_and_proofs_case_valid_{identifier}', {
+        yield f'compute_cells_and_kzg_proofs_case_valid_{identifier}', {
             'input': {
                 'blob': encode_hex(blob),
             },
@@ -79,9 +79,9 @@ def case02_compute_cells_and_proofs():
 
     # Edge case: Invalid blobs
     for blob in INVALID_BLOBS:
-        expect_exception(spec.compute_cells_and_proofs, blob)
+        expect_exception(spec.compute_cells_and_kzg_proofs, blob)
         identifier = make_id(blob)
-        yield f'compute_cells_and_proofs_case_invalid_blob_{identifier}', {
+        yield f'compute_cells_and_kzg_proofs_case_invalid_blob_{identifier}', {
             'input': {
                 'blob': encode_hex(blob)
             },
@@ -830,7 +830,7 @@ if __name__ == "__main__":
     gen_runner.run_generator("kzg_7594", [
         # EIP-7594
         create_provider(EIP7594, 'compute_cells', case01_compute_cells),
-        create_provider(EIP7594, 'compute_cells_and_proofs', case02_compute_cells_and_proofs),
+        create_provider(EIP7594, 'compute_cells_and_kzg_proofs', case02_compute_cells_and_kzg_proofs),
         create_provider(EIP7594, 'verify_cell_kzg_proof', case03_verify_cell_kzg_proof),
         create_provider(EIP7594, 'verify_cell_kzg_proof_batch', case04_verify_cell_kzg_proof_batch),
         create_provider(EIP7594, 'recover_all_cells', case05_recover_all_cells),


### PR DESCRIPTION
We should rename these for consistency with the EIP-4844 functions, e.g.:
* `compute_kzg_proof`
* `verify_blob_kzg_proof`
* `verify_blob_kzg_proof_batch`