### PR TITLE
Fix rng of tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -324,7 +324,7 @@ def test_zero_length_transaction_regular_payload(spec, state):
     yield from run_zero_length_transaction_test(spec, state)
 
 
-def run_randomized_non_validated_execution_fields_test(spec, state, execution_valid=True, rng=Random(5555)):
+def run_randomized_non_validated_execution_fields_test(spec, state, rng, execution_valid=True):
     next_slot(spec, state)
     execution_payload = build_randomized_execution_payload(spec, state, rng)
 
@@ -340,7 +340,7 @@ def run_randomized_non_validated_execution_fields_test(spec, state, execution_va
 def test_randomized_non_validated_execution_fields_first_payload__execution_valid(spec, state):
     rng = Random(1111)
     state = build_state_with_incomplete_transition(spec, state)
-    yield from run_randomized_non_validated_execution_fields_test(spec, state, rng=rng)
+    yield from run_randomized_non_validated_execution_fields_test(spec, state, rng)
 
 
 @with_bellatrix_and_later
@@ -348,7 +348,7 @@ def test_randomized_non_validated_execution_fields_first_payload__execution_vali
 def test_randomized_non_validated_execution_fields_regular_payload__execution_valid(spec, state):
     rng = Random(2222)
     state = build_state_with_complete_transition(spec, state)
-    yield from run_randomized_non_validated_execution_fields_test(spec, state, rng=rng)
+    yield from run_randomized_non_validated_execution_fields_test(spec, state, rng)
 
 
 @with_bellatrix_and_later
@@ -356,7 +356,7 @@ def test_randomized_non_validated_execution_fields_regular_payload__execution_va
 def test_invalid_randomized_non_validated_execution_fields_first_payload__execution_invalid(spec, state):
     rng = Random(3333)
     state = build_state_with_incomplete_transition(spec, state)
-    yield from run_randomized_non_validated_execution_fields_test(spec, state, execution_valid=False, rng=rng)
+    yield from run_randomized_non_validated_execution_fields_test(spec, state, rng, execution_valid=False)
 
 
 @with_bellatrix_and_later
@@ -364,4 +364,4 @@ def test_invalid_randomized_non_validated_execution_fields_first_payload__execut
 def test_invalid_randomized_non_validated_execution_fields_regular_payload__execution_invalid(spec, state):
     rng = Random(4444)
     state = build_state_with_complete_transition(spec, state)
-    yield from run_randomized_non_validated_execution_fields_test(spec, state, execution_valid=False, rng=rng)
+    yield from run_randomized_non_validated_execution_fields_test(spec, state, rng, execution_valid=False)

--- a/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_withdrawals.py
@@ -113,7 +113,7 @@ def test_success_zero_expected_withdrawals(spec, state):
 @spec_state_test
 def test_success_one_full_withdrawal(spec, state):
     fully_withdrawable_indices, partial_withdrawals_indices = prepare_expected_withdrawals(
-        spec, state, num_full_withdrawals=1)
+        spec, state, rng=random.Random(42), num_full_withdrawals=1)
     assert len(fully_withdrawable_indices) == 1
     assert len(partial_withdrawals_indices) == 0
 
@@ -130,7 +130,7 @@ def test_success_one_full_withdrawal(spec, state):
 @spec_state_test
 def test_success_one_partial_withdrawal(spec, state):
     fully_withdrawable_indices, partial_withdrawals_indices = prepare_expected_withdrawals(
-        spec, state, num_partial_withdrawals=1)
+        spec, state, rng=random.Random(42), num_partial_withdrawals=1)
     assert len(fully_withdrawable_indices) == 0
     assert len(partial_withdrawals_indices) == 1
     for index in partial_withdrawals_indices:
@@ -153,6 +153,7 @@ def test_success_mixed_fully_and_partial_withdrawable(spec, state):
     num_partial_withdrawals = spec.MAX_WITHDRAWALS_PER_PAYLOAD - num_full_withdrawals
     fully_withdrawable_indices, partial_withdrawals_indices = prepare_expected_withdrawals(
         spec, state,
+        rng=random.Random(42),
         num_full_withdrawals=num_full_withdrawals,
         num_partial_withdrawals=num_partial_withdrawals,
     )
