### PR TITLE
Simplify `test_verify_cell_kzg_proof_batch`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -125,7 +125,7 @@ def test_verify_cell_kzg_proof_batch_zero_cells(spec):
 @spec_test
 @single_phase
 def test_compute_verify_recover(spec):
-    rng = random.Random(5566)
+    rng = random.Random(1234)
 
     # Get a blob and a commitment to that blob
     blob = get_sample_blob(spec)

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -125,106 +125,25 @@ def test_verify_cell_kzg_proof_batch_zero_cells(spec):
 @spec_test
 @single_phase
 def test_verify_cell_kzg_proof_batch(spec):
+    rng = random.Random(5566)
 
-    # test with a single blob / commitment
+    # Compute commitment/cells/proofs for a blob
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
     cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
-
     assert len(cells) == len(proofs)
 
+    # Verify five random cells/proofs
+    cell_indices = list(range(spec.CELLS_PER_EXT_BLOB))
+    rng.shuffle(cell_indices)
+    cell_indices = cell_indices[:5]
+
+    # This should return true
     assert spec.verify_cell_kzg_proof_batch(
-        commitments_bytes=[commitment, commitment],
-        cell_indices=[0, 4],
-        cells=[cells[0], cells[4]],
-        proofs_bytes=[proofs[0], proofs[4]],
-    )
-
-    # now test with three blobs / commitments
-    all_blobs = []
-    all_commitments = []
-    all_cells = []
-    all_proofs = []
-    for _ in range(3):
-        blob = get_sample_blob(spec)
-        commitment = spec.blob_to_kzg_commitment(blob)
-        cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
-
-        assert len(cells) == len(proofs)
-
-        all_blobs.append(blob)
-        all_commitments.append(commitment)
-        all_cells.append(cells)
-        all_proofs.append(proofs)
-
-    # the cells of interest
-    commitment_indices = [0, 0, 1, 2, 1]
-    cell_indices = [0, 4, 0, 1, 2]
-    cells = [all_cells[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
-    proofs = [all_proofs[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
-    commitments = [all_commitments[i] for i in commitment_indices]
-
-    # do the check
-    assert spec.verify_cell_kzg_proof_batch(
-        commitments_bytes=commitments,
+        commitments_bytes=[commitment] * len(cell_indices),
         cell_indices=cell_indices,
-        cells=cells,
-        proofs_bytes=proofs,
-    )
-
-
-@with_eip7594_and_later
-@spec_test
-@single_phase
-def test_verify_cell_kzg_proof_batch_invalid(spec):
-
-    # test with a single blob / commitment
-    blob = get_sample_blob(spec)
-    commitment = spec.blob_to_kzg_commitment(blob)
-    cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
-
-    assert len(cells) == len(proofs)
-
-    assert not spec.verify_cell_kzg_proof_batch(
-        commitments_bytes=[commitment, commitment],
-        cell_indices=[0, 4],
-        cells=[cells[0], cells[5]],  # Note: this is where it should go wrong
-        proofs_bytes=[proofs[0], proofs[4]],
-    )
-
-    # now test with three blobs / commitments
-    all_blobs = []
-    all_commitments = []
-    all_cells = []
-    all_proofs = []
-    for _ in range(3):
-        blob = get_sample_blob(spec)
-        commitment = spec.blob_to_kzg_commitment(blob)
-        cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
-
-        assert len(cells) == len(proofs)
-
-        all_blobs.append(blob)
-        all_commitments.append(commitment)
-        all_cells.append(cells)
-        all_proofs.append(proofs)
-
-    # the cells of interest
-    commitment_indices = [0, 0, 1, 2, 1]
-    cell_indices = [0, 4, 0, 1, 2]
-    cells = [all_cells[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
-    proofs = [all_proofs[i][j] for (i, j) in zip(commitment_indices, cell_indices)]
-    commitments = [all_commitments[i] for i in commitment_indices]
-
-    # let's change one of the cells. Then it should not verify
-    cells[1] = all_cells[1][3]
-
-    # do the check
-    assert not spec.verify_cell_kzg_proof_batch(
-        commitments_bytes=commitments,
-        cell_indices=cell_indices,
-        cells=cells,
-        proofs_bytes=proofs,
+        cells=[cells[i] for i in cell_indices],
+        proofs_bytes=[proofs[i] for i in cell_indices],
     )
 
 


### PR DESCRIPTION
This PR simplifies `test_verify_cell_kzg_proof_batch` by doing the following:

* Only call `compute_cells_and_kzg_proofs` once, for a single blob.
* Remove multi-blob verification.
* Remove `test_verify_cell_kzg_proof_batch_invalid` which wasn't that valuable.
  * Not worth 6+ mins of CI time.

This PR should reduce the eip7594 CI time from 15 mins to only a few minutes.

Edit: hmm this only reduces it to 12 mins. I'll investigate.

Edit 2: wow it took 22 mins for the second commit.

Edit 3: I now believe that `test_recover_matrix` is the slowest test. It computes all cells/proofs 4 times in total. Reducing this is not straight-forward, we need to test with at least 2 blobs. Not sure what to do here.