### PR TITLE
In batch cell verification, take commitment for each cell

### DIFF
--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -68,19 +68,18 @@ class DataColumnIdentifier(Container):
 ```python
 def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
     """
-    Verify if the proofs are correct
+    Verify if the proofs are correct.
     """
     assert sidecar.index < NUMBER_OF_COLUMNS
     assert len(sidecar.column) == len(sidecar.kzg_commitments) == len(sidecar.kzg_proofs)
 
-    row_indices = [RowIndex(i) for i in range(len(sidecar.column))]
+    commitments = [sidecar.kzg_commitments[i] for i in range(len(sidecar.column))]
     column_indices = [sidecar.index] * len(sidecar.column)
 
     # KZG batch verifies that the cells match the corresponding commitments and proofs
     return verify_cell_kzg_proof_batch(
-        row_commitments_bytes=sidecar.kzg_commitments,
-        row_indices=row_indices,  # all rows
-        column_indices=column_indices,  # specific column
+        commitments_bytes=commitments,
+        column_indices=column_indices,
         cells=sidecar.column,
         proofs_bytes=sidecar.kzg_proofs,
     )

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -73,12 +73,11 @@ def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
     assert sidecar.index < NUMBER_OF_COLUMNS
     assert len(sidecar.column) == len(sidecar.kzg_commitments) == len(sidecar.kzg_proofs)
 
-    commitments = [sidecar.kzg_commitments[i] for i in range(len(sidecar.column))]
     column_indices = [sidecar.index] * len(sidecar.column)
 
     # KZG batch verifies that the cells match the corresponding commitments and proofs
     return verify_cell_kzg_proof_batch(
-        commitments_bytes=commitments,
+        commitments_bytes=sidecar.kzg_commitments,
         column_indices=column_indices,
         cells=sidecar.column,
         proofs_bytes=sidecar.kzg_proofs,

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -686,9 +686,9 @@ def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
     """
     Verify that a set of cells belong to their corresponding commitments.
 
-    Specifically, given a set of tuples (`commitment`, `column_index`, `cell`, `proof`), for every tuple the function
-    verifies `proof` which shows that `cell` are the evaluations of the polynomial behind the `commitment`. The
-    evaluation domain is determined by `column_index`.
+    Specifically, given a set of tuples (``commitment``, ``column_index``, ``cell``, ``proof``), for every tuple
+    the function verifies `proof` which shows that ``cell`` are the evaluations of the polynomial behind the
+    ``commitment``. The evaluation domain is determined by ``column_index``.
 
     This function implements the universal verification equation that has been introduced here:
     https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -483,13 +483,14 @@ def verify_cell_kzg_proof_batch_impl(row_commitments: Sequence[KZGCommitment],
     """
     Helper: Verify that a set of cells belong to their corresponding commitment.
 
-    Specifically, given a set of tuples ((`row_index`, `column_index`), `evals`, `proof`), for every tuple it verifies
-    `proof` which shows that `evals` are actually the evaluations of the polynomial behind the corresponding commitment.
+    Specifically, given a set of tuples (``row_index``, ``column_index``, ``evals``, ``proof``), for every tuple it
+    verifies ``proof`` which shows that ``evals`` are actually the evaluations of the polynomial behind the
+    corresponding commitment.
 
-    The value `row_index` points to the right commitment in the array `row_commitments`, while the value `column_index`
+    The value ``row_index`` points to a commitment in the array ``row_commitments``, while the value ``column_index``
     determines the evaluation domain of the polynomial.
 
-    This function is the internal implementation of verify_cell_kzg_proof_batch().
+    This function is the internal implementation of ``verify_cell_kzg_proof_batch``.
     """
     assert len(row_indices) == len(column_indices) == len(cosets_evals) == len(proofs)
     for row_index in row_indices:
@@ -705,7 +706,6 @@ def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
     for proof_bytes in proofs_bytes:
         assert len(proof_bytes) == BYTES_PER_PROOF
 
-    # Get objects from bytes
     # Create the list of unique commitments we are dealing with
     deduplicated_commitments = list(set(commitments_bytes))
     row_commitments = [bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in deduplicated_commitments]

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -483,9 +483,10 @@ def verify_cell_kzg_proof_batch_impl(row_commitments: Sequence[KZGCommitment],
     """
     Helper: Verify that a set of cells belong to their corresponding commitment.
 
-    Given a list of ``row_commitments`` and four lists representing tuples of (``row_index``, ``column_index``,
-    ``evals``, ``proof``), the function verifies ``proof`` which shows that ``evals`` are the evaluations of
-    the polynomial associated with ``row_commitments[row_index]``, evaluated over the domain specified by ``column_index``.
+    Given a list of ``row_commitments`` and four lists representing tuples of (``row_index``,
+    ``column_index``, ``evals``, ``proof``), the function verifies ``proof`` which shows that
+    ``evals`` are the evaluations of the polynomial associated with ``row_commitments[row_index]``,
+    evaluated over the domain specified by ``column_index``.
 
     This function is the internal implementation of ``verify_cell_kzg_proof_batch``.
     """

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -695,9 +695,9 @@ def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
         assert len(proof_bytes) == BYTES_PER_PROOF
 
     # Get objects from bytes
-    row_commitments_bytes = list(set(commitments_bytes))
-    row_commitments = [bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in row_commitments_bytes]
-    row_indices = [row_commitments_bytes.index(commitment_bytes) for commitment_bytes in commitments_bytes]
+    deduplicated_commitments = list(set(commitments_bytes))
+    row_commitments = [bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in deduplicated_commitments]
+    row_indices = [deduplicated_commitments.index(commitment_bytes) for commitment_bytes in commitments_bytes]
     cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
     proofs = [bytes_to_kzg_proof(proof_bytes) for proof_bytes in proofs_bytes]
 

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -687,7 +687,7 @@ def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
     Verify that a set of cells belong to their corresponding commitments.
 
     Specifically, given a set of tuples (``commitment``, ``column_index``, ``cell``, ``proof``), for every tuple
-    the function verifies `proof` which shows that ``cell`` are the evaluations of the polynomial behind the
+    the function verifies ``proof`` which shows that ``cell`` are the evaluations of the polynomial behind the
     ``commitment``. The evaluation domain is determined by ``column_index``.
 
     This function implements the universal verification equation that has been introduced here:

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -671,15 +671,12 @@ def verify_cell_kzg_proof(commitment_bytes: Bytes48,
 #### `verify_cell_kzg_proof_batch`
 
 ```python
