### PR TITLE
Remove `assert len(missing_cell_indices) != 0` check

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -565,9 +565,6 @@ def construct_vanishing_polynomial(missing_cell_indices: Sequence[CellIndex]) ->
     We never encounter this case however because this method is used solely for recovery and recovery only
     works if at least half of the cells are available.
     """
-
-    assert len(missing_cell_indices) != 0
-
     # Get the small domain
     roots_of_unity_reduced = compute_roots_of_unity(CELLS_PER_EXT_BLOB)
 


### PR DESCRIPTION
Hotfix for the `v1.5.0-alpha.3` release
Revert this line from https://github.com/ethereum/consensus-specs/issues/3781

Note from @kevaundray 
> That was a defensive assert so it should, it’s meant to be testing that we don’t have any cells missing, but in that function the parameter is the number of missing cells (inverted), so I think it needs to be `!= CELLS_PER_EXT_BLOB` ie not all of the missing cell ids are present