### PR TITLE
Separate type for onchain attestation aggregates

### DIFF
--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -13,9 +13,6 @@ The specification of these changes continues in the same format as the network s
 - [Modifications in Electra](#modifications-in-electra)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
-    - [Global topics](#global-topics)
-      - [`beacon_aggregate_and_proof`](#beacon_aggregate_and_proof)
-      - [`beacon_attestation_{subnet_id}`](#beacon_attestation_subnet_id)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -32,28 +29,6 @@ Topics follow the same specification as in prior upgrades.
 
 The `beacon_block` topic is modified to also support Electra blocks.
 
-The `beacon_aggregate_and_proof` and `beacon_attestation_{subnet_id}` topics are modified to support the gossip of the new attestation type.
-
 The specification around the creation, validation, and dissemination of messages has not changed from the Capella document unless explicitly noted here.
 
 The derivation of the `message-id` remains stable.
-
-#### Global topics
-
-##### `beacon_aggregate_and_proof`
-
-The following convenience variables are re-defined
-- `index = get_committee_indices(aggregate.committee_bits)[0]`
-
-The following validations are added:
-* [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(aggregate)`.
-* [REJECT] `aggregate.data.index == 0`
-
-##### `beacon_attestation_{subnet_id}`
-
-The following convenience variables are re-defined
-- `index = get_committee_indices(attestation.committee_bits)[0]`
-
-The following validations are added:
-* [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(attestation)`.
-* [REJECT] `attestation.data.index == 0`

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -150,7 +150,7 @@ def prepare_execution_payload(state: BeaconState,
 
 ##### Modified aggregate signature
 
-*Note:* The `get_attestation_sinagure` is modified to use signing attestation data.
+*Note:* The `get_attestation_signature` method is modified to use signing attestation data.
 
 Set `attestation.signature = attestation_signature` where `attestation_signature` is obtained from:
 

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -70,7 +70,7 @@ Changed the max attester slashings size to `MAX_ATTESTER_SLASHINGS_ELECTRA`.
 Changed the max attestations size to `MAX_ATTESTATIONS_ELECTRA`.
 
 The network attestation aggregates contain only the assigned committee attestations.
-Attestation aggregates received by the block proposer from the committee aggregators with disjoint `committee_bits` sets and equal signing `AttestationData` SHOULD be consolidated into a single `Attestation` object.
+Attestation aggregates received by the block proposer from the committee aggregators with disjoint `committee_bits` sets and equal signing `AttestationData` SHOULD be consolidated into a single `OnchainAttestation` object.
 The proposer should run the following function to construct an on chain final aggregate form a list of network aggregates with equal signing `AttestationData`:
 
 ```python


### PR DESCRIPTION
Experimental PR outlining an idea of having a separate container for on chain attestation aggregates proposed by @arnetheduck during [ACDC#134](https://github.com/ethereum/pm/issues/1050).

Change set:
* New `OnchainAttestation` type to be used for aggregates included into a block with the corresponding `process_onchain_attestation` function used during the block processing; the old `process_attestation` is preserved for the purpose of gossip and attestation mempool
* New `compute_signing_attestation_data` which is used to compute signing attestation data. The reason for that is to keep the logic around `Attestation` container that is still used in the network as is as far as it is possible. EIP7549 requires signing data to have committee index set to 0, and to retain the logic around non-zero `index` field inside of the `Attestation` this PR employs a trick when the index is zeroed for the purpose of signing.
  There is the corresponding change to the honest validator doc and aggregate signature verification. `OnchainAttestation` contains signing `AttestationData` (i.e. with index always set to `0`). The old `process_attestation` function should switch to the modified `is_valid_indexed_attestation` (not explicit in this PR)
* p2p changes related to the modification of the `Attestation` type are dropped as the type remain unmodified, except for the signature verification part

Other changes that aren’t scoped in this PR:
* Attestation mempool will have to support `Attestation` and `OnchainAttestation` types, and use different validation functions for them which depending on the pool design might have different impact on the client implementation
* Fork choice `on_attestation` handler will have to be appended with `on_onchain_attestation` to handle the on chain aggregate type

P.S. The above scope of changes might not be exhaustive.