### PR TITLE
Add decorator to all "invalid" test cases

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_consolidation.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_consolidation.py
@@ -1,6 +1,5 @@
 from eth2spec.test.helpers.constants import MINIMAL
 from eth2spec.test.context import (
-    spec_state_test,
     with_electra_and_later,
     with_presets,
     always_bls,
@@ -407,7 +406,13 @@ def test_consolidation_balance_through_two_churn_epochs(spec, state):
 # Failing tests
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_source_equals_target(spec, state):
     current_epoch = spec.get_current_epoch(state)
     validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
@@ -433,7 +438,13 @@ def test_invalid_source_equals_target(spec, state):
 
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_exceed_pending_consolidations_limit(spec, state):
     state.pending_consolidations = [
         spec.PendingConsolidation(source_index=0, target_index=1)
@@ -457,7 +468,13 @@ def test_invalid_exceed_pending_consolidations_limit(spec, state):
 
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_not_enough_consolidation_churn_available(spec, state):
     state.validators = state.validators[0:2]
     state.pending_consolidations = [
@@ -482,7 +499,13 @@ def test_invalid_not_enough_consolidation_churn_available(spec, state):
 
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_exited_source(spec, state):
     current_epoch = spec.get_current_epoch(state)
     source_privkey = pubkey_to_privkey[state.validators[0].pubkey]
@@ -504,7 +527,13 @@ def test_invalid_exited_source(spec, state):
 
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_exited_target(spec, state):
     current_epoch = spec.get_current_epoch(state)
     source_privkey = pubkey_to_privkey[state.validators[0].pubkey]
@@ -527,7 +556,13 @@ def test_invalid_exited_target(spec, state):
 
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_inactive_source(spec, state):
     current_epoch = spec.get_current_epoch(state)
     source_privkey = pubkey_to_privkey[state.validators[0].pubkey]
@@ -549,7 +584,13 @@ def test_invalid_inactive_source(spec, state):
 
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_inactive_target(spec, state):
     current_epoch = spec.get_current_epoch(state)
     source_privkey = pubkey_to_privkey[state.validators[0].pubkey]
@@ -572,7 +613,13 @@ def test_invalid_inactive_target(spec, state):
 
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_no_execution_withdrawal_credential(spec, state):
     current_epoch = spec.get_current_epoch(state)
     source_privkey = pubkey_to_privkey[state.validators[0].pubkey]
@@ -590,7 +637,13 @@ def test_invalid_no_execution_withdrawal_credential(spec, state):
 
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_different_credentials(spec, state):
     current_epoch = spec.get_current_epoch(state)
     source_privkey = pubkey_to_privkey[state.validators[0].pubkey]
@@ -731,7 +784,13 @@ def test_invalid_target_signature(spec, state):
 
 
 @with_electra_and_later
-@spec_state_test
+@with_presets([MINIMAL], "need sufficient consolidation churn limit")
+@with_custom_state(
+    balances_fn=scaled_churn_balances_exceed_activation_exit_churn_limit,
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
 def test_invalid_before_specified_epoch(spec, state):
     current_epoch = spec.get_current_epoch(state)
     source_privkey = pubkey_to_privkey[state.validators[0].pubkey]


### PR DESCRIPTION
Fix #3739

I think they all miss the decorator like #3728.

- [x] Check if each case failed at the position we expected.