### PR TITLE
Enable pylint for eip7594

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ MARKDOWN_FILES = $(wildcard $(SPEC_DIR)/*/*.md) \
                  $(wildcard $(SPEC_DIR)/_features/*/*/*.md) \
                  $(wildcard $(SSZ_DIR)/*.md)
 
-ALL_EXECUTABLE_SPEC_NAMES = phase0 altair bellatrix capella deneb electra whisk eip6800 eip7732
+ALL_EXECUTABLE_SPEC_NAMES = phase0 altair bellatrix capella deneb electra whisk eip6800 eip7594 eip7732
 # The parameters for commands. Use `foreach` to avoid listing specs again.
 COVERAGE_SCOPE := $(foreach S,$(ALL_EXECUTABLE_SPEC_NAMES), --cov=eth2spec.$S.$(TEST_PRESET_TYPE))
 PYLINT_SCOPE := $(foreach S,$(ALL_EXECUTABLE_SPEC_NAMES), ./eth2spec/$S)

--- a/pysetup/spec_builders/eip7594.py
+++ b/pysetup/spec_builders/eip7594.py
@@ -18,6 +18,7 @@ from eth2spec.deneb import {preset_name} as deneb
     def sundry_functions(cls) -> str:
         return """
 def retrieve_column_sidecars(beacon_block_root: Root) -> Sequence[DataColumnSidecar]:
+    # pylint: disable=unused-argument
     return []
 """
 

--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -307,12 +307,6 @@ def divide_polynomialcoeff(a: Sequence[BLSFieldElement], b: Sequence[BLSFieldEle
     """
     Long polynomial division for two coefficient form polynomials ``a`` and ``b``.
     """
-    def fast_div(x: int, y: int) -> int:
-        """
-        A helper which does BLSFieldElement division faster.
-        """
-        return (x * pow(y, -1, BLS_MODULUS)) % BLS_MODULUS
-
     a_int = [int(val) for val in a]
     b_int = [int(val) for val in b]
 
@@ -321,7 +315,7 @@ def divide_polynomialcoeff(a: Sequence[BLSFieldElement], b: Sequence[BLSFieldEle
     bpos = len(b) - 1
     diff = apos - bpos
     while diff >= 0:
-        quot = fast_div(a_int[apos], b_int[bpos])
+        quot = (a_int[apos] * pow(b_int[bpos], -1, BLS_MODULUS)) % BLS_MODULUS
         o.insert(0, quot)
         for i in range(bpos, -1, -1):
             a_int[diff + i] = (a_int[diff + i] - (b_int[i] + BLS_MODULUS) * quot) % BLS_MODULUS

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -125,27 +125,11 @@ def test_verify_cell_kzg_proof_batch_zero_cells(spec):
 @spec_test
 @single_phase
 def test_verify_cell_kzg_proof_batch(spec):
-
-    # test with a single blob / commitment
-    blob = get_sample_blob(spec)
-    commitment = spec.blob_to_kzg_commitment(blob)
-    cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
-
-    assert len(cells) == len(proofs)
-
-    assert spec.verify_cell_kzg_proof_batch(
-        commitments_bytes=[commitment, commitment],
-        cell_indices=[0, 4],
-        cells=[cells[0], cells[4]],
-        proofs_bytes=[proofs[0], proofs[4]],
-    )
-
-    # now test with three blobs / commitments
     all_blobs = []
     all_commitments = []
     all_cells = []
     all_proofs = []
-    for _ in range(3):
+    for _ in range(2):
         blob = get_sample_blob(spec)
         commitment = spec.blob_to_kzg_commitment(blob)
         cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
@@ -158,7 +142,7 @@ def test_verify_cell_kzg_proof_batch(spec):
         all_proofs.append(proofs)
 
     # the cells of interest
-    commitment_indices = [0, 0, 1, 2, 1]
+    commitment_indices = [0, 0, 1, 0, 1]
     cell_indices = [0, 4, 0, 1, 2]
     cells = [all_cells[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
     proofs = [all_proofs[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
@@ -171,50 +155,6 @@ def test_verify_cell_kzg_proof_batch(spec):
         cells=cells,
         proofs_bytes=proofs,
     )
-
-
-@with_eip7594_and_later
-@spec_test
-@single_phase
-def test_verify_cell_kzg_proof_batch_invalid(spec):
-
-    # test with a single blob / commitment
-    blob = get_sample_blob(spec)
-    commitment = spec.blob_to_kzg_commitment(blob)
-    cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
-
-    assert len(cells) == len(proofs)
-
-    assert not spec.verify_cell_kzg_proof_batch(
-        commitments_bytes=[commitment, commitment],
-        cell_indices=[0, 4],
-        cells=[cells[0], cells[5]],  # Note: this is where it should go wrong
-        proofs_bytes=[proofs[0], proofs[4]],
-    )
-
-    # now test with three blobs / commitments
-    all_blobs = []
-    all_commitments = []
-    all_cells = []
-    all_proofs = []
-    for _ in range(3):
-        blob = get_sample_blob(spec)
-        commitment = spec.blob_to_kzg_commitment(blob)
-        cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
-
-        assert len(cells) == len(proofs)
-
-        all_blobs.append(blob)
-        all_commitments.append(commitment)
-        all_cells.append(cells)
-        all_proofs.append(proofs)
-
-    # the cells of interest
-    commitment_indices = [0, 0, 1, 2, 1]
-    cell_indices = [0, 4, 0, 1, 2]
-    cells = [all_cells[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
-    proofs = [all_proofs[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
-    commitments = [all_commitments[i] for i in commitment_indices]
 
     # let's change one of the cells. Then it should not verify
     cells[1] = all_cells[1][3]


### PR DESCRIPTION
This fixes the typing issues in the eip7594 spec & enables pylint.

Using `remerkleable` types in cryptography is very slow. We might want to consider using `int` (instead of `BLSFieldElement`) in all of the internal functions. This isn't ideal either, but I don't know of a better idea.

This PR removes the `PolynomialCoeff` type because converting to it over-and-over was very slow. It also modifies the `verify_cell_kzg_proof_batch` tests so cells/proofs aren't computed multiple times unnecessarily.

I don't love the changes in this PR but it's a necessary evil.