### PR TITLE
Adds cronjob for test vector generation

### DIFF
--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           repository: 'ethereum/consensus-specs'
           path: 'consensus-specs'
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ inputs.source_ref || 'dev' }}
       - name: Checkout consensus-spec-tests repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -12,6 +12,8 @@ on:
         default: dev
         type: string
         required: true
+  schedule:
+    - cron:  '0 2 * * *'
 
 jobs:
   generate-tests:


### PR DESCRIPTION
This PR will trigger the generate vectors job nightly at 2AM and upload the results as a job artifact. These artifacts can be consumed by anyone who relies on nightlies, with the knowledge that the tests haven't been verified or sanity checked (that only happens on releases). 