### PR TITLE
Fix yield statement in test_get_custody_columns

### DIFF
--- a/tests/core/pyspec/eth2spec/test/eip7594/networking/test_get_custody_columns.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/networking/test_get_custody_columns.py
@@ -16,7 +16,7 @@ def _run_get_custody_columns(spec, rng, node_id=None, custody_subnet_count=None)
 
     result = spec.get_custody_columns(node_id, custody_subnet_count)
     yield 'node_id', 'meta', node_id
-    yield 'custody_subnet_count', 'meta', custody_subnet_count
+    yield 'custody_subnet_count', 'meta', int(custody_subnet_count)
 
     assert len(result) == len(set(result))
     assert len(result) == (


### PR DESCRIPTION
We noticed this error during test generation:
```
ruamel.yaml.representer.RepresenterError: cannot represent an object: 128
```

https://github.com/ethereum/consensus-specs/blob/dbc746fb8b35018e2a1b646e43190c964e58fcc2/tests/core/pyspec/eth2spec/test/eip7594/networking/test_get_custody_columns.py#L19

Called here:

https://github.com/ethereum/consensus-specs/blob/dbc746fb8b35018e2a1b646e43190c964e58fcc2/tests/core/pyspec/eth2spec/test/eip7594/networking/test_get_custody_columns.py#L44-L46

This was happening because we changed the type of `DATA_COLUMN_SIDECAR_SUBNET_COUNT` to `uint64`.

https://github.com/ethereum/consensus-specs/blob/423bb4d0ebd31d6d468b8ecddc4f3e3c6d11d644/specs/_features/eip7594/das-core.md?plain=1#L70

https://github.com/ethereum/consensus-specs/blob/dbc746fb8b35018e2a1b646e43190c964e58fcc2/specs/_features/eip7594/das-core.md?plain=1#L70

The solution is to cast this to a native `int` type that ruamel understands.