### PR TITLE
Remove `compute_cells` method

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -39,7 +39,6 @@
 - [Cells](#cells-1)
   - [Cell computation](#cell-computation)
     - [`compute_cells_and_kzg_proofs`](#compute_cells_and_kzg_proofs)
-    - [`compute_cells`](#compute_cells)
   - [Cell verification](#cell-verification)
     - [`verify_cell_kzg_proof`](#verify_cell_kzg_proof)
     - [`verify_cell_kzg_proof_batch`](#verify_cell_kzg_proof_batch)
@@ -457,31 +456,6 @@ def compute_cells_and_kzg_proofs(blob: Blob) -> Tuple[
         proofs.append(proof)
 
     return cells, proofs
-```
-
-#### `compute_cells`
-
-```python
-def compute_cells(blob: Blob) -> Vector[Cell, CELLS_PER_EXT_BLOB]:
-    """
-    Compute the cell data for an extended blob (without computing the proofs).
-
-    Public method.
-    """
-    assert len(blob) == BYTES_PER_BLOB
-    
-    polynomial = blob_to_polynomial(blob)
-    polynomial_coeff = polynomial_eval_to_coeff(polynomial)
-
-    extended_data = fft_field(polynomial_coeff + [0] * FIELD_ELEMENTS_PER_BLOB,
-                              compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB))
-    extended_data_rbo = bit_reversal_permutation(extended_data)
-    cells = []
-    for cell_index in range(CELLS_PER_EXT_BLOB):
-        start = cell_index * FIELD_ELEMENTS_PER_CELL
-        end = (cell_index + 1) * FIELD_ELEMENTS_PER_CELL
-        cells.append(coset_evals_to_cell(CosetEvals(extended_data_rbo[start:end])))
-    return cells
 ```
 
 ### Cell verification

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -64,7 +64,6 @@ Public functions MUST accept raw bytes as input and perform the required cryptog
 The following is a list of the public methods:
 
 * [`compute_cells_and_kzg_proofs`](#compute_cells_and_kzg_proofs)
-* [`compute_cells`](#compute_cells)
 * [`verify_cell_kzg_proof`](#verify_cell_kzg_proof)
 * [`verify_cell_kzg_proof_batch`](#verify_cell_kzg_proof_batch)
 * [`recover_cells_and_kzg_proofs`](#recover_cells_and_kzg_proofs)

--- a/tests/generators/kzg_7594/main.py
+++ b/tests/generators/kzg_7594/main.py
@@ -30,38 +30,10 @@ from eth2spec.utils import bls
 
 
 ###############################################################################
-# Test cases for compute_cells
-###############################################################################
-
-def case01_compute_cells():
-    # Valid cases
-    for blob in VALID_BLOBS:
-        cells = spec.compute_cells(blob)
-        identifier = make_id(blob)
-        yield f'compute_cells_case_valid_{identifier}', {
-            'input': {
-                'blob': encode_hex(blob),
-            },
-            'output': encode_hex_list(cells)
-        }
-
-    # Edge case: Invalid blobs
-    for blob in INVALID_BLOBS:
-        expect_exception(spec.compute_cells, blob)
-        identifier = make_id(blob)
-        yield f'compute_cells_case_invalid_blob_{identifier}', {
-            'input': {
-                'blob': encode_hex(blob)
-            },
-            'output': None
-        }
-
-
-###############################################################################
 # Test cases for compute_cells_and_kzg_proofs
 ###############################################################################
 
-def case02_compute_cells_and_kzg_proofs():
+def case_compute_cells_and_kzg_proofs():
     # Valid cases
     for blob in VALID_BLOBS:
         cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
@@ -91,7 +63,7 @@ def case02_compute_cells_and_kzg_proofs():
 # Test cases for verify_cell_kzg_proof
 ###############################################################################
 
-def case03_verify_cell_kzg_proof():
+def case_verify_cell_kzg_proof():
     # Valid cases
     for i in range(len(VALID_BLOBS)):
         cells, proofs = VALID_CELLS_AND_PROOFS[i]
@@ -245,7 +217,7 @@ def case03_verify_cell_kzg_proof():
 # Test cases for verify_cell_kzg_proof_batch
 ###############################################################################
 
-def case04_verify_cell_kzg_proof_batch():
+def case_verify_cell_kzg_proof_batch():
     # Valid cases
     for i in range(len(VALID_BLOBS)):
         cells, proofs = VALID_CELLS_AND_PROOFS[i]
@@ -617,7 +589,7 @@ def case04_verify_cell_kzg_proof_batch():
 # Test cases for recover_cells_and_kzg_proofs
 ###############################################################################
 
-def case05_recover_cells_and_kzg_proofs():
+def case_recover_cells_and_kzg_proofs():
     # Valid: No missing cells
     cells, proofs = VALID_CELLS_AND_PROOFS[0]
     cell_indices = list(range(spec.CELLS_PER_EXT_BLOB))
@@ -899,9 +871,8 @@ if __name__ == "__main__":
     bls.use_arkworks()
     gen_runner.run_generator("kzg_7594", [
         # EIP-7594
-        create_provider(EIP7594, 'compute_cells', case01_compute_cells),
-        create_provider(EIP7594, 'compute_cells_and_kzg_proofs', case02_compute_cells_and_kzg_proofs),
-        create_provider(EIP7594, 'verify_cell_kzg_proof', case03_verify_cell_kzg_proof),
-        create_provider(EIP7594, 'verify_cell_kzg_proof_batch', case04_verify_cell_kzg_proof_batch),
-        create_provider(EIP7594, 'recover_cells_and_kzg_proofs', case05_recover_cells_and_kzg_proofs),
+        create_provider(EIP7594, 'compute_cells_and_kzg_proofs', case_compute_cells_and_kzg_proofs),
+        create_provider(EIP7594, 'verify_cell_kzg_proof', case_verify_cell_kzg_proof),
+        create_provider(EIP7594, 'verify_cell_kzg_proof_batch', case_verify_cell_kzg_proof_batch),
+        create_provider(EIP7594, 'recover_cells_and_kzg_proofs', case_recover_cells_and_kzg_proofs),
     ])


### PR DESCRIPTION
As of https://github.com/ethereum/consensus-specs/pull/3788, `compute_cells` has been replaced by `compute_cells_and_kzg_proofs` and as a result `compute_cells` is no longer used. I don't believe this function is necessary now. I'm unaware of a situation where one would need the cells without proofs. Also, if you don't care about the proofs, you could use `compute_cells_and_kzg_proofs` and discard the proofs.