### PR TITLE
EIP7594-Polynomial-Commitments-Tests: Extend Tests for FFT and Coset FFT.

### DIFF
--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -20,7 +20,7 @@ def test_fft(spec):
     # then we apply an FFT to get evaluations over the roots of unity
     # we then apply an inverse FFT to the evaluations to get coefficients
 
-    # we check two things: 
+    # we check two things:
     # 1) the original coefficients and the resulting coefficients match
     # 2) the evaluations that we got are the same as if we would have evaluated individually
 
@@ -42,19 +42,19 @@ def test_fft(spec):
     # second check: result of FFT are really the evaluations
     for i, w in enumerate(roots_of_unity):
         individual_evaluation = spec.evaluate_polynomialcoeff(poly_coeff, w)
-        assert individual_evaluation == poly_eval[i] 
+        assert individual_evaluation == poly_eval[i]
 
 
 @with_eip7594_and_later
 @spec_test
 @single_phase
 def test_coset_fft(spec):
-    
+
     # in this test we sample a random polynomial in coefficient form
     # then we apply a Coset FFT to get evaluations over the coset of the roots of unity
     # we then apply an inverse Coset FFT to the evaluations to get coefficients
 
-    # we check two things: 
+    # we check two things:
     # 1) the original coefficients and the resulting coefficients match
     # 2) the evaluations that we got are the same as if we would have evaluated individually
 
@@ -81,7 +81,7 @@ def test_coset_fft(spec):
         # the element of the coset is coset_shift * w
         shifted_w = spec.BLSFieldElement((coset_shift * int(w)) % BLS_MODULUS)
         individual_evaluation = spec.evaluate_polynomialcoeff(poly_coeff, shifted_w)
-        assert individual_evaluation == poly_eval[i] 
+        assert individual_evaluation == poly_eval[i]
 
 
 @with_eip7594_and_later

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -49,17 +49,39 @@ def test_fft(spec):
 @spec_test
 @single_phase
 def test_coset_fft(spec):
+    
+    # in this test we sample a random polynomial in coefficient form
+    # then we apply a Coset FFT to get evaluations over the coset of the roots of unity
+    # we then apply an inverse Coset FFT to the evaluations to get coefficients
+
+    # we check two things: 
+    # 1) the original coefficients and the resulting coefficients match
+    # 2) the evaluations that we got are the same as if we would have evaluated individually
+
     rng = random.Random(5566)
 
     roots_of_unity = spec.compute_roots_of_unity(spec.FIELD_ELEMENTS_PER_BLOB)
 
+    # this is the shift that generates the coset
+    coset_shift = spec.PRIMITIVE_ROOT_OF_UNITY
+
+    # sample a random polynomial
     poly_coeff = [rng.randint(0, BLS_MODULUS - 1) for _ in range(spec.FIELD_ELEMENTS_PER_BLOB)]
 
+    # do a coset FFT and then an inverse coset FFT
     poly_eval = spec.coset_fft_field(poly_coeff, roots_of_unity)
     poly_coeff_inversed = spec.coset_fft_field(poly_eval, roots_of_unity, inv=True)
 
+    # first check: inverse coset FFT after coset FFT results in original coefficients
     assert len(poly_eval) == len(poly_coeff) == len(poly_coeff_inversed)
     assert poly_coeff_inversed == poly_coeff
+
+    # second check: result of FFT are really the evaluations over the coset
+    for i, w in enumerate(roots_of_unity):
+        # the element of the coset is coset_shift * w
+        shifted_w = spec.BLSFieldElement((coset_shift * int(w)) % BLS_MODULUS)
+        individual_evaluation = spec.evaluate_polynomialcoeff(poly_coeff, shifted_w)
+        assert individual_evaluation == poly_eval[i] 
 
 
 @with_eip7594_and_later


### PR DESCRIPTION
This PR extends the tests for `fft_field` and `coset_fft_field` in EIP7594.

Previously, the tests just checked that doing an inverse FFT after an FFT results in the original coefficients. 
Especially, the tests would have accepted even if both FFT and inverse FFT had done nothing. 

The new test additionally checks that the result of the FFT is consistent with individually evaluating the polynomial via `evaluate_polynomialcoeff`.