### PR TITLE
Randomize validator index in partial withdrawal test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
@@ -1,3 +1,4 @@
+import random
 from eth2spec.test.context import (
     spec_state_test,
     expect_assertion_error,
@@ -23,7 +24,7 @@ def test_basic_withdrawal_request(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -47,7 +48,7 @@ def test_basic_withdrawal_request_with_compounding_credentials(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
@@ -68,7 +69,7 @@ def test_basic_withdrawal_request_with_compounding_credentials(spec, state):
 def test_basic_withdrawal_request_with_full_partial_withdrawal_queue(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -106,7 +107,7 @@ def test_incorrect_source_address(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     incorrect_address = b"\x33" * 20
@@ -131,7 +132,7 @@ def test_incorrect_withdrawal_credential_prefix(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -160,7 +161,7 @@ def test_on_withdrawal_request_initiated_validator(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -183,7 +184,7 @@ def test_on_withdrawal_request_initiated_validator(spec, state):
 @spec_state_test
 def test_activation_epoch_less_than_shard_committee_period(spec, state):
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -213,7 +214,7 @@ def test_activation_epoch_less_than_shard_committee_period(spec, state):
 def test_basic_partial_withdrawal_request(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -245,7 +246,7 @@ def test_basic_partial_withdrawal_request(spec, state):
 def test_basic_partial_withdrawal_request_higher_excess_balance(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -277,7 +278,7 @@ def test_basic_partial_withdrawal_request_higher_excess_balance(spec, state):
 def test_basic_partial_withdrawal_request_lower_than_excess_balance(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     excess_balance = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -310,7 +311,7 @@ def test_basic_partial_withdrawal_request_lower_than_excess_balance(spec, state)
 def test_partial_withdrawal_request_with_pending_withdrawals(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -351,7 +352,7 @@ def test_partial_withdrawal_request_with_pending_withdrawals_and_high_amount(
 ):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.UINT64_MAX
@@ -389,7 +390,7 @@ def test_partial_withdrawal_request_with_pending_withdrawals_and_high_amount(
 def test_partial_withdrawal_request_with_high_balance(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
@@ -426,7 +427,7 @@ def test_partial_withdrawal_request_with_high_balance(spec, state):
 def test_partial_withdrawal_request_with_high_amount(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     # Set high amount requested to withdraw
@@ -459,7 +460,7 @@ def test_partial_withdrawal_request_with_high_amount(spec, state):
 def test_partial_withdrawal_request_with_low_amount(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = 1
@@ -494,7 +495,7 @@ def test_partial_withdrawal_request_with_low_amount(spec, state):
 def test_partial_withdrawal_queue_full(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -524,7 +525,7 @@ def test_partial_withdrawal_queue_full(spec, state):
 def test_no_compounding_credentials(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -553,7 +554,7 @@ def test_no_compounding_credentials(spec, state):
 def test_no_excess_balance(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -575,7 +576,7 @@ def test_no_excess_balance(spec, state):
 def test_pending_withdrawals_consume_all_excess_balance(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -605,7 +606,7 @@ def test_pending_withdrawals_consume_all_excess_balance(spec, state):
 def test_insufficient_effective_balance(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -636,7 +637,7 @@ def test_partial_withdrawal_incorrect_source_address(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     incorrect_address = b"\x33" * 20
@@ -662,7 +663,7 @@ def test_partial_withdrawal_incorrect_withdrawal_credential_prefix(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -691,7 +692,7 @@ def test_partial_withdrawal_on_exit_initiated_validator(spec, state):
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -716,7 +717,7 @@ def test_partial_withdrawal_activation_epoch_less_than_shard_committee_period(
     spec, state
 ):
     current_epoch = spec.get_current_epoch(state)
-    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
@@ -20,11 +20,12 @@ from eth2spec.test.helpers.withdrawals import (
 @with_electra_and_later
 @spec_state_test
 def test_basic_withdrawal_request(spec, state):
+    rng = random.Random(1337)
     # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -40,15 +41,38 @@ def test_basic_withdrawal_request(spec, state):
         spec, state, withdrawal_request
     )
 
-
 @with_electra_and_later
 @spec_state_test
-def test_basic_withdrawal_request_with_compounding_credentials(spec, state):
+def test_basic_withdrawal_request_with_first_validator(spec, state):
     # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = spec.get_active_validator_indices(state, current_epoch)[0]
+    validator_pubkey = state.validators[validator_index].pubkey
+    address = b"\x22" * 20
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, validator_index, address=address
+    )
+    withdrawal_request = spec.WithdrawalRequest(
+        source_address=address,
+        validator_pubkey=validator_pubkey,
+        amount=spec.FULL_EXIT_REQUEST_AMOUNT,
+    )
+
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request
+    )
+
+@with_electra_and_later
+@spec_state_test
+def test_basic_withdrawal_request_with_compounding_credentials(spec, state):
+    rng = random.Random(1338)
+    # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
+    state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
+
+    current_epoch = spec.get_current_epoch(state)
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
@@ -67,9 +91,10 @@ def test_basic_withdrawal_request_with_compounding_credentials(spec, state):
 @spec_state_test
 @with_presets([MINIMAL], "need full partial withdrawal queue")
 def test_basic_withdrawal_request_with_full_partial_withdrawal_queue(spec, state):
+    rng = random.Random(1339)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -103,11 +128,12 @@ def test_basic_withdrawal_request_with_full_partial_withdrawal_queue(spec, state
 @with_electra_and_later
 @spec_state_test
 def test_incorrect_source_address(spec, state):
+    rng = random.Random(1340)
     # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     incorrect_address = b"\x33" * 20
@@ -128,11 +154,12 @@ def test_incorrect_source_address(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_incorrect_withdrawal_credential_prefix(spec, state):
+    rng = random.Random(1341)
     # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -157,11 +184,12 @@ def test_incorrect_withdrawal_credential_prefix(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_on_withdrawal_request_initiated_validator(spec, state):
+    rng = random.Random(1342)
     # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -183,8 +211,9 @@ def test_on_withdrawal_request_initiated_validator(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_activation_epoch_less_than_shard_committee_period(spec, state):
+    rng = random.Random(1343)
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
@@ -212,9 +241,10 @@ def test_activation_epoch_less_than_shard_committee_period(spec, state):
 @spec_state_test
 @with_presets([MINIMAL])
 def test_basic_partial_withdrawal_request(spec, state):
+    rng = random.Random(1344)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -244,9 +274,10 @@ def test_basic_partial_withdrawal_request(spec, state):
 @spec_state_test
 @with_presets([MINIMAL])
 def test_basic_partial_withdrawal_request_higher_excess_balance(spec, state):
+    rng = random.Random(1345)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -276,9 +307,10 @@ def test_basic_partial_withdrawal_request_higher_excess_balance(spec, state):
 @spec_state_test
 @with_presets([MINIMAL])
 def test_basic_partial_withdrawal_request_lower_than_excess_balance(spec, state):
+    rng = random.Random(1346)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     excess_balance = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -309,9 +341,10 @@ def test_basic_partial_withdrawal_request_lower_than_excess_balance(spec, state)
 @spec_state_test
 @with_presets([MINIMAL])
 def test_partial_withdrawal_request_with_pending_withdrawals(spec, state):
+    rng = random.Random(1347)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -350,9 +383,10 @@ def test_partial_withdrawal_request_with_pending_withdrawals(spec, state):
 def test_partial_withdrawal_request_with_pending_withdrawals_and_high_amount(
     spec, state
 ):
+    rng = random.Random(1348)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.UINT64_MAX
@@ -388,9 +422,10 @@ def test_partial_withdrawal_request_with_pending_withdrawals_and_high_amount(
 @spec_state_test
 @with_presets([MINIMAL])
 def test_partial_withdrawal_request_with_high_balance(spec, state):
+    rng = random.Random(1349)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
@@ -425,9 +460,10 @@ def test_partial_withdrawal_request_with_high_balance(spec, state):
 @spec_state_test
 @with_presets([MINIMAL])
 def test_partial_withdrawal_request_with_high_amount(spec, state):
+    rng = random.Random(1350)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     # Set high amount requested to withdraw
@@ -458,9 +494,10 @@ def test_partial_withdrawal_request_with_high_amount(spec, state):
 @spec_state_test
 @with_presets([MINIMAL])
 def test_partial_withdrawal_request_with_low_amount(spec, state):
+    rng = random.Random(1351)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = 1
@@ -493,9 +530,10 @@ def test_partial_withdrawal_request_with_low_amount(spec, state):
 @spec_state_test
 @with_presets([MINIMAL], "need full partial withdrawal queue")
 def test_partial_withdrawal_queue_full(spec, state):
+    rng = random.Random(1352)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -523,9 +561,10 @@ def test_partial_withdrawal_queue_full(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_no_compounding_credentials(spec, state):
+    rng = random.Random(1353)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -552,9 +591,10 @@ def test_no_compounding_credentials(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_no_excess_balance(spec, state):
+    rng = random.Random(1354)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -574,9 +614,10 @@ def test_no_excess_balance(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_pending_withdrawals_consume_all_excess_balance(spec, state):
+    rng = random.Random(1355)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -604,9 +645,10 @@ def test_pending_withdrawals_consume_all_excess_balance(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_insufficient_effective_balance(spec, state):
+    rng = random.Random(1356)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -633,11 +675,12 @@ def test_insufficient_effective_balance(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_partial_withdrawal_incorrect_source_address(spec, state):
+    rng = random.Random(1357)
     # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     incorrect_address = b"\x33" * 20
@@ -659,11 +702,12 @@ def test_partial_withdrawal_incorrect_source_address(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_partial_withdrawal_incorrect_withdrawal_credential_prefix(spec, state):
+    rng = random.Random(1358)
     # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -688,11 +732,12 @@ def test_partial_withdrawal_incorrect_withdrawal_credential_prefix(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_partial_withdrawal_on_exit_initiated_validator(spec, state):
+    rng = random.Random(1359)
     # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
 
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
@@ -716,8 +761,9 @@ def test_partial_withdrawal_on_exit_initiated_validator(spec, state):
 def test_partial_withdrawal_activation_epoch_less_than_shard_committee_period(
     spec, state
 ):
+    rng = random.Random(1360)
     current_epoch = spec.get_current_epoch(state)
-    validator_index = random.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
     validator_pubkey = state.validators[validator_index].pubkey
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
@@ -41,6 +41,7 @@ def test_basic_withdrawal_request(spec, state):
         spec, state, withdrawal_request
     )
 
+
 @with_electra_and_later
 @spec_state_test
 def test_basic_withdrawal_request_with_first_validator(spec, state):
@@ -63,6 +64,7 @@ def test_basic_withdrawal_request_with_first_validator(spec, state):
     yield from run_withdrawal_request_processing(
         spec, state, withdrawal_request
     )
+
 
 @with_electra_and_later
 @spec_state_test


### PR DESCRIPTION
### Background

Raised by @pk910 in discord that Lodestar forked off in devnet 2 on partial withdrawals. After debugging, it was because Lodestar incorrectly checks validator with index `state.next_withdrawal_index` instead of `withdrawal.index` for partial withdrawal eligibility in `get_expected_withdrawals`. 

See discord [discussion](https://discord.com/channels/595666850260713488/892088344438255616/1275400126831005747) for detail.

This bug is not caught by partial withdrawal spec test because every test case uses fixed validator index
```validator_index = spec.get_active_validator_indices(state, current_epoch)[0]```
which is 0 and it coincides with the default value of `state.next_withdrawal_index` which is 0 as well.

### Proposal

Make each test pick validator index at random ie. 
```
validator_index = rng(spec.get_active_validator_indices(state, current_epoch))
```

