### PR TITLE
Add electra version of AggregateAndProof

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -298,7 +298,7 @@ class Attestation(Container):
 ```python
 class AggregateAndProof(Container):
     aggregator_index: ValidatorIndex
-    aggregate: Attestation  # [New in Electra:EIP7549]
+    aggregate: Attestation  # [Modified in Electra:EIP7549]
     selection_proof: BLSSignature
 ```
 
@@ -306,7 +306,7 @@ class AggregateAndProof(Container):
 
 ```python
 class SignedAggregateAndProof(Container):
-    message: AggregateAndProof   # [New in Electra:EIP7549]
+    message: AggregateAndProof   # [Modified in Electra:EIP7549]
     signature: BLSSignature
 ```
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -33,9 +33,9 @@
     - [`PendingConsolidation`](#pendingconsolidation)
   - [Modified Containers](#modified-containers)
     - [`AttesterSlashing`](#attesterslashing)
-    - [`IndexedAttestation`](#indexedattestation)
   - [Extended Containers](#extended-containers)
     - [`Attestation`](#attestation)
+    - [`IndexedAttestation`](#indexedattestation)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`ExecutionPayload`](#executionpayload)
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
@@ -279,16 +279,6 @@ class AttesterSlashing(Container):
     attestation_2: IndexedAttestation  # [Modified in Electra:EIP7549]
 ```
 
-#### `IndexedAttestation`
-
-```python
-class IndexedAttestation(Container):
-    # [Modified in Electra:EIP7549]
-    attesting_indices: List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
-    data: AttestationData
-    signature: BLSSignature
-```
-
 ### Extended Containers
 
 #### `Attestation`
@@ -298,6 +288,16 @@ class Attestation(Container):
     aggregation_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]  # [Modified in Electra:EIP7549]
     data: AttestationData
     committee_bits: Bitvector[MAX_COMMITTEES_PER_SLOT]  # [New in Electra:EIP7549]
+    signature: BLSSignature
+```
+
+#### `IndexedAttestation`
+
+```python
+class IndexedAttestation(Container):
+    # [Modified in Electra:EIP7549]
+    attesting_indices: List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
+    data: AttestationData
     signature: BLSSignature
 ```
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -35,6 +35,8 @@
     - [`AttesterSlashing`](#attesterslashing)
   - [Extended Containers](#extended-containers)
     - [`Attestation`](#attestation)
+    - [`AggregateAndProof`](#aggregateandproof)
+    - [`SignedAggregateAndProof`](#signedaggregateandproof)
     - [`IndexedAttestation`](#indexedattestation)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`ExecutionPayload`](#executionpayload)

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -291,6 +291,23 @@ class Attestation(Container):
     signature: BLSSignature
 ```
 
+#### `AggregateAndProof`
+
+```python
+class AggregateAndProof(Container):
+    aggregator_index: ValidatorIndex
+    aggregate: Attestation  # [New in Electra:EIP7549]
+    selection_proof: BLSSignature
+```
+
+#### `SignedAggregateAndProof`
+
+```python
+class SignedAggregateAndProof(Container):
+    message: AggregateAndProof   # [New in Electra:EIP7549]
+    signature: BLSSignature
+```
+
 #### `IndexedAttestation`
 
 ```python

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -33,11 +33,9 @@
     - [`PendingConsolidation`](#pendingconsolidation)
   - [Modified Containers](#modified-containers)
     - [`AttesterSlashing`](#attesterslashing)
+    - [`IndexedAttestation`](#indexedattestation)
   - [Extended Containers](#extended-containers)
     - [`Attestation`](#attestation)
-    - [`AggregateAndProof`](#aggregateandproof)
-    - [`SignedAggregateAndProof`](#signedaggregateandproof)
-    - [`IndexedAttestation`](#indexedattestation)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`ExecutionPayload`](#executionpayload)
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
@@ -281,6 +279,16 @@ class AttesterSlashing(Container):
     attestation_2: IndexedAttestation  # [Modified in Electra:EIP7549]
 ```
 
+#### `IndexedAttestation`
+
+```python
+class IndexedAttestation(Container):
+    # [Modified in Electra:EIP7549]
+    attesting_indices: List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
+    data: AttestationData
+    signature: BLSSignature
+```
+
 ### Extended Containers
 
 #### `Attestation`
@@ -290,33 +298,6 @@ class Attestation(Container):
     aggregation_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]  # [Modified in Electra:EIP7549]
     data: AttestationData
     committee_bits: Bitvector[MAX_COMMITTEES_PER_SLOT]  # [New in Electra:EIP7549]
-    signature: BLSSignature
-```
-
-#### `AggregateAndProof`
-
-```python
-class AggregateAndProof(Container):
-    aggregator_index: ValidatorIndex
-    aggregate: Attestation  # [Modified in Electra:EIP7549]
-    selection_proof: BLSSignature
-```
-
-#### `SignedAggregateAndProof`
-
-```python
-class SignedAggregateAndProof(Container):
-    message: AggregateAndProof   # [Modified in Electra:EIP7549]
-    signature: BLSSignature
-```
-
-#### `IndexedAttestation`
-
-```python
-class IndexedAttestation(Container):
-    # [Modified in Electra:EIP7549]
-    attesting_indices: List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
-    data: AttestationData
     signature: BLSSignature
 ```
 

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -8,6 +8,10 @@
 
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
+- [Containers](#containers)
+  - [Modified Containers](#modified-containers)
+    - [`AggregateAndProof`](#aggregateandproof)
+    - [`SignedAggregateAndProof`](#signedaggregateandproof)
 - [Block proposal](#block-proposal)
   - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
     - [Attester slashings](#attester-slashings)
@@ -33,6 +37,27 @@ All behaviors and definitions defined in this document, and documents it extends
 
 All terminology, constants, functions, and protocol mechanics defined in the updated Beacon Chain doc of [Electra](./beacon-chain.md) are requisite for this document and used throughout.
 Please see related Beacon Chain doc before continuing and use them as a reference throughout.
+
+## Containers
+
+### Modified Containers
+
+#### `AggregateAndProof`
+
+```python
+class AggregateAndProof(Container):
+    aggregator_index: ValidatorIndex
+    aggregate: Attestation  # [Modified in Electra:EIP7549]
+    selection_proof: BLSSignature
+```
+
+#### `SignedAggregateAndProof`
+
+```python
+class SignedAggregateAndProof(Container):
+    message: AggregateAndProof   # [Modified in Electra:EIP7549]
+    signature: BLSSignature
+```
 
 ## Block proposal
 


### PR DESCRIPTION
For Electra, we need to extend `AggregateAndProof` (and `SignedAggregateAndProof`) to use the new `Attestation` type.