### PR TITLE
Add BeaconBlocksByRange v3

### DIFF
--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -87,6 +87,6 @@ Response Content:
 
 Extends behaviour of BeaconBlocksByRange v2 as defined in [the altair p2p spec](../altair/p2p-interface.md).
 
-Requests beacon blocks in the slot range `[start_slot, start_slot + count)`, leading up to `block_root`. If the block with `block_root` is unknown the responder MUST respond with `3: ResourceUnavailable`. If the slot of the block with `block_root` is less than `start_slot` the responder MUST respond with `1: InvalidRequest`.
+Requests beacon blocks in the slot range `[start_slot, start_slot + count)`, leading up to `block_root`. If the block with `block_root` is unknown the responder MUST respond with `3: ResourceUnavailable`. If the slot of the block with `block_root` is less than `start_slot + count` the responder MUST respond with `1: InvalidRequest`.
 
 

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -16,6 +16,9 @@ The specification of these changes continues in the same format as the network s
     - [Global topics](#global-topics)
       - [`beacon_aggregate_and_proof`](#beacon_aggregate_and_proof)
       - [`beacon_attestation_{subnet_id}`](#beacon_attestation_subnet_id)
+- [The Req/Resp domain](#the-reqresp-domain)
+  - [Messages](#messages)
+    - [BeaconBlocksByRange v3](#beaconblocksbyrange-v3)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -57,3 +60,33 @@ The following convenience variables are re-defined
 The following validations are added:
 * [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(attestation)`.
 * [REJECT] `attestation.data.index == 0`
+
+## The Req/Resp domain
+
+### Messages
+
+#### BeaconBlocksByRange v3
+
+**Protocol ID:** `/eth2/beacon_chain/req/beacon_blocks_by_range/3/`
+
+Request Content:
+```
+(
+  block_root: Root
+  start_slot: Slot
+  count: uint64
+)
+```
+
+Response Content:
+```
+(
+  List[SignedBeaconBlock, MAX_REQUEST_BLOCKS]
+)
+```
+
+Extends behaviour of BeaconBlocksByRange v2 as defined in [the altair p2p spec](../altair/p2p-interface.md).
+
+Requests beacon blocks in the slot range `[start_slot, start_slot + count)`, leading up to `block_root`. If the block with `block_root` is unknown the responder MUST respond with `3: ResourceUnavailable`. If the slot of the block with `block_root` is less than `start_slot` the responder MUST respond with `1: InvalidRequest`.
+
+

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -106,7 +106,7 @@ Request Content:
 Response Content:
 ```
 (
-  List[SignedBeaconBlock, MAX_REQUEST_BLOCKS]
+  List[BlobSidecar, MAX_REQUEST_BLOB_SIDECARS]
 )
 ```
 

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -19,6 +19,7 @@ The specification of these changes continues in the same format as the network s
 - [The Req/Resp domain](#the-reqresp-domain)
   - [Messages](#messages)
     - [BeaconBlocksByRange v3](#beaconblocksbyrange-v3)
+    - [BlobSidecarsByRange v2](#blobsidecarsbyrange-v2)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -89,4 +90,27 @@ Extends behaviour of BeaconBlocksByRange v2 as defined in [the altair p2p spec](
 
 Requests beacon blocks in the slot range `[start_slot, start_slot + count)`, leading up to `block_root`. If the block with `block_root` is unknown the responder MUST respond with `3: ResourceUnavailable`. If the slot of the block with `block_root` is less than `start_slot + count` the responder MUST respond with `1: InvalidRequest`.
 
+#### BlobSidecarsByRange v2
+
+**Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/2/`
+
+Request Content:
+```
+(
+  block_root: Root
+  start_slot: Slot
+  count: uint64
+)
+```
+
+Response Content:
+```
+(
+  List[SignedBeaconBlock, MAX_REQUEST_BLOCKS]
+)
+```
+
+Extends behaviour of BlobSidecarByRange v2 as defined in [the deneb p2p spec](../deneb/p2p-interface.md).
+
+Requests blob sidecars in the slot range `[start_slot, start_slot + count)`, leading up to `block_root`. If the block with `block_root` is unknown the responder MUST respond with `3: ResourceUnavailable`. If the slot of the block with `block_root` is less than `start_slot + count` the responder MUST respond with `1: InvalidRequest`.
 


### PR DESCRIPTION
BeaconBlocksByRange v2 allows to sync blocks exclusively from the peer's canonical chain.

Consider an unstable network with a competing forks. One can group peers by their head with status Req Resp messages. However, there's asynchrony between receiving that status message and requesting blocks by range, as the head of the remote peer can change at any time.

Consider a case where you syncing a head chain with BeaconBlocksByRange v2 and peer changes its head before you issue a by range request. It changes into a fork that has all missed slots in the requested range. You should downscore the peer since its giving incorrect blocks for the segment you are intending to sync. However, the root of the issue is the risk of mixing ranges of blocks from different forks without being aware of it.

BeaconBlocksByRange v3 allows requesters to specify which fork they intend to sync. An exemplary consumer would:
- Status all its peers
- Group them by head_root
- Issue BeaconBlocksByRange v3 requests to each group where block_root = head_root

If other clients believe this protocol to be unnecessary I'm keen to know how you handle these situations with the existing protocols.
