### PR TITLE
Rename column_index to cell_index in KZG spec

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -68,7 +68,7 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value | Description |
 | - | - | - |
-| `NUMBER_OF_COLUMNS` | `uint64(CELLS_PER_EXT_BLOB)` (= 128) | Number of columns in the extended data matrix. |
+| `NUMBER_OF_COLUMNS` | `uint64(CELLS_PER_EXT_BLOB)` (= 128) | Number of columns in the extended data matrix |
 | `MAX_CELLS_IN_EXTENDED_MATRIX` | `uint64(MAX_BLOBS_PER_BLOCK * NUMBER_OF_COLUMNS)` (= 768) | The data size of `ExtendedMatrix` |
 
 ### Networking

--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -69,7 +69,7 @@ The following values are (non-configurable) constants used throughout the specif
 | Name | Value | Description |
 | - | - | - |
 | `NUMBER_OF_COLUMNS` | `uint64(CELLS_PER_EXT_BLOB)` (= 128) | Number of columns in the extended data matrix. |
-| `MAX_CELLS_IN_EXTENDED_MATRIX` | `uint64(MAX_BLOBS_PER_BLOCK * NUMBER_OF_COLUMNS)` (= 768) | The data size of `ExtendedMatrix`. |
+| `MAX_CELLS_IN_EXTENDED_MATRIX` | `uint64(MAX_BLOBS_PER_BLOCK * NUMBER_OF_COLUMNS)` (= 768) | The data size of `ExtendedMatrix` |
 
 ### Networking
 

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -73,12 +73,13 @@ def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
     assert sidecar.index < NUMBER_OF_COLUMNS
     assert len(sidecar.column) == len(sidecar.kzg_commitments) == len(sidecar.kzg_proofs)
 
-    column_indices = [sidecar.index] * len(sidecar.column)
+    # The column index also represents the cell index
+    cell_indices = [CellIndex(sidecar.index)] * len(sidecar.column)
 
