### PR TITLE
Fix EL block hash computation for Deneb

### DIFF
--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -133,7 +133,7 @@ def test_bad_parent_hash_first_payload(spec, state):
 
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.parent_hash = b'\x55' * 32
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
 
@@ -146,7 +146,7 @@ def test_invalid_bad_parent_hash_regular_payload(spec, state):
 
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.parent_hash = spec.Hash32()
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
 
@@ -156,7 +156,7 @@ def run_bad_prev_randao_test(spec, state):
 
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.prev_randao = b'\x42' * 32
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
 
@@ -182,7 +182,7 @@ def run_bad_everything_test(spec, state):
     execution_payload.parent_hash = spec.Hash32()
     execution_payload.prev_randao = spec.Bytes32()
     execution_payload.timestamp = 0
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
 
@@ -211,7 +211,7 @@ def run_bad_timestamp_test(spec, state, is_future):
     else:
         timestamp = execution_payload.timestamp - 1
     execution_payload.timestamp = timestamp
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)
 
@@ -249,7 +249,7 @@ def run_non_empty_extra_data_test(spec, state):
 
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.extra_data = b'\x45' * 12
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
     assert state.latest_execution_payload_header.extra_data == execution_payload.extra_data
@@ -278,7 +278,7 @@ def run_non_empty_transactions_test(spec, state):
         spec.Transaction(b'\x99' * 128)
         for _ in range(num_transactions)
     ]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
     assert state.latest_execution_payload_header.transactions_root == execution_payload.transactions.hash_tree_root()
@@ -304,7 +304,7 @@ def run_zero_length_transaction_test(spec, state):
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.transactions = [spec.Transaction(b'')]
     assert len(execution_payload.transactions[0]) == 0
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
     assert state.latest_execution_payload_header.transactions_root == execution_payload.transactions.hash_tree_root()

--- a/tests/core/pyspec/eth2spec/test/bellatrix/fork_choice/test_on_merge_block.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/fork_choice/test_on_merge_block.py
@@ -75,7 +75,7 @@ def test_all_valid(spec, state):
     def run_func():
         block = build_empty_block_for_next_slot(spec, state)
         block.body.execution_payload.parent_hash = pow_block.block_hash
-        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
         signed_block = state_transition_and_sign_block(spec, state, block)
         yield from tick_and_add_block(spec, store, signed_block, test_steps, merge_block=True)
         # valid
@@ -107,7 +107,7 @@ def test_block_lookup_failed(spec, state):
     def run_func():
         block = build_empty_block_for_next_slot(spec, state)
         block.body.execution_payload.parent_hash = pow_block.block_hash
-        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
         signed_block = state_transition_and_sign_block(spec, state, block)
         yield from tick_and_add_block(spec, store, signed_block, test_steps, valid=False, merge_block=True,
                                       block_not_found=True)
@@ -141,7 +141,7 @@ def test_too_early_for_merge(spec, state):
     def run_func():
         block = build_empty_block_for_next_slot(spec, state)
         block.body.execution_payload.parent_hash = pow_block.block_hash
-        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
         signed_block = state_transition_and_sign_block(spec, state, block)
         yield from tick_and_add_block(spec, store, signed_block, test_steps, valid=False, merge_block=True)
 
@@ -174,7 +174,7 @@ def test_too_late_for_merge(spec, state):
     def run_func():
         block = build_empty_block_for_next_slot(spec, state)
         block.body.execution_payload.parent_hash = pow_block.block_hash
-        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
         signed_block = state_transition_and_sign_block(spec, state, block)
         yield from tick_and_add_block(spec, store, signed_block, test_steps, valid=False, merge_block=True)
 

--- a/tests/core/pyspec/eth2spec/test/bellatrix/sync/test_optimistic.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/sync/test_optimistic.py
@@ -65,7 +65,7 @@ def test_from_syncing_to_invalid(spec, state):
             block_hashes[f'chain_a_{i - 1}'] if i != 0 else block_hashes['block_0']
         )
         block.body.execution_payload.extra_data = spec.hash(bytes(f'chain_a_{i}', 'UTF-8'))
