### PR TITLE
EIP7594: Universal Verification in verify_cell_kzg_proof_batch

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -525,7 +525,7 @@ def verify_cell_kzg_proof_batch_impl(row_commitments: Sequence[KZGCommitment],
     # Step 4.3: Compute RLP = sum_k r^k * h_k^n * proofs[k]
     weighted_r_powers = []
     for k in range(num_cells):
-        cosetshift = coset_shift_for_cell(column_indices[k])
+        cosetshift = int(coset_shift_for_cell(column_indices[k]))
         cosetshift_pow = pow(cosetshift, n, BLS_MODULUS)
         wrp = (r_powers[k] * cosetshift_pow) % BLS_MODULUS
         weighted_r_powers.append(wrp)

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -22,7 +22,7 @@
     - [`_fft_field`](#_fft_field)
     - [`fft_field`](#fft_field)
     - [`coset_fft_field`](#coset_fft_field)
-    - [`verify_cell_kzg_proof_batch_challenge`](#verify_cell_kzg_proof_batch_challenge)
+    - [`compute_verify_cell_kzg_proof_batch_challenge`](#compute_verify_cell_kzg_proof_batch_challenge)
   - [Polynomials in coefficient form](#polynomials-in-coefficient-form)
     - [`polynomial_eval_to_coeff`](#polynomial_eval_to_coeff)
     - [`add_polynomialcoeff`](#add_polynomialcoeff)
@@ -225,14 +225,14 @@ def coset_fft_field(vals: Sequence[BLSFieldElement],
         return fft_field(vals, roots_of_unity, inv)
 ```
 
-#### `verify_cell_kzg_proof_batch_challenge`
+#### `compute_verify_cell_kzg_proof_batch_challenge`
 
 ```python
-def verify_cell_kzg_proof_batch_challenge(row_commitments: Sequence[KZGCommitment],
-                                          row_indices: Sequence[RowIndex],
-                                          column_indices: Sequence[ColumnIndex],
-                                          cosets_evals: Sequence[CosetEvals],
-                                          proofs: Sequence[KZGProof]) -> BLSFieldElement:
+def compute_verify_cell_kzg_proof_batch_challenge(row_commitments: Sequence[KZGCommitment],
+                                                  row_indices: Sequence[RowIndex],
+                                                  column_indices: Sequence[ColumnIndex],
+                                                  cosets_evals: Sequence[CosetEvals],
+                                                  proofs: Sequence[KZGProof]) -> BLSFieldElement:
     """
     Compute a random challenge r used in the universal verification equation, see
     https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240
@@ -511,7 +511,7 @@ def verify_cell_kzg_proof_batch_impl(row_commitments: Sequence[KZGCommitment],
 
     # Step 1: Derive powers of r, i.e., r^0, ..., r^{num_cells-1}
     r = int(
-        verify_cell_kzg_proof_batch_challenge(
+        compute_verify_cell_kzg_proof_batch_challenge(
             row_commitments,
             row_indices,
             column_indices,

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -140,6 +140,24 @@ def test_verify_cell_kzg_proof_batch(spec):
         proofs_bytes=[proofs[0], proofs[4]],
     )
 
+@with_eip7594_and_later
+@spec_test
+@single_phase
+def test_verify_cell_kzg_proof_batch_invalid(spec):
+    blob = get_sample_blob(spec)
+    commitment = spec.blob_to_kzg_commitment(blob)
+    cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
+
+    assert len(cells) == len(proofs)
+
+    assert not spec.verify_cell_kzg_proof_batch(
+        row_commitments_bytes=[commitment],
+        row_indices=[0, 0],
+        column_indices=[0, 4],
+        cells=[cells[0], cells[5]],
+        proofs_bytes=[proofs[0], proofs[4]],
+    )
+
 
 @with_eip7594_and_later
 @spec_test

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -126,6 +126,8 @@ def test_verify_cell_kzg_proof(spec):
 @spec_test
 @single_phase
 def test_verify_cell_kzg_proof_batch(spec):
+
+    # test with a single blob / commitment
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
     cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
@@ -140,11 +142,45 @@ def test_verify_cell_kzg_proof_batch(spec):
         proofs_bytes=[proofs[0], proofs[4]],
     )
 
+    # now test with three blobs / commitments
+    all_blobs = []
+    all_commitments = []
+    all_cells = []
+    all_proofs = []
+    for _ in range(3):
+        blob = get_sample_blob(spec)
+        commitment = spec.blob_to_kzg_commitment(blob)
+        cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
+
+        assert len(cells) == len(proofs)
+
+        all_blobs.append(blob)
+        all_commitments.append(commitment)
+        all_cells.append(cells)
+        all_proofs.append(proofs)
+
+    # the cells of interest
+    row_indices = [0, 0, 1, 2, 1]
+    column_indices = [0, 4, 0, 1, 2]
+    cells = [all_cells[i][j] for (i, j) in zip(row_indices, column_indices)]
+    proofs = [all_proofs[i][j] for (i, j) in zip(row_indices, column_indices)]
+
+    # do the check
+    assert spec.verify_cell_kzg_proof_batch(
+        row_commitments_bytes=all_commitments,
+        row_indices=row_indices,
+        column_indices=column_indices,
+        cells=cells,
+        proofs_bytes=proofs,
+    )
+
 
 @with_eip7594_and_later
 @spec_test
 @single_phase
 def test_verify_cell_kzg_proof_batch_invalid(spec):
+
+    # test with a single blob / commitment
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
     cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
@@ -155,8 +191,43 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
         row_commitments_bytes=[commitment],
         row_indices=[0, 0],
         column_indices=[0, 4],
-        cells=[cells[0], cells[5]],
+        cells=[cells[0], cells[5]],  # Note: this is where it should go wrong
         proofs_bytes=[proofs[0], proofs[4]],
+    )
+
+    # now test with three blobs / commitments
+    all_blobs = []
+    all_commitments = []
+    all_cells = []
+    all_proofs = []
+    for _ in range(3):
+        blob = get_sample_blob(spec)
+        commitment = spec.blob_to_kzg_commitment(blob)
+        cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
+
+        assert len(cells) == len(proofs)
+
+        all_blobs.append(blob)
+        all_commitments.append(commitment)
+        all_cells.append(cells)
+        all_proofs.append(proofs)
+
+    # the cells of interest
+    row_indices = [0, 0, 1, 2, 1]
+    column_indices = [0, 4, 0, 1, 2]
+    cells = [all_cells[i][j] for (i, j) in zip(row_indices, column_indices)]
+    proofs = [all_proofs[i][j] for (i, j) in zip(row_indices, column_indices)]
+
+    # let's change one of the cells. Then it should not verify
+    cells[1] = all_cells[1][3]
+
+    # do the check
+    assert not spec.verify_cell_kzg_proof_batch(
+        row_commitments_bytes=all_commitments,
+        row_indices=row_indices,
+        column_indices=column_indices,
+        cells=cells,
+        proofs_bytes=proofs,
     )
 
 

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -140,6 +140,7 @@ def test_verify_cell_kzg_proof_batch(spec):
         proofs_bytes=[proofs[0], proofs[4]],
     )
 
+
 @with_eip7594_and_later
 @spec_test
 @single_phase


### PR DESCRIPTION
## Summary
This PR adds an implementation of the [universal verification equation](https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240) for verifying multiple cell KZG proofs.
Before, the spec recommended to use the universal verification equation in a comment, but the code specified verifying proofs individually.

The following has been changed:
- improved tests for `verify_cell_kzg_proof_batch`
- added a function `verify_cell_kzg_proof_batch_impl` that is called by `verify_cell_kzg_proof_batch`
- added a function `coset_shift_for_cell` to get the shift that specifies a coset
- added a function `verify_cell_kzg_proof_batch_challenge` to get the challenge used for random linear combination

## Motivation
Arguably one of the most important if not the most important thing to do right in terms of security for PeerDAS is how to verify cell proofs. To me, it feels dangerous to leave it to the implementors to read the and implement it correctly, given that verification is that important. In other words, I don't believe it is a good idea (especially for verification) that we *actively* cause a gap between what is specified and what will be implemented.

I would be happy to hear your feedback before investing more time.

## Notes
I did not implement the efficient way of computing the combined interpolation polynomial (Appendix of the blogpost) and instead used a *fully equivalent* naive way of doing this. The rationale behind this is that we do not want to make the spec to complicated. At the same time, the "random linear combination" part is important to have in the spec, as it is no longer fully equivalent to a naive implementation that verifies each proof individually. Concretely, it really changes the success probability of an adversary (by a negligible amount).
