### PR TITLE
Use multiprocessing in compute_cells_and_kzg_proofs

### DIFF
--- a/specs/_features/eip7594/polynomial-commitments-sampling.md
+++ b/specs/_features/eip7594/polynomial-commitments-sampling.md
@@ -39,6 +39,7 @@
     - [`coset_for_cell`](#coset_for_cell)
 - [Cells](#cells-1)
   - [Cell computation](#cell-computation)
+    - [`compute_cell_and_kzg_proof`](#compute_cell_and_kzg_proof)
     - [`compute_cells_and_kzg_proofs_polynomialcoeff`](#compute_cells_and_kzg_proofs_polynomialcoeff)
     - [`compute_cells_and_kzg_proofs`](#compute_cells_and_kzg_proofs)
   - [Cell verification](#cell-verification)


### PR DESCRIPTION
I'm curious how much faster CI tests finish with multiprocessing. Hoping to reduce CI test time.