### PR TITLE
Update get_data_column_sidecars to take cells/proofs

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -195,18 +195,15 @@ def recover_matrix(partial_matrix: Sequence[MatrixEntry],
 
 ```python
 def get_data_column_sidecars(signed_block: SignedBeaconBlock,
-                             cells_and_kzg_proofs: Sequence[
-                                Tuple[
-                                    Vector[Cell, CELLS_PER_EXT_BLOB],
-                                    Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-                                ]) -> Sequence[DataColumnSidecar]:
+                             cells_and_kzg_proofs: Sequence[Tuple[
+        Vector[Cell, CELLS_PER_EXT_BLOB],
+        Vector[KZGProof, CELLS_PER_EXT_BLOB]]]) -> Sequence[DataColumnSidecar]:
     """
     Given a signed block and the cells/proofs associated with each blob in the
-    blob, assemble the sidecars which can be distributed to peers.
+    block, assemble the sidecars which can be distributed to peers.
     
-    Since there is no method which converts cells back to a blob, this method
-    takes cells/proofs instead of blobs so that it can be re-create sidecars
-    after recovery.
+    Since there is no method which converts cells to a blob, this method takes
+    cells/proofs instead of blobs so it can re-create sidecars after recovery.
     """
     blob_kzg_commitments = signed_block.message.body.blob_kzg_commitments
     assert len(cells_and_kzg_proofs) == len(blob_kzg_commitments)

--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -201,9 +201,6 @@ def get_data_column_sidecars(signed_block: SignedBeaconBlock,
     """
     Given a signed block and the cells/proofs associated with each blob in the
     block, assemble the sidecars which can be distributed to peers.
-    
-    Since there is no method which converts cells to a blob, this method takes
-    cells/proofs instead of blobs so it can re-create sidecars after recovery.
     """
     blob_kzg_commitments = signed_block.message.body.blob_kzg_commitments
     assert len(cells_and_kzg_proofs) == len(blob_kzg_commitments)

--- a/tests/core/pyspec/eth2spec/test/eip7594/merkle_proof/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/merkle_proof/test_single_merkle_proof.py
@@ -38,7 +38,8 @@ def _run_blob_kzg_commitments_merkle_proof_test(spec, state, rng=None):
     block.body.execution_payload.transactions = [opaque_tx]
     block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     signed_block = sign_block(spec, state, block, proposer_index=0)
-    column_sidcars = spec.get_data_column_sidecars(signed_block, blobs)
+    cells_and_kzg_proofs = [spec.compute_cells_and_kzg_proofs(blob) for blob in blobs]
+    column_sidcars = spec.get_data_column_sidecars(signed_block, cells_and_kzg_proofs)
     column_sidcar = column_sidcars[0]
 
     yield "object", block.body


### PR DESCRIPTION
We received feedback from clients that they were unable to re-create data column sidecars after performing recovery because `get_data_column_sidecars` took blobs, but `recover_cells_and_kzg_proofs` provided cells/proofs and there was no public method to convert the cells back to a blob. I think it makes sense to change this function to take cells/proofs instead of blobs.