### PR TITLE
Fix scripts/build_run_docker_tests.sh

### DIFF
--- a/scripts/build_run_docker_tests.sh
+++ b/scripts/build_run_docker_tests.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 # Run 'consensus-specs' tests from a docker container instance.
 # *Be sure to launch Docker before running this script.*


### PR DESCRIPTION
The script was not working with /bin/sh, but works with /bin/bash.

Fixes the following error:

```
./build_run_docker_tests.sh: 13: Syntax error: "(" unexpected
```
