### PR TITLE
Remove stale comment on latest_execution_payload_header in Electra

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -362,7 +362,7 @@ class BeaconState(Container):
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
     # Execution
-    latest_execution_payload_header: ExecutionPayloadHeader  # [Modified in Electra:EIP6110:EIP7002]
+    latest_execution_payload_header: ExecutionPayloadHeader
     # Withdrawals
     next_withdrawal_index: WithdrawalIndex
     next_withdrawal_validator_index: ValidatorIndex


### PR DESCRIPTION
`latest_execution_payload_header` in beacon state is no longer modified in Electra since https://github.com/ethereum/consensus-specs/pull/3875