### PR TITLE
Remove SSZ unions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -257,7 +257,7 @@ def get_spec(file_name: Path, preset: Dict[str, str], config: Dict[str, str], pr
 
                     if not _is_constant_id(name):
                         # Check for short type declarations
-                        if value.startswith(("uint", "Bytes", "ByteList", "Union", "Vector", "List", "ByteVector")):
+                        if value.startswith(("uint", "Bytes", "ByteList", "Vector", "List", "ByteVector")):
                             custom_types[name] = value
                         continue
 

--- a/tests/core/pyspec/eth2spec/debug/decode.py
+++ b/tests/core/pyspec/eth2spec/debug/decode.py
@@ -2,7 +2,7 @@ from typing import Any
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root
 from eth2spec.utils.ssz.ssz_typing import (
     uint, Container, List, boolean,
-    Vector, ByteVector, ByteList, Union, View
+    Vector, ByteVector, ByteList, View
 )
 
 
@@ -27,16 +27,5 @@ def decode(data: Any, typ):
             assert (data["hash_tree_root"][2:] ==
                     hash_tree_root(ret).hex())
         return ret
-    elif issubclass(typ, Union):
-        selector = int(data["selector"])
-        options = typ.options()
-        value_typ = options[selector]
-        value: View
-        if value_typ is None:  # handle the "nil" type case
-            assert data["value"] is None
-            value = None
-        else:
-            value = decode(data["value"], value_typ)
-        return typ(selector=selector, value=value)
     else:
         raise Exception(f"Type not recognized: data={data}, typ={typ}")

--- a/tests/core/pyspec/eth2spec/debug/decode.py
+++ b/tests/core/pyspec/eth2spec/debug/decode.py
@@ -2,7 +2,7 @@ from typing import Any
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root
 from eth2spec.utils.ssz.ssz_typing import (
     uint, Container, List, boolean,
-    Vector, ByteVector, ByteList, View
+    Vector, ByteVector, ByteList
 )
 
 

--- a/tests/core/pyspec/eth2spec/debug/random_value.py
+++ b/tests/core/pyspec/eth2spec/debug/random_value.py
@@ -5,7 +5,7 @@ from typing import Type
 
 from eth2spec.utils.ssz.ssz_typing import (
     View, BasicView, uint, Container, List, boolean,
-    Vector, ByteVector, ByteList, Bitlist, Bitvector, Union
+    Vector, ByteVector, ByteList, Bitlist, Bitvector
 )
 
 # in bytes
@@ -115,22 +115,6 @@ def get_random_ssz_object(rng: Random,
                 get_random_ssz_object(rng, field_type, max_bytes_length, max_list_length, mode, chaos)
             for field_name, field_type in fields.items()
         })
-    elif issubclass(typ, Union):
-        options = typ.options()
-        selector: int
-        if mode == RandomizationMode.mode_zero:
-            selector = 0
-        elif mode == RandomizationMode.mode_max:
-            selector = len(options) - 1
-        else:
-            selector = rng.randrange(0, len(options))
-        elem_type = options[selector]
-        elem: View
-        if elem_type is None:
-            elem = None
-        else:
-            elem = get_random_ssz_object(rng, elem_type, max_bytes_length, max_list_length, mode, chaos)
-        return typ(selector=selector, value=elem)
     else:
         raise Exception(f"Type not recognized: typ={typ}")
 


### PR DESCRIPTION
SSZ unions are not used and have never been used in any version of deployed consensus-layer Ethereum. Align spec with this.