-    # KZG batch verifies that the cells match the corresponding commitments and proofs
+    # Batch verify that the cells match the corresponding commitments and proofs
     return verify_cell_kzg_proof_batch(
         commitments_bytes=sidecar.kzg_commitments,
-        column_indices=column_indices,
+        cell_indices=cell_indices,
         cells=sidecar.column,
         proofs_bytes=sidecar.kzg_proofs,
     )

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -469,7 +469,7 @@ def verify_cell_kzg_proof_batch_impl(commitments: Sequence[KZGCommitment],
     This function is the internal implementation of ``verify_cell_kzg_proof_batch``.
     """
     assert len(commitment_indices) == len(cell_indices) == len(cosets_evals) == len(proofs)
-    assert len(commitments) == len(list(set(commitments)))
+    assert len(commitments) == len(set(commitments))
     for commitment_index in commitment_indices:
         assert commitment_index < len(commitments)
 
@@ -683,7 +683,7 @@ def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
         assert len(proof_bytes) == BYTES_PER_PROOF
 
     # Create the list of unique commitments we are dealing with
-    unique_commitments = [bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in list(set(commitments_bytes))]
+    unique_commitments = [bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in set(commitments_bytes)]
     # Create indices list mapping initial commitments (that potentially contains duplicates) to the unique commitments
     commitment_indices = [unique_commitments.index(commitment_bytes) for commitment_bytes in commitments_bytes]
 

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -9,7 +9,6 @@
 - [Introduction](#introduction)
 - [Public Methods](#public-methods)
 - [Custom types](#custom-types)
-- [Constants](#constants)
 - [Preset](#preset)
   - [Cells](#cells)
 - [Helper functions](#helper-functions)

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -684,16 +684,22 @@ def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
     for proof_bytes in proofs_bytes:
         assert len(proof_bytes) == BYTES_PER_PROOF
 
-    # Create the list of unique commitments we are dealing with
-    unique_commitments = [bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in set(commitments_bytes)]
-    # Create indices list mapping initial commitments (that potentially contains duplicates) to the unique commitments
-    commitment_indices = [unique_commitments.index(commitment_bytes) for commitment_bytes in commitments_bytes]
+    # Create the list of deduplicated commitments we are dealing with
+    deduplicated_commitments = [bytes_to_kzg_commitment(commitment_bytes)
+                                for commitment_bytes in set(commitments_bytes)]
+    # Create indices list mapping initial commitments (that may contain duplicates) to the deduplicated commitments
+    commitment_indices = [deduplicated_commitments.index(commitment_bytes) for commitment_bytes in commitments_bytes]
 
     cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
     proofs = [bytes_to_kzg_proof(proof_bytes) for proof_bytes in proofs_bytes]
 
     # Do the actual verification
-    return verify_cell_kzg_proof_batch_impl(unique_commitments, commitment_indices, cell_indices, cosets_evals, proofs)
+    return verify_cell_kzg_proof_batch_impl(
+        deduplicated_commitments,
+        commitment_indices,
+        cell_indices,
+        cosets_evals,
+        proofs)
 ```
 
 ## Reconstruction

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -237,7 +237,7 @@ def compute_verify_cell_kzg_proof_batch_challenge(commitments: Sequence[KZGCommi
     hashinput += int.to_bytes(FIELD_ELEMENTS_PER_BLOB, 8, KZG_ENDIANNESS)
     hashinput += int.to_bytes(FIELD_ELEMENTS_PER_CELL, 8, KZG_ENDIANNESS)
     hashinput += int.to_bytes(len(commitments), 8, KZG_ENDIANNESS)
-    hashinput += int.to_bytes(len(cosets_evals), 8, KZG_ENDIANNESS)
+    hashinput += int.to_bytes(len(cell_indices), 8, KZG_ENDIANNESS)
     for commitment in commitments:
         hashinput += commitment
     for k, coset_evals in enumerate(cosets_evals):
@@ -482,7 +482,7 @@ def verify_cell_kzg_proof_batch_impl(commitments: Sequence[KZGCommitment],
     #   RLP = sum_k (r^k * h_k^n) proofs[k]
     #
     # Here, the variables have the following meaning:
-    # - k < len(cosets_evals) is an index iterating over all cells in the input
+    # - k < len(cell_indices) is an index iterating over all cells in the input
     # - r is a random coefficient, derived from hashing all data provided by the prover
     # - s is the secret embedded in the KZG setup
     # - n = FIELD_ELEMENTS_PER_CELL is the size of the evaluation domain
@@ -492,7 +492,7 @@ def verify_cell_kzg_proof_batch_impl(commitments: Sequence[KZGCommitment],
     # - h_k is the coset shift specifying the evaluation domain of the kth cell
 
     # Preparation
-    num_cells = len(cosets_evals)
+    num_cells = len(cell_indices)
     n = FIELD_ELEMENTS_PER_CELL
     num_commitments = len(commitments)
 

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -129,7 +129,7 @@ def test_verify_cell_kzg_proof_batch_zero_cells(spec):
     # Verify with zero cells should return true
     assert spec.verify_cell_kzg_proof_batch(
         commitments_bytes=[],
-        column_indices=[],
+        cell_indices=[],
         cells=[],
         proofs_bytes=[],
     )
@@ -149,7 +149,7 @@ def test_verify_cell_kzg_proof_batch(spec):
 
     assert spec.verify_cell_kzg_proof_batch(
         commitments_bytes=[commitment, commitment],
-        column_indices=[0, 4],
+        cell_indices=[0, 4],
         cells=[cells[0], cells[4]],
         proofs_bytes=[proofs[0], proofs[4]],
     )
@@ -172,16 +172,16 @@ def test_verify_cell_kzg_proof_batch(spec):
         all_proofs.append(proofs)
 
     # the cells of interest
-    row_indices = [0, 0, 1, 2, 1]
-    column_indices = [0, 4, 0, 1, 2]
-    cells = [all_cells[i][j] for (i, j) in zip(row_indices, column_indices)]
-    proofs = [all_proofs[i][j] for (i, j) in zip(row_indices, column_indices)]
-    commitments = [all_commitments[i] for i in row_indices]
+    commitment_indices = [0, 0, 1, 2, 1]
+    cell_indices = [0, 4, 0, 1, 2]
+    cells = [all_cells[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
+    proofs = [all_proofs[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
+    commitments = [all_commitments[i] for i in commitment_indices]
 
     # do the check
     assert spec.verify_cell_kzg_proof_batch(
         commitments_bytes=commitments,
-        column_indices=column_indices,
+        cell_indices=cell_indices,
         cells=cells,
         proofs_bytes=proofs,
     )
@@ -201,7 +201,7 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
 
     assert not spec.verify_cell_kzg_proof_batch(
         commitments_bytes=[commitment, commitment],
-        column_indices=[0, 4],
+        cell_indices=[0, 4],
         cells=[cells[0], cells[5]],  # Note: this is where it should go wrong
         proofs_bytes=[proofs[0], proofs[4]],
     )
@@ -224,11 +224,11 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
         all_proofs.append(proofs)
 
     # the cells of interest
-    row_indices = [0, 0, 1, 2, 1]
-    column_indices = [0, 4, 0, 1, 2]
-    cells = [all_cells[i][j] for (i, j) in zip(row_indices, column_indices)]
-    proofs = [all_proofs[i][j] for (i, j) in zip(row_indices, column_indices)]
-    commitments = [all_commitments[i] for i in row_indices]
+    commitment_indices = [0, 0, 1, 2, 1]
+    cell_indices = [0, 4, 0, 1, 2]
+    cells = [all_cells[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
+    proofs = [all_proofs[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
+    commitments = [all_commitments[i] for i in commitment_indices]
 
     # let's change one of the cells. Then it should not verify
     cells[1] = all_cells[1][3]
@@ -236,7 +236,7 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
     # do the check
     assert not spec.verify_cell_kzg_proof_batch(
         commitments_bytes=commitments,
-        column_indices=column_indices,
+        cell_indices=cell_indices,
         cells=cells,
         proofs_bytes=proofs,
     )

--- a/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md
+++ b/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md
@@ -9,14 +9,14 @@ The test data is declared in a `data.yaml` file:
 ```yaml
 input:
   commitments: List[Bytes48] -- the KZG commitments for each cell
-  column_indices: List[ColumnIndex] -- the column index for each cell
+  cell_indices: List[CellIndex] -- the cell index for each cell
   cells: List[Cell] -- the cells
   proofs: List[Bytes48] -- the KZG proof for each cell
 output: bool -- true (all proofs are correct) or false (some proofs incorrect)
 ```
 
 - `Bytes48` is a 48-byte hexadecimal string, prefixed with `0x`.
-- `ColumnIndex` is an unsigned 64-bit integer.
+- `CellIndex` is an unsigned 64-bit integer.
 - `Cell` is a 2048-byte hexadecimal string, prefixed with `0x`.
 
 All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.

--- a/tests/generators/kzg_7594/main.py
+++ b/tests/generators/kzg_7594/main.py
@@ -221,13 +221,13 @@ def case_verify_cell_kzg_proof_batch():
     for i in range(len(VALID_BLOBS)):
         cells, proofs = VALID_CELLS_AND_PROOFS[i]
         commitments = [VALID_COMMITMENTS[i] for _ in cells]
-        column_indices = list(range(spec.CELLS_PER_EXT_BLOB))
-        assert spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
-        identifier = make_id(commitments, column_indices, cells, proofs)
+        cell_indices = list(range(spec.CELLS_PER_EXT_BLOB))
+        assert spec.verify_cell_kzg_proof_batch(commitments, cell_indices, cells, proofs)
+        identifier = make_id(commitments, cell_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_valid_{identifier}', {
             'input': {
                 'commitments': encode_hex_list(commitments),
-                'column_indices': column_indices,
+                'cell_indices': cell_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
             },
@@ -235,13 +235,13 @@ def case_verify_cell_kzg_proof_batch():
         }
 
     # Valid: zero cells
-    cells, commitments, column_indices, proofs = [], [], [], []
-    assert spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
-    identifier = make_id(commitments, column_indices, cells, proofs)
+    cells, commitments, cell_indices, proofs = [], [], [], []
+    assert spec.verify_cell_kzg_proof_batch(commitments, cell_indices, cells, proofs)
+    identifier = make_id(commitments, cell_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_valid_zero_cells_{identifier}', {
         'input': {
             'commitments': encode_hex_list(commitments),
-            'column_indices': column_indices,
+            'cell_indices': cell_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
         },
@@ -252,15 +252,15 @@ def case_verify_cell_kzg_proof_batch():
     cells0, proofs0 = VALID_CELLS_AND_PROOFS[0]
     cells1, proofs1 = VALID_CELLS_AND_PROOFS[1]
     commitments = [VALID_COMMITMENTS[0], VALID_COMMITMENTS[1]]
-    column_indices = [0, 0]
+    cell_indices = [0, 0]
     cells = [cells0[0], cells1[0]]
     proofs = [proofs0[0], proofs1[0]]
-    assert spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
-    identifier = make_id(commitments, column_indices, cells, proofs)
+    assert spec.verify_cell_kzg_proof_batch(commitments, cell_indices, cells, proofs)
+    identifier = make_id(commitments, cell_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_valid_multiple_blobs_{identifier}', {
         'input': {
             'commitments': encode_hex_list(commitments),
-            'column_indices': column_indices,
+            'cell_indices': cell_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
         },
@@ -270,15 +270,15 @@ def case_verify_cell_kzg_proof_batch():
     # Valid: Same cell multiple times
     num_duplicates = 3
     commitments = [VALID_COMMITMENTS[3]] * num_duplicates
-    column_indices = [0] * num_duplicates
+    cell_indices = [0] * num_duplicates
     cells = [VALID_CELLS_AND_PROOFS[3][0][0]] * num_duplicates
     proofs = [VALID_CELLS_AND_PROOFS[3][1][0]] * num_duplicates
-    assert spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
-    identifier = make_id(commitments, column_indices, cells, proofs)
+    assert spec.verify_cell_kzg_proof_batch(commitments, cell_indices, cells, proofs)
+    identifier = make_id(commitments, cell_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_valid_same_cell_multiple_times_{identifier}', {
         'input': {
             'commitments': encode_hex_list(commitments),
-            'column_indices': column_indices,
+            'cell_indices': cell_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
         },
@@ -290,13 +290,13 @@ def case_verify_cell_kzg_proof_batch():
     cells, proofs = cells[:1], proofs[:1]
     # Use the wrong commitment
     commitments = [bls_add_one(VALID_COMMITMENTS[5])]
-    column_indices = list(range(len(cells)))
-    assert not spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
-    identifier = make_id(commitments, column_indices, cells, proofs)
+    cell_indices = list(range(len(cells)))
+    assert not spec.verify_cell_kzg_proof_batch(commitments, cell_indices, cells, proofs)
+    identifier = make_id(commitments, cell_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_incorrect_commitment_{identifier}', {
         'input': {
             'commitments': encode_hex_list(commitments),
-            'column_indices': column_indices,
+            'cell_indices': cell_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
         },
@@ -307,15 +307,15 @@ def case_verify_cell_kzg_proof_batch():
     cells, proofs = VALID_CELLS_AND_PROOFS[6]
     cells, proofs = cells[:1], proofs[:1]
     commitments = [VALID_COMMITMENTS[6]]
-    column_indices = list(range(len(cells)))
+    cell_indices = list(range(len(cells)))
     # Change last cell so it's wrong
     cells[-1] = CELL_RANDOM_VALID2
-    assert not spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
-    identifier = make_id(commitments, column_indices, cells, proofs)
+    assert not spec.verify_cell_kzg_proof_batch(commitments, cell_indices, cells, proofs)
+    identifier = make_id(commitments, cell_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_incorrect_cell_{identifier}', {
         'input': {
             'commitments': encode_hex_list(commitments),
-            'column_indices': column_indices,
+            'cell_indices': cell_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
         },
@@ -326,15 +326,15 @@ def case_verify_cell_kzg_proof_batch():
     cells, proofs = VALID_CELLS_AND_PROOFS[0]
     cells, proofs = cells[:1], proofs[:1]
     commitments = [VALID_COMMITMENTS[0]]
-    column_indices = list(range(len(cells)))
+    cell_indices = list(range(len(cells)))
     # Change last proof so it's wrong
     proofs[-1] = bls_add_one(proofs[-1])
-    assert not spec.verify_cell_kzg_proof_batch(commitments, column_indices, cells, proofs)
-    identifier = make_id(commitments, column_indices, cells, proofs)
+    assert not spec.verify_cell_kzg_proof_batch(commitments, cell_indices, cells, proofs)
+    identifier = make_id(commitments, cell_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_incorrect_proof_{identifier}', {
         'input': {
             'commitments': encode_hex_list(commitments),
-            'column_indices': column_indices,
+            'cell_indices': cell_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
         },
@@ -347,32 +347,32 @@ def case_verify_cell_kzg_proof_batch():
         cells, proofs = cells[:1], proofs[:1]
         # Set commitments to the invalid commitment
         commitments = [commitment]
-        column_indices = list(range(len(cells)))
-        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
-        identifier = make_id(commitments, column_indices, cells, proofs)
+        cell_indices = list(range(len(cells)))
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, cell_indices, cells, proofs)
+        identifier = make_id(commitments, cell_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_commitment_{identifier}', {
             'input': {
                 'commitments': encode_hex_list(commitments),
-                'column_indices': column_indices,
+                'cell_indices': cell_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
             },
             'output': None
         }
 
-    # Edge case: Invalid column_index
+    # Edge case: Invalid cell_index
     cells, proofs = VALID_CELLS_AND_PROOFS[1]
     cells, proofs = cells[:1], proofs[:1]
     commitments = [VALID_COMMITMENTS[1]]
-    column_indices = list(range(len(cells)))
-    # Set first column index to an invalid value
-    column_indices[0] = spec.CELLS_PER_EXT_BLOB
-    expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
-    identifier = make_id(commitments, column_indices, cells, proofs)
-    yield f'verify_cell_kzg_proof_batch_case_invalid_column_index_{identifier}', {
+    cell_indices = list(range(len(cells)))
+    # Set first cell index to an invalid value
+    cell_indices[0] = spec.CELLS_PER_EXT_BLOB
+    expect_exception(spec.verify_cell_kzg_proof_batch, commitments, cell_indices, cells, proofs)
+    identifier = make_id(commitments, cell_indices, cells, proofs)
+    yield f'verify_cell_kzg_proof_batch_case_invalid_cell_index_{identifier}', {
         'input': {
             'commitments': encode_hex_list(commitments),
-            'column_indices': column_indices,
+            'cell_indices': cell_indices,
             'cells': encode_hex_list(cells),
             'proofs': encode_hex_list(proofs),
         },
@@ -384,15 +384,15 @@ def case_verify_cell_kzg_proof_batch():
         cells, proofs = VALID_CELLS_AND_PROOFS[i % len(INVALID_INDIVIDUAL_CELL_BYTES)]
         cells, proofs = cells[:1], proofs[:1]
         commitments = [VALID_COMMITMENTS[i % len(INVALID_INDIVIDUAL_CELL_BYTES)]]
-        column_indices = list(range(len(cells)))
+        cell_indices = list(range(len(cells)))
         # Set first cell to the invalid cell
         cells[0] = cell
-        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
-        identifier = make_id(commitments, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, cell_indices, cells, proofs)
+        identifier = make_id(commitments, cell_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_cell_{identifier}', {
             'input': {
                 'commitments': encode_hex_list(commitments),
-                'column_indices': column_indices,
+                'cell_indices': cell_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
             },
@@ -404,15 +404,15 @@ def case_verify_cell_kzg_proof_batch():
         cells, proofs = VALID_CELLS_AND_PROOFS[i % len(INVALID_G1_POINTS)]
         cells, proofs = cells[:1], proofs[:1]
         commitments = [VALID_COMMITMENTS[i % len(INVALID_G1_POINTS)]]
-        column_indices = list(range(len(cells)))
+        cell_indices = list(range(len(cells)))
         # Set first proof to the invalid proof
         proofs[0] = proof
-        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
-        identifier = make_id(commitments, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, cell_indices, cells, proofs)
+        identifier = make_id(commitments, cell_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_proof_{identifier}', {
             'input': {
                 'commitments': encode_hex_list(commitments),
-                'column_indices': column_indices,
+                'cell_indices': cell_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
             },
@@ -424,31 +424,31 @@ def case_verify_cell_kzg_proof_batch():
         cells, proofs = cells[:2], proofs[:2]
         # Do not include the second commitment
         commitments = [VALID_COMMITMENTS[0]]
-        column_indices = list(range(len(cells)))
-        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
-        identifier = make_id(commitments, column_indices, cells, proofs)
+        cell_indices = list(range(len(cells)))
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, cell_indices, cells, proofs)
+        identifier = make_id(commitments, cell_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_missing_commitment_{identifier}', {
             'input': {
                 'commitments': encode_hex_list(commitments),
-                'column_indices': column_indices,
+                'cell_indices': cell_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
             },
             'output': None
         }
 
-        # Edge case: Missing a column index
+        # Edge case: Missing a cell index
         cells, proofs = VALID_CELLS_AND_PROOFS[2]
         cells, proofs = cells[:2], proofs[:2]
         commitments = [VALID_COMMITMENTS[2], VALID_COMMITMENTS[2]]
-        # Leave off one of the column indices
-        column_indices = list(range(len(cells) - 1))
-        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
-        identifier = make_id(commitments, column_indices, cells, proofs)
-        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_column_index_{identifier}', {
+        # Leave off one of the cell indices
+        cell_indices = list(range(len(cells) - 1))
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, cell_indices, cells, proofs)
+        identifier = make_id(commitments, cell_indices, cells, proofs)
+        yield f'verify_cell_kzg_proof_batch_case_invalid_missing_cell_index_{identifier}', {
             'input': {
                 'commitments': encode_hex_list(commitments),
-                'column_indices': column_indices,
+                'cell_indices': cell_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
             },
@@ -459,15 +459,15 @@ def case_verify_cell_kzg_proof_batch():
         cells, proofs = VALID_CELLS_AND_PROOFS[3]
         cells, proofs = cells[:2], proofs[:2]
         commitments = [VALID_COMMITMENTS[3], VALID_COMMITMENTS[3]]
-        column_indices = list(range(len(cells)))
+        cell_indices = list(range(len(cells)))
         # Remove the last proof
         cells = cells[:-1]
-        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
-        identifier = make_id(commitments, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, cell_indices, cells, proofs)
+        identifier = make_id(commitments, cell_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_missing_cell_{identifier}', {
             'input': {
                 'commitments': encode_hex_list(commitments),
-                'column_indices': column_indices,
+                'cell_indices': cell_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
             },
@@ -478,15 +478,15 @@ def case_verify_cell_kzg_proof_batch():
         cells, proofs = VALID_CELLS_AND_PROOFS[4]
         cells, proofs = cells[:2], proofs[:2]
         commitments = [VALID_COMMITMENTS[4], VALID_COMMITMENTS[4]]
-        column_indices = list(range(len(cells)))
+        cell_indices = list(range(len(cells)))
         # Remove the last proof
         proofs = proofs[:-1]
-        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, column_indices, cells, proofs)
-        identifier = make_id(commitments, column_indices, cells, proofs)
+        expect_exception(spec.verify_cell_kzg_proof_batch, commitments, cell_indices, cells, proofs)
+        identifier = make_id(commitments, cell_indices, cells, proofs)
         yield f'verify_cell_kzg_proof_batch_case_invalid_missing_proof_{identifier}', {
             'input': {
                 'commitments': encode_hex_list(commitments),
-                'column_indices': column_indices,
+                'cell_indices': cell_indices,
                 'cells': encode_hex_list(cells),
                 'proofs': encode_hex_list(proofs),
             },


### PR DESCRIPTION
Primarily, this PR renames some of the index params in the polynomial commitment spec. We do this because KZG libraries should have no concept of "row" or "column". The core DAS spec will still use `RowIndex` and `ColumnIndex` types.

Notably:
* `column_indices` -> `cell_indices`
* `row_indices` -> `commitment_indices`
* `row_commitments` -> `commitments`

It also does some other small things like:

* Add a new `CommitmentIndex` type.
* Improve `compute_verify_cell_kzg_proof_batch_challenge` function.
* Remove punctuation from `MAX_CELLS_IN_EXTENDED_MATRIX` description.
* Rename constants section which had no constants.