-        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
         block_hashes[f'chain_a_{i}'] = block.body.execution_payload.block_hash
 
         signed_block = state_transition_and_sign_block(spec, state, block)
@@ -82,7 +82,7 @@ def test_from_syncing_to_invalid(spec, state):
             block_hashes[f'chain_b_{i - 1}'] if i != 0 else block_hashes['block_0']
         )
         block.body.execution_payload.extra_data = spec.hash(bytes(f'chain_b_{i}', 'UTF-8'))
-        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+        block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
         block_hashes[f'chain_b_{i}'] = block.body.execution_payload.block_hash
 
         signed_block = state_transition_with_full_block(spec, state, True, True, block=block)
@@ -95,7 +95,7 @@ def test_from_syncing_to_invalid(spec, state):
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.parent_hash = signed_blocks_b[-1].message.body.execution_payload.block_hash
     block.body.execution_payload.extra_data = spec.hash(bytes(f'chain_b_{i}', 'UTF-8'))
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     block_hashes['chain_b_3'] = block.body.execution_payload.block_hash
 
     # Ensure that no duplicate block hashes

--- a/tests/core/pyspec/eth2spec/test/bellatrix/unittests/test_validate_merge_block.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/unittests/test_validate_merge_block.py
@@ -60,7 +60,7 @@ def test_validate_merge_block_success(spec, state):
     pow_chain.head().total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.parent_hash = pow_chain.head().block_hash
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     run_validate_merge_block(spec, pow_chain, block)
 
 
@@ -81,7 +81,7 @@ def test_validate_merge_block_fail_parent_block_lookup(spec, state):
     pow_chain.head().total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.parent_hash = pow_chain.head().block_hash
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     run_validate_merge_block(spec, pow_chain, block, valid=False)
 
 
@@ -93,7 +93,7 @@ def test_validate_merge_block_fail_after_terminal(spec, state):
     pow_chain.head().total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY + uint256(1)
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.parent_hash = pow_chain.head().block_hash
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     run_validate_merge_block(spec, pow_chain, block, valid=False)
 
 
@@ -110,7 +110,7 @@ def test_validate_merge_block_tbh_override_success(spec, state):
     pow_chain.head().block_hash = TERMINAL_BLOCK_HASH
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.parent_hash = pow_chain.head().block_hash
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     run_validate_merge_block(spec, pow_chain, block)
 
 
@@ -126,7 +126,7 @@ def test_validate_merge_block_fail_parent_hash_is_not_tbh(spec, state):
     pow_chain.head().total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.parent_hash = pow_chain.head().block_hash
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     run_validate_merge_block(spec, pow_chain, block, valid=False)
 
 
@@ -143,7 +143,7 @@ def test_validate_merge_block_terminal_block_hash_fail_activation_not_reached(sp
     pow_chain.head().block_hash = TERMINAL_BLOCK_HASH
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.parent_hash = pow_chain.head().block_hash
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     run_validate_merge_block(spec, pow_chain, block, valid=False)
 
 
@@ -159,5 +159,5 @@ def test_validate_merge_block_fail_activation_not_reached_parent_hash_is_not_tbh
     pow_chain.head().total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.parent_hash = pow_chain.head().block_hash
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     run_validate_merge_block(spec, pow_chain, block, valid=False)

--- a/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_execution_payload.py
@@ -19,6 +19,6 @@ def test_invalid_bad_parent_hash_first_payload(spec, state):
 
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.parent_hash = b'\x55' * 32
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, valid=False)