-def verify_cell_kzg_proof_batch(row_commitments_bytes: Sequence[Bytes48],
-                                row_indices: Sequence[RowIndex],
+def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
                                 column_indices: Sequence[ColumnIndex],
                                 cells: Sequence[Cell],
                                 proofs_bytes: Sequence[Bytes48]) -> bool:
     """
-    Verify a set of cells, given their corresponding proofs and their coordinates (row_index, column_index) in the blob
-    matrix. The i-th cell is in row = row_indices[i] and in column = column_indices[i].
-    The list of all commitments is provided in row_commitments_bytes.
+    Verify a set of cells given their corresponding commitments/proofs/column_indices.
 
     This function implements the universal verification equation that has been introduced here:
     https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240
@@ -687,11 +684,9 @@ def verify_cell_kzg_proof_batch(row_commitments_bytes: Sequence[Bytes48],
     Public method.
     """
 
-    assert len(cells) == len(proofs_bytes) == len(row_indices) == len(column_indices)
-    for commitment_bytes in row_commitments_bytes:
+    assert len(commitments_bytes) == len(cells) == len(proofs_bytes) == len(column_indices)
+    for commitment_bytes in commitments_bytes:
         assert len(commitment_bytes) == BYTES_PER_COMMITMENT
-    for row_index in row_indices:
-        assert row_index < len(row_commitments_bytes)
     for column_index in column_indices:
         assert column_index < CELLS_PER_EXT_BLOB
     for cell in cells:
@@ -700,7 +695,9 @@ def verify_cell_kzg_proof_batch(row_commitments_bytes: Sequence[Bytes48],
         assert len(proof_bytes) == BYTES_PER_PROOF
 
     # Get objects from bytes
+    row_commitments_bytes = list(set(commitments_bytes))
     row_commitments = [bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in row_commitments_bytes]
+    row_indices = [row_commitments_bytes.index(commitment_bytes) for commitment_bytes in commitments_bytes]
     cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
     proofs = [bytes_to_kzg_proof(proof_bytes) for proof_bytes in proofs_bytes]
 

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -483,12 +483,9 @@ def verify_cell_kzg_proof_batch_impl(row_commitments: Sequence[KZGCommitment],
     """
     Helper: Verify that a set of cells belong to their corresponding commitment.
 
-    Specifically, given a set of tuples (``row_index``, ``column_index``, ``evals``, ``proof``), for every tuple it
-    verifies ``proof`` which shows that ``evals`` are actually the evaluations of the polynomial behind the
-    corresponding commitment.
-
-    The value ``row_index`` points to a commitment in the array ``row_commitments``, while the value ``column_index``
-    determines the evaluation domain of the polynomial.
+    Given a list of ``row_commitments`` and four lists representing tuples of (``row_index``, ``column_index``,
+    ``evals``, ``proof``), the function verifies ``proof`` which shows that ``evals`` are the evaluations of
+    the polynomial associated with ``row_commitments[row_index]``, evaluated over the domain specified by ``column_index``.
 
     This function is the internal implementation of ``verify_cell_kzg_proof_batch``.
     """
@@ -685,9 +682,9 @@ def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
     """
     Verify that a set of cells belong to their corresponding commitments.
 
-    Specifically, given a set of tuples (``commitment``, ``column_index``, ``cell``, ``proof``), for every tuple
-    the function verifies ``proof`` which shows that ``cell`` are the evaluations of the polynomial behind the
-    ``commitment``. The evaluation domain is determined by ``column_index``.
+    Given four lists representing tuples of (``commitment``, ``column_index``, ``cell``, ``proof``),
+    the function verifies ``proof`` which shows that ``cell`` are the evaluations of the polynomial
+    associated with ``commitment``, evaluated over the domain specified by ``column_index``.
 
     This function implements the universal verification equation that has been introduced here:
     https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -188,7 +188,6 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
 
     assert not spec.verify_cell_kzg_proof_batch(
         commitments_bytes=[commitment, commitment],
-        row_indices=[0, 0],
         column_indices=[0, 4],
         cells=[cells[0], cells[5]],  # Note: this is where it should go wrong
         proofs_bytes=[proofs[0], proofs[4]],

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -135,8 +135,7 @@ def test_verify_cell_kzg_proof_batch(spec):
     assert len(cells) == len(proofs)
 
     assert spec.verify_cell_kzg_proof_batch(
-        row_commitments_bytes=[commitment],
-        row_indices=[0, 0],
+        commitments_bytes=[commitment, commitment],
         column_indices=[0, 4],
         cells=[cells[0], cells[4]],
         proofs_bytes=[proofs[0], proofs[4]],
@@ -164,11 +163,11 @@ def test_verify_cell_kzg_proof_batch(spec):
     column_indices = [0, 4, 0, 1, 2]
     cells = [all_cells[i][j] for (i, j) in zip(row_indices, column_indices)]
     proofs = [all_proofs[i][j] for (i, j) in zip(row_indices, column_indices)]
+    commitments = [all_commitments[i] for i in row_indices]
 
     # do the check
     assert spec.verify_cell_kzg_proof_batch(
-        row_commitments_bytes=all_commitments,
-        row_indices=row_indices,
+        commitments_bytes=commitments,
         column_indices=column_indices,
         cells=cells,
         proofs_bytes=proofs,
@@ -188,7 +187,7 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
     assert len(cells) == len(proofs)
 
     assert not spec.verify_cell_kzg_proof_batch(
-        row_commitments_bytes=[commitment],
+        commitments_bytes=[commitment, commitment],
         row_indices=[0, 0],
         column_indices=[0, 4],
         cells=[cells[0], cells[5]],  # Note: this is where it should go wrong
@@ -217,14 +216,14 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
     column_indices = [0, 4, 0, 1, 2]
     cells = [all_cells[i][j] for (i, j) in zip(row_indices, column_indices)]
     proofs = [all_proofs[i][j] for (i, j) in zip(row_indices, column_indices)]
+    commitments = [all_commitments[i] for i in row_indices]
 
     # let's change one of the cells. Then it should not verify
     cells[1] = all_cells[1][3]
 
     # do the check
     assert not spec.verify_cell_kzg_proof_batch(
-        row_commitments_bytes=all_commitments,
-        row_indices=row_indices,
+        commitments_bytes=commitments,
         column_indices=column_indices,
         cells=cells,
         proofs_bytes=proofs,

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -128,8 +128,7 @@ def test_verify_cell_kzg_proof(spec):
 def test_verify_cell_kzg_proof_batch_zero_cells(spec):
     # Verify with zero cells should return true
     assert spec.verify_cell_kzg_proof_batch(
-        row_commitments_bytes=[],
-        row_indices=[],
+        commitments_bytes=[],
         column_indices=[],
         cells=[],
         proofs_bytes=[],

--- a/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md
+++ b/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md
@@ -1,6 +1,6 @@
 # Test format: Verify cell KZG proof batch
 
-Use the cell KZG `proofs` to verify that the KZG `row_commitments` for the given `cells` are correct.
+Use the cell KZG `proofs` to verify that the KZG `commitments` for the given `cells` are correct.
 
 ## Test case format
 
@@ -8,8 +8,7 @@ The test data is declared in a `data.yaml` file:
 
 ```yaml
 input:
-  row_commitments: List[Bytes48] -- the KZG commitments
-  row_indices: List[RowIndex] -- the commitment index for each cell
+  commitments: List[Bytes48] -- the KZG commitments for each cell
   column_indices: List[ColumnIndex] -- the column index for each cell
   cells: List[Cell] -- the cells
   proofs: List[Bytes48] -- the KZG proof for each cell
@@ -17,7 +16,6 @@ output: bool -- true (all proofs are correct) or false (some proofs incorrect)
 ```
 
 - `Bytes48` is a 48-byte hexadecimal string, prefixed with `0x`.
-- `RowIndex` is an unsigned 64-bit integer.
 - `ColumnIndex` is an unsigned 64-bit integer.
 - `Cell` is a 2048-byte hexadecimal string, prefixed with `0x`.
 
@@ -25,4 +23,4 @@ All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `
 
 ## Condition
 
-The `verify_cell_kzg_proof_batch` handler should verify that `row_commitments` are correct KZG commitments to `cells` by using the cell KZG proofs `proofs`, and the result should match the expected `output`. If any of the commitments or proofs are invalid (e.g. not on the curve or not in the G1 subgroup of the BLS curve), any cell is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element), or any `cell_index` is invalid (e.g. greater than the number of cells for an extended blob), it should error, i.e. the output should be `null`.
+The `verify_cell_kzg_proof_batch` handler should verify that `commitments` are correct KZG commitments to `cells` by using the cell KZG proofs `proofs`, and the result should match the expected `output`. If any of the commitments or proofs are invalid (e.g. not on the curve or not in the G1 subgroup of the BLS curve), any cell is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element), or any `cell_index` is invalid (e.g. greater than the number of cells for an extended blob), it should error, i.e. the output should be `null`.

--- a/tests/generators/kzg_7594/main.py
+++ b/tests/generators/kzg_7594/main.py
@@ -220,15 +220,13 @@ def case_verify_cell_kzg_proof_batch():
     # Valid cases
     for i in range(len(VALID_BLOBS)):
         cells, proofs = VALID_CELLS_AND_PROOFS[i]
-        row_commitments = [VALID_COMMITMENTS[i]]
-        row_indices = [0] * spec.CELLS_PER_EXT_BLOB
+        commitments = [VALID_COMMITMENTS[i] for _ in cells]
         column_indices = list(range(spec.CELLS_PER_EXT_BLOB))
-        assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
-        identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+        assert spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
+        identifier = make_id(commitments, column_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_valid_{identifier}', {
             'input': {
-                'row_commitments': encode_hex_list(row_commitments),
-                'row_indices': row_indices,
+                'commitments': encode_hex_list(commitments),
                 'column_indices': column_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
@@ -237,13 +235,12 @@ def case_verify_cell_kzg_proof_batch():
         }
 
     # Valid: zero cells
-    cells, row_commitments, row_indices, column_indices, proofs = [], [], [], [], []
-    assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
-    identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+    cells, commitments, column_indices, proofs = [], [], [], []
+    assert spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
+    identifier = make_id(commitments, column_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_valid_zero_cells_{identifier}', {
         'input': {
-            'row_commitments': encode_hex_list(row_commitments),
-            'row_indices': row_indices,
+            'commitments': encode_hex_list(commitments),
             'column_indices': column_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
@@ -254,37 +251,15 @@ def case_verify_cell_kzg_proof_batch():
     # Valid: Verify cells from multiple blobs
     cells0, proofs0 = VALID_CELLS_AND_PROOFS[0]
     cells1, proofs1 = VALID_CELLS_AND_PROOFS[1]
-    row_commitments = VALID_COMMITMENTS[:2]
-    row_indices = [0, 1]
+    commitments = [VALID_CELLS_AND_PROOFS[0], VALID_COMMITMENTS[1]]
     column_indices = [0, 0]
     cells = [cells0[0], cells1[0]]
     proofs = [proofs0[0], proofs1[0]]
-    assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
-    identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+    assert spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
+    identifier = make_id(commitments, column_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_valid_multiple_blobs_{identifier}', {
         'input': {
-            'row_commitments': encode_hex_list(row_commitments),
-            'row_indices': row_indices,
-            'column_indices': column_indices,
-            'cells': encode_hex_list(cells),
-            'proofs': encode_hex_list(proofs),
-        },
-        'output': True
-    }
-
-    # Valid: Unused row commitments
-    cells, proofs = VALID_CELLS_AND_PROOFS[2]
-    cells, proofs = cells[:3], proofs[:3]
-    # Provide list of all commitments
-    row_commitments = VALID_COMMITMENTS
-    row_indices = [2] * len(cells)
-    column_indices = list(range(len(cells)))
-    assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
-    identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_kzg_proof_batch_case_valid_unused_row_commitments_{identifier}', {
-        'input': {
-            'row_commitments': encode_hex_list(row_commitments),
-            'row_indices': row_indices,
+            'commitments': encode_hex_list(commitments),
             'column_indices': column_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
@@ -293,18 +268,16 @@ def case_verify_cell_kzg_proof_batch():
     }
 
     # Valid: Same cell multiple times
-    row_commitments = [VALID_COMMITMENTS[3]]
     num_duplicates = 3
-    row_indices = [0] * num_duplicates
+    commitments = [VALID_COMMITMENTS[3]] * num_duplicates
     column_indices = [0] * num_duplicates
     cells = [VALID_CELLS_AND_PROOFS[3][0][0]] * num_duplicates
     proofs = [VALID_CELLS_AND_PROOFS[3][1][0]] * num_duplicates
-    assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
-    identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+    assert spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
+    identifier = make_id(commitments, column_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_valid_same_cell_multiple_times_{identifier}', {
         'input': {
-            'row_commitments': encode_hex_list(row_commitments),
-            'row_indices': row_indices,
+            'commitments': encode_hex_list(commitments),
             'column_indices': column_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
@@ -312,19 +285,17 @@ def case_verify_cell_kzg_proof_batch():
         'output': True
     }
 
-    # Incorrect row commitment
+    # Incorrect commitment
     cells, proofs = VALID_CELLS_AND_PROOFS[5]
     cells, proofs = cells[:1], proofs[:1]
-    # Change commitment so it's wrong
-    row_commitments = [bls_add_one(VALID_COMMITMENTS[5])]
-    row_indices = [0] * len(cells)
+    # Use the wrong commitment
+    commitments = [bls_add_one(VALID_COMMITMENTS[5])]
     column_indices = list(range(len(cells)))
-    assert not spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
-    identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_kzg_proof_batch_case_incorrect_row_commitment_{identifier}', {
+    assert not spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
+    identifier = make_id(commitments, column_indices, cells, proofs)
+    yield f'verify_cell_kzg_proof_batch_case_incorrect_commitment_{identifier}', {
         'input': {
-            'row_commitments': encode_hex_list(row_commitments),
-            'row_indices': row_indices,
+            'commitments': encode_hex_list(commitments),
             'column_indices': column_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
@@ -335,17 +306,15 @@ def case_verify_cell_kzg_proof_batch():
     # Incorrect cell
     cells, proofs = VALID_CELLS_AND_PROOFS[6]
     cells, proofs = cells[:1], proofs[:1]
-    row_commitments = [VALID_COMMITMENTS[6]]
-    row_indices = [0] * len(cells)
+    commitments = [VALID_COMMITMENTS[6]]
     column_indices = list(range(len(cells)))
     # Change last cell so it's wrong
     cells[-1] = CELL_RANDOM_VALID2
-    assert not spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
-    identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+    assert not spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
+    identifier = make_id(commitments, column_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_incorrect_cell_{identifier}', {
         'input': {
-            'row_commitments': encode_hex_list(row_commitments),
-            'row_indices': row_indices,
+            'commitments': encode_hex_list(commitments),
             'column_indices': column_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
@@ -356,17 +325,15 @@ def case_verify_cell_kzg_proof_batch():
     # Incorrect proof
     cells, proofs = VALID_CELLS_AND_PROOFS[0]
     cells, proofs = cells[:1], proofs[:1]
-    row_commitments = [VALID_COMMITMENTS[0]]
-    row_indices = [0] * len(cells)
+    commitments = [VALID_COMMITMENTS[0]]
     column_indices = list(range(len(cells)))
     # Change last proof so it's wrong
     proofs[-1] = bls_add_one(proofs[-1])
-    assert not spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
-    identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+    assert not spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
+    identifier = make_id(commitments, column_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_incorrect_proof_{identifier}', {
         'input': {
-            'row_commitments': encode_hex_list(row_commitments),
-            'row_indices': row_indices,
+            'commitments': encode_hex_list(commitments),
             'column_indices': column_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
@@ -374,20 +341,18 @@ def case_verify_cell_kzg_proof_batch():
         'output': False
     }
 
-    # Edge case: Invalid row commitment
+    # Edge case: Invalid commitment
     for i, commitment in enumerate(INVALID_G1_POINTS):
         cells, proofs = VALID_CELLS_AND_PROOFS[i % len(INVALID_G1_POINTS)]
         cells, proofs = cells[:1], proofs[:1]
-        # Set row_commitments to the invalid commitment
-        row_commitments = [commitment]
-        row_indices = [0] * len(cells)
+        # Set commitments to the invalid commitment
+        commitments = [commitment]
         column_indices = list(range(len(cells)))
-        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-        identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_kzg_proof_batch_case_invalid_row_commitment_{identifier}', {
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
+        identifier = make_id(commitments, column_indices, cells, proofs)
+        yield f'verify_cell_kzg_proof_batch_case_invalid_commitment_{identifier}', {
             'input': {
-                'row_commitments': encode_hex_list(row_commitments),
-                'row_indices': row_indices,
+                'commitments': encode_hex_list(commitments),
                 'column_indices': column_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
@@ -395,41 +360,18 @@ def case_verify_cell_kzg_proof_batch():
             'output': None
         }
 
-    # Edge case: Invalid row_index
-    cells, proofs = VALID_CELLS_AND_PROOFS[0]
-    cells, proofs = cells[:1], proofs[:1]
-    row_commitments = [VALID_COMMITMENTS[0]]
-    row_indices = [0] * len(cells)
-    # Set first row index to an invalid value
-    row_indices[0] = 1
-    column_indices = list(range(len(cells)))
-    expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-    identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-    yield f'verify_cell_kzg_proof_batch_case_invalid_row_index_{identifier}', {
-        'input': {
-            'row_commitments': encode_hex_list(row_commitments),
-            'row_indices': row_indices,
-            'column_indices': column_indices,
-            'cells': encode_hex_list(cells),
-            'proofs': encode_hex_list(proofs),
-        },
-        'output': None
-    }
-
     # Edge case: Invalid column_index
     cells, proofs = VALID_CELLS_AND_PROOFS[1]
     cells, proofs = cells[:1], proofs[:1]
-    row_commitments = [VALID_COMMITMENTS[1]]
-    row_indices = [0] * len(cells)
+    commitments = [VALID_COMMITMENTS[1]]
     column_indices = list(range(len(cells)))
     # Set first column index to an invalid value
     column_indices[0] = spec.CELLS_PER_EXT_BLOB
-    expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-    identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+    expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
+    identifier = make_id(commitments, column_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_invalid_column_index_{identifier}', {
         'input': {
-            'row_commitments': encode_hex_list(row_commitments),
-            'row_indices': row_indices,
+            'commitments': encode_hex_list(commitments),
             'column_indices': column_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
@@ -441,17 +383,15 @@ def case_verify_cell_kzg_proof_batch():
     for i, cell in enumerate(INVALID_INDIVIDUAL_CELL_BYTES):
         cells, proofs = VALID_CELLS_AND_PROOFS[i % len(INVALID_INDIVIDUAL_CELL_BYTES)]
         cells, proofs = cells[:1], proofs[:1]
-        row_commitments = [VALID_COMMITMENTS[i % len(INVALID_INDIVIDUAL_CELL_BYTES)]]
-        row_indices = [0] * len(cells)
+        commitments = [VALID_COMMITMENTS[i % len(INVALID_INDIVIDUAL_CELL_BYTES)]]
         column_indices = list(range(len(cells)))
         # Set first cell to the invalid cell
         cells[0] = cell
-        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-        identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
+        identifier = make_id(commitments, column_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_cell_{identifier}', {
             'input': {
-                'row_commitments': encode_hex_list(row_commitments),
-                'row_indices': row_indices,
+                'commitments': encode_hex_list(commitments),
                 'column_indices': column_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
@@ -463,17 +403,15 @@ def case_verify_cell_kzg_proof_batch():
     for i, proof in enumerate(INVALID_G1_POINTS):
         cells, proofs = VALID_CELLS_AND_PROOFS[i % len(INVALID_G1_POINTS)]
         cells, proofs = cells[:1], proofs[:1]
-        row_commitments = [VALID_COMMITMENTS[i % len(INVALID_G1_POINTS)]]
-        row_indices = [0] * len(cells)
+        commitments = [VALID_COMMITMENTS[i % len(INVALID_G1_POINTS)]]
         column_indices = list(range(len(cells)))
         # Set first proof to the invalid proof
         proofs[0] = proof
-        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-        identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
+        identifier = make_id(commitments, column_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_proof_{identifier}', {
             'input': {
-                'row_commitments': encode_hex_list(row_commitments),
-                'row_indices': row_indices,
+                'commitments': encode_hex_list(commitments),
                 'column_indices': column_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
@@ -481,39 +419,17 @@ def case_verify_cell_kzg_proof_batch():
             'output': None
         }
 
-        # Edge case: Missing a row commitment
+        # Edge case: Missing a commitment
         cells, proofs = VALID_CELLS_AND_PROOFS[0]
-        cells, proofs = cells[:1], proofs[:1]
-        # Do not include the row commitment
-        row_commitments = []
-        row_indices = [0] * len(cells)
-        column_indices = list(range(len(cells)))
-        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-        identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_row_commitment_{identifier}', {
-            'input': {
-                'row_commitments': encode_hex_list(row_commitments),
-                'row_indices': row_indices,
-                'column_indices': column_indices,
-                'cells': encode_hex_list(cells),
-                'proofs': encode_hex_list(proofs),
-            },
-            'output': None
-        }
-
-        # Edge case: Missing a row index
-        cells, proofs = VALID_CELLS_AND_PROOFS[1]
         cells, proofs = cells[:2], proofs[:2]
-        row_commitments = [VALID_COMMITMENTS[1]]
-        # Leave off one of the row indices
-        row_indices = [0] * (len(cells) - 1)
+        # Do not include the second commitment
+        commitments = [VALID_COMMITMENTS[0]]
         column_indices = list(range(len(cells)))
-        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-        identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
-        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_row_index_{identifier}', {
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
+        identifier = make_id(commitments, column_indices, cells, proofs)
+        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_commitment_{identifier}', {
             'input': {
-                'row_commitments': encode_hex_list(row_commitments),
-                'row_indices': row_indices,
+                'commitments': encode_hex_list(commitments),
                 'column_indices': column_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
@@ -524,16 +440,14 @@ def case_verify_cell_kzg_proof_batch():
         # Edge case: Missing a column index
         cells, proofs = VALID_CELLS_AND_PROOFS[2]
         cells, proofs = cells[:2], proofs[:2]
-        row_commitments = [VALID_COMMITMENTS[2]]
-        row_indices = [0] * len(cells)
+        commitments = [VALID_COMMITMENTS[2], VALID_COMMITMENTS[2]]
         # Leave off one of the column indices
         column_indices = list(range(len(cells) - 1))
-        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-        identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
+        identifier = make_id(commitments, column_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_missing_column_index_{identifier}', {
             'input': {
-                'row_commitments': encode_hex_list(row_commitments),
-                'row_indices': row_indices,
+                'commitments': encode_hex_list(commitments),
                 'column_indices': column_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
@@ -544,17 +458,15 @@ def case_verify_cell_kzg_proof_batch():
         # Edge case: Missing a cell
         cells, proofs = VALID_CELLS_AND_PROOFS[3]
         cells, proofs = cells[:2], proofs[:2]
-        row_commitments = [VALID_COMMITMENTS[3]]
-        row_indices = [0] * len(cells)
+        commitments = [VALID_COMMITMENTS[3], VALID_COMMITMENTS[3]]
         column_indices = list(range(len(cells)))
         # Remove the last proof
         cells = cells[:-1]
-        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-        identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
+        identifier = make_id(commitments, column_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_missing_cell_{identifier}', {
             'input': {
-                'row_commitments': encode_hex_list(row_commitments),
-                'row_indices': row_indices,
+                'commitments': encode_hex_list(commitments),
                 'column_indices': column_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
@@ -565,17 +477,15 @@ def case_verify_cell_kzg_proof_batch():
         # Edge case: Missing a proof
         cells, proofs = VALID_CELLS_AND_PROOFS[4]
         cells, proofs = cells[:2], proofs[:2]
-        row_commitments = [VALID_COMMITMENTS[4]]
-        row_indices = [0] * len(cells)
+        commitments = [VALID_COMMITMENTS[4], VALID_COMMITMENTS[4]]
         column_indices = list(range(len(cells)))
         # Remove the last proof
         proofs = proofs[:-1]
-        expect_exception(spec.verify_cell_kzg_proof_batch, row_commitments, row_indices, column_indices, cells, proofs)
-        identifier = make_id(row_commitments, row_indices, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
+        identifier = make_id(commitments, column_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_missing_proof_{identifier}', {
             'input': {
-                'row_commitments': encode_hex_list(row_commitments),
-                'row_indices': row_indices,
+                'commitments': encode_hex_list(commitments),
                 'column_indices': column_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),

--- a/tests/generators/kzg_7594/main.py
+++ b/tests/generators/kzg_7594/main.py
@@ -251,7 +251,7 @@ def case_verify_cell_kzg_proof_batch():
     # Valid: Verify cells from multiple blobs
     cells0, proofs0 = VALID_CELLS_AND_PROOFS[0]
     cells1, proofs1 = VALID_CELLS_AND_PROOFS[1]
-    commitments = [VALID_CELLS_AND_PROOFS[0], VALID_COMMITMENTS[1]]
+    commitments = [VALID_COMMITMENTS[0], VALID_COMMITMENTS[1]]
     column_indices = [0, 0]
     cells = [cells0[0], cells1[0]]
     proofs = [proofs0[0], proofs1[0]]


### PR DESCRIPTION
In `verify_cell_kzg_proof_batch()`, we used to take as input a list of deduplicated commitments. This PR changes it so that it takes as input all the commitments. This is done for UI reasons since it's more natural for clients who do batch verification across multiple sidecars, and [also for security](https://github.com/sigp/lighthouse/pull/6029#issuecomment-2205216913) reasons because it forces us to validate all the  received sidecar commitments.

Specifically, to verify all cells from column 0 and column 1 we would pass something like this to `verify_cell_kzg_proof_batch()`:
```
Inputs:
row_commitments = {commitment1, commitment2, commitment3}
row_indices = {0,1,2,0,1,2}
column_indices = {0,0,0,1,1,1}
cells = {cell1, cell2, cell3, cell4, cell5, cell6}
proofs = {proof1, proof2, proof3, proof4, proof5, proof6}
```
whereas after this PR we would give inputs:
```
Inputs:
row_commitments = {commitment1, commitment2, commitment3, commitment1, commitment2, commitment3}
column_indices = {0,0,0,1,1,1}
cells = {cell1, cell2, cell3, cell4, cell5, cell6}
proofs = {proof1, proof2, proof3, proof4, proof5, proof6}
```

Keep in mind that the helper function `verify_cell_kzg_proof_batch_impl()` stays the same as before (using the old input format), and we have the public function `verify_cell_kzg_proof_batch()` move from the new input format to the old input format, by checking the commitments provided and recreating `row_indices`.