### PR TITLE
Add proof recovery & matrix clean up

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -51,15 +51,6 @@ The following values are (non-configurable) constants used throughout the specif
 | - | - |
 | `UINT256_MAX` | `uint256(2**256 - 1)` |
 
-## Custom types
-
-We define the following Python custom types for type hinting and readability:
-
-| Name | SSZ equivalent | Description |
-| - | - | - |
-| `DataColumn` | `List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]` | The data of each column in EIP-7594 |
-| `ExtendedMatrix` | `List[Cell, MAX_CELLS_IN_EXTENDED_MATRIX]` | The full data of one-dimensional erasure coding extended blobs (in row major format). |
-
 ## Configuration
 
 ### Data size
@@ -79,7 +70,7 @@ We define the following Python custom types for type hinting and readability:
 
 | Name | Value | Description |
 | - | - | - |
-| `SAMPLES_PER_SLOT` | `8` | Number of `DataColumn` random samples a node queries per slot |
+| `SAMPLES_PER_SLOT` | `8` | Number of `DataColumnSidecar` random samples a node queries per slot |
 | `CUSTODY_REQUIREMENT` | `1` | Minimum number of subnets an honest node custodies and serves samples from |
 | `TARGET_NUMBER_OF_PEERS` | `70` | Suggested minimum peer count |
 
@@ -90,11 +81,21 @@ We define the following Python custom types for type hinting and readability:
 ```python
 class DataColumnSidecar(Container):
     index: ColumnIndex  # Index of column in extended matrix
-    column: DataColumn
+    column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     signed_block_header: SignedBeaconBlockHeader
     kzg_commitments_inclusion_proof: Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH]
+```
+
+#### `MatrixEntry`
+
+```python
+class MatrixEntry(Container):
+    cell: Cell
+    proof: KZGProof
+    column_index: ColumnIndex
+    row_index: RowIndex
 ```
 
 ### Helper functions
@@ -132,37 +133,52 @@ def get_custody_columns(node_id: NodeID, custody_subnet_count: uint64) -> Sequen
 #### `compute_extended_matrix`
 
 ```python
-def compute_extended_matrix(blobs: Sequence[Blob]) -> ExtendedMatrix:
+def compute_extended_matrix(blobs: Sequence[Blob]) -> List[MatrixEntry, MAX_CELLS_IN_EXTENDED_MATRIX]:
     """
     Return the full ``ExtendedMatrix``.
 
     This helper demonstrates the relationship between blobs and ``ExtendedMatrix``.
     The data structure for storing cells is implementation-dependent.
     """
-    extended_matrix = []
-    for blob in blobs:
-        extended_matrix.extend(compute_cells(blob))
-    return ExtendedMatrix(extended_matrix)
+    extended_matrix: List[MatrixEntry, MAX_CELLS_IN_EXTENDED_MATRIX] = []
+    for row_index, blob in enumerate(blobs):
+        cells, proofs = compute_cells_and_kzg_proofs(blob)
+        for column_index, (cell, proof) in enumerate(zip(cells, proofs)):
+            extended_matrix.append(MatrixEntry(
+                cell=cell,
+                proof=proof,
+                row_index=row_index,
+                column_index=column_index,
+            ))
+    return extended_matrix
 ```
 
 #### `recover_matrix`
 
 ```python
-def recover_matrix(cells_dict: Dict[Tuple[BlobIndex, CellID], Cell], blob_count: uint64) -> ExtendedMatrix:
+def recover_matrix(partial_matrix: Sequence[MatrixEntry],
+                   blob_count: uint64) -> List[MatrixEntry, MAX_CELLS_IN_EXTENDED_MATRIX]:
     """
-    Return the recovered ``ExtendedMatrix``.
+    Return the recovered extended matrix.
 
-    This helper demonstrates how to apply ``recover_all_cells``.
+    This helper demonstrates how to apply ``recover_cells_and_kzg_proofs``.
     The data structure for storing cells is implementation-dependent.
     """
-    extended_matrix: List[Cell] = []
+    extended_matrix: List[MatrixEntry, MAX_CELLS_IN_EXTENDED_MATRIX] = []
     for blob_index in range(blob_count):
-        cell_ids = [cell_id for b_index, cell_id in cells_dict.keys() if b_index == blob_index]
-        cells = [cells_dict[(BlobIndex(blob_index), cell_id)] for cell_id in cell_ids]
+        cell_ids = [e.column_index for e in partial_matrix if e.row_index == blob_index]
+        cells = [e.cell for e in partial_matrix if e.row_index == blob_index]
+        proofs = [e.proof for e in partial_matrix if e.row_index == blob_index]
 
-        all_cells_for_row = recover_all_cells(cell_ids, cells)
-        extended_matrix.extend(all_cells_for_row)
-    return ExtendedMatrix(extended_matrix)
+        recovered_cells, recovered_proofs = recover_cells_and_kzg_proofs(cell_ids, cells, proofs)
+        for cell_id, (cell, proof) in enumerate(zip(recovered_cells, recovered_proofs)):
+            extended_matrix.append(MatrixEntry(
+                cell=cell,
+                proof=proof,
+                row_index=blob_index,
+                column_index=cell_id,
+            ))
+    return extended_matrix
 ```
 
 #### `get_data_column_sidecars`