--- a/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_withdrawals.py
@@ -259,7 +259,7 @@ def test_invalid_non_withdrawable_non_empty_withdrawals(spec, state):
         amount=420,
     )
     execution_payload.withdrawals.append(withdrawal)
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -272,7 +272,7 @@ def test_invalid_one_expected_full_withdrawal_and_none_in_withdrawals(spec, stat
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals = []
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -285,7 +285,7 @@ def test_invalid_one_expected_partial_withdrawal_and_none_in_withdrawals(spec, s
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals = []
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -298,7 +298,7 @@ def test_invalid_one_expected_full_withdrawal_and_duplicate_in_withdrawals(spec,
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals.append(execution_payload.withdrawals[0].copy())
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -311,7 +311,7 @@ def test_invalid_two_expected_partial_withdrawal_and_duplicate_in_withdrawals(sp
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals.append(execution_payload.withdrawals[0].copy())
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -325,7 +325,7 @@ def test_invalid_max_per_slot_full_withdrawals_and_one_less_in_withdrawals(spec,
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals = execution_payload.withdrawals[:-1]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -339,7 +339,7 @@ def test_invalid_max_per_slot_partial_withdrawals_and_one_less_in_withdrawals(sp
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals = execution_payload.withdrawals[:-1]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -353,7 +353,7 @@ def test_invalid_a_lot_fully_withdrawable_too_few_in_withdrawals(spec, state):
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals = execution_payload.withdrawals[:-1]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -367,7 +367,7 @@ def test_invalid_a_lot_partially_withdrawable_too_few_in_withdrawals(spec, state
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals = execution_payload.withdrawals[:-1]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -382,7 +382,7 @@ def test_invalid_a_lot_mixed_withdrawable_in_queue_too_few_in_withdrawals(spec, 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals = execution_payload.withdrawals[:-1]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -400,7 +400,7 @@ def test_invalid_incorrect_withdrawal_index(spec, state):
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals[0].index += 1
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -414,7 +414,7 @@ def test_invalid_incorrect_address_full(spec, state):
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals[0].address = b'\xff' * 20
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -428,7 +428,7 @@ def test_invalid_incorrect_address_partial(spec, state):
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals[0].address = b'\xff' * 20
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -441,7 +441,7 @@ def test_invalid_incorrect_amount_full(spec, state):
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals[0].amount += 1
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -454,7 +454,7 @@ def test_invalid_incorrect_amount_partial(spec, state):
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.withdrawals[0].amount += 1
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -474,7 +474,7 @@ def test_invalid_one_of_many_incorrectly_full(spec, state):
     withdrawal.index += 1
     withdrawal.address = b'\x99' * 20
     withdrawal.amount += 4000000
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -494,7 +494,7 @@ def test_invalid_one_of_many_incorrectly_partial(spec, state):
     withdrawal.index += 1
     withdrawal.address = b'\x99' * 20
     withdrawal.amount += 4000000
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -514,7 +514,7 @@ def test_invalid_many_incorrectly_full(spec, state):
             withdrawal.address = i.to_bytes(20, 'big')
         else:
             withdrawal.amount += 1
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 
@@ -534,7 +534,7 @@ def test_invalid_many_incorrectly_partial(spec, state):
             withdrawal.address = i.to_bytes(20, 'big')
         else:
             withdrawal.amount += 1
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_withdrawals_processing(spec, state, execution_payload, valid=False)
 

--- a/tests/core/pyspec/eth2spec/test/deneb/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/block_processing/test_process_execution_payload.py
@@ -78,7 +78,7 @@ def test_incorrect_blob_tx_type(spec, state):
     opaque_tx = b'\x04' + opaque_tx[1:]  # incorrect tx type
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments)
 
@@ -95,7 +95,7 @@ def test_incorrect_transaction_length_1_extra_byte(spec, state):
     opaque_tx = opaque_tx + b'\x12'  # incorrect tx length, longer
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments)
 
@@ -112,7 +112,7 @@ def test_incorrect_transaction_length_1_byte_short(spec, state):
     opaque_tx = opaque_tx[:-1]  # incorrect tx length, shorter
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments)
 
@@ -129,7 +129,7 @@ def test_incorrect_transaction_length_empty(spec, state):
     opaque_tx = opaque_tx[0:0]  # incorrect tx length, empty
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments)
 
@@ -146,7 +146,7 @@ def test_incorrect_transaction_length_32_extra_bytes(spec, state):
     opaque_tx = opaque_tx + b'\x12' * 32  # incorrect tx length
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments)
 
@@ -162,7 +162,7 @@ def test_no_transactions_with_commitments(spec, state):
     _, _, blob_kzg_commitments, _ = get_sample_opaque_tx(spec)
 
     execution_payload.transactions = []
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments)
 
@@ -179,7 +179,7 @@ def test_incorrect_commitment(spec, state):
     blob_kzg_commitments[0] = b'\x12' * 48  # incorrect commitment
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments)
 
@@ -196,7 +196,7 @@ def test_incorrect_commitments_order(spec, state):
     blob_kzg_commitments = [blob_kzg_commitments[1], blob_kzg_commitments[0]]  # incorrect order
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments)
 
