### PR TITLE
Minor fixes on Electra spec and test helper

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1145,7 +1145,7 @@ def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
     for_ops(body.proposer_slashings, process_proposer_slashing)
     for_ops(body.attester_slashings, process_attester_slashing)
     for_ops(body.attestations, process_attestation)  # [Modified in Electra:EIP7549]
-    for_ops(body.deposits, process_deposit)  # [Modified in Electra:EIP7251]
+    for_ops(body.deposits, process_deposit)
     for_ops(body.voluntary_exits, process_voluntary_exit)  # [Modified in Electra:EIP7251]
     for_ops(body.bls_to_execution_changes, process_bls_to_execution_change)
     for_ops(body.execution_payload.deposit_requests, process_deposit_request)  # [New in Electra:EIP6110]
@@ -1206,7 +1206,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
 
 ###### Modified `apply_deposit`
 
-*Note*: The function `process_deposit` is modified to support EIP7251.
+*Note*: The function `apply_deposit` is modified to support EIP7251.
 
 ```python
 def apply_deposit(state: BeaconState,

--- a/tests/core/pyspec/eth2spec/test/helpers/epoch_processing.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/epoch_processing.py
@@ -36,8 +36,6 @@ def get_process_calls(spec):
             'process_participation_record_updates'
         ),
         'process_sync_committee_updates',  # altair
-        'process_full_withdrawals',  # capella
-        'process_partial_withdrawals',  # capella
         # TODO: add sharding processing functions when spec stabilizes.
     ]
 


### PR DESCRIPTION
- Untag `process_deposit` as modified to correctly reflect the current spec
- Remove `process_full_withdrawals` and `process_partial_withdrawals` which no longer exist in the spec