### PR TITLE
Remove Deneb from all phases

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/constants.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/constants.py
@@ -34,7 +34,6 @@ LATEST_FORK = MAINNET_FORKS[-1]
 ALL_PHASES = (
     # Formal forks
     *MAINNET_FORKS,
-    DENEB,
     ELECTRA,
     # Experimental patches
     EIP7594,


### PR DESCRIPTION
`DENEB` is part of `MAINNET_FORKS`. Should we remove it under `ALL_PHASES`?