### PR TITLE
remove redundant copy()

### DIFF
--- a/specs/capella/fork-choice.md
+++ b/specs/capella/fork-choice.md
@@ -75,8 +75,6 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     block = signed_block.message
     # Parent block must be known
     assert block.parent_root in store.block_states
-    # Make a copy of the state to avoid mutability issues
-    pre_state = copy(store.block_states[block.parent_root])
     # Blocks cannot be in the future. If they are, their consideration must be delayed until they are in the past.
     assert get_current_slot(store) >= block.slot
 
@@ -92,7 +90,8 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     assert store.finalized_checkpoint.root == finalized_checkpoint_block
 
     # Check the block is valid and compute the post-state
-    state = pre_state.copy()
+    # Make a copy of the state to avoid mutability issues
+    state = copy(store.block_states[block.parent_root])
     block_root = hash_tree_root(block)
     state_transition(state, signed_block, True)
 

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -74,8 +74,6 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     block = signed_block.message
     # Parent block must be known
     assert block.parent_root in store.block_states
-    # Make a copy of the state to avoid mutability issues
-    pre_state = copy(store.block_states[block.parent_root])
     # Blocks cannot be in the future. If they are, their consideration must be delayed until they are in the past.
     assert get_current_slot(store) >= block.slot
 
@@ -98,7 +96,8 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     assert is_data_available(hash_tree_root(block), block.body.blob_kzg_commitments)
 
     # Check the block is valid and compute the post-state
-    state = pre_state.copy()
+    # Make a copy of the state to avoid mutability issues
+    state = copy(store.block_states[block.parent_root])
     block_root = hash_tree_root(block)
     state_transition(state, signed_block, True)
 


### PR DESCRIPTION
`pre_state` is used in the Bellatrix spec, in `is_merge_transition_block`, but is unused in all other specs, other than to make a second copy of it, in `state`.