### PR TITLE
Install pip to fix test vector generators

### DIFF
--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -40,6 +40,11 @@ jobs:
         run: |
           cd consensus-specs
           make clean
+      # Necessary to build/install python-snappy
+      - name: Install snappy development headers
+        run: |
+          sudo apt update
+          sudo apt install -y libsnappy-dev
       - name: Install dependencies and generate pyspec
         run: |
           cd consensus-specs

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ SSZ_DIR = ./ssz
 SYNC_DIR = ./sync
 FORK_CHOICE_DIR = ./fork_choice
 
+# Get absolute path to the preinstall requirements, this uses := for immediate evaluation.
+REQUIREMENTS_PREINSTALLATION := $(realpath requirements_preinstallation.txt)
+
 # To check generator matching:
 #$(info $$GENERATOR_TARGETS is [${GENERATOR_TARGETS}])
 
@@ -195,6 +198,7 @@ define run_generator
 	cd $(GENERATOR_DIR)/$(1); \
 	if ! test -d venv; then python3 -m venv venv; fi; \
 	. venv/bin/activate; \
+	pip3 install -r $(REQUIREMENTS_PREINSTALLATION); \
 	pip3 install -r requirements.txt; \
 	python3 main.py -o $(CURRENT_DIR)/$(TEST_VECTOR_DIR); \
 	echo "generator $(1) finished"


### PR DESCRIPTION
Since upgrading to python v3.12, pip is not longer installed by default. We must install it ourselves.

See this error in the test vector generation action:

https://github.com/ethereum/consensus-specs/actions/runs/10895315028/job/30233349401

The error messages are long, but this is the important part:

```
venv/bin/python3: No module named pip
```

We cannot add pip to the test generator requirements, as it's needed before then. So we must install pip in another step. An easy way to do this is to install the "preinstallation requirements" which includes pip.