### PR TITLE
Update description for test format

### DIFF
--- a/tests/formats/kzg_7594/recover_cells_and_kzg_proofs.md
+++ b/tests/formats/kzg_7594/recover_cells_and_kzg_proofs.md
@@ -1,6 +1,6 @@
 # Test format: Recover cells and KZG proofs
 
-Recover all cells/proofs given at least 50% of the original `cells` and `proofs`.
+Recover all cells/proofs given at least 50% of the original `cells`.
 
 ## Test case format
 


### PR DESCRIPTION
@zilm13 pointed out that the description is out-of-date and misleading. This fixes that.

This function only takes cells now, not cells and proofs.