### PR TITLE
Simplify is_better_update condition

### DIFF
--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -204,7 +204,7 @@ def is_better_update(new_update: LightClientUpdate, old_update: LightClientUpdat
     new_has_supermajority = new_num_active_participants * 3 >= max_active_participants * 2
     old_has_supermajority = old_num_active_participants * 3 >= max_active_participants * 2
     if new_has_supermajority != old_has_supermajority:
-        return new_has_supermajority > old_has_supermajority
+        return new_has_supermajority
     if not new_has_supermajority and new_num_active_participants != old_num_active_participants:
         return new_num_active_participants > old_num_active_participants
 


### PR DESCRIPTION
If `new_has_supermajority != old_has_supermajority` 

| new | old | new > old | 
| --- | --- | --------- | 
| 1   | 0   | 1         | 
| 0   | 1   | 0         | 

So the statement is equivalent to just `new_has_supermajority`