### PR TITLE
eip6800: add concurrent execution information

### DIFF
--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -130,6 +130,10 @@ class StemStateDiff(Container):
     stem: Stem
     # Valid only if list is sorted by suffixes
     suffix_diffs: List[SuffixStateDiff, VERKLE_WIDTH]
+    # Bitmap to indicate which tx accesses this stem,
+    # if bit #n is set, then transaction #n accesses
+    # this stem. Used to execute txs concurrently.
+    tx_accesses: BitList[MAX_TRANSACTIONS_PER_PAYLOAD]
 ```
 
 #### `IPAProof`

--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -133,7 +133,7 @@ class StemStateDiff(Container):
     # Bitmap to indicate which tx accesses this stem,
     # if bit #n is set, then transaction #n accesses
     # this stem. Used to execute txs concurrently.
-    tx_accesses: BitList[MAX_TRANSACTIONS_PER_PAYLOAD]
+    tx_accesses: Bitlist[MAX_TRANSACTIONS_PER_PAYLOAD]
 ```
 
 #### `IPAProof`


### PR DESCRIPTION
Modifies the stateless witness to mark each stem with a transaction access bitmap. This bitmap is used by the client to run compatible transactions concurrently.