### PR TITLE
P2P clarifications when introducing `engine_getBlobsV1`

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -314,7 +314,7 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer (i.e. via `engine_getBlobsV1`)
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
-When clients uses local execution layer to retrieve blobs relative to the current slot they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
+When clients uses local execution layer to recover missing blobs relative to the current slot, they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
 - publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet.
 - update gossip rule related data structures (ie update the anti-equivocation cache).
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -296,7 +296,7 @@ Before consuming the next response chunk, the response reader SHOULD verify the 
 
 No more than `MAX_REQUEST_BLOB_SIDECARS` may be requested at a time.
 
-`BlobSidecarsByRoot` is primarily used to recover recent blobs (e.g. when receiving a block with a transaction whose corresponding blob is missing). In addition, it is possible to retrieve recent blobs by quering the Execution Layer via `engine_getBlobsV1` engine API method.
+`BlobSidecarsByRoot` is primarily used to recover recent blobs (e.g. when receiving a block with a transaction whose corresponding blob is missing). In addition, it is possible to retrieve recent blobs by querying the Execution Layer via `engine_getBlobsV1` engine API method.
 
 The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `BlobSidecar` payload.

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -314,7 +314,9 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer (i.e. via `engine_getBlobsV1`)
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
-Clients MUST publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet whenever it successfully recovers blobs via local execution layer client. In such case, clients MUST also treat the `blob_sidecar` as if it had been received via gossip (ie update the anti-equivocation cache)
+When clients uses local execution layer to retrieve blobs relative to the current slot they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
+- publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet.
+- update gossip rule related data structures (ie update the anti-equivocation cache).
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -34,6 +34,7 @@ The specification of these changes continues in the same format as the network s
       - [BeaconBlocksByRange v2](#beaconblocksbyrange-v2)
       - [BeaconBlocksByRoot v2](#beaconblocksbyroot-v2)
       - [BlobSidecarsByRoot v1](#blobsidecarsbyroot-v1)
+        - [Usage of `engine_getBlobsV1` engine API method](#usage-of-engine_getblobsv1-engine-api-method)
       - [BlobSidecarsByRange v1](#blobsidecarsbyrange-v1)
 - [Design decision rationale](#design-decision-rationale)
   - [Why are blobs relayed as a sidecar, separate from beacon blocks?](#why-are-blobs-relayed-as-a-sidecar-separate-from-beacon-blocks)

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -34,7 +34,7 @@ The specification of these changes continues in the same format as the network s
       - [BeaconBlocksByRange v2](#beaconblocksbyrange-v2)
       - [BeaconBlocksByRoot v2](#beaconblocksbyroot-v2)
       - [BlobSidecarsByRoot v1](#blobsidecarsbyroot-v1)
-        - [Usage of `engine_getBlobsV1` engine API method](#usage-of-engine_getblobsv1-engine-api-method)
+        - [Blobs recovery via local execution layer client](#blobs-recovery-via-local-execution-layer-client)
       - [BlobSidecarsByRange v1](#blobsidecarsbyrange-v1)
 - [Design decision rationale](#design-decision-rationale)
   - [Why are blobs relayed as a sidecar, separate from beacon blocks?](#why-are-blobs-relayed-as-a-sidecar-separate-from-beacon-blocks)
@@ -311,11 +311,11 @@ Clients SHOULD include a sidecar in the response as soon as it passes the gossip
 Clients SHOULD NOT respond with sidecars related to blocks that fail gossip validation rules.
 Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon chain state transition
 
-###### Usage of `engine_getBlobsV1` engine API method
-In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer via `engine_getBlobsV1`.
+###### Blobs recovery via local execution layer client
+In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer (i.e. via `engine_getBlobsV1`)
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
-Client MUST publish the corresponding `blob_sidecar` whenever successfully recovers blobs via `engine_getBlobsV1`.
+Client MUST publish the corresponding `blob_sidecar` whenever successfully recovers blobs via local execution layer client.
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -315,7 +315,7 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 In addition to `BlobSidecarsByRoot` requests, recent blobs MAY be retrieved by querying the Execution Layer (i.e. via `engine_getBlobsV1`).
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
-When clients use local execution layer to recover missing blobs relative to the current slot, they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
+When clients use the local execution layer to retrieve blobs, they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
 * publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet.
 * update gossip rule related data structures (i.e. update the anti-equivocation cache).
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -312,11 +312,11 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 
 ###### Usage of `engine_getBlobsV1` engine API method
 In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer via `engine_getBlobsV1`.
-Implementers are encouraged to leverege this method to encrease the likelyhood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
+Implementers are encouraged to leverege this method to encrease the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
 Client MAY use this method when serving `BlobSidecarsByRoot` requests.
 
-Client MUST publish the corresponding `blob_sidecar` whenever succesfully recovers blobs via `engine_getBlobsV1`.
+Client MUST publish the corresponding `blob_sidecar` whenever successfully recovers blobs via `engine_getBlobsV1`.
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -314,7 +314,7 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer (i.e. via `engine_getBlobsV1`)
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
-Clients MUST publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet whenever it successfully recovers blobs via local execution layer client. In such case, clients MUST also consider the `blob_sidecar` as "seen" with regards to blob subnet gossip rules.
+Clients MUST publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet whenever it successfully recovers blobs via local execution layer client. In such case, clients MUST also treat the `blob_sidecar` as if it had been received via gossip (ie update the anti-equivocation cache)
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -315,8 +315,6 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer via `engine_getBlobsV1`.
 Implementers are encouraged to leverege this method to encrease the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
-Client MAY use this method when serving `BlobSidecarsByRoot` requests.
-
 Client MUST publish the corresponding `blob_sidecar` whenever successfully recovers blobs via `engine_getBlobsV1`.
 
 ##### BlobSidecarsByRange v1

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -34,7 +34,7 @@ The specification of these changes continues in the same format as the network s
       - [BeaconBlocksByRange v2](#beaconblocksbyrange-v2)
       - [BeaconBlocksByRoot v2](#beaconblocksbyroot-v2)
       - [BlobSidecarsByRoot v1](#blobsidecarsbyroot-v1)
-        - [Blobs recovery via local execution layer client](#blobs-recovery-via-local-execution-layer-client)
+        - [Blob retrieval via local execution layer client](#blob-retrieval-via-local-execution-layer-client)
       - [BlobSidecarsByRange v1](#blobsidecarsbyrange-v1)
 - [Design decision rationale](#design-decision-rationale)
   - [Why are blobs relayed as a sidecar, separate from beacon blocks?](#why-are-blobs-relayed-as-a-sidecar-separate-from-beacon-blocks)

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -317,7 +317,7 @@ Implementers are encouraged to leverage this method to increase the likelihood o
 
 When clients use local execution layer to recover missing blobs relative to the current slot, they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
 - publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet.
-- update gossip rule related data structures (ie update the anti-equivocation cache).
+- update gossip rule related data structures (i.e. update the anti-equivocation cache).
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -316,8 +316,8 @@ In addition to `BlobSidecarsByRoot` requests, recent blobs MAY be retrieved by q
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
 When clients use local execution layer to recover missing blobs relative to the current slot, they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
-- publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet.
-- update gossip rule related data structures (i.e. update the anti-equivocation cache).
+* publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet.
+* update gossip rule related data structures (i.e. update the anti-equivocation cache).
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -312,7 +312,7 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 
 ###### Blob retrieval via local execution layer client
 
-In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer (i.e. via `engine_getBlobsV1`)
+In addition to `BlobSidecarsByRoot` requests, recent blobs MAY be retrieved by querying the Execution Layer (i.e. via `engine_getBlobsV1`).
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
 When clients use local execution layer to recover missing blobs relative to the current slot, they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -184,7 +184,7 @@ The following validations MUST pass before forwarding the `blob_sidecar` on the 
 - _[REJECT]_ The sidecar's inclusion proof is valid as verified by `verify_blob_sidecar_inclusion_proof(blob_sidecar)`.
 - _[REJECT]_ The sidecar's blob is valid as verified by `verify_blob_kzg_proof(blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof)`.
 - _[IGNORE]_ The sidecar is the first sidecar for the tuple `(block_header.slot, block_header.proposer_index, blob_sidecar.index)` with valid header signature, sidecar inclusion proof, and kzg proof.
-*Note:* If client obtains the blob via `engine_getBlobV1` or any other method before receiving the corresponding sidecar via this topic, it MUST NOT consider the tuple as "seen" (i.e. it MUST participate in the dissemination of the blob_sidecar even if it already obtained the blob)
+*Note:* If client obtains the blob via `engine_getBlobsV1` or any other method before receiving the corresponding sidecar via this topic, it MUST NOT consider the tuple as "seen" (i.e. it MUST participate in the dissemination of the blob_sidecar even if it already obtained the blob)
 - _[REJECT]_ The sidecar is proposed by the expected `proposer_index` for the block's slot in the context of the current shuffling (defined by `block_header.parent_root`/`block_header.slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling, the sidecar MAY be queued for later processing while proposers for the block's branch are calculated -- in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
@@ -296,7 +296,7 @@ Before consuming the next response chunk, the response reader SHOULD verify the 
 
 No more than `MAX_REQUEST_BLOB_SIDECARS` may be requested at a time.
 
-`BlobSidecarsByRoot` is primarily used to recover recent blobs (e.g. when receiving a block with a transaction whose corresponding blob is missing). In addition, it is possible to retrieve recent blobs by quering the Execution Layer via `engine_getBlobV1` engine API method.
+`BlobSidecarsByRoot` is primarily used to recover recent blobs (e.g. when receiving a block with a transaction whose corresponding blob is missing). In addition, it is possible to retrieve recent blobs by quering the Execution Layer via `engine_getBlobsV1` engine API method.
 
 The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `BlobSidecar` payload.

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -185,7 +185,7 @@ The following validations MUST pass before forwarding the `blob_sidecar` on the 
 - _[REJECT]_ The sidecar's inclusion proof is valid as verified by `verify_blob_sidecar_inclusion_proof(blob_sidecar)`.
 - _[REJECT]_ The sidecar's blob is valid as verified by `verify_blob_kzg_proof(blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof)`.
 - _[IGNORE]_ The sidecar is the first sidecar for the tuple `(block_header.slot, block_header.proposer_index, blob_sidecar.index)` with valid header signature, sidecar inclusion proof, and kzg proof.
-*Note:* If client obtains the blob via `engine_getBlobsV1` or any other method before receiving the corresponding sidecar via this topic, it MUST NOT consider the tuple as "seen" (i.e. it MUST participate in the dissemination of the blob_sidecar even if it already obtained the blob)
+*Note:* If client obtains the blob via local execution layer client or any other method before receiving the corresponding sidecar via this topic, it MUST NOT consider the tuple as "seen" (i.e. it MUST participate in the dissemination of the blob_sidecar even if it already obtained the blob)
 - _[REJECT]_ The sidecar is proposed by the expected `proposer_index` for the block's slot in the context of the current shuffling (defined by `block_header.parent_root`/`block_header.slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling, the sidecar MAY be queued for later processing while proposers for the block's branch are calculated -- in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -314,7 +314,7 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer (i.e. via `engine_getBlobsV1`)
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
-When clients uses local execution layer to recover missing blobs relative to the current slot, they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
+When clients use local execution layer to recover missing blobs relative to the current slot, they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
 - publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet.
 - update gossip rule related data structures (ie update the anti-equivocation cache).
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -185,7 +185,6 @@ The following validations MUST pass before forwarding the `blob_sidecar` on the 
 - _[REJECT]_ The sidecar's inclusion proof is valid as verified by `verify_blob_sidecar_inclusion_proof(blob_sidecar)`.
 - _[REJECT]_ The sidecar's blob is valid as verified by `verify_blob_kzg_proof(blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof)`.
 - _[IGNORE]_ The sidecar is the first sidecar for the tuple `(block_header.slot, block_header.proposer_index, blob_sidecar.index)` with valid header signature, sidecar inclusion proof, and kzg proof.
-*Note:* If client obtains the blob via local execution layer client or any other method before receiving the corresponding sidecar via this topic, it MUST NOT consider the tuple as "seen" (i.e. it MUST participate in the dissemination of the blob_sidecar even if it already obtained the blob)
 - _[REJECT]_ The sidecar is proposed by the expected `proposer_index` for the block's slot in the context of the current shuffling (defined by `block_header.parent_root`/`block_header.slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling, the sidecar MAY be queued for later processing while proposers for the block's branch are calculated -- in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
@@ -315,7 +314,7 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer (i.e. via `engine_getBlobsV1`)
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
-Client MUST publish the corresponding `blob_sidecar` whenever successfully recovers blobs via local execution layer client.
+Clients MUST publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet whenever it successfully recovers blobs via local execution layer client. In such case, clients MUST also consider the `blob_sidecar` as "seen" with regards to blob subnet gossip rules.
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -296,7 +296,7 @@ Before consuming the next response chunk, the response reader SHOULD verify the 
 
 No more than `MAX_REQUEST_BLOB_SIDECARS` may be requested at a time.
 
-`BlobSidecarsByRoot` is primarily used to recover recent blobs (e.g. when receiving a block with a transaction whose corresponding blob is missing). In addition, it is possible to retrieve recent blobs by querying the Execution Layer via `engine_getBlobsV1` engine API method.
+`BlobSidecarsByRoot` is primarily used to recover recent blobs (e.g. when receiving a block with a transaction whose corresponding blob is missing).
 
 The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `BlobSidecar` payload.
@@ -309,6 +309,14 @@ Clients MAY limit the number of blocks and sidecars in the response.
 Clients SHOULD include a sidecar in the response as soon as it passes the gossip validation rules.
 Clients SHOULD NOT respond with sidecars related to blocks that fail gossip validation rules.
 Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon chain state transition
+
+###### Usage of `engine_getBlobsV1` engine API method
+In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer via `engine_getBlobsV1`.
+Implementers are encouraged to leverege this method to encrease the likelyhood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
+
+Client MAY use this method when serving `BlobSidecarsByRoot` requests.
+
+Client MUST publish the corresponding `blob_sidecar` whenever succesfully recovers blobs via `engine_getBlobsV1`.
 
 ##### BlobSidecarsByRange v1
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -313,7 +313,7 @@ Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon 
 
 ###### Usage of `engine_getBlobsV1` engine API method
 In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer via `engine_getBlobsV1`.
-Implementers are encouraged to leverege this method to encrease the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
+Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
 Client MUST publish the corresponding `blob_sidecar` whenever successfully recovers blobs via `engine_getBlobsV1`.
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -310,7 +310,8 @@ Clients SHOULD include a sidecar in the response as soon as it passes the gossip
 Clients SHOULD NOT respond with sidecars related to blocks that fail gossip validation rules.
 Clients SHOULD NOT respond with sidecars related to blocks that fail the beacon chain state transition
 
-###### Blobs recovery via local execution layer client
+###### Blob retrieval via local execution layer client
+
 In addition to `BlobSidecarsByRoot` requests, recent blobs recovery MAY also be done by querying the Execution Layer (i.e. via `engine_getBlobsV1`)
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -184,6 +184,7 @@ The following validations MUST pass before forwarding the `blob_sidecar` on the 
 - _[REJECT]_ The sidecar's inclusion proof is valid as verified by `verify_blob_sidecar_inclusion_proof(blob_sidecar)`.
 - _[REJECT]_ The sidecar's blob is valid as verified by `verify_blob_kzg_proof(blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof)`.
 - _[IGNORE]_ The sidecar is the first sidecar for the tuple `(block_header.slot, block_header.proposer_index, blob_sidecar.index)` with valid header signature, sidecar inclusion proof, and kzg proof.
+*Note:* If client obtains the blob via `engine_getBlobV1` or any other method before receiving the corresponding sidecar via this topic, it MUST NOT consider the tuple as "seen" (i.e. it MUST participate in the dissemination of the blob_sidecar even if it already obtained the blob)
 - _[REJECT]_ The sidecar is proposed by the expected `proposer_index` for the block's slot in the context of the current shuffling (defined by `block_header.parent_root`/`block_header.slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling, the sidecar MAY be queued for later processing while proposers for the block's branch are calculated -- in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
@@ -295,7 +296,7 @@ Before consuming the next response chunk, the response reader SHOULD verify the 
 
 No more than `MAX_REQUEST_BLOB_SIDECARS` may be requested at a time.
 
-`BlobSidecarsByRoot` is primarily used to recover recent blobs (e.g. when receiving a block with a transaction whose corresponding blob is missing).
+`BlobSidecarsByRoot` is primarily used to recover recent blobs (e.g. when receiving a block with a transaction whose corresponding blob is missing). In addition, it is possible to retrieve recent blobs by quering the Execution Layer via `engine_getBlobV1` engine API method.
 
 The response MUST consist of zero or more `response_chunk`.
 Each _successful_ `response_chunk` MUST contain a single `BlobSidecar` payload.


### PR DESCRIPTION
This PR adds some clarifications in the P2P spec if [engine_getBlobsV1](https://github.com/ethereum/execution-apis/pull/559) become a viable method to retrieve blobs.

Dictates that an honest validator, when successfully recover blobs for the current slot using local EL MUST:
- republish the `blob_sidecar` over the p2p layer
- make sure it updates all the data structures as if client had received the `blob_sidecar` over the gossip (ie update equivocation cache)

The basic idea is that, if `engine_getBlobsV1` is used to recover missing blobs while following the head, it should behave like it has been received via gossip.
If it is used to retrieve recent past blobs the node could have missed, it should act as a byRoot RPC request (no republish)