@@ -227,7 +227,7 @@ def test_zeroed_commitment(spec, state):
     assert all(commitment == b'\x00' * 48 for commitment in blob_kzg_commitments)
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments)
 
@@ -243,7 +243,7 @@ def test_invalid_correct_input__execution_invalid(spec, state):
     opaque_tx, _, blob_kzg_commitments, _ = get_sample_opaque_tx(spec)
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments,
                                                 valid=False, execution_valid=False)
@@ -257,6 +257,6 @@ def test_invalid_exceed_max_blobs_per_block(spec, state):
     opaque_tx, _, blob_kzg_commitments, _ = get_sample_opaque_tx(spec, blob_count=spec.MAX_BLOBS_PER_BLOCK + 1)
 
     execution_payload.transactions = [opaque_tx]
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments, valid=False)

--- a/tests/core/pyspec/eth2spec/test/deneb/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/fork_choice/test_on_block.py
@@ -29,7 +29,7 @@ def get_block_with_blob(spec, state, rng=None):
     block = build_empty_block_for_next_slot(spec, state)
     opaque_tx, blobs, blob_kzg_commitments, blob_kzg_proofs = get_sample_opaque_tx(spec, blob_count=1, rng=rng)
     block.body.execution_payload.transactions = [opaque_tx]
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     block.body.blob_kzg_commitments = blob_kzg_commitments
     return block, blobs, blob_kzg_proofs
 

--- a/tests/core/pyspec/eth2spec/test/deneb/merkle_proof/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/merkle_proof/test_single_merkle_proof.py
@@ -36,7 +36,7 @@ def _run_blob_kzg_commitment_merkle_proof_test(spec, state, rng=None):
         )
     block.body.blob_kzg_commitments = blob_kzg_commitments
     block.body.execution_payload.transactions = [opaque_tx]
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     signed_block = sign_block(spec, state, block, proposer_index=0)
     blob_sidecars = spec.get_blob_sidecars(signed_block, blobs, proofs)
     blob_index = 0

--- a/tests/core/pyspec/eth2spec/test/deneb/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/sanity/test_blocks.py
@@ -40,7 +40,7 @@ def run_block_with_blobs(spec, state, blob_count, tx_count=1, blob_gas_used=1, e
     block.body.execution_payload.transactions = txs
     block.body.execution_payload.blob_gas_used = blob_gas_used
     block.body.execution_payload.excess_blob_gas = excess_blob_gas
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
 
     if valid:
         signed_block = state_transition_and_sign_block(spec, state, block)

--- a/tests/core/pyspec/eth2spec/test/deneb/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/unittests/validator/test_validator.py
@@ -26,7 +26,7 @@ def _get_sample_sidecars(spec, state, rng):
 
     block.body.blob_kzg_commitments = blob_kzg_commitments_1 + blob_kzg_commitments_2
     block.body.execution_payload.transactions = [opaque_tx_1, opaque_tx_2]
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
 
     blobs = blobs_1 + blobs_2
     proofs = proofs_1 + proofs_2

--- a/tests/core/pyspec/eth2spec/test/eip7594/merkle_proof/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/merkle_proof/test_single_merkle_proof.py
@@ -36,7 +36,7 @@ def _run_blob_kzg_commitments_merkle_proof_test(spec, state, rng=None):
         )
     block.body.blob_kzg_commitments = blob_kzg_commitments
     block.body.execution_payload.transactions = [opaque_tx]
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     signed_block = sign_block(spec, state, block, proposer_index=0)
     column_sidcars = spec.get_data_column_sidecars(signed_block, blobs)
     column_sidcar = column_sidcars[0]

--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
@@ -42,7 +42,7 @@ def test_basic_el_withdrawal_request(spec, state):
     )
     block = build_empty_block_for_next_slot(spec, state)
     block.body.execution_payload.withdrawal_requests = [withdrawal_request]
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     yield 'blocks', [signed_block]
@@ -79,7 +79,7 @@ def test_basic_btec_and_el_withdrawal_request_in_same_block(spec, state):
     )
     block.body.execution_payload.withdrawal_requests = [withdrawal_request]
 
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     yield 'blocks', [signed_block]
@@ -131,7 +131,7 @@ def test_basic_btec_before_el_withdrawal_request(spec, state):
     )
     block_2 = build_empty_block_for_next_slot(spec, state)
     block_2.body.execution_payload.withdrawal_requests = [withdrawal_request]
-    block_2.body.execution_payload.block_hash = compute_el_block_hash(spec, block_2.body.execution_payload)
+    block_2.body.execution_payload.block_hash = compute_el_block_hash(spec, block_2.body.execution_payload, state)
     signed_block_2 = state_transition_and_sign_block(spec, state, block_2)
 
     yield 'blocks', [signed_block_1, signed_block_2]
@@ -164,7 +164,7 @@ def test_cl_exit_and_el_withdrawal_request_in_same_block(spec, state):
     block = build_empty_block_for_next_slot(spec, state)
     block.body.voluntary_exits = signed_voluntary_exits
     block.body.execution_payload.withdrawal_requests = [withdrawal_request]
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     yield 'blocks', [signed_block]

--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
@@ -103,7 +103,7 @@ def prepare_state_and_block(spec,
     # Assign deposits and deposit requests
     block.body.deposits = deposits
     block.body.execution_payload.deposit_requests = deposit_requests
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
 
     return state, block
 
@@ -220,7 +220,7 @@ def test_deposit_transition__deposit_and_top_up_same_block(spec, state):
     # Artificially assign deposit's pubkey to a deposit request of the same block
     top_up_keys = [block.body.deposits[0].data.pubkey]
     block.body.execution_payload.deposit_requests[0].pubkey = top_up_keys[0]
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
 
     pre_pending_deposits = len(state.pending_balance_deposits)
 

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -59,6 +59,7 @@ def compute_el_header_block_hash(spec,
                                  payload_header,
                                  transactions_trie_root,
                                  withdrawals_trie_root=None,
+                                 parent_beacon_block_root=None,
                                  requests_trie_root=None):
     """
     Computes the RLP execution block hash described by an `ExecutionPayloadHeader`.
@@ -106,8 +107,7 @@ def compute_el_header_block_hash(spec,
         # excess_blob_gas
         execution_payload_header_rlp.append((big_endian_int, payload_header.excess_blob_gas))
         # parent_beacon_root
-        empty_root = bytes.fromhex("0000000000000000000000000000000000000000000000000000000000000000")
-        execution_payload_header_rlp.append((Binary(32, 32), empty_root))
+        execution_payload_header_rlp.append((Binary(32, 32), parent_beacon_block_root))
     if is_post_electra(spec):
         # requests_root
         execution_payload_header_rlp.append((Binary(32, 32), requests_trie_root))
@@ -186,15 +186,18 @@ def get_consolidation_request_rlp_bytes(consolidation_request):
     return b"\x02" + encode(values, sedes)
 
 
-def compute_el_block_hash(spec, payload):
+def compute_el_block_hash(spec, payload, pre_state):
     transactions_trie_root = compute_trie_root_from_indexed_data(payload.transactions)
 
     withdrawals_trie_root = None
+    parent_beacon_block_root = None
     requests_trie_root = None
 
     if is_post_capella(spec):
         withdrawals_encoded = [get_withdrawal_rlp(withdrawal) for withdrawal in payload.withdrawals]
         withdrawals_trie_root = compute_trie_root_from_indexed_data(withdrawals_encoded)
+    if is_post_deneb(spec):
+        parent_beacon_block_root = pre_state.latest_block_header.hash_tree_root()
     if is_post_electra(spec):
         requests_encoded = []
         requests_encoded += [get_deposit_request_rlp_bytes(request) for request in payload.deposit_requests]
@@ -210,6 +213,7 @@ def compute_el_block_hash(spec, payload):
         payload_header,
         transactions_trie_root,
         withdrawals_trie_root,
+        parent_beacon_block_root,
         requests_trie_root,
     )
 
@@ -250,7 +254,7 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
         payload.withdrawal_requests = []
         payload.consolidation_requests = []
 
-    payload.block_hash = compute_el_block_hash(spec, payload)
+    payload.block_hash = compute_el_block_hash(spec, payload, state)
 
     return payload
 
@@ -278,7 +282,7 @@ def build_randomized_execution_payload(spec, state, rng):
         for _ in range(num_transactions)
     ]
 
-    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload)
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     return execution_payload
 

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -6,7 +6,7 @@ from eth2spec.test.helpers.execution_payload import (
     compute_el_header_block_hash,
 )
 from eth2spec.test.helpers.forks import (
-    is_post_altair, is_post_bellatrix, is_post_capella, is_post_electra, is_post_whisk,
+    is_post_altair, is_post_bellatrix, is_post_capella, is_post_deneb, is_post_electra, is_post_whisk,
 )
 from eth2spec.test.helpers.keys import pubkeys
 from eth2spec.test.helpers.whisk import compute_whisk_initial_tracker_cached, compute_whisk_initial_k_commitment_cached
@@ -65,10 +65,13 @@ def get_sample_genesis_execution_payload_header(spec,
 
     transactions_trie_root = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
     withdrawals_trie_root = None
+    parent_beacon_block_root = None
     requests_trie_root = None
 
     if is_post_capella(spec):
         withdrawals_trie_root = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+    if is_post_deneb(spec):
+        parent_beacon_block_root = bytes.fromhex("0000000000000000000000000000000000000000000000000000000000000000")
     if is_post_electra(spec):
         requests_trie_root = bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 
@@ -77,6 +80,7 @@ def get_sample_genesis_execution_payload_header(spec,
         payload_header,
         transactions_trie_root,
         withdrawals_trie_root,
+        parent_beacon_block_root,
         requests_trie_root,
     )
     return payload_header

--- a/tests/core/pyspec/eth2spec/test/utils/randomized_block_tests.py
+++ b/tests/core/pyspec/eth2spec/test/utils/randomized_block_tests.py
@@ -253,7 +253,7 @@ def random_block_deneb(spec, state, signed_blocks, scenario_state, rng=Random(34
     opaque_tx, _, blob_kzg_commitments, _ = get_sample_opaque_tx(
         spec, blob_count=rng.randint(0, spec.MAX_BLOBS_PER_BLOCK), rng=rng)
     block.body.execution_payload.transactions.append(opaque_tx)
-    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload)
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     block.body.blob_kzg_commitments = blob_kzg_commitments
 
     return block


### PR DESCRIPTION
The parent beacon block hash was incorrectly set to zero in #3778. Passing the state to the computation function allows correct hash computation.