### PR TITLE
eip6800: add parent's root to the witness

### DIFF
--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -158,6 +158,7 @@ class VerkleProof(Container):
 class ExecutionWitness(Container):
     state_diff: List[StemStateDiff, MAX_STEMS]
     verkle_proof: VerkleProof
+    parent_state_root: Root
 ```
 
 ## Beacon chain state transition function


### PR DESCRIPTION
Include a block's parent's state root hash, so that stateless clients are able to execute a block without having to download the block's parent