### PR TITLE
Split `get_data_column_sidecars` parameters

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -194,21 +194,18 @@ def recover_matrix(partial_matrix: Sequence[MatrixEntry],
 #### `get_data_column_sidecars`
 
 ```python
-def get_data_column_sidecars(signed_block: SignedBeaconBlock,
+def get_data_column_sidecars(signed_block_header: SignedBeaconBlockHeader,
+                             blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+                             kzg_commitments_inclusion_proof: Sequence[Bytes32],
                              cells_and_kzg_proofs: Sequence[Tuple[
         Vector[Cell, CELLS_PER_EXT_BLOB],
         Vector[KZGProof, CELLS_PER_EXT_BLOB]]]) -> Sequence[DataColumnSidecar]:
     """
-    Given a signed block and the cells/proofs associated with each blob in the
-    block, assemble the sidecars which can be distributed to peers.
+    Given a signed block header, the blob KZG commitments, the KZG commitments inclusion proof,
+    and the cells/proofs associated with each blob in the block, assemble the sidecars which can be
+    distributed to peers.
     """
-    blob_kzg_commitments = signed_block.message.body.blob_kzg_commitments
     assert len(cells_and_kzg_proofs) == len(blob_kzg_commitments)
-    signed_block_header = compute_signed_block_header(signed_block)
-    kzg_commitments_inclusion_proof = compute_merkle_proof(
-        signed_block.message.body,
-        get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments'),
-    )
 
     sidecars = []
     for column_index in range(NUMBER_OF_COLUMNS):


### PR DESCRIPTION
In the `data-availability-sampling` channel in the Eth R&D server, Potuz brought this up:

> I have a little problem with peer DAS that it's not specification related but rather implementation. In many parts of Prysm code we assume that the commitments come in the beacon block. Within ePBS this is not true. Working on top of Electra requires us to change the DA code to take the commitments instead of the blocks on most helpers. Peer DAS is a complication cause clients keep a separate branch for it. So ePBS is explicitly in conflict with peer DAS at the time of merging. Could it be possible to clean the spec to make minimal assumptions that the commitments are in blocks and have the helpers take them directly rather than accessing them from blocks?

> @potuz would something like this work for you? Only get_data_column_sidecars needs to change, right?

> Thanks for getting back to me Justin, yeah those changes are the kind of things that I'd like to see. I Don't follow the peer das spec to know where else it appears and surely clients will have their own separate signatures on implementations. I would just ask to err on the safe side and take the commitments as you did there (and if it appears somewhere else). This will at least make my life easier when I need to rebase 7732 on top of peer DAS. Otherwise you'll have me pushing to ship both together 😝

I believe `get_data_column_sidecars` is the only pain-point. This PR splits the `signed_block` parameter into three: `signed_block_header`, `blob_kzg_commitments `, and `kzg_commitments_inclusion_proof `.