### PR TITLE
Get rid of compute_state_by_epoch_processing_to

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/epoch_processing/test_process_pending_consolidations.py
+++ b/tests/core/pyspec/eth2spec/test/electra/epoch_processing/test_process_pending_consolidations.py
@@ -1,6 +1,6 @@
 from eth2spec.test.helpers.epoch_processing import (
     run_epoch_processing_with,
-    compute_state_by_epoch_processing_to,
+    run_epoch_processing_to,
 )
 from eth2spec.test.context import (
     spec_state_test,
@@ -219,7 +219,8 @@ def test_pending_consolidation_future_epoch(spec, state):
         next_epoch_with_full_participation(spec, state)
 
     # Obtain state before the call to process_pending_consolidations
-    state_before_consolidation = compute_state_by_epoch_processing_to(spec, state, "process_pending_consolidations")
+    state_before_consolidation = state.copy()
+    run_epoch_processing_to(spec, state_before_consolidation, "process_pending_consolidations")
 
     yield from run_epoch_processing_with(spec, state, "process_pending_consolidations")
 
@@ -270,7 +271,8 @@ def test_pending_consolidation_compounding_creds(spec, state):
         next_epoch_with_full_participation(spec, state)
 
     # Obtain state before the call to process_pending_consolidations
-    state_before_consolidation = compute_state_by_epoch_processing_to(spec, state, "process_pending_consolidations")
+    state_before_consolidation = state.copy()
+    run_epoch_processing_to(spec, state_before_consolidation, "process_pending_consolidations")
 
     yield from run_epoch_processing_with(spec, state, "process_pending_consolidations")
 
@@ -325,7 +327,8 @@ def test_pending_consolidation_with_pending_deposit(spec, state):
         next_epoch_with_full_participation(spec, state)
 
     # Obtain state before the call to process_pending_balance_deposits
-    state_before_consolidation = compute_state_by_epoch_processing_to(spec, state, "process_pending_balance_deposits")
+    state_before_consolidation = state.copy()
+    run_epoch_processing_to(spec, state_before_consolidation, "process_pending_consolidations")
 
     yield from run_epoch_processing_with(spec, state, "process_pending_consolidations")
 

--- a/tests/core/pyspec/eth2spec/test/helpers/epoch_processing.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/epoch_processing.py
@@ -74,9 +74,3 @@ def run_epoch_processing_with(spec, state, process_name: str):
     yield 'pre', state
     getattr(spec, process_name)(state)
     yield 'post', state
-
-
-def compute_state_by_epoch_processing_to(spec, state, process_name: str):
-    state_copy = state.copy()
-    run_epoch_processing_to(spec, state_copy, process_name)
-    return state_copy


### PR DESCRIPTION
Replaces a recently introduced `compute_state_by_epoch_processing_to` helper with:
```python
state_copy = state.copy()
run_epoch_processing_to(spec, state_copy, …)
```