### PR TITLE
EIP-7251: Update correlation penalty computation

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -813,7 +813,7 @@ def process_epoch(state: BeaconState) -> None:
     process_inactivity_updates(state)
     process_rewards_and_penalties(state)
     process_registry_updates(state)  # [Modified in Electra:EIP7251]
-    process_slashings(state)
+    process_slashings(state)  # [Modified in Electra:EIP7251]
     process_eth1_data_reset(state)
     process_pending_balance_deposits(state)  # [New in Electra:EIP7251]
     process_pending_consolidations(state)  # [New in Electra:EIP7251]
@@ -848,6 +848,28 @@ def process_registry_updates(state: BeaconState) -> None:
     for validator in state.validators:
         if is_eligible_for_activation(state, validator):
             validator.activation_epoch = activation_epoch
+```
+
+#### Modified `process_slashings`
+
+*Note*: The function `process_slashings` is modified to use a new algorithm to compute correlation penalty.
+
+```python
+def process_slashings(state: BeaconState) -> None:
+    epoch = get_current_epoch(state)
+    total_balance = get_total_active_balance(state)
+    adjusted_total_slashing_balance = min(
+        sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX,
+        total_balance
+    )
+    increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from total balance to avoid uint64 overflow
+    penalty_per_effective_balance_increment = adjusted_total_slashing_balance // (total_balance // increment)
+    for index, validator in enumerate(state.validators):
+        if validator.slashed and epoch + EPOCHS_PER_SLASHINGS_VECTOR // 2 == validator.withdrawable_epoch:
+            effective_balance_increments = validator.effective_balance // increment
+            # [Modified in Electra:EIP7251]
+            penalty = penalty_per_effective_balance_increment * effective_balance_increments
+            decrease_balance(state, ValidatorIndex(index), penalty)
 ```
 
 #### New `process_pending_balance_deposits`

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -71,6 +71,7 @@
   - [Epoch processing](#epoch-processing)
     - [Modified `process_epoch`](#modified-process_epoch)
     - [Modified `process_registry_updates`](#modified-process_registry_updates)
+    - [Modified `process_slashings`](#modified-process_slashings)
     - [New `process_pending_balance_deposits`](#new-process_pending_balance_deposits)
     - [New `process_pending_consolidations`](#new-process_pending_consolidations)
     - [Modified `process_effective_balance_updates`](#modified-process_effective_balance_updates)


### PR DESCRIPTION
Fixes an issue in the correlation penalty computation that under certain total slashed balances (`sum(state.slashings)`) lead to zero penalty for 32 ETH validators and non-zero penalty for 2048 ETH validators, and as a result imbalance between the penalty for 64 x 32 ETH (= 0) and 1 x 2048 ETH (> 0) validators. It also fixes potential overflow in the same computation.

_Many thanks to [Pavel](https://x.com/PaulYa5hin) for finding the issue._
_Many thanks to @fradamt for co-authoring the fix._

### Problem

If validator effective_balance = 2048 ETH and > 30.024M ETH is slashed, the overflow can occur in the first line of the following code :
```python
penalty_numerator = validator.effective_balance // increment * adjusted_total_slashing_balance
penalty = penalty_numerator // total_balance * increment
```

The cause of the imbalance problem is in the integer division in the second line of the above code.
Whenever `validator.effective_balance // increment * adjusted_total_slashing_balance < total_balance` the penalty would be zero. Let us use real numbers for effective balance to highlight the discrepancy:
```python
penalty_32eth   =   32 * adjusted_total_slashing_balance // total_balance * increment
penalty_2048eth = 2048 * adjusted_total_slashing_balance // total_balance * increment
```
Obviously, for 32 ETH validator to experience non-zero penalty the `adjusted_total_slashing_balance` value should be 64 times higher than in the 2048 ETH case. Which is also illustrated by the following plot:

![image](https://github.com/user-attachments/assets/54378db4-fa07-4730-bab5-f19847e81b09)

### Fix

The idea of the fix is to compute penalty per EB increment in a way that never overflows and then multiply it by a number of increments to alleviate the imbalance between 64 x 32 ETH and 1 x 2048 ETH validators:
```python
penalty_per_effective_balance_increment = adjusted_total_slashing_balance // (total_balance // increment)
effective_balance_increments = validator.effective_balance // increment
penalty = penalty_per_effective_balance_increment * effective_balance_increments
```

### Analysis

_Notebook with more details can be found [here](https://colab.research.google.com/drive/1-pdJdrlRnTzy51l3Y6r0FOV8RB3moltK)._

The fix has the following effects:
1) Correlation penalty becomes linearly dependent on the amount of total slashed balance and number of effective balance increments. Which in its turn makes the penalty unaffected by effective balance distribution between validators, and makes the total effective balance of all slashed validators as the main factor for the penalty computation. In other words, 64 validators each having 32 ETH effective balance accrue the same penalty as a single 2048 ETH validator.
2) Correlation penalty is always non-zero, even when only one validator is slashed, but the amount of it in this case is negligible with respect to the initial and attestation penalties that validator is experiencing when it gets slashed.
3) Correlation penalty becomes a bit higher on average, but the total slashing penalty in Electra (with this fix) is reduced, especially for the cases when less than 320,000 ETH gets slashed. This is achieved by the initial penalty reduction.

![image](https://github.com/user-attachments/assets/e99b01b1-64b8-4627-8d1a-984fac81780a)

![image](https://github.com/user-attachments/assets/3954344b-1901-409e-98cb-ac2cbbfca557)

![image](https://github.com/user-attachments/assets/b1ada3e1-c3f0-4875-9385-2de2be0fcf1d)

![image](https://github.com/user-attachments/assets/fb05867e-591d-48e9-a681-22a5c27fddca)



