### PR TITLE
Provide Max Size For Columns By Range Request

### DIFF
--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -218,7 +218,7 @@ Request Content:
 (
   start_slot: Slot
   count: uint64
-  columns: List[ColumnIndex, MAX_REQUEST_DATA_COLUMN_SIDECARS]
+  columns: List[ColumnIndex, NUMBER_OF_COLUMNS]
 )
 ```
 

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -218,7 +218,7 @@ Request Content:
 (
   start_slot: Slot
   count: uint64
-  columns: List[ColumnIndex]
+  columns: List[ColumnIndex, MAX_REQUEST_DATA_COLUMN_SIDECARS]
 )
 ```
 


### PR DESCRIPTION
Inline with our other P2P request types, we provide a maximum size for the list of column indexes so that they can be serialized accurately.