### PR TITLE
PeerDAS cryptography: Add a missing check and a missing test vector (coverage report of test vectors)

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -683,6 +683,9 @@ def recover_all_cells(cell_ids: Sequence[CellID], cells: Sequence[Cell]) -> Sequ
     # Check that each cell is the correct length
     for cell in cells:
         assert len(cell) == BYTES_PER_CELL
+    # Check that the cell ids are within bounds
+    for cell_id in cell_ids:
+        assert cell_id < CELLS_PER_EXT_BLOB
 
     # Get the extended domain
     roots_of_unity_extended = compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB)

--- a/tests/generators/kzg_7594/main.py
+++ b/tests/generators/kzg_7594/main.py
@@ -710,6 +710,21 @@ def case05_recover_all_cells():
         'output': None
     }
 
+    # Edge case: More cells provided than CELLS_PER_EXT_BLOB
+    blob = BLOB_RANDOM_VALID2
+    cells = spec.compute_cells(blob)
+    cell_ids = list(range(spec.CELLS_PER_EXT_BLOB)) + [0]
+    partial_cells = [cells[cell_id] for cell_id in cell_ids]
+    expect_exception(spec.recover_all_cells, cell_ids, partial_cells)
+    identifier = make_id(cell_ids, partial_cells)
+    yield f'recover_all_cells_case_invalid_more_cells_than_cells_per_ext_blob_{identifier}', {
+        'input': {
+            'cell_ids': cell_ids,
+            'cells': encode_hex_list(partial_cells),
+        },
+        'output': None
+    }
+
     # Edge case: Invalid cell_id
     blob = BLOB_RANDOM_VALID1
     cells = spec.compute_cells(blob)


### PR DESCRIPTION
I spent some time checking which parts of c-kzg are not tested by the test vectors. I did this by exporting coverage information of the C code of c-kzg when the test vectors are tested through the Rust bindings. I was forced to go through the Rust bindings because only the bindings run the test vectors at the moment (and IMO that's fine).

For what it's worth, I used the [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) project and the following command:
```CC=clang LLVM_COV=llvm-cov LLVM_PROFDATA=llvm-profdata cargo llvm-cov --include-ffi --html```.
In case you are curious, I attach a zip file ([c_kzg_coverage.zip](https://github.com/ethereum/consensus-specs/files/15309079/c_kzg_coverage.zip)) with the coverage report of c-kzg (commit `f5e4b030f`) when running the tests of the Rust bindings.

All in all, the coverage results were very good (i.e. the test vectors are well thought out!).

In this PR, I fix some minor issues found during the above procedure:
- I add a missing `cell_id` range check in `recover_all_cells()` (which was actually tested by the test vectors)
- Add a test vector for too many cells in  `recover_all_cells()` which represents the right side of the spec assertion: `assert CELLS_PER_EXT_BLOB / 2 <= len(cell_ids) <= CELLS_PER_EXT_BLOB`. The test vector is sorta rendundant because the combination of the duplicate cell_id check and the cell_id range check would have caught this edge case, but still worth checking explicitly since it's not trivial (and it shows up in the coverage as well).

Some more notes:
- [This c-kzg check](https://github.com/ethereum/c-kzg-4844/blob/f5e4b030fe8c62795b998bc64011ebb3ef0f1d63/src/c_kzg_4844.c#L3673) shows up as unvisited in the coverage report, but it's not covered by the spec. We should either add it to the spec, or remove it from c-kzg?
- [This c-kzg check](https://github.com/ethereum/c-kzg-4844/blob/f5e4b030fe8c62795b998bc64011ebb3ef0f1d63/src/c_kzg_4844.c#L2809) shows up as unvisited in the coverage report, but it's actually tested by the function's caller. Perhaps it should be an assert? Similar to [the sanity check](https://github.com/ethereum/c-kzg-4844/blob/f5e4b030fe8c62795b998bc64011ebb3ef0f1d63/src/c_kzg_4844.c#L3436) in recover cells?
