### PR TITLE
EIP-7732: Refactor Beacon chain state transition function

### DIFF
--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -52,7 +52,7 @@
         - [`process_payload_attestation`](#process_payload_attestation)
     - [Modified `is_merge_transition_complete`](#modified-is_merge_transition_complete)
     - [Modified `validate_merge_block`](#modified-validate_merge_block)
-   - [Execution payload processing](#execution-payload-processing)
+  - [Execution payload processing](#execution-payload-processing)
     - [New `verify_execution_payload_envelope_signature`](#new-verify_execution_payload_envelope_signature)
     - [New `process_execution_payload`](#new-process_execution_payload)
 

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -638,7 +638,7 @@ def validate_merge_block(block: BeaconBlock) -> None:
 
 ### Execution payload processing
 
-##### New `verify_execution_payload_envelope_signature`
+#### New `verify_execution_payload_envelope_signature`
 
 ```python
 def verify_execution_payload_envelope_signature(


### PR DESCRIPTION
Move `process_execution_payload` to new `Execution payload processing` section to separate it from `Block processing`
