### PR TITLE
Remove duplicate check in `switch_to_compounding_validator`

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -683,9 +683,8 @@ def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
 ```python
 def switch_to_compounding_validator(state: BeaconState, index: ValidatorIndex) -> None:
     validator = state.validators[index]
-    if has_eth1_withdrawal_credential(validator):
-        validator.withdrawal_credentials = COMPOUNDING_WITHDRAWAL_PREFIX + validator.withdrawal_credentials[1:]
-        queue_excess_active_balance(state, index)
+    validator.withdrawal_credentials = COMPOUNDING_WITHDRAWAL_PREFIX + validator.withdrawal_credentials[1:]
+    queue_excess_active_balance(state, index)
 ```
 
 #### New `queue_excess_active_balance`


### PR DESCRIPTION
As written, this is a duplicate check and I'd like to simplify the electra spec as much as possible

One counter argument would be that this function as-is is safer, e.g. in the event it is called somewhere else (even in the future) where this invariant may not be maintained

Curious to hear feedback/input