### PR TITLE
Add MetadataV3 with custody_subnet_count

### DIFF
--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -11,16 +11,38 @@ The specification of these changes continues in the same format as the network s
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Modifications in Electra](#modifications-in-electra)
+  - [MetaData](#metadata)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
     - [Global topics](#global-topics)
       - [`beacon_aggregate_and_proof`](#beacon_aggregate_and_proof)
       - [`beacon_attestation_{subnet_id}`](#beacon_attestation_subnet_id)
+  - [The Req/Resp domain](#the-reqresp-domain)
+    - [Messages](#messages)
+      - [GetMetaData v3](#getmetadata-v3)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
 ## Modifications in Electra
+
+### MetaData
+
+The `MetaData` stored locally by clients is updated with an additional field to communicate the custody subnet count.
+
+```
+(
+  seq_number: uint64
+  attnets: Bitvector[ATTESTATION_SUBNET_COUNT]
+  syncnets: Bitvector[SYNC_COMMITTEE_SUBNET_COUNT]
+  custody_subnet_count: uint64
+)
+```
+
+Where
+
+- `seq_number`, `attnets`, and `syncnets` have the same meaning defined in the Altair document.
+- `custody_subnet_count` represents the node's custody subnet count. Clients MAY reject ENRs with a value less than `CUSTODY_REQUIREMENT`.
 
 ### The gossip domain: gossipsub
 
@@ -57,3 +79,23 @@ The following convenience variables are re-defined
 The following validations are added:
 * [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(attestation)`.
 * [REJECT] `attestation.data.index == 0`
+
+### The Req/Resp domain
+
+#### Messages
+
+##### GetMetaData v3
+
+**Protocol ID:** `/eth2/beacon_chain/req/metadata/3/`
+
+No Request Content.
+
+Response Content:
+
+```
+(
+  MetaData
+)
+```
+
+Requests the MetaData of a peer, using the new `MetaData` definition given above that is extended from Altair. Other conditions for the `GetMetaData` protocol are unchanged from the Altair p2p networking document.

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -11,38 +11,16 @@ The specification of these changes continues in the same format as the network s
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Modifications in Electra](#modifications-in-electra)
-  - [MetaData](#metadata)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
     - [Global topics](#global-topics)
       - [`beacon_aggregate_and_proof`](#beacon_aggregate_and_proof)
       - [`beacon_attestation_{subnet_id}`](#beacon_attestation_subnet_id)
-  - [The Req/Resp domain](#the-reqresp-domain)
-    - [Messages](#messages)
-      - [GetMetaData v3](#getmetadata-v3)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
 ## Modifications in Electra
-
-### MetaData
-
-The `MetaData` stored locally by clients is updated with an additional field to communicate the custody subnet count.
-
-```
-(
-  seq_number: uint64
-  attnets: Bitvector[ATTESTATION_SUBNET_COUNT]
-  syncnets: Bitvector[SYNC_COMMITTEE_SUBNET_COUNT]
-  custody_subnet_count: uint64
-)
-```
-
-Where
-
-- `seq_number`, `attnets`, and `syncnets` have the same meaning defined in the Altair document.
-- `custody_subnet_count` represents the node's custody subnet count. Clients MAY reject ENRs with a value less than `CUSTODY_REQUIREMENT`.
 
 ### The gossip domain: gossipsub
 
@@ -79,23 +57,3 @@ The following convenience variables are re-defined
 The following validations are added:
 * [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(attestation)`.
 * [REJECT] `attestation.data.index == 0`
-
-### The Req/Resp domain
-
-#### Messages
-
-##### GetMetaData v3
-
-**Protocol ID:** `/eth2/beacon_chain/req/metadata/3/`
-
-No Request Content.
-
-Response Content:
-
-```
-(
-  MetaData
-)
-```
-
-Requests the MetaData of a peer, using the new `MetaData` definition given above that is extended from Altair. Other conditions for the `GetMetaData` protocol are unchanged from the Altair p2p networking document.


### PR DESCRIPTION
When a node receives an inbound connection from another node it does not have a way to learn its `custody_subnet_count`. Currently, this value is only propagated via ENRs, so it's only guaranteed to be available in the outbound connection code-path.

It's important to learn the custody_subnet_count of all peers to discover and utilize supernodes.