### PR TITLE
Separate type for unaggregated network attestations

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -30,6 +30,7 @@
     - [`WithdrawalRequest`](#withdrawalrequest)
     - [`ConsolidationRequest`](#consolidationrequest)
     - [`PendingConsolidation`](#pendingconsolidation)
+    - [`SingleAttestation`](#singleattestation)
   - [Modified Containers](#modified-containers)
     - [`AttesterSlashing`](#attesterslashing)
   - [Extended Containers](#extended-containers)
@@ -256,6 +257,17 @@ class ConsolidationRequest(Container):
 class PendingConsolidation(Container):
     source_index: ValidatorIndex
     target_index: ValidatorIndex
+```
+
+
+#### `SingleAttestation`
+
+```python
+class SingleAttestation(Container):
+    committee_index: CommitteeIndex
+    attester_index: ValidatorIndex
+    data: AttestationData
+    signature: BLSSignature
 ```
 
 ### Modified Containers
@@ -875,7 +887,7 @@ def process_pending_balance_deposits(state: BeaconState) -> None:
             if processed_amount + deposit.amount > available_for_processing:
                 break
             # Deposit fits in the churn, process it. Increase balance and consume churn.
-            else: 
+            else:
                 increase_balance(state, deposit.index, deposit.amount)
                 processed_amount += deposit.amount
         # Regardless of how the deposit was handled, we move on in the queue.

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -54,9 +54,10 @@ The following validations are added:
 
 ##### `beacon_attestation_{subnet_id}`
 
+The topic is updated to propagate `SingleAttestation` objects.
+
 The following convenience variables are re-defined
-- `index = get_committee_indices(attestation.committee_bits)[0]`
+- `index = attestation.committee_index`
 
 The following validations are added:
-* [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(attestation)`.
 * [REJECT] `attestation.data.index == 0`


### PR DESCRIPTION
As a complement to
https://github.com/ethereum/consensus-specs/pull/3787, this PR introduces a `SingleAttestation` type used for network propagation only.

In Electra, the on-chain attestation format introduced in [EIP-7549](https://github.com/ethereum/consensus-specs/pull/3559) presents several difficulties - not only are the new fields to be interpreted differently during network processing and onchain which adds complexity in clients, they also introduce inefficiency both in hash computation and bandwidth.

The new type puts the validator and committee indices directly in the attestation type, this simplifying processing and increasing security.

* placing the validator index directly in the attestation allows verifying the signature without computing a shuffling - this closes a loophole where clients either must drop attestations or risk being overwhelmed by shuffling computations during attestation verification
* the simpler "structure" of the attestation saves several hash calls during processing (a single-item List has significant hashing overhead compared to a field)
* we save a few bytes here and there - we can also put stricter bounds on message size on the attestation topic because `SingleAttestation` is now fixed-size
* the ambiguity of interpreting the `attestation_bits` list indices which became contextual under EIP-7549 is removed

Because this change only affects the network encoding (and not block contents), the implementation impact on clients should be minimal.