### PR TITLE
Update recover_cells_and_kzg_proofs.md

### DIFF
--- a/tests/formats/kzg_7594/recover_cells_and_kzg_proofs.md
+++ b/tests/formats/kzg_7594/recover_cells_and_kzg_proofs.md
@@ -15,7 +15,6 @@ output: Tuple[List[Cell], List[KZGProof]] -- all cells and proofs
 
 - `CellIndex` is an unsigned 64-bit integer.
 - `Cell` is a 2048-byte hexadecimal string, prefixed with `0x`.
-- `KZGProof` is a 48-byte hexadecimal string, prefixed with `0x`.
 
 All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
 


### PR DESCRIPTION
We don't use `KzgProof` anymore for v1.5.0-alpha.3 and +  Relase link: https://github.com/ethereum/consensus-specs/releases/tag/v1.5.0-alpha.3