### PR TITLE
EIP-7594: clarifying reconstruction and cross-seeding

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -235,11 +235,11 @@ Due to the deterministic custody functions, a node knows exactly what a peer sho
 
 ## Reconstruction and cross-seeding
 
-If the node obtains 50%+ of all the columns, they can reconstruct the full data matrix via `recover_matrix` helper.
+If a node fails to get a column on the column subnet, a node can also utilize the Req/Resp message to query the missing column from other peers.
 
-If a node fails to sample a peer or fails to get a column on the column subnet, a node can utilize the Req/Resp message to query the missing column from other peers.
+If the node obtains 50%+ of all the columns, it SHOULD reconstruct the full data matrix via `recover_matrix` helper. Nodes MAY delay this reconstruction allowing time for other columns to arrive over the network. If delaying reconstruction, nodes may use a random delay in order to desynchronize reconstruction among nodes, thus reducing overall CPU load.
 
-Once the node obtain the column, the node SHOULD send the missing columns to the column subnets.
+Once the node obtains a column through reconstruction, the node MUST expose the new column as if it had received it over the network. If the node is subscribed to the subnet corresponding to the column, it MUST send the reconstructed DataColumnSidecar to its topic mesh neighbors. If instead the node is not subscribed to the corresponding subnet, it SHOULD still expose the availability of the DataColumnSidecar as part of the gossip emission process.
 
 *Note*: A node always maintains a matrix view of the rows and columns they are following, able to cross-reference and cross-seed in either direction.
 

--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -223,7 +223,7 @@ In this construction, we extend the blobs using a one-dimensional erasure coding
 
 For each column -- use `data_column_sidecar_{subnet_id}` subnets, where `subnet_id` can be computed with the `compute_subnet_for_data_column_sidecar(column_index: ColumnIndex)` helper. The sidecars can be computed with the `get_data_column_sidecars(signed_block: SignedBeaconBlock, blobs: Sequence[Blob])` helper.
 
-To custody a particular column, a node joins the respective gossip subnet. Verifiable samples from their respective column are gossiped on the assigned subnet.
+Verifiable samples from their respective column are distributed on the assigned subnet. To custody a particular column, a node joins the respective gossipsub subnet. If a node fails to get a column on the column subnet, a node can also utilize the Req/Resp protocol to query the missing column from other peers.
 
 ## Peer sampling
 
@@ -234,8 +234,6 @@ A node SHOULD maintain a diverse set of peers for each column and each slot by v
 Due to the deterministic custody functions, a node knows exactly what a peer should be able to respond to. In the event that a peer does not respond to samples of their custodied rows/columns, a node may downscore or disconnect from a peer.
 
 ## Reconstruction and cross-seeding
-
-If a node fails to get a column on the column subnet, a node can also utilize the Req/Resp message to query the missing column from other peers.
 
 If the node obtains 50%+ of all the columns, it SHOULD reconstruct the full data matrix via `recover_matrix` helper. Nodes MAY delay this reconstruction allowing time for other columns to arrive over the network. If delaying reconstruction, nodes may use a random delay in order to desynchronize reconstruction among nodes, thus reducing overall CPU load.
 


### PR DESCRIPTION
Attempt to clarify rules and recommendations for on-the-fly reconstruction and cross-seeding:
- make reconstruction a SHOULD if a node has enough data,
- allos delaying reconstruction,
- specify how to corss-seed reconstructed columns for subscribed and for unsubscribed topics.

Notes: For unsubscribed topics, we are not seeding to avoid potentially gererating too many duplicates. If, however, we want to speed up spread in this case, it might make sense to send it to a limited number (e.g. 1) of fanout peers, or to immediately generate IHAVE messages without waiting for the heartbeat.