### PR TITLE
Add a negative test for inactive validator for withdrawal request

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
@@ -787,6 +787,35 @@ def test_partial_withdrawal_activation_epoch_less_than_shard_committee_period(
     )
 
 
+@with_electra_and_later
+@spec_state_test
+def test_incorrect_inactive_validator(spec, state):
+    rng = random.Random(1361)
+    # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
+    state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
+
+    current_epoch = spec.get_current_epoch(state)
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_pubkey = state.validators[validator_index].pubkey
+    address = b"\x22" * 20
+    incorrect_address = b"\x33" * 20
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, validator_index, address=address
+    )
+    withdrawal_request = spec.WithdrawalRequest(
+        source_address=incorrect_address,
+        validator_pubkey=validator_pubkey,
+        amount=spec.FULL_EXIT_REQUEST_AMOUNT,
+    )
+
+    # set validator as not yet activated
+    state.validators[validator_index].activation_epoch = spec.FAR_FUTURE_EPOCH
+    assert not spec.is_active_validator(state.validators[validator_index], current_epoch)
+
+    yield from run_withdrawal_request_processing(
+        spec, state, withdrawal_request, success=False
+    )
+
 #
 # Run processing
 #


### PR DESCRIPTION
I noticed that by commenting out the inactive check for `process_withdrawal_request`, the test still passes. This PR adds a test case to ensure an inactive validator doesn't pass. It's my first time adding a spec test, so it may be off. Note to the reviewer: feel free to push any changes to my PR as needed
```
    # Verify the validator is active
    if not is_active_validator(validator, get_current_epoch(state)):
        return
```