### PR TITLE
Electra: Rename objects with prefix ExecutionLayerXXX

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_execution_layer_consolidation_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_execution_layer_consolidation_request.py
@@ -39,7 +39,7 @@ def test_basic_consolidation_in_current_consolidation_epoch(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with source address
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -88,7 +88,7 @@ def test_basic_consolidation_in_new_consolidation_epoch(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with source address
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -131,7 +131,7 @@ def test_basic_consolidation_with_preexisting_churn(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with source address
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -178,7 +178,7 @@ def test_basic_consolidation_with_insufficient_preexisting_churn(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with source address
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -229,7 +229,7 @@ def test_basic_consolidation_with_compounding_credentials(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with source address
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -274,7 +274,7 @@ def test_consolidation_churn_limit_balance(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with source address
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -322,7 +322,7 @@ def test_consolidation_balance_larger_than_churn_limit(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with source address
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -369,7 +369,7 @@ def test_consolidation_balance_through_two_churn_epochs(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with source address
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -415,7 +415,7 @@ def test_incorrect_source_equals_target(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation from source to source
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[source_index].pubkey,
@@ -447,7 +447,7 @@ def test_incorrect_exceed_pending_consolidations_limit(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -476,7 +476,7 @@ def test_incorrect_not_enough_consolidation_churn_available(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -504,7 +504,7 @@ def test_incorrect_exited_source(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -536,7 +536,7 @@ def test_incorrect_exited_target(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -566,7 +566,7 @@ def test_incorrect_inactive_source(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -598,7 +598,7 @@ def test_incorrect_inactive_target(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -627,7 +627,7 @@ def test_incorrect_no_source_execution_withdrawal_credential(spec, state):
     source_index = spec.get_active_validator_indices(state, current_epoch)[0]
     target_index = spec.get_active_validator_indices(state, current_epoch)[1]
     source_address = b"\x22" * 20
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -656,7 +656,7 @@ def test_incorrect_no_target_execution_withdrawal_credential(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -684,7 +684,7 @@ def test_incorrect_incorrect_source_address(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with different source address
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=b"\x33" * 20,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
@@ -714,7 +714,7 @@ def test_incorrect_unknown_source_pubkey(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with different source pubkey
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=b"\x00" * 48,
         target_pubkey=state.validators[target_index].pubkey,
@@ -744,7 +744,7 @@ def test_incorrect_unknown_target_pubkey(spec, state):
         spec, state, source_index, address=source_address
     )
     # Make consolidation with different target pubkey
-    consolidation = spec.ExecutionLayerConsolidationRequest(
+    consolidation = spec.ConsolidationRequest(
         source_address=b"\x33" * 20,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=b"\x00" * 48,
@@ -760,7 +760,7 @@ def run_consolidation_processing(spec, state, consolidation, success=True):
     """
     Run ``process_consolidation``, yielding:
       - pre-state ('pre')
-      - execution_layer_consolidation_request ('execution_layer_consolidation_request')
+      - consolidation_request ('consolidation_request')
       - post-state ('post').
     If ``valid == False``, run expecting ``AssertionError``
     """
@@ -778,9 +778,9 @@ def run_consolidation_processing(spec, state, consolidation, success=True):
         pre_state = state.copy()
 
     yield 'pre', state
-    yield 'execution_layer_consolidation_request', consolidation
+    yield 'consolidation_request', consolidation
 
-    spec.process_execution_layer_consolidation_request(state, consolidation)
+    spec.process_consolidation_request(state, consolidation)
 
     yield 'post', state
 

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_execution_layer_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_execution_layer_withdrawal_request.py
@@ -29,14 +29,14 @@ def test_basic_withdrawal_request(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, validator_index, address=address
     )
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=spec.FULL_EXIT_REQUEST_AMOUNT,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request
     )
 
 
@@ -51,14 +51,14 @@ def test_basic_withdrawal_request_with_compounding_credentials(spec, state):
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=spec.FULL_EXIT_REQUEST_AMOUNT,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request
     )
 
 
@@ -74,7 +74,7 @@ def test_basic_withdrawal_request_with_full_partial_withdrawal_queue(spec, state
     set_eth1_withdrawal_credential_with_balance(
         spec, state, validator_index, address=address
     )
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=spec.FULL_EXIT_REQUEST_AMOUNT,
@@ -89,10 +89,10 @@ def test_basic_withdrawal_request_with_full_partial_withdrawal_queue(spec, state
     ] * spec.PENDING_PARTIAL_WITHDRAWALS_LIMIT
 
     # Exit should still be processed
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
     )
 
 
@@ -113,14 +113,14 @@ def test_incorrect_source_address(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, validator_index, address=address
     )
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=incorrect_address,
         validator_pubkey=validator_pubkey,
         amount=spec.FULL_EXIT_REQUEST_AMOUNT,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -142,14 +142,14 @@ def test_incorrect_withdrawal_credential_prefix(spec, state):
         spec.BLS_WITHDRAWAL_PREFIX
         + state.validators[validator_index].withdrawal_credentials[1:]
     )
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=spec.FULL_EXIT_REQUEST_AMOUNT,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -168,14 +168,14 @@ def test_on_withdrawal_request_initiated_validator(spec, state):
     )
     # Initiate exit earlier
     spec.initiate_validator_exit(state, validator_index)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=spec.FULL_EXIT_REQUEST_AMOUNT,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -189,7 +189,7 @@ def test_activation_epoch_less_than_shard_committee_period(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, validator_index, address=address
     )
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=spec.FULL_EXIT_REQUEST_AMOUNT,
@@ -200,8 +200,8 @@ def test_activation_epoch_less_than_shard_committee_period(spec, state):
         + spec.config.SHARD_COMMITTEE_PERIOD
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -221,16 +221,16 @@ def test_basic_partial_withdrawal_request(spec, state):
     state.balances[validator_index] += amount
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
     )
 
     # Check that the assigned exit epoch is correct
@@ -253,16 +253,16 @@ def test_basic_partial_withdrawal_request_higher_excess_balance(spec, state):
     state.balances[validator_index] += 2 * amount
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
     )
 
     # Check that the assigned exit epoch is correct
@@ -286,16 +286,16 @@ def test_basic_partial_withdrawal_request_lower_than_excess_balance(spec, state)
     state.balances[validator_index] += excess_balance
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
     )
 
     # Check that the assigned exit epoch is correct
@@ -316,7 +316,7 @@ def test_partial_withdrawal_request_with_pending_withdrawals(spec, state):
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
@@ -331,10 +331,10 @@ def test_partial_withdrawal_request_with_pending_withdrawals(spec, state):
     # Set balance so that the validator still has excess balance even with the pending withdrawals
     state.balances[validator_index] += 3 * amount
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
     )
 
     # Check that the assigned exit epoch is correct
@@ -357,7 +357,7 @@ def test_partial_withdrawal_request_with_pending_withdrawals_and_high_amount(
     amount = spec.UINT64_MAX
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
@@ -376,10 +376,10 @@ def test_partial_withdrawal_request_with_pending_withdrawals_and_high_amount(
     # Set balance so that the validator still has excess balance even with the pending withdrawals
     state.balances[validator_index] = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
     )
 
 
@@ -399,7 +399,7 @@ def test_partial_withdrawal_request_with_high_balance(spec, state):
     )
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
@@ -407,10 +407,10 @@ def test_partial_withdrawal_request_with_high_balance(spec, state):
 
     churn_limit = spec.get_activation_exit_churn_limit(state)
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
     )
 
     # Check that the assigned exit epoch is correct
@@ -435,16 +435,16 @@ def test_partial_withdrawal_request_with_high_amount(spec, state):
     state.balances[validator_index] += 1
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
     )
 
     # Check that the assigned exit epoch is correct
@@ -467,16 +467,16 @@ def test_partial_withdrawal_request_with_low_amount(spec, state):
     state.balances[validator_index] += amount
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
     )
 
     # Check that the assigned exit epoch is correct
@@ -501,7 +501,7 @@ def test_partial_withdrawal_queue_full(spec, state):
     # Ensure that the validator has sufficient excess balance
     state.balances[validator_index] += 2 * amount
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
@@ -514,8 +514,8 @@ def test_partial_withdrawal_queue_full(spec, state):
     state.pending_partial_withdrawals = [
         partial_withdrawal
     ] * spec.PENDING_PARTIAL_WITHDRAWALS_LIMIT
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -534,16 +534,16 @@ def test_no_compounding_credentials(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, validator_index, address=address
     )
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
         success=False,
     )
 
@@ -559,14 +559,14 @@ def test_no_excess_balance(spec, state):
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -583,7 +583,7 @@ def test_pending_withdrawals_consume_all_excess_balance(spec, state):
     state.balances[validator_index] += 10 * amount
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
@@ -595,8 +595,8 @@ def test_pending_withdrawals_consume_all_excess_balance(spec, state):
     )
     state.pending_partial_withdrawals = [partial_withdrawal] * 10
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -615,16 +615,16 @@ def test_insufficient_effective_balance(spec, state):
     ].effective_balance -= spec.EFFECTIVE_BALANCE_INCREMENT
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
+    yield from run_withdrawal_request_processing(
         spec,
         state,
-        execution_layer_withdrawal_request,
+        withdrawal_request,
         success=False,
     )
 
@@ -644,14 +644,14 @@ def test_partial_withdrawal_incorrect_source_address(spec, state):
     state.balances[validator_index] += 2 * amount
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=incorrect_address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -673,14 +673,14 @@ def test_partial_withdrawal_incorrect_withdrawal_credential_prefix(spec, state):
         spec.BLS_WITHDRAWAL_PREFIX
         + state.validators[validator_index].withdrawal_credentials[1:]
     )
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -699,14 +699,14 @@ def test_partial_withdrawal_on_exit_initiated_validator(spec, state):
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
     # Initiate exit earlier
     spec.initiate_validator_exit(state, validator_index)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -722,7 +722,7 @@ def test_partial_withdrawal_activation_epoch_less_than_shard_committee_period(
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
     state.balances[validator_index] += 2 * amount
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
         amount=amount,
@@ -733,8 +733,8 @@ def test_partial_withdrawal_activation_epoch_less_than_shard_committee_period(
         + spec.config.SHARD_COMMITTEE_PERIOD
     )
 
-    yield from run_execution_layer_withdrawal_request_processing(
-        spec, state, execution_layer_withdrawal_request, success=False
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
     )
 
 
@@ -743,28 +743,28 @@ def test_partial_withdrawal_activation_epoch_less_than_shard_committee_period(
 #
 
 
-def run_execution_layer_withdrawal_request_processing(
-    spec, state, execution_layer_withdrawal_request, valid=True, success=True
+def run_withdrawal_request_processing(
+    spec, state, withdrawal_request, valid=True, success=True
 ):
     """
-    Run ``process_execution_layer_withdrawal_request``, yielding:
+    Run ``process_withdrawal_request``, yielding:
       - pre-state ('pre')
-      - execution_layer_withdrawal_request ('execution_layer_withdrawal_request')
+      - withdrawal_request ('withdrawal_request')
       - post-state ('post').
     If ``valid == False``, run expecting ``AssertionError``
     If ``success == False``, it doesn't initiate exit successfully
     """
     validator_index = get_validator_index_by_pubkey(
-        state, execution_layer_withdrawal_request.validator_pubkey
+        state, withdrawal_request.validator_pubkey
     )
 
     yield "pre", state
-    yield "execution_layer_withdrawal_request", execution_layer_withdrawal_request
+    yield "withdrawal_request", withdrawal_request
 
     if not valid:
         expect_assertion_error(
-            lambda: spec.process_execution_layer_withdrawal_request(
-                state, execution_layer_withdrawal_request
+            lambda: spec.process_withdrawal_request(
+                state, withdrawal_request
             )
         )
         yield "post", None
@@ -776,11 +776,11 @@ def run_execution_layer_withdrawal_request_processing(
     pre_effective_balance = state.validators[validator_index].effective_balance
     pre_state = state.copy()
     expected_amount_to_withdraw = compute_amount_to_withdraw(
-        spec, state, validator_index, execution_layer_withdrawal_request.amount
+        spec, state, validator_index, withdrawal_request.amount
     )
 
-    spec.process_execution_layer_withdrawal_request(
-        state, execution_layer_withdrawal_request
+    spec.process_withdrawal_request(
+        state, withdrawal_request
     )
 
     yield "post", state
@@ -794,7 +794,7 @@ def run_execution_layer_withdrawal_request_processing(
             state.validators[validator_index].effective_balance == pre_effective_balance
         )
         # Full exit request
-        if execution_layer_withdrawal_request.amount == spec.FULL_EXIT_REQUEST_AMOUNT:
+        if withdrawal_request.amount == spec.FULL_EXIT_REQUEST_AMOUNT:
             assert pre_exit_epoch == spec.FAR_FUTURE_EPOCH
             assert state.validators[validator_index].exit_epoch < spec.FAR_FUTURE_EPOCH
             assert spec.get_pending_balance_to_withdraw(state, validator_index) == 0

--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
@@ -36,12 +36,12 @@ def test_basic_el_withdrawal_request(spec, state):
     assert state.validators[validator_index].exit_epoch == spec.FAR_FUTURE_EPOCH
 
     validator_pubkey = state.validators[validator_index].pubkey
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
     )
     block = build_empty_block_for_next_slot(spec, state)
-    block.body.execution_payload.withdrawal_requests = [execution_layer_withdrawal_request]
+    block.body.execution_payload.withdrawal_requests = [withdrawal_request]
     block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
     signed_block = state_transition_and_sign_block(spec, state, block)
 
@@ -73,11 +73,11 @@ def test_basic_btec_and_el_withdrawal_request_in_same_block(spec, state):
     block.body.bls_to_execution_changes = [signed_address_change]
 
     validator_pubkey = state.validators[validator_index].pubkey
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
     )
-    block.body.execution_payload.withdrawal_requests = [execution_layer_withdrawal_request]
+    block.body.execution_payload.withdrawal_requests = [withdrawal_request]
 
     block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
     signed_block = state_transition_and_sign_block(spec, state, block)
@@ -125,12 +125,12 @@ def test_basic_btec_before_el_withdrawal_request(spec, state):
 
     # block_2 contains an EL-Exit operation of the given validator
     validator_pubkey = state.validators[validator_index].pubkey
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
     )
     block_2 = build_empty_block_for_next_slot(spec, state)
-    block_2.body.execution_payload.withdrawal_requests = [execution_layer_withdrawal_request]
+    block_2.body.execution_payload.withdrawal_requests = [withdrawal_request]
     block_2.body.execution_payload.block_hash = compute_el_block_hash(spec, block_2.body.execution_payload)
     signed_block_2 = state_transition_and_sign_block(spec, state, block_2)
 
@@ -157,13 +157,13 @@ def test_cl_exit_and_el_withdrawal_request_in_same_block(spec, state):
     signed_voluntary_exits = prepare_signed_exits(spec, state, indices=[validator_index])
     # EL-Exit
     validator_pubkey = state.validators[validator_index].pubkey
-    execution_layer_withdrawal_request = spec.ExecutionLayerWithdrawalRequest(
+    withdrawal_request = spec.WithdrawalRequest(
         source_address=address,
         validator_pubkey=validator_pubkey,
     )
     block = build_empty_block_for_next_slot(spec, state)
     block.body.voluntary_exits = signed_voluntary_exits
-    block.body.execution_payload.withdrawal_requests = [execution_layer_withdrawal_request]
+    block.body.execution_payload.withdrawal_requests = [withdrawal_request]
     block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
     signed_block = state_transition_and_sign_block(spec, state, block)
 

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_layer_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_layer_withdrawal_request.py
@@ -7,9 +7,9 @@ from eth2spec.test.helpers.state import get_validator_index_by_pubkey
 #
 
 
-def run_execution_layer_withdrawal_request_processing(spec, state, withdrawal_request, valid=True, success=True):
+def run_withdrawal_request_processing(spec, state, withdrawal_request, valid=True, success=True):
     """
-    Run ``process_execution_layer_withdrawal_request``, yielding:
+    Run ``process_withdrawal_request``, yielding:
       - pre-state ('pre')
       - withdrawal_request ('withdrawal_request')
       - post-state ('post').

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -46,7 +46,7 @@ Operations:
 | `withdrawals`             | `ExecutionPayload`           | `execution_payload` | `process_withdrawals(state, execution_payload)` (new in Capella)                 |
 | `bls_to_execution_change` | `SignedBLSToExecutionChange` | `address_change`    | `process_bls_to_execution_change(state, address_change)` (new in Capella) |
 | `deposit_request`         | `DepositRequest`             | `deposit_request`   | `process_deposit_request(state, deposit_request)` (new in Electra)               |
-| `execution_layer_withdrawal_request`                   | `ExecutionLayerWithdrawalRequest`         | `execution_layer_withdrawal_request` | `process_execution_layer_withdrawal_request(state, execution_layer_withdrawal_request)` (new in Electra) |
+| `withdrawal_request`      | `WithdrawalRequest`          | `withdrawal_request` | `process_withdrawal_request(state, withdrawal_request)` (new in Electra) |
 | `execution_layer_consolidation_request`                   | `ExecutionLayerConsolidationRequest`         | `execution_layer_consolidation_request` | `process_execution_layer_consolidation_request(state, execution_layer_consolidation_request)` (new in Electra) |
 
 Note that `block_header` is not strictly an operation (and is a full `Block`), but processed in the same manner, and hence included here.

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -47,7 +47,7 @@ Operations:
 | `bls_to_execution_change` | `SignedBLSToExecutionChange` | `address_change`    | `process_bls_to_execution_change(state, address_change)` (new in Capella) |
 | `deposit_request`         | `DepositRequest`             | `deposit_request`   | `process_deposit_request(state, deposit_request)` (new in Electra)               |
 | `withdrawal_request`      | `WithdrawalRequest`          | `withdrawal_request` | `process_withdrawal_request(state, withdrawal_request)` (new in Electra) |
-| `execution_layer_consolidation_request`                   | `ExecutionLayerConsolidationRequest`         | `execution_layer_consolidation_request` | `process_execution_layer_consolidation_request(state, execution_layer_consolidation_request)` (new in Electra) |
+| `consolidation_request`   | `ConsolidationRequest`        | `consolidation_request` | `process_consolidation_request(state, consolidation_request)` (new in Electra) |
 
 Note that `block_header` is not strictly an operation (and is a full `Block`), but processed in the same manner, and hence included here.
 

--- a/tests/generators/operations/main.py
+++ b/tests/generators/operations/main.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         'attestation',
         'execution_layer_consolidation_request',
         'deposit_request',
-        'execution_layer_withdrawal_request',
+        'withdrawal_request',
         'voluntary_exit'
     ]}
     electra_mods = combine_mods(_new_electra_mods, deneb_mods)

--- a/tests/generators/operations/main.py
+++ b/tests/generators/operations/main.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
 
     _new_electra_mods = {key: 'eth2spec.test.electra.block_processing.test_process_' + key for key in [
         'attestation',
-        'execution_layer_consolidation_request',
+        'consolidation_request',
         'deposit_request',
         'withdrawal_request',
         'voluntary_exit'


### PR DESCRIPTION
# Rationale:

Following https://github.com/ethereum/consensus-specs/pull/3757, which renames from DepositReceipt to DepositRequest to conform with the patterns in [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685), this PR aims to have further conformity by dropping the ExecutionLayer prefix from WithdrawalRequest and ConsolidationRequest.


**Changes:**

- Rename `ExecutionLayerWithdrawalRequest`->`WithdrawalRequest`
- Rename `ExecutionLayerConsolidationRequest`->`ConsolidationRequest`
- Rename `process_execution_layer_withdrawal_request`->`process_withdrawal_request`
- Rename `process_execution_layer_consolidation_request`->`process_consolidation_request`
- Rename variable/argument `execution_layer_withdrawal_request`->`withdrawal_request`
- Rename variable/argument `execution_layer_consolidation_request`->`consolidation_request`
