### PR TITLE
fix process pending consolidations

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -895,12 +895,13 @@ def process_pending_balance_deposits(state: BeaconState) -> None:
 ```python
 def process_pending_consolidations(state: BeaconState) -> None:
     next_pending_consolidation = 0
+    next_epoch = Epoch(get_current_epoch(state) + 1)
     for pending_consolidation in state.pending_consolidations:
         source_validator = state.validators[pending_consolidation.source_index]
         if source_validator.slashed:
             next_pending_consolidation += 1
             continue
-        if source_validator.withdrawable_epoch > get_current_epoch(state):
+        if source_validator.withdrawable_epoch > next_epoch:
             break
 
         # Churn any target excess active balance of target and raise its max


### PR DESCRIPTION
fix the consolidation bug in devnet 2

tl-dr of the incident:

a consolidation was initiated for a validator 106 into 107 and got accepted with withdrawal epoch (consolidation epoch 1386) 
![image](https://github.com/user-attachments/assets/9f5e9ff8-5689-45b9-8aa3-cac5a69bc421)

so it was to be consolidated on epoch transition before slot 1386*32= 44352

but it was not processed untill the next epoch transition before the slot 1387*32 = 44384

in the mean time before 1386 and 1387 epoch, it was fully withdrawn in slot: `44359` because of process withdrawals
![image](https://github.com/user-attachments/assets/e9e0b794-8d4c-43d7-a970-f1922791db68)

so ideally it should have been processed on 1386 epoch transition but was not because of this condition:
```python
 if source_validator.withdrawable_epoch > get_current_epoch(state):
            break
```
where epoch of state still comes out to be 1385 because state's slot has not yet ticked to `44352` which happens in processSlot which follows process epoch

full context: https://discord.com/channels/595666850260713488/1268911253913337897/1270009116571472065

this was the second consolidation which exhibited the same issue, previous one was triggered to consolidate 105 into 106 which again was not processed at its `"withdrawable_epoch": "697"` but 1 epoch later