### PR TITLE
In batch cell verification, check if there are zero cells

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -511,10 +511,6 @@ def verify_cell_kzg_proof_batch_impl(row_commitments: Sequence[KZGCommitment],
     n = FIELD_ELEMENTS_PER_CELL
     num_rows = len(row_commitments)
 
-    # Given zero cells, the result is true
-    if num_cells == 0:
-        return True
-
     # Step 1: Compute a challenge r and its powers r^0, ..., r^{num_cells-1}
     r = compute_verify_cell_kzg_proof_batch_challenge(
         row_commitments,
@@ -544,7 +540,7 @@ def verify_cell_kzg_proof_batch_impl(row_commitments: Sequence[KZGCommitment],
 
     # Step 4.2: Compute RLI = [sum_k r^k interpolation_poly_k(s)]
     # Note: an efficient implementation would use the IDFT based method explained in the blog post
-    sum_interp_polys_coeff = [0]
+    sum_interp_polys_coeff = [0] * n
     for k in range(num_cells):
         interp_poly_coeff = interpolate_polynomialcoeff(coset_for_cell(column_indices[k]), cosets_evals[k])
         interp_poly_scaled_coeff = multiply_polynomialcoeff([r_powers[k]], interp_poly_coeff)

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -511,6 +511,10 @@ def verify_cell_kzg_proof_batch_impl(row_commitments: Sequence[KZGCommitment],
     n = FIELD_ELEMENTS_PER_CELL
     num_rows = len(row_commitments)
 
+    # Given zero cells, the result is true
+    if num_cells == 0:
+        return True
+
     # Step 1: Compute a challenge r and its powers r^0, ..., r^{num_cells-1}
     r = compute_verify_cell_kzg_proof_batch_challenge(
         row_commitments,
@@ -566,7 +570,6 @@ def verify_cell_kzg_proof_batch_impl(row_commitments: Sequence[KZGCommitment],
         [rl, bls.neg(bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[0]))],
     ]))
 ```
-
 
 ### Cell cosets
 

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -125,6 +125,20 @@ def test_verify_cell_kzg_proof(spec):
 @with_eip7594_and_later
 @spec_test
 @single_phase
+def test_verify_cell_kzg_proof_batch_zero_cells(spec):
+    # Verify with zero cells should return true
+    assert spec.verify_cell_kzg_proof_batch(
+        row_commitments_bytes=[],
+        row_indices=[],
+        column_indices=[],
+        cells=[],
+        proofs_bytes=[],
+    )
+
+
+@with_eip7594_and_later
+@spec_test
+@single_phase
 def test_verify_cell_kzg_proof_batch(spec):
 
     # test with a single blob / commitment


### PR DESCRIPTION
Given zero cells, this will throw an exception. We can check for this & return true.

```
Traceback (most recent call last):
  File "/Users/jtraglia/Projects/jtraglia/consensus-specs/tests/generators/kzg_7594/main.py", line 812, in <module>
    gen_runner.run_generator("kzg_7594", [
  File "/Users/jtraglia/.asdf/installs/python/3.10.4/lib/python3.10/site-packages/eth2spec/gen_helpers/gen_base/gen_runner.py", line 238, in run_generator
    for test_case in tprov.make_cases():
  File "/Users/jtraglia/Projects/jtraglia/consensus-specs/tests/generators/kzg_7594/main.py", line 795, in cases_fn
    for data in test_case_fn():
  File "/Users/jtraglia/Projects/jtraglia/consensus-specs/tests/generators/kzg_7594/main.py", line 241, in case_verify_cell_kzg_proof_batch
    assert spec.verify_cell_kzg_proof_batch(row_commitments, row_indices, column_indices, cells, proofs)
  File "/Users/jtraglia/.asdf/installs/python/3.10.4/lib/python3.10/site-packages/eth2spec/eip7594/mainnet.py", line 5405, in verify_cell_kzg_proof_batch
    return verify_cell_kzg_proof_batch_impl(row_commitments, row_indices, column_indices, cosets_evals, proofs)
  File "/Users/jtraglia/.asdf/installs/python/3.10.4/lib/python3.10/site-packages/eth2spec/eip7594/mainnet.py", line 5269, in verify_cell_kzg_proof_batch_impl
    rli = bls.bytes48_to_G1(g1_lincomb(KZG_SETUP_G1_MONOMIAL[:n], sum_interp_polys_coeff))
  File "/Users/jtraglia/.asdf/installs/python/3.10.4/lib/python3.10/site-packages/eth2spec/eip7594/mainnet.py", line 4395, in g1_lincomb
    assert len(points) == len(scalars)
```