### PR TITLE
Replace "updated" with "modified" in Electra spec

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -60,7 +60,7 @@
     - [Modified `get_attesting_indices`](#modified-get_attesting_indices)
     - [Modified `get_next_sync_committee_indices`](#modified-get_next_sync_committee_indices)
   - [Beacon state mutators](#beacon-state-mutators)
-    - [Modified `initiate_validator_exit`](#modified--initiate_validator_exit)
+    - [Modified `initiate_validator_exit`](#modified-initiate_validator_exit)
     - [New `switch_to_compounding_validator`](#new-switch_to_compounding_validator)
     - [New `queue_excess_active_balance`](#new-queue_excess_active_balance)
     - [New `queue_entire_balance_and_reset_validator`](#new-queue_entire_balance_and_reset_validator)
@@ -655,7 +655,7 @@ def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorInd
 
 ### Beacon state mutators
 
-#### Modified  `initiate_validator_exit`
+#### Modified `initiate_validator_exit`
 
 *Note*: The function `initiate_validator_exit` is modified to use the new `compute_exit_epoch_and_update_churn` function.
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -41,13 +41,13 @@
     - [`BeaconState`](#beaconstate)
 - [Helper functions](#helper-functions)
   - [Predicates](#predicates)
-    - [Updated `compute_proposer_index`](#updated-compute_proposer_index)
-    - [Updated `is_eligible_for_activation_queue`](#updated-is_eligible_for_activation_queue)
+    - [Modified `compute_proposer_index`](#modified-compute_proposer_index)
+    - [Modified `is_eligible_for_activation_queue`](#modified-is_eligible_for_activation_queue)
     - [New `is_compounding_withdrawal_credential`](#new-is_compounding_withdrawal_credential)
     - [New `has_compounding_withdrawal_credential`](#new-has_compounding_withdrawal_credential)
     - [New `has_execution_withdrawal_credential`](#new-has_execution_withdrawal_credential)
-    - [Updated `is_fully_withdrawable_validator`](#updated-is_fully_withdrawable_validator)
-    - [Updated `is_partially_withdrawable_validator`](#updated-is_partially_withdrawable_validator)
+    - [Modified `is_fully_withdrawable_validator`](#modified-is_fully_withdrawable_validator)
+    - [Modified `is_partially_withdrawable_validator`](#modified-is_partially_withdrawable_validator)
   - [Misc](#misc-1)
     - [`get_committee_indices`](#get_committee_indices)
     - [`get_validator_max_effective_balance`](#get_validator_max_effective_balance)
@@ -60,24 +60,24 @@
     - [Modified `get_attesting_indices`](#modified-get_attesting_indices)
     - [Modified `get_next_sync_committee_indices`](#modified-get_next_sync_committee_indices)
   - [Beacon state mutators](#beacon-state-mutators)
-    - [Updated  `initiate_validator_exit`](#updated--initiate_validator_exit)
+    - [Modified  `initiate_validator_exit`](#modified--initiate_validator_exit)
     - [New `switch_to_compounding_validator`](#new-switch_to_compounding_validator)
     - [New `queue_excess_active_balance`](#new-queue_excess_active_balance)
     - [New `queue_entire_balance_and_reset_validator`](#new-queue_entire_balance_and_reset_validator)
     - [New `compute_exit_epoch_and_update_churn`](#new-compute_exit_epoch_and_update_churn)
     - [New `compute_consolidation_epoch_and_update_churn`](#new-compute_consolidation_epoch_and_update_churn)
-    - [Updated `slash_validator`](#updated-slash_validator)
+    - [Modified `slash_validator`](#modified-slash_validator)
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
   - [Epoch processing](#epoch-processing)
-    - [Updated `process_epoch`](#updated-process_epoch)
-    - [Updated  `process_registry_updates`](#updated--process_registry_updates)
+    - [Modified `process_epoch`](#modified-process_epoch)
+    - [Modified `process_registry_updates`](#modified-process_registry_updates)
     - [New `process_pending_balance_deposits`](#new-process_pending_balance_deposits)
     - [New `process_pending_consolidations`](#new-process_pending_consolidations)
-    - [Updated `process_effective_balance_updates`](#updated-process_effective_balance_updates)
+    - [Modified `process_effective_balance_updates`](#modified-process_effective_balance_updates)
   - [Block processing](#block-processing)
     - [Withdrawals](#withdrawals)
-      - [Updated `get_expected_withdrawals`](#updated-get_expected_withdrawals)
-      - [Updated `process_withdrawals`](#updated-process_withdrawals)
+      - [Modified `get_expected_withdrawals`](#modified-get_expected_withdrawals)
+      - [Modified `process_withdrawals`](#modified-process_withdrawals)
     - [Execution payload](#execution-payload)
       - [Modified `process_execution_payload`](#modified-process_execution_payload)
     - [Operations](#operations)
@@ -85,12 +85,12 @@
       - [Attestations](#attestations)
         - [Modified `process_attestation`](#modified-process_attestation)
       - [Deposits](#deposits)
-        - [Updated  `apply_deposit`](#updated--apply_deposit)
+        - [Modified `apply_deposit`](#modified-apply_deposit)
         - [New `is_valid_deposit_signature`](#new-is_valid_deposit_signature)
         - [Modified `add_validator_to_registry`](#modified-add_validator_to_registry)
-        - [Updated `get_validator_from_deposit`](#updated-get_validator_from_deposit)
+        - [Modified `get_validator_from_deposit`](#modified-get_validator_from_deposit)
       - [Voluntary exits](#voluntary-exits)
-        - [Updated `process_voluntary_exit`](#updated-process_voluntary_exit)
+        - [Modified `process_voluntary_exit`](#modified-process_voluntary_exit)
       - [Execution layer withdrawal requests](#execution-layer-withdrawal-requests)
         - [New `process_withdrawal_request`](#new-process_withdrawal_request)
       - [Deposit requests](#deposit-requests)
@@ -429,9 +429,9 @@ class BeaconState(Container):
 
 ### Predicates
 
-#### Updated `compute_proposer_index`
+#### Modified `compute_proposer_index`
 
-*Note*: The function is modified to use `MAX_EFFECTIVE_BALANCE_ELECTRA` preset.
+*Note*: The function `compute_proposer_index` is modified to use `MAX_EFFECTIVE_BALANCE_ELECTRA`.
 
 ```python
 def compute_proposer_index(state: BeaconState, indices: Sequence[ValidatorIndex], seed: Bytes32) -> ValidatorIndex:
@@ -452,7 +452,9 @@ def compute_proposer_index(state: BeaconState, indices: Sequence[ValidatorIndex]
         i += 1
 ```
 
-#### Updated `is_eligible_for_activation_queue`
+#### Modified `is_eligible_for_activation_queue`
+
+*Note*: The function `is_eligible_for_activation_queue` is modified to use `MIN_ACTIVATION_BALANCE` instead of `MAX_EFFECTIVE_BALANCE`.
 
 ```python
 def is_eligible_for_activation_queue(validator: Validator) -> bool:
@@ -492,7 +494,9 @@ def has_execution_withdrawal_credential(validator: Validator) -> bool:
     return has_compounding_withdrawal_credential(validator) or has_eth1_withdrawal_credential(validator)
 ```
 
-#### Updated `is_fully_withdrawable_validator`
+#### Modified `is_fully_withdrawable_validator`
+
+*Note*: The function `is_fully_withdrawable_validator` is modified to use `has_execution_withdrawal_credential` instead of `has_eth1_withdrawal_credential`.
 
 ```python
 def is_fully_withdrawable_validator(validator: Validator, balance: Gwei, epoch: Epoch) -> bool:
@@ -506,7 +510,9 @@ def is_fully_withdrawable_validator(validator: Validator, balance: Gwei, epoch: 
     )
 ```
 
-#### Updated `is_partially_withdrawable_validator`
+#### Modified `is_partially_withdrawable_validator`
+
+*Note*: The function `is_partially_withdrawable_validator` is modified to use `get_validator_max_effective_balance` instead of `MAX_EFFECTIVE_BALANCE` and `has_execution_withdrawal_credential` instead of `has_eth1_withdrawal_credential`.
 
 ```python
 def is_partially_withdrawable_validator(validator: Validator, balance: Gwei) -> bool:
@@ -597,6 +603,8 @@ def get_pending_balance_to_withdraw(state: BeaconState, validator_index: Validat
 
 #### Modified `get_attesting_indices`
 
+*Note*: The function `get_attesting_indices` is modified to support EIP7549.
+
 ```python
 def get_attesting_indices(state: BeaconState, attestation: Attestation) -> Set[ValidatorIndex]:
     """
@@ -618,7 +626,7 @@ def get_attesting_indices(state: BeaconState, attestation: Attestation) -> Set[V
 
 #### Modified `get_next_sync_committee_indices`
 
-*Note*: The function is modified to use `MAX_EFFECTIVE_BALANCE_ELECTRA` preset.
+*Note*: The function `get_next_sync_committee_indices` is modified to use `MAX_EFFECTIVE_BALANCE_ELECTRA`.
 
 ```python
 def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
@@ -645,10 +653,11 @@ def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorInd
     return sync_committee_indices
 ```
 
-
 ### Beacon state mutators
 
-#### Updated  `initiate_validator_exit`
+#### Modified  `initiate_validator_exit`
+
+*Note*: The function `initiate_validator_exit` is modified to use the new `compute_exit_epoch_and_update_churn` function.
 
 ```python
 def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
@@ -692,6 +701,7 @@ def queue_excess_active_balance(state: BeaconState, index: ValidatorIndex) -> No
 ```
 
 #### New `queue_entire_balance_and_reset_validator`
+
 ```python
 def queue_entire_balance_and_reset_validator(state: BeaconState, index: ValidatorIndex) -> None:
     balance = state.balances[index]
@@ -757,7 +767,9 @@ def compute_consolidation_epoch_and_update_churn(state: BeaconState, consolidati
     return state.earliest_consolidation_epoch
 ```
 
-#### Updated `slash_validator`
+#### Modified `slash_validator`
+
+*Note*: The function `slash_validator` is modified to change how the slashing penalty and proposer/whistleblower rewards are calculated in accordance with EIP7251.
 
 ```python
 def slash_validator(state: BeaconState,
@@ -791,7 +803,10 @@ def slash_validator(state: BeaconState,
 
 ### Epoch processing
 
-#### Updated `process_epoch`
+#### Modified `process_epoch`
+
+*Note*: The function `process_epoch` is modified to call updated functions and to process pending balance deposits and pending consolidations which are new in Electra.
+
 ```python
 def process_epoch(state: BeaconState) -> None:
     process_justification_and_finalization(state)
@@ -810,9 +825,9 @@ def process_epoch(state: BeaconState) -> None:
     process_sync_committee_updates(state)
 ```
 
-#### Updated  `process_registry_updates`
+#### Modified `process_registry_updates`
 
-`process_registry_updates` uses the updated definition of `initiate_validator_exit`
+*Note*: The function `process_registry_updates` is modified to use the updated definition of `initiate_validator_exit`
 and changes how the activation epochs are computed for eligible validators.
 
 ```python
@@ -899,9 +914,9 @@ def process_pending_consolidations(state: BeaconState) -> None:
     state.pending_consolidations = state.pending_consolidations[next_pending_consolidation:]
 ```
 
-#### Updated `process_effective_balance_updates`
+#### Modified `process_effective_balance_updates`
 
-`process_effective_balance_updates` is updated with a new limit for the maximum effective balance.
+*Note*: The function `process_effective_balance_updates` is modified to use the new limit for the maximum effective balance.
 
 ```python
 def process_effective_balance_updates(state: BeaconState) -> None:
@@ -911,6 +926,7 @@ def process_effective_balance_updates(state: BeaconState) -> None:
         HYSTERESIS_INCREMENT = uint64(EFFECTIVE_BALANCE_INCREMENT // HYSTERESIS_QUOTIENT)
         DOWNWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_DOWNWARD_MULTIPLIER
         UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_UPWARD_MULTIPLIER
+        # [Modified in Electra:EIP7251]
         EFFECTIVE_BALANCE_LIMIT = (
             MAX_EFFECTIVE_BALANCE_ELECTRA if has_compounding_withdrawal_credential(validator)
             else MIN_ACTIVATION_BALANCE
@@ -938,7 +954,9 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 #### Withdrawals
 
-##### Updated `get_expected_withdrawals`
+##### Modified `get_expected_withdrawals`
+
+*Note*: The function `get_expected_withdrawals` is modified to support EIP7251.
 
 ```python
 def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64]:
@@ -994,7 +1012,7 @@ def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], 
     return withdrawals, partial_withdrawals_count
 ```
 
-##### Updated `process_withdrawals`
+##### Modified `process_withdrawals`
 
 ```python
 def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
@@ -1160,9 +1178,9 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
 
 ##### Deposits
 
-###### Updated  `apply_deposit`
+###### Modified `apply_deposit`
 
-*NOTE*: `process_deposit` is updated with a new definition of `apply_deposit`.
+*Note*: The function `process_deposit` is modified to support EIP7251.
 
 ```python
 def apply_deposit(state: BeaconState,
@@ -1180,7 +1198,7 @@ def apply_deposit(state: BeaconState,
         index = ValidatorIndex(validator_pubkeys.index(pubkey))
         state.pending_balance_deposits.append(
             PendingBalanceDeposit(index=index, amount=amount)
-        )  # [Modified in Electra:EIP-7251]
+        )  # [Modified in Electra:EIP7251]
         # Check if valid deposit switch to compounding credentials
         if (
             is_compounding_withdrawal_credential(withdrawal_credentials)
@@ -1210,6 +1228,8 @@ def is_valid_deposit_signature(pubkey: BLSPubkey,
 
 ###### Modified `add_validator_to_registry`
 
+*Note*: The function `add_validator_to_registry` is modified to initialize the validator with a balance of zero and add a pending balance deposit to the queue.
+
 ```python
 def add_validator_to_registry(state: BeaconState,
                               pubkey: BLSPubkey,
@@ -1225,7 +1245,9 @@ def add_validator_to_registry(state: BeaconState,
     state.pending_balance_deposits.append(PendingBalanceDeposit(index=index, amount=amount))  # [New in Electra:EIP7251]
 ```
 
-###### Updated `get_validator_from_deposit`
+###### Modified `get_validator_from_deposit`
+
+*Note*: The function `get_validator_from_deposit` is modified to initialize the validator with an effective balance of zero.
 
 ```python
 def get_validator_from_deposit(pubkey: BLSPubkey, withdrawal_credentials: Bytes32) -> Validator:
@@ -1241,7 +1263,10 @@ def get_validator_from_deposit(pubkey: BLSPubkey, withdrawal_credentials: Bytes3
 ```
 
 ##### Voluntary exits
-###### Updated `process_voluntary_exit`
+
+###### Modified `process_voluntary_exit`
+
+*Note*: The function `process_voluntary_exit` is modified to ensure the validator has no pending withdrawals in the queue.
 
 ```python
 def process_voluntary_exit(state: BeaconState, signed_voluntary_exit: SignedVoluntaryExit) -> None:
@@ -1268,8 +1293,6 @@ def process_voluntary_exit(state: BeaconState, signed_voluntary_exit: SignedVolu
 ##### Execution layer withdrawal requests
 
 ###### New `process_withdrawal_request`
-
-*Note*: This function is new in Electra following EIP-7002 and EIP-7251.
 
 ```python
 def process_withdrawal_request(
@@ -1337,8 +1360,6 @@ def process_withdrawal_request(
 ##### Deposit requests
 
 ###### New `process_deposit_request`
-
-*Note*: This function is new in Electra:EIP6110.
 
 ```python
 def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1014,6 +1014,8 @@ def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], 
 
 ##### Modified `process_withdrawals`
 
+*Note*: The function `process_withdrawals` is modified to support EIP7251.
+
 ```python
 def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
     expected_withdrawals, partial_withdrawals_count = get_expected_withdrawals(state)  # [Modified in Electra:EIP7251]


### PR DESCRIPTION
This PR does the following:

* Replace usages of "updated" with "modified" to be consistent with previous specs.
* For modified functions, ensure there is a note about the changes.
  * I updated some of these notes to be consistent with other specs.
  * Some of these notes could be better 😅
* Delete notes for new functions as we don't normally do this.
  * This was for `process_withdrawal_request` and `process_deposit_request`.
* Replace "NOTE" with "Note" and "Electra:EIP-7251" with "Electra:EIP7251" for consistency.
* Fix some excess blank lines & missing blank line nits.