### PR TITLE
Remove queue_entire_balance_and_reset_validator

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -61,7 +61,6 @@
     - [Modified `initiate_validator_exit`](#modified-initiate_validator_exit)
     - [New `switch_to_compounding_validator`](#new-switch_to_compounding_validator)
     - [New `queue_excess_active_balance`](#new-queue_excess_active_balance)
-    - [New `queue_entire_balance_and_reset_validator`](#new-queue_entire_balance_and_reset_validator)
     - [New `compute_exit_epoch_and_update_churn`](#new-compute_exit_epoch_and_update_churn)
     - [New `compute_consolidation_epoch_and_update_churn`](#new-compute_consolidation_epoch_and_update_churn)
     - [Modified `slash_validator`](#modified-slash_validator)
@@ -653,20 +652,6 @@ def queue_excess_active_balance(state: BeaconState, index: ValidatorIndex) -> No
         state.pending_balance_deposits.append(
             PendingBalanceDeposit(index=index, amount=excess_balance)
         )
-```
-
-#### New `queue_entire_balance_and_reset_validator`
-
-```python
-def queue_entire_balance_and_reset_validator(state: BeaconState, index: ValidatorIndex) -> None:
-    balance = state.balances[index]
-    state.balances[index] = 0
-    validator = state.validators[index]
-    validator.effective_balance = 0
-    validator.activation_eligibility_epoch = FAR_FUTURE_EPOCH
-    state.pending_balance_deposits.append(
-        PendingBalanceDeposit(index=index, amount=balance)
-    )
 ```
 
 #### New `compute_exit_epoch_and_update_churn`

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -152,7 +152,14 @@ def upgrade_to_electra(pre: deneb.BeaconState) -> BeaconState:
     ))
 
     for index in pre_activation:
-        queue_entire_balance_and_reset_validator(post, ValidatorIndex(index))
+        balance = post.balances[index]
+        post.balances[index] = 0
+        validator = post.validators[index]
+        validator.effective_balance = 0
+        validator.activation_eligibility_epoch = FAR_FUTURE_EPOCH
+        post.pending_balance_deposits.append(
+            PendingBalanceDeposit(index=index, amount=balance)
+        )
 
     # Ensure early adopters of compounding credentials go through the activation churn
     for index, validator in enumerate(post.validators):


### PR DESCRIPTION
Since queue_entire_balance_and_reset_validator is used only in the fork transition, it shouldn't be in beacon-chain.md at all.