### PR TITLE
Require the builder is active and non-slashed

### DIFF
--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -493,9 +493,12 @@ def process_execution_payload_header(state: BeaconState, block: BeaconBlock) -> 
     signed_header = block.body.signed_execution_payload_header
     assert verify_execution_payload_header_signature(state, signed_header)
 
-    # Check that the builder has funds to cover the bid
+    # Check that the builder is active non-slashed has funds to cover the bid
     header = signed_header.message
     builder_index = header.builder_index
+    builder = state.validators[builder_index]
+    assert is_active_validator(builder, get_current_epoch(state))
+    assert not builder.slashed
     amount = header.value
     assert state.balances[builder_index] >= amount
 

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -170,9 +170,10 @@ The following validations MUST pass before forwarding the `signed_execution_payl
 
 - _[IGNORE]_ this is the first signed bid seen with a valid signature from the given builder for this slot.
 - _[IGNORE]_ this bid is the highest value bid seen for the pair of the corresponding slot and the given parent block hash.
-- _[REJECT]_ The signed builder bid, `header.builder_index` is a valid and non-slashed builder index in state.
+- _[REJECT]_ The signed builder bid, `header.builder_index` is a valid, active, and non-slashed builder index in state.
 - _[IGNORE]_ The signed builder bid value, `header.value`, is less or equal than the builder's balance in state.  i.e. `MIN_BUILDER_BALANCE + header.value < state.builder_balances[header.builder_index]`.
 - _[IGNORE]_ `header.parent_block_hash` is the block hash of a known execution payload in fork choice.
+_ _[IGNORE]_ `header.parent_block_root` is the hash tree root of a known beacon block in fork choice. 
 - _[IGNORE]_ `header.slot` is the current slot or the next slot. 
 - _[REJECT]_ The builder signature, `signed_execution_payload_header_envelope.signature`, is valid with respect to the `header_envelope.builder_index`.
 


### PR DESCRIPTION
This PR adds the requirement that the builder is active and non-slashed on the P2P spec for execution payload headers and the corresponding checks on the state transition function. 

h/t to @terencechain for finding these omissions. 