### PR TITLE
Fix link to Deneb spec

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -110,7 +110,7 @@ Electra is a consensus-layer upgrade containing a number of features. Including:
 * [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): Increase the MAX_EFFECTIVE_BALANCE
 * [EIP-7549](https://eips.ethereum.org/EIPS/eip-7549): Move committee index outside Attestation
 
-*Note:* This specification is built upon [Deneb](../../deneb/beacon_chain.md) and is under active development.
+*Note:* This specification is built upon [Deneb](../deneb/beacon_chain.md) and is under active development.
 
 ## Constants
 


### PR DESCRIPTION
The link to the Deneb spec went back one too many times.

<img width="931" alt="image" src="https://github.com/ethereum/consensus-specs/assets/95511699/6f668c1a-d757-4653-8c23-12b154d42968">
