### PR TITLE
chore: try remove usage of add_polynomialcoeff from multiplication procedure

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -232,8 +232,9 @@ def multiply_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> Polynomi
 
     for i, a_coeff in enumerate(a):
         for j, b_coeff in enumerate(b):
-            r[i + j] += (a_coeff * b_coeff) % BLS_MODULUS
-
+            r[i + j] += a_coeff * b_coeff
+            r[i + j] = r[i + j] % BLS_MODULUS
+ 
     return PolynomialCoeff(r)
 ```
 

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -228,11 +228,13 @@ def multiply_polynomialcoeff(a: PolynomialCoeff, b: PolynomialCoeff) -> Polynomi
     """
     assert len(a) + len(b) <= FIELD_ELEMENTS_PER_EXT_BLOB
 
-    r = [0]
-    for power, coef in enumerate(a):
-        summand = [0] * power + [int(coef) * int(x) % BLS_MODULUS for x in b]
-        r = add_polynomialcoeff(r, summand)
-    return r
+    r = [0] * (len(a) + len(b) - 1)
+
+    for i, a_coeff in enumerate(a):
+        for j, b_coeff in enumerate(b):
+            r[i + j] += (a_coeff * b_coeff) % BLS_MODULUS
+
+    return PolynomialCoeff(r)
 ```
 
 #### `divide_polynomialcoeff`


### PR DESCRIPTION
This removes the usage of `add_polynomialcoeff`  in `multiply_polynomial_coeff` in addition to removing the zero-padding in the loop.

This is currently an experiment to evaluate the effect on CI.