@@ -174,7 +175,7 @@ def test_success_all_fully_withdrawable_in_one_sweep(spec, state):
 
     withdrawal_count = len(state.validators)
     fully_withdrawable_indices, partial_withdrawals_indices = prepare_expected_withdrawals(
-        spec, state, num_full_withdrawals=withdrawal_count)
+        spec, state, rng=random.Random(42), num_full_withdrawals=withdrawal_count)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -193,7 +194,7 @@ def test_success_all_fully_withdrawable(spec, state):
 
     withdrawal_count = spec.MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
     fully_withdrawable_indices, partial_withdrawals_indices = prepare_expected_withdrawals(
-        spec, state, num_full_withdrawals=withdrawal_count)
+        spec, state, rng=random.Random(42), num_full_withdrawals=withdrawal_count)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -212,7 +213,7 @@ def test_success_all_partially_withdrawable_in_one_sweep(spec, state):
 
     withdrawal_count = len(state.validators)
     fully_withdrawable_indices, partial_withdrawals_indices = prepare_expected_withdrawals(
-        spec, state, num_partial_withdrawals=withdrawal_count)
+        spec, state, rng=random.Random(42), num_partial_withdrawals=withdrawal_count)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -231,7 +232,7 @@ def test_success_all_partially_withdrawable(spec, state):
 
     withdrawal_count = spec.MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
     fully_withdrawable_indices, partial_withdrawals_indices = prepare_expected_withdrawals(
-        spec, state, num_partial_withdrawals=withdrawal_count)
+        spec, state, rng=random.Random(42), num_partial_withdrawals=withdrawal_count)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -266,7 +267,7 @@ def test_invalid_non_withdrawable_non_empty_withdrawals(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_one_expected_full_withdrawal_and_none_in_withdrawals(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=1)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42), num_full_withdrawals=1)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -279,7 +280,7 @@ def test_invalid_one_expected_full_withdrawal_and_none_in_withdrawals(spec, stat
 @with_capella_and_later
 @spec_state_test
 def test_invalid_one_expected_partial_withdrawal_and_none_in_withdrawals(spec, state):
-    prepare_expected_withdrawals(spec, state, num_partial_withdrawals=1)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42), num_partial_withdrawals=1)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -292,7 +293,7 @@ def test_invalid_one_expected_partial_withdrawal_and_none_in_withdrawals(spec, s
 @with_capella_and_later
 @spec_state_test
 def test_invalid_one_expected_full_withdrawal_and_duplicate_in_withdrawals(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=2)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42), num_full_withdrawals=2)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -305,7 +306,7 @@ def test_invalid_one_expected_full_withdrawal_and_duplicate_in_withdrawals(spec,
 @with_capella_and_later
 @spec_state_test
 def test_invalid_two_expected_partial_withdrawal_and_duplicate_in_withdrawals(spec, state):
-    prepare_expected_withdrawals(spec, state, num_partial_withdrawals=2)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42), num_partial_withdrawals=2)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -318,7 +319,8 @@ def test_invalid_two_expected_partial_withdrawal_and_duplicate_in_withdrawals(sp
 @with_capella_and_later
 @spec_state_test
 def test_invalid_max_per_slot_full_withdrawals_and_one_less_in_withdrawals(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -331,7 +333,8 @@ def test_invalid_max_per_slot_full_withdrawals_and_one_less_in_withdrawals(spec,
 @with_capella_and_later
 @spec_state_test
 def test_invalid_max_per_slot_partial_withdrawals_and_one_less_in_withdrawals(spec, state):
-    prepare_expected_withdrawals(spec, state, num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -344,7 +347,8 @@ def test_invalid_max_per_slot_partial_withdrawals_and_one_less_in_withdrawals(sp
 @with_capella_and_later
 @spec_state_test
 def test_invalid_a_lot_fully_withdrawable_too_few_in_withdrawals(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -357,7 +361,8 @@ def test_invalid_a_lot_fully_withdrawable_too_few_in_withdrawals(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_a_lot_partially_withdrawable_too_few_in_withdrawals(spec, state):
-    prepare_expected_withdrawals(spec, state, num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -370,7 +375,8 @@ def test_invalid_a_lot_partially_withdrawable_too_few_in_withdrawals(spec, state
 @with_capella_and_later
 @spec_state_test
 def test_invalid_a_lot_mixed_withdrawable_in_queue_too_few_in_withdrawals(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD,
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD,
                                  num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD)
 
     next_slot(spec, state)
@@ -388,7 +394,8 @@ def test_invalid_a_lot_mixed_withdrawable_in_queue_too_few_in_withdrawals(spec, 
 @with_capella_and_later
 @spec_state_test
 def test_invalid_incorrect_withdrawal_index(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=1)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_full_withdrawals=1)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -401,7 +408,8 @@ def test_invalid_incorrect_withdrawal_index(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_incorrect_address_full(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=1)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_full_withdrawals=1)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -414,7 +422,8 @@ def test_invalid_incorrect_address_full(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_incorrect_address_partial(spec, state):
-    prepare_expected_withdrawals(spec, state, num_partial_withdrawals=1)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_partial_withdrawals=1)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -427,7 +436,7 @@ def test_invalid_incorrect_address_partial(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_incorrect_amount_full(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=1)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42), num_full_withdrawals=1)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -440,7 +449,7 @@ def test_invalid_incorrect_amount_full(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_incorrect_amount_partial(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=1)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42), num_full_withdrawals=1)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -453,7 +462,8 @@ def test_invalid_incorrect_amount_partial(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_one_of_many_incorrectly_full(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -472,7 +482,8 @@ def test_invalid_one_of_many_incorrectly_full(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_one_of_many_incorrectly_partial(spec, state):
-    prepare_expected_withdrawals(spec, state, num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -491,7 +502,8 @@ def test_invalid_one_of_many_incorrectly_partial(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_many_incorrectly_full(spec, state):
-    prepare_expected_withdrawals(spec, state, num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -510,7 +522,8 @@ def test_invalid_many_incorrectly_full(spec, state):
 @with_capella_and_later
 @spec_state_test
 def test_invalid_many_incorrectly_partial(spec, state):
-    prepare_expected_withdrawals(spec, state, num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
+    prepare_expected_withdrawals(spec, state, rng=random.Random(42),
+                                 num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 4)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)

--- a/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
@@ -1,3 +1,4 @@
+import random
 from eth2spec.test.helpers.constants import MINIMAL
 from eth2spec.test.helpers.forks import is_post_electra
 from eth2spec.test.context import (
@@ -268,7 +269,8 @@ def test_many_partial_withdrawals_in_epoch_transition(spec, state):
 
 def _perform_valid_withdrawal(spec, state):
     fully_withdrawable_indices, partial_withdrawals_indices = prepare_expected_withdrawals(
-        spec, state, num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 2,
+        spec, state, rng=random.Random(42),
+        num_partial_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 2,
         num_full_withdrawals=spec.MAX_WITHDRAWALS_PER_PAYLOAD * 2)
 
     next_slot(spec, state)

--- a/tests/core/pyspec/eth2spec/test/helpers/withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/withdrawals.py
@@ -1,4 +1,3 @@
-import random
 from eth2spec.test.helpers.forks import is_post_electra
 
 
@@ -48,8 +47,8 @@ def set_validator_partially_withdrawable(spec, state, index, excess_balance=1000
     assert spec.is_partially_withdrawable_validator(validator, state.balances[index])
 
 
-def prepare_expected_withdrawals(spec, state,
-                                 num_full_withdrawals=0, num_partial_withdrawals=0, rng=random.Random(5566)):
+def prepare_expected_withdrawals(spec, state, rng,
+                                 num_full_withdrawals=0, num_partial_withdrawals=0):
     bound = min(len(state.validators), spec.MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
     assert num_full_withdrawals + num_partial_withdrawals <= bound
     eligible_validator_indices = list(range(bound))


### PR DESCRIPTION
The `rng` should be initialized per test for parallel execution.