### PR TITLE
`get_custody_columns`: Move `node_id` test against `UINT256_MAX` out of the `while` loop.

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -105,12 +105,13 @@ class DataColumnSidecar(Container):
 def get_custody_columns(node_id: NodeID, custody_subnet_count: uint64) -> Sequence[ColumnIndex]:
     assert custody_subnet_count <= DATA_COLUMN_SIDECAR_SUBNET_COUNT
 
+    if node_id == UINT256_MAX:
+        node_id = NodeID(0)
+
     subnet_ids: List[uint64] = []
     i = 0
-    while len(subnet_ids) < custody_subnet_count:
-        if node_id == UINT256_MAX:
-            node_id = NodeID(0)
 
+    while len(subnet_ids) < custody_subnet_count:
         subnet_id = (
             bytes_to_uint64(hash(uint_to_bytes(uint256(node_id + i)))[0:8])
             % DATA_COLUMN_SIDECAR_SUBNET_COUNT

--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -105,6 +105,7 @@ class DataColumnSidecar(Container):
 def get_custody_columns(node_id: NodeID, custody_subnet_count: uint64) -> Sequence[ColumnIndex]:
     assert custody_subnet_count <= DATA_COLUMN_SIDECAR_SUBNET_COUNT
 
+    # Overflow prevention
     if node_id == UINT256_MAX:
         node_id = NodeID(0)
 


### PR DESCRIPTION
`node_id` is not modified in the loop, and moving the check against `UINT256_MAX` does not impact specification readability.