### PR TITLE
Add a multi committee attestation spec test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_attestation.py
@@ -68,6 +68,15 @@ def test_invalid_too_many_committe_bits(spec, state):
 
 @with_electra_and_later
 @spec_state_test
+def test_correct_attestation_with_two_attestation_committees(spec, state):
+    attestation = get_valid_attestation(spec, state, signed=True, index=[0, 1])
+    next_slots(spec, state, spec.MIN_ATTESTATION_INCLUSION_DELAY)
+
+    yield from run_attestation_processing(spec, state, attestation)
+
+
+@with_electra_and_later
+@spec_state_test
 def test_invalid_nonset_committe_bits(spec, state):
     """
     EIP-7549 test

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -105,13 +105,24 @@ def get_valid_attestation(spec,
     if index is None:
         index = 0
 
-    attestation_data = build_attestation_data(spec, state, slot=slot, index=index, beacon_block_root=beacon_block_root)
+    if isinstance(index, (list, tuple)):
+        if not is_post_electra(spec): 
+            raise Exception("Attestation from multiple committees can be generated only after electra fork")
+        
+        attestation_data = build_attestation_data(spec, state, slot=slot, index=0, beacon_block_root=beacon_block_root)
+    else:
+        attestation_data = build_attestation_data(spec, state, slot=slot, index=index, beacon_block_root=beacon_block_root)
 
     attestation = spec.Attestation(data=attestation_data)
 
-    # fill the attestation with (optionally filtered) participants, and optionally sign it
-    fill_aggregate_attestation(spec, state, attestation, signed=signed,
-                               filter_participant_set=filter_participant_set, committee_index=index)
+    if isinstance(index, (list, tuple)):
+        for i in index:
+            fill_aggregate_attestation(spec, state, attestation, signed=signed,
+                            filter_participant_set=filter_participant_set, committee_index=i)
+    else:
+        # fill the attestation with (optionally filtered) participants, and optionally sign it
+        fill_aggregate_attestation(spec, state, attestation, signed=signed,
+                                filter_participant_set=filter_participant_set, committee_index=index)
 
     return attestation
 


### PR DESCRIPTION
At [Lodestar](https://github.com/ChainSafe/lodestar) we encounter a scenario for an attestation from multi-committee was failing. This could have identified earlier if we had a spec for this scenario. 