@@ -182,15 +198,15 @@ def get_data_column_sidecars(signed_block: SignedBeaconBlock,
     proofs = [cells_and_proofs[i][1] for i in range(blob_count)]
     sidecars = []
     for column_index in range(NUMBER_OF_COLUMNS):
-        column = DataColumn([cells[row_index][column_index]
-                             for row_index in range(blob_count)])
-        kzg_proof_of_column = [proofs[row_index][column_index]
-                               for row_index in range(blob_count)]
+        column_cells = [cells[row_index][column_index]
+                        for row_index in range(blob_count)]
+        column_proofs = [proofs[row_index][column_index]
+                         for row_index in range(blob_count)]
         sidecars.append(DataColumnSidecar(
             index=column_index,
-            column=column,
+            column=column_cells,
             kzg_commitments=block.body.blob_kzg_commitments,
-            kzg_proofs=kzg_proof_of_column,
+            kzg_proofs=column_proofs,
             signed_block_header=signed_block_header,
             kzg_commitments_inclusion_proof=kzg_commitments_inclusion_proof,
         ))
@@ -283,7 +299,7 @@ Such trailing techniques and their analysis will be valuable for any DAS constru
 
 ### Row (blob) custody
 
-In the one-dimension construction, a node samples the peers by requesting the whole `DataColumn`. In reconstruction, a node can reconstruct all the blobs by 50% of the columns. Note that nodes can still download the row via `blob_sidecar_{subnet_id}` subnets.
+In the one-dimension construction, a node samples the peers by requesting the whole `DataColumnSidecar`. In reconstruction, a node can reconstruct all the blobs by 50% of the columns. Note that nodes can still download the row via `blob_sidecar_{subnet_id}` subnets.
 
 The potential benefits of having row custody could include:
 

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/das/test_das.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/das/test_das.py
@@ -9,6 +9,11 @@ from eth2spec.test.helpers.sharding import (
 )
 
 
+def chunks(lst, n):
+    """Helper that splits a list into N sized chunks."""
+    return [lst[i:i + n] for i in range(0, len(lst), n)]
+
+
 @with_eip7594_and_later
 @spec_test
 @single_phase
@@ -20,15 +25,15 @@ def test_compute_extended_matrix(spec):
     extended_matrix = spec.compute_extended_matrix(input_blobs)
     assert len(extended_matrix) == spec.CELLS_PER_EXT_BLOB * blob_count
 
-    rows = [extended_matrix[i:(i + spec.CELLS_PER_EXT_BLOB)]
-            for i in range(0, len(extended_matrix), spec.CELLS_PER_EXT_BLOB)]
+    rows = chunks(extended_matrix, spec.CELLS_PER_EXT_BLOB)
     assert len(rows) == blob_count
-    assert len(rows[0]) == spec.CELLS_PER_EXT_BLOB
+    for row in rows:
+        assert len(row) == spec.CELLS_PER_EXT_BLOB
 
     for blob_index, row in enumerate(rows):
         extended_blob = []
-        for cell in row:
-            extended_blob.extend(spec.cell_to_coset_evals(cell))
+        for entry in row:
+            extended_blob.extend(spec.cell_to_coset_evals(entry.cell))
         blob_part = extended_blob[0:len(extended_blob) // 2]
         blob = b''.join([spec.bls_field_to_bytes(x) for x in blob_part])
         assert blob == input_blobs[blob_index]
@@ -43,27 +48,19 @@ def test_recover_matrix(spec):
     # Number of samples we will be recovering from
     N_SAMPLES = spec.CELLS_PER_EXT_BLOB // 2
 
+    # Compute an extended matrix with two blobs
     blob_count = 2
-    cells_dict = {}
-    original_cells = []
-    for blob_index in range(blob_count):
-        # Get the data we will be working with
-        blob = get_sample_blob(spec, rng=rng)
-        # Extend data with Reed-Solomon and split the extended data in cells
-        cells = spec.compute_cells(blob)
-        original_cells.append(cells)
-        cell_ids = []
-        # First figure out just the indices of the cells
-        for _ in range(N_SAMPLES):
-            cell_id = rng.randint(0, spec.CELLS_PER_EXT_BLOB - 1)
-            while cell_id in cell_ids:
-                cell_id = rng.randint(0, spec.CELLS_PER_EXT_BLOB - 1)
-            cell_ids.append(cell_id)
-            cell = cells[cell_id]
-            cells_dict[(blob_index, cell_id)] = cell
-        assert len(cell_ids) == N_SAMPLES
+    blobs = [get_sample_blob(spec, rng=rng) for _ in range(blob_count)]
+    extended_matrix = spec.compute_extended_matrix(blobs)
 
-    # Recover the matrix
-    recovered_matrix = spec.recover_matrix(cells_dict, blob_count)
-    flatten_original_cells = [cell for cells in original_cells for cell in cells]
-    assert recovered_matrix == flatten_original_cells
+    # Construct a matrix with some entries missing
+    partial_matrix = []
+    for blob_entries in chunks(extended_matrix, spec.CELLS_PER_EXT_BLOB):
+        rng.shuffle(blob_entries)
+        partial_matrix.extend(blob_entries[:N_SAMPLES])
+
+    # Given the partial matrix, recover the missing entries
+    recovered_matrix = spec.recover_matrix(partial_matrix, blob_count)
+
+    # Ensure that the recovered matrix matches the original matrix
+    assert recovered_matrix == extended_matrix

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -64,7 +64,7 @@ def test_verify_cell_kzg_proof_batch(spec):
 @with_eip7594_and_later
 @spec_test
 @single_phase
-def test_recover_all_cells(spec):
+def test_recover_cells_and_kzg_proofs(spec):
     rng = random.Random(5566)
 
     # Number of samples we will be recovering from
@@ -74,7 +74,7 @@ def test_recover_all_cells(spec):
     blob = get_sample_blob(spec)
 
     # Extend data with Reed-Solomon and split the extended data in cells
-    cells = spec.compute_cells(blob)
+    cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
 
     # Compute the cells we will be recovering from
     cell_ids = []
@@ -84,19 +84,21 @@ def test_recover_all_cells(spec):
         while j in cell_ids:
             j = rng.randint(0, spec.CELLS_PER_EXT_BLOB - 1)
         cell_ids.append(j)
-    # Now the cells themselves
+    # Now the cells/proofs themselves
     known_cells = [cells[cell_id] for cell_id in cell_ids]
+    known_proofs = [proofs[cell_id] for cell_id in cell_ids]
 
-    # Recover all of the cells
-    recovered_cells = spec.recover_all_cells(cell_ids, known_cells)
+    # Recover the missing cells and proofs
+    recovered_cells, recovered_proofs = spec.recover_cells_and_kzg_proofs(cell_ids, known_cells, known_proofs)
     recovered_data = [x for xs in recovered_cells for x in xs]
 
     # Check that the original data match the non-extended portion of the recovered data
     blob_byte_array = [b for b in blob]
     assert blob_byte_array == recovered_data[:len(recovered_data) // 2]
 
-    # Check that the recovered cells match the original cells
+    # Check that the recovered cells/proofs match the original cells/proofs
     assert cells == recovered_cells
+    assert proofs == recovered_proofs
 
 
 @with_eip7594_and_later


### PR DESCRIPTION
This PR does the following:

* Rename `recover_all_cells` to `recover_cells_and_kzg_proofs`.
* Add proof recovery to the bottom of the function.
* Replace `ExtendedMatrix` and `DataColumn` types with `MatrixEntry` container.
* Replace `cells_dict` with sequence of `MatrixEntry` values.

TODO: update reference test generator.