### PR TITLE
Peerdas Change csc types to uint64

### DIFF
--- a/specs/_features/eip7594/das-core.md
+++ b/specs/_features/eip7594/das-core.md
@@ -67,7 +67,7 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value | Description |
 | - | - | - |
-| `DATA_COLUMN_SIDECAR_SUBNET_COUNT` | `uint8(128)` | The number of data column sidecar subnets used in the gossipsub protocol |
+| `DATA_COLUMN_SIDECAR_SUBNET_COUNT` | `uint64(128)` | The number of data column sidecar subnets used in the gossipsub protocol |
 
 ### Custody setting
 
@@ -105,7 +105,7 @@ class MatrixEntry(Container):
 ### `get_custody_columns`
 
 ```python
-def get_custody_columns(node_id: NodeID, custody_subnet_count: uint8) -> Sequence[ColumnIndex]:
+def get_custody_columns(node_id: NodeID, custody_subnet_count: uint64) -> Sequence[ColumnIndex]:
     assert custody_subnet_count <= DATA_COLUMN_SIDECAR_SUBNET_COUNT
 
     subnet_ids: List[uint64] = []
@@ -113,7 +113,7 @@ def get_custody_columns(node_id: NodeID, custody_subnet_count: uint8) -> Sequenc
     while len(subnet_ids) < custody_subnet_count:
         subnet_id = (
             bytes_to_uint64(hash(uint_to_bytes(uint256(current_id)))[0:8])
-            % int(DATA_COLUMN_SIDECAR_SUBNET_COUNT)
+            % DATA_COLUMN_SIDECAR_SUBNET_COUNT
         )
         if subnet_id not in subnet_ids:
             subnet_ids.append(subnet_id)
@@ -124,9 +124,9 @@ def get_custody_columns(node_id: NodeID, custody_subnet_count: uint8) -> Sequenc
 
     assert len(subnet_ids) == len(set(subnet_ids))
 
-    columns_per_subnet = NUMBER_OF_COLUMNS // int(DATA_COLUMN_SIDECAR_SUBNET_COUNT)
+    columns_per_subnet = NUMBER_OF_COLUMNS // DATA_COLUMN_SIDECAR_SUBNET_COUNT
     return sorted([
-        ColumnIndex(int(DATA_COLUMN_SIDECAR_SUBNET_COUNT) * i + subnet_id)
+        ColumnIndex(DATA_COLUMN_SIDECAR_SUBNET_COUNT * i + subnet_id)
         for i in range(columns_per_subnet)
         for subnet_id in subnet_ids
     ])

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -119,14 +119,14 @@ The `MetaData` stored locally by clients is updated with an additional field to 
   seq_number: uint64
   attnets: Bitvector[ATTESTATION_SUBNET_COUNT]
   syncnets: Bitvector[SYNC_COMMITTEE_SUBNET_COUNT]
-  custody_subnet_count: uint8 # csc
+  custody_subnet_count: uint64 # csc
 )
 ```
 
 Where
 
 - `seq_number`, `attnets`, and `syncnets` have the same meaning defined in the Altair document.
-- `csc` represents the node's custody subnet count. Clients MAY reject ENRs with a value less than `CUSTODY_REQUIREMENT`.
+- `custody_subnet_count` represents the node's custody subnet count. Clients MAY reject peers with a value less than `CUSTODY_REQUIREMENT`.
 
 ### The gossip domain: gossipsub
 
@@ -322,6 +322,6 @@ Requests the MetaData of a peer, using the new `MetaData` definition given above
 
 A new field is added to the ENR under the key `csc` to facilitate custody data column discovery.
 
-| Key    | Value                               |
-|--------|-------------------------------------|
-| `csc`  | Custody subnet count, uint8 integer |
+| Key    | Value                                    |
+|--------|------------------------------------------|
+| `csc`  | Custody subnet count, big endian integer |

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -324,4 +324,4 @@ A new field is added to the ENR under the key `csc` to facilitate custody data c
 
 | Key    | Value                                    |
 |--------|------------------------------------------|
-| `csc`  | Custody subnet count, big endian integer |
+| `csc`  | Custody subnet count, `uint64` big endian integer with no leading zero bytes (`0` is encoded as empty byte string) |

--- a/tests/core/pyspec/eth2spec/test/eip7594/networking/test_get_custody_columns.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/networking/test_get_custody_columns.py
@@ -20,7 +20,7 @@ def _run_get_custody_columns(spec, rng, node_id=None, custody_subnet_count=None)
 
     assert len(result) == len(set(result))
     assert len(result) == (
-        int(custody_subnet_count) * spec.config.NUMBER_OF_COLUMNS // int(spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT)
+        custody_subnet_count * spec.config.NUMBER_OF_COLUMNS // spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT
     )
     assert all(i < spec.config.NUMBER_OF_COLUMNS for i in result)
     python_list_result = [int(i) for i in result]

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_config_invariants.py
@@ -3,7 +3,6 @@ from eth2spec.test.context import (
     spec_test,
     with_eip7594_and_later,
 )
-from eth2spec.utils.ssz.ssz_typing import uint8
 
 
 @with_eip7594_and_later
@@ -13,10 +12,9 @@ def test_invariants(spec):
     assert spec.FIELD_ELEMENTS_PER_BLOB % spec.FIELD_ELEMENTS_PER_CELL == 0
     assert spec.FIELD_ELEMENTS_PER_EXT_BLOB % spec.config.NUMBER_OF_COLUMNS == 0
     assert spec.config.SAMPLES_PER_SLOT <= spec.config.NUMBER_OF_COLUMNS
-    assert spec.config.NUMBER_OF_COLUMNS == uint8(spec.config.NUMBER_OF_COLUMNS)  # ENR field is uint8
     assert spec.config.CUSTODY_REQUIREMENT <= spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT
     assert spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT <= spec.config.NUMBER_OF_COLUMNS
-    assert spec.config.NUMBER_OF_COLUMNS % int(spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT) == 0
+    assert spec.config.NUMBER_OF_COLUMNS % spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT == 0
     assert spec.config.MAX_REQUEST_DATA_COLUMN_SIDECARS == (
         spec.config.MAX_REQUEST_BLOCKS_DENEB * spec.config.NUMBER_OF_COLUMNS
     )

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_custody.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_custody.py
@@ -9,9 +9,9 @@ from eth2spec.test.context import (
 def run_get_custody_columns(spec, peer_count, custody_subnet_count):
     assignments = [spec.get_custody_columns(node_id, custody_subnet_count) for node_id in range(peer_count)]
 
-    columns_per_subnet = spec.config.NUMBER_OF_COLUMNS // int(spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT)
+    columns_per_subnet = spec.config.NUMBER_OF_COLUMNS // spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT
     for assignment in assignments:
-        assert len(assignment) == int(custody_subnet_count) * columns_per_subnet
+        assert len(assignment) == custody_subnet_count * columns_per_subnet
         assert len(assignment) == len(set(assignment))
 
 


### PR DESCRIPTION
Reverts #3897 

As discussed on discord:

Since ENRs are already rlp encoded, the csc field will get rlp encoded based on its size, so we can just keep it as a big endian integer value.

For metadata, I kept it as uint64 because its better to keep things consistent imo. And saving 6 bytes on metadata responses won't get us more than a couple hundred kilobytes savings per day which isn't significant