### PR TITLE
Fix insufficient effective bal test and add a bal test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
@@ -658,6 +658,8 @@ def test_insufficient_effective_balance(spec, state):
     state.validators[
         validator_index
     ].effective_balance -= spec.EFFECTIVE_BALANCE_INCREMENT
+    # Make sure validator has enough balance to withdraw
+    state.balances[validator_index] += spec.EFFECTIVE_BALANCE_INCREMENT
 
     set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
     withdrawal_request = spec.WithdrawalRequest(
@@ -786,6 +788,30 @@ def test_partial_withdrawal_activation_epoch_less_than_shard_committee_period(
         spec, state, withdrawal_request, success=False
     )
 
+
+def test_insufficient_balance(spec, state):
+    rng = random.Random(1361)
+    state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
+    current_epoch = spec.get_current_epoch(state)
+    validator_index = rng.choice(spec.get_active_validator_indices(state, current_epoch))
+    validator_pubkey = state.validators[validator_index].pubkey
+    address = b"\x22" * 20
+    amount = spec.EFFECTIVE_BALANCE_INCREMENT
+
+    # Validator will not be able to partial withdrawal because MIN_ACTIVATION_BALANCE + amount > balance
+    set_compounding_withdrawal_credential(spec, state, validator_index, address=address)
+    withdrawal_request = spec.WithdrawalRequest(
+        source_address=address,
+        validator_pubkey=validator_pubkey,
+        amount=amount,
+    )
+
+    yield from run_withdrawal_request_processing(
+        spec,
+        state,
+        withdrawal_request,
+        success=False,
+    )
 
 #
 # Run processing


### PR DESCRIPTION
This PR updated two things:
- Fixed the `test_insufficient_effective_balance` test. Although the effective balance was set to be less than 32 ETH, the actual balance was also set incorrectly because the balance needs to exceed 32 ETH plus the withdrawal amount. This PR added the withdrawal amount to the validator's balance to ensure the effective balance is the only condition triggering the failure
- Added a new `test_insufficient_balance` which has a sufficient effective balance but not enough actual balance, mimicking the above condition