### PR TITLE
Fix the install_pyspec_test CI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ jobs:
     steps:
       - restore_cache:
           key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
-      #- restore_pyspec_cached_venv
       - run:
           name: Install pyspec requirements
           command: make install_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,13 +83,13 @@ jobs:
       - image: cimg/python:3.12.4
     working_directory: ~/specs-repo
     steps:
-      #- restore_cache:
-      #    key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
+      - restore_cache:
+          key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
       #- restore_pyspec_cached_venv
       - run:
           name: Install pyspec requirements
           command: make install_test
-      #- save_pyspec_cached_venv
+      - save_pyspec_cached_venv
   test-phase0:
     docker:
       - image: cimg/python:3.12.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,13 @@ commands:
     description: "Restore the cache with pyspec keys"
     steps:
       - restore_cached_venv:
-          venv_name: v24-pyspec
+          venv_name: v25-pyspec
           reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "requirements_preinstallation.txt" }}
   save_pyspec_cached_venv:
     description: Save a venv into a cache with pyspec keys"
     steps:
       - save_cached_venv:
-          venv_name: v24-pyspec
+          venv_name: v25-pyspec
           reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "requirements_preinstallation.txt" }}
           venv_path: ./venv
   restore_deposit_contract_tester_cached_venv:
@@ -85,6 +85,7 @@ jobs:
     steps:
       - restore_cache:
           key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
+      - restore_pyspec_cached_venv
       - run:
           name: Install pyspec requirements
           command: make install_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             - ~/specs-repo
   install_pyspec_test:
     docker:
-      - image: ethpandaops/circleci-python-rust:latest
+      - image: cimg/python:3.12.4
     working_directory: ~/specs-repo
     steps:
       - restore_cache:
@@ -88,7 +88,7 @@ jobs:
       - restore_pyspec_cached_venv
       - run:
           name: Install pyspec requirements
-          command: make install_test && make preinstallation
+          command: make install_test
       - save_pyspec_cached_venv
   test-phase0:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,13 +83,13 @@ jobs:
       - image: cimg/python:3.12.4
     working_directory: ~/specs-repo
     steps:
-      - restore_cache:
-          key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
-      - restore_pyspec_cached_venv
+      #- restore_cache:
+      #    key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
+      #- restore_pyspec_cached_venv
       - run:
           name: Install pyspec requirements
           command: make install_test
-      - save_pyspec_cached_venv
+      #- save_pyspec_cached_venv
   test-phase0:
     docker:
       - image: cimg/python:3.12.4


### PR DESCRIPTION
It looks like this CI test was accidentally broken in this PR. We just need to update the cache version.

* https://github.com/ethereum/consensus-specs/pull/3880

I'm not sure why Rust (via `ethpandaops/circleci-python-rust:latest`) is necessary. I don't think it should be. If there's an issue, I'm hoping the CI check will tell me which package needs it. (edit: Oh it's `py_arkworks_bls12381`, that makes sense. But this is a mistake. It only provides pre-built wheels up to python 3.11, we can fix this).

Also, there's no need to call `make preinstallation` as `preinstallation` is a dependency of `install_test`:

https://github.com/ethereum/consensus-specs/blob/ad91a835c03248dbb8a220ca157788d3e88853c7/Makefile#L107-L115