### PR TITLE
chore: Pad column indices when calling `verify_cell_kzg_proof_batch`

### DIFF
--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -71,15 +71,15 @@ def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
     """
     assert sidecar.index < NUMBER_OF_COLUMNS
     assert len(sidecar.column) == len(sidecar.kzg_commitments) == len(sidecar.kzg_proofs)
-    row_ids = [RowIndex(i) for i in range(len(sidecar.column))]
 
+    row_indices = [RowIndex(i) for i in range(len(sidecar.column))]
     column_indices = [sidecar.index] * len(sidecar.column)
 
     # KZG batch verifies that the cells match the corresponding commitments and proofs
     return verify_cell_kzg_proof_batch(
         row_commitments_bytes=sidecar.kzg_commitments,
-        row_indices=row_ids,  # all rows
-        column_indices=column_indices,
+        row_indices=row_indices,  # all rows
+        column_indices=column_indices,  # specific column
         cells=sidecar.column,
         proofs_bytes=sidecar.kzg_proofs,
     )

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -73,11 +73,13 @@ def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
     assert len(sidecar.column) == len(sidecar.kzg_commitments) == len(sidecar.kzg_proofs)
     row_ids = [RowIndex(i) for i in range(len(sidecar.column))]
 
+    column_indices = [sidecar.index] * len(sidecar.column)
+
     # KZG batch verifies that the cells match the corresponding commitments and proofs
     return verify_cell_kzg_proof_batch(
         row_commitments_bytes=sidecar.kzg_commitments,
         row_indices=row_ids,  # all rows
-        column_indices=[sidecar.index],
+        column_indices=column_indices,
         cells=sidecar.column,
         proofs_bytes=sidecar.kzg_proofs,
     )

--- a/tests/core/pyspec/eth2spec/test/eip7594/merkle_proof/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/merkle_proof/test_single_merkle_proof.py
@@ -56,6 +56,7 @@ def _run_blob_kzg_commitments_merkle_proof_test(spec, state, rng=None):
         index=spec.get_subtree_index(gindex),
         root=column_sidcar.signed_block_header.message.body_root,
     )
+    assert spec.verify_data_column_sidecar_kzg_proofs(column_sidcar)    
     assert spec.verify_data_column_sidecar_inclusion_proof(column_sidcar)
 
 

--- a/tests/core/pyspec/eth2spec/test/eip7594/merkle_proof/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/merkle_proof/test_single_merkle_proof.py
@@ -56,7 +56,7 @@ def _run_blob_kzg_commitments_merkle_proof_test(spec, state, rng=None):
         index=spec.get_subtree_index(gindex),
         root=column_sidcar.signed_block_header.message.body_root,
     )
-    assert spec.verify_data_column_sidecar_kzg_proofs(column_sidcar)    
+    assert spec.verify_data_column_sidecar_kzg_proofs(column_sidcar)
     assert spec.verify_data_column_sidecar_inclusion_proof(column_sidcar)
 
 


### PR DESCRIPTION
`verify_cell_kzg_proof_batch` expects the column indices array to be the same length as the row_indices array and the commitments array.