### PR TITLE
Reject invalid `DataColumnSidecar` for zero blobs

### DIFF
--- a/specs/_features/eip7594/fork-choice.md
+++ b/specs/_features/eip7594/fork-choice.md
@@ -31,6 +31,7 @@ def is_data_available(beacon_block_root: Root) -> bool:
     # `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs.  
     column_sidecars = retrieve_column_sidecars(beacon_block_root)
     return all(
+        verify_data_column_sidecar(column_sidecar) and
         verify_data_column_sidecar_kzg_proofs(column_sidecar)
         for column_sidecar in column_sidecars
     )

--- a/specs/_features/eip7594/fork-choice.md
+++ b/specs/_features/eip7594/fork-choice.md
@@ -31,8 +31,8 @@ def is_data_available(beacon_block_root: Root) -> bool:
     # `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs.  
     column_sidecars = retrieve_column_sidecars(beacon_block_root)
     return all(
-        verify_data_column_sidecar(column_sidecar) and
-        verify_data_column_sidecar_kzg_proofs(column_sidecar)
+        verify_data_column_sidecar(column_sidecar)
+        and verify_data_column_sidecar_kzg_proofs(column_sidecar)
         for column_sidecar in column_sidecars
     )
 ```

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -71,7 +71,11 @@ def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
     """
     Verify if the proofs are correct.
     """
+    # A sidecar for zero blobs is invalid
+    assert len(sidecar.kzg_commitments) > 0
+    # The sidecar index must be within the valid range
     assert sidecar.index < NUMBER_OF_COLUMNS
+    # There should be an equal number of cells/commitments/proofs
     assert len(sidecar.column) == len(sidecar.kzg_commitments) == len(sidecar.kzg_proofs)
 
     # The column index also represents the cell index
@@ -93,6 +97,9 @@ def verify_data_column_sidecar_inclusion_proof(sidecar: DataColumnSidecar) -> bo
     """
     Verify if the given KZG commitments included in the given beacon block.
     """
+    # A sidecar for zero blobs is invalid
+    assert len(sidecar.kzg_commitments) > 0
+
     gindex = get_subtree_index(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments'))
     return is_valid_merkle_branch(
         leaf=hash_tree_root(sidecar.kzg_commitments),

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -72,10 +72,10 @@ def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
     """
     Verify if the data column sidecar is valid.
     """
-    # A sidecar for zero blobs is invalid
-    assert len(sidecar.kzg_commitments) > 0
     # The sidecar index must be within the valid range
     assert sidecar.index < NUMBER_OF_COLUMNS
+    # A sidecar for zero blobs is invalid
+    assert len(sidecar.kzg_commitments) > 0
     # There should be an equal number of cells/commitments/proofs
     assert len(sidecar.column) == len(sidecar.kzg_commitments) == len(sidecar.kzg_proofs)
 

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -80,7 +80,7 @@ def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
     if len(sidecar.kzg_commitments) == 0:
         return False
 
-    # There should be an equal number of cells/commitments/proofs
+    # The column length must be equal to the number of commitments/proofs
     if len(sidecar.column) != len(sidecar.kzg_commitments) or len(sidecar.column) != len(sidecar.kzg_proofs):
         return False
 
@@ -92,7 +92,7 @@ def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
 ```python
 def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
     """
-    Verify if the proofs are correct.
+    Verify if the KZG proofs are correct.
     """
     # The column index also represents the cell index
     cell_indices = [CellIndex(sidecar.index)] * len(sidecar.column)

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -73,11 +73,16 @@ def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
     Verify if the data column sidecar is valid.
     """
     # The sidecar index must be within the valid range
-    assert sidecar.index < NUMBER_OF_COLUMNS
+    if sidecar.index >= NUMBER_OF_COLUMNS
+        return False
+
     # A sidecar for zero blobs is invalid
-    assert len(sidecar.kzg_commitments) > 0
+    if len(sidecar.kzg_commitments) == 0:
+        return False
+
     # There should be an equal number of cells/commitments/proofs
-    assert len(sidecar.column) == len(sidecar.kzg_commitments) == len(sidecar.kzg_proofs)
+    if len(sidecar.column) != len(sidecar.kzg_commitments) or len(sidecar.column) != len(sidecar.kzg_proofs):
+        return False
 
     return True
 ```

--- a/specs/_features/eip7594/p2p-interface.md
+++ b/specs/_features/eip7594/p2p-interface.md
@@ -73,7 +73,7 @@ def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
     Verify if the data column sidecar is valid.
     """
     # The sidecar index must be within the valid range
-    if sidecar.index >= NUMBER_OF_COLUMNS
+    if sidecar.index >= NUMBER_OF_COLUMNS:
         return False
 
     # A sidecar for zero blobs is invalid

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
@@ -1,6 +1,5 @@
 import random
 from eth2spec.test.context import (
-    expect_assertion_error,
     single_phase,
     spec_state_test,
     spec_test,
@@ -62,7 +61,7 @@ def test_verify_data_column_sidecar__invalid_zero_blobs(spec, state):
     sidecar.column = []
     sidecar.kzg_commitments = []
     sidecar.kzg_proofs = []
-    expect_assertion_error(lambda: spec.verify_data_column_sidecar(sidecar))
+    assert not spec.verify_data_column_sidecar(sidecar)
 
 
 @with_eip7594_and_later
@@ -71,7 +70,7 @@ def test_verify_data_column_sidecar__invalid_zero_blobs(spec, state):
 def test_verify_data_column_sidecar__invalid_index(spec, state):
     sidecar = compute_data_column_sidecar(spec, state)
     sidecar.index = 128
-    expect_assertion_error(lambda: spec.verify_data_column_sidecar(sidecar))
+    assert not spec.verify_data_column_sidecar(sidecar)
 
 
 @with_eip7594_and_later
@@ -80,7 +79,7 @@ def test_verify_data_column_sidecar__invalid_index(spec, state):
 def test_verify_data_column_sidecar__invalid_mismatch_len_column(spec, state):
     sidecar = compute_data_column_sidecar(spec, state)
     sidecar.column = sidecar.column[1:]
-    expect_assertion_error(lambda: spec.verify_data_column_sidecar(sidecar))
+    assert not spec.verify_data_column_sidecar(sidecar)
 
 
 @with_eip7594_and_later
@@ -89,7 +88,7 @@ def test_verify_data_column_sidecar__invalid_mismatch_len_column(spec, state):
 def test_verify_data_column_sidecar__invalid_mismatch_len_kzg_commitments(spec, state):
     sidecar = compute_data_column_sidecar(spec, state)
     sidecar.kzg_commitments = sidecar.kzg_commitments[1:]
-    expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
+    assert not spec.verify_data_column_sidecar(sidecar)
 
 
 @with_eip7594_and_later
@@ -98,7 +97,7 @@ def test_verify_data_column_sidecar__invalid_mismatch_len_kzg_commitments(spec, 
 def test_verify_data_column_sidecars__invalid_mismatch_len_kzg_proofs(spec, state):
     sidecar = compute_data_column_sidecar(spec, state)
     sidecar.kzg_proofs = sidecar.kzg_proofs[1:]
-    expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
+    assert not spec.verify_data_column_sidecar(sidecar)
 
 
 # Tests for verify_data_column_sidecar_kzg_proofs

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
@@ -45,6 +45,7 @@ def compute_data_column_sidecar(spec, state):
 
 # Tests for verify_data_column_sidecar
 
+
 @with_eip7594_and_later
 @spec_state_test
 @single_phase

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import random
 import threading
@@ -38,7 +39,7 @@ def test_compute_subnet_for_data_column_sidecar(spec):
 
 
 @functools.cache
-def compute_data_column_sidecars(spec, state):
+def compute_data_column_sidecar(spec, state):
     rng = random.Random(5566)
     opaque_tx, blobs, blob_kzg_commitments, _ = get_sample_opaque_tx(spec, blob_count=2)
     block = get_random_ssz_object(
@@ -54,20 +55,20 @@ def compute_data_column_sidecars(spec, state):
     block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
     signed_block = sign_block(spec, state, block, proposer_index=0)
     cells_and_kzg_proofs = [spec.compute_cells_and_kzg_proofs(blob) for blob in blobs]
-    return spec.get_data_column_sidecars(signed_block, cells_and_kzg_proofs)
+    return spec.get_data_column_sidecars(signed_block, cells_and_kzg_proofs)[0]
 
 
-# Necessary to cache the result of compute_data_column_sidecars().
+# Necessary to cache the result of compute_data_column_sidecar().
 # So multiple tests do not attempt to compute the sidecars at the same time.
-compute_data_column_sidecars_lock = threading.Lock()
+compute_data_column_sidecar_lock = threading.Lock()
 
 
 @with_eip7594_and_later
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_kzg_proofs__valid(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         assert spec.verify_data_column_sidecar_kzg_proofs(sidecar)
 
 
@@ -75,8 +76,8 @@ def test_verify_data_column_sidecar_kzg_proofs__valid(spec, state):
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_kzg_proofs__invalid_zero_blobs(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         sidecar.column = []
         sidecar.kzg_commitments = []
         sidecar.kzg_proofs = []
@@ -87,8 +88,8 @@ def test_verify_data_column_sidecar_kzg_proofs__invalid_zero_blobs(spec, state):
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_index(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         sidecar.index = 128
         expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
 
@@ -97,8 +98,8 @@ def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_index(spec, stat
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_mismatch_len_column(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         sidecar.column = sidecar.column[1:]
         expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
 
@@ -107,8 +108,8 @@ def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_mismatch_len_col
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_mismatch_len_kzg_commitments(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         sidecar.kzg_commitments = sidecar.kzg_commitments[1:]
         expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
 
@@ -117,8 +118,8 @@ def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_mismatch_len_kzg
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_mismatch_len_kzg_proofs(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         sidecar.kzg_proofs = sidecar.kzg_proofs[1:]
         expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
 
@@ -127,8 +128,8 @@ def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_mismatch_len_kzg
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_inclusion_proof__valid(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         assert spec.verify_data_column_sidecar_inclusion_proof(sidecar)
 
 
@@ -136,8 +137,8 @@ def test_verify_data_column_sidecar_inclusion_proof__valid(spec, state):
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_inclusion_proof__valid_but_missing_commitment(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         sidecar.kzg_commitments = sidecar.kzg_commitments[1:]
         assert not spec.verify_data_column_sidecar_inclusion_proof(sidecar)
 
@@ -146,8 +147,8 @@ def test_verify_data_column_sidecar_inclusion_proof__valid_but_missing_commitmen
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_inclusion_proof__valid_but_duplicate_commitment(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         sidecar.kzg_commitments = sidecar.kzg_commitments + [sidecar.kzg_commitments[0]]
         assert not spec.verify_data_column_sidecar_inclusion_proof(sidecar)
 
@@ -156,8 +157,8 @@ def test_verify_data_column_sidecar_inclusion_proof__valid_but_duplicate_commitm
 @spec_state_test
 @single_phase
 def test_verify_data_column_sidecar_inclusion_proof__invalid_zero_blobs(spec, state):
-    with compute_data_column_sidecars_lock:
-        sidecar = compute_data_column_sidecars(spec, state)[0]
+    with compute_data_column_sidecar_lock:
+        sidecar = copy.deepcopy(compute_data_column_sidecar(spec, state))
         sidecar.column = []
         sidecar.kzg_commitments = []
         sidecar.kzg_proofs = []

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
@@ -114,7 +114,7 @@ def test_verify_data_column_sidecar_kzg_proofs__valid(spec, state):
 @with_eip7594_and_later
 @spec_state_test
 @single_phase
-def test_verify_data_column_sidecar_kzg_proofs__valid_but_wrong_column(spec, state):
+def test_verify_data_column_sidecar_kzg_proofs__invalid_wrong_column(spec, state):
     sidecar = compute_data_column_sidecar(spec, state)
     sidecar.column[0] = sidecar.column[1]
     assert not spec.verify_data_column_sidecar_kzg_proofs(sidecar)
@@ -123,7 +123,7 @@ def test_verify_data_column_sidecar_kzg_proofs__valid_but_wrong_column(spec, sta
 @with_eip7594_and_later
 @spec_state_test
 @single_phase
-def test_verify_data_column_sidecar_kzg_proofs__valid_but_wrong_commitment(spec, state):
+def test_verify_data_column_sidecar_kzg_proofs__invalid_wrong_commitment(spec, state):
     sidecar = compute_data_column_sidecar(spec, state)
     sidecar.kzg_commitments[0] = sidecar.kzg_commitments[1]
     assert not spec.verify_data_column_sidecar_kzg_proofs(sidecar)
@@ -132,7 +132,7 @@ def test_verify_data_column_sidecar_kzg_proofs__valid_but_wrong_commitment(spec,
 @with_eip7594_and_later
 @spec_state_test
 @single_phase
-def test_verify_data_column_sidecar_kzg_proofs__valid_but_wrong_proof(spec, state):
+def test_verify_data_column_sidecar_kzg_proofs__invalid_wrong_proof(spec, state):
     sidecar = compute_data_column_sidecar(spec, state)
     sidecar.kzg_proofs[0] = sidecar.kzg_proofs[1]
     assert not spec.verify_data_column_sidecar_kzg_proofs(sidecar)
@@ -152,7 +152,7 @@ def test_verify_data_column_sidecar_inclusion_proof__valid(spec, state):
 @with_eip7594_and_later
 @spec_state_test
 @single_phase
-def test_verify_data_column_sidecar_inclusion_proof__valid_but_missing_commitment(spec, state):
+def test_verify_data_column_sidecar_inclusion_proof__invalid_missing_commitment(spec, state):
     sidecar = compute_data_column_sidecar(spec, state)
     sidecar.kzg_commitments = sidecar.kzg_commitments[1:]
     assert not spec.verify_data_column_sidecar_inclusion_proof(sidecar)
@@ -161,7 +161,7 @@ def test_verify_data_column_sidecar_inclusion_proof__valid_but_missing_commitmen
 @with_eip7594_and_later
 @spec_state_test
 @single_phase
-def test_verify_data_column_sidecar_inclusion_proof__valid_but_duplicate_commitment(spec, state):
+def test_verify_data_column_sidecar_inclusion_proof__invalid_duplicate_commitment(spec, state):
     sidecar = compute_data_column_sidecar(spec, state)
     sidecar.kzg_commitments = sidecar.kzg_commitments + [sidecar.kzg_commitments[0]]
     assert not spec.verify_data_column_sidecar_inclusion_proof(sidecar)

--- a/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
+++ b/tests/core/pyspec/eth2spec/test/eip7594/unittests/test_networking.py
@@ -1,7 +1,25 @@
+import functools
+import random
+import threading
 from eth2spec.test.context import (
-    spec_test,
+    expect_assertion_error,
     single_phase,
+    spec_state_test,
+    spec_test,
     with_eip7594_and_later,
+)
+from eth2spec.debug.random_value import (
+    RandomizationMode,
+    get_random_ssz_object,
+)
+from eth2spec.test.helpers.block import (
+    sign_block,
+)
+from eth2spec.test.helpers.execution_payload import (
+    compute_el_block_hash,
+)
+from eth2spec.test.helpers.sharding import (
+    get_sample_opaque_tx,
 )
 
 
@@ -17,3 +35,130 @@ def test_compute_subnet_for_data_column_sidecar(spec):
     # next one should be duplicate
     next_subnet = spec.compute_subnet_for_data_column_sidecar(spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT)
     assert next_subnet == subnet_results[0]
+
+
+@functools.cache
+def compute_data_column_sidecars(spec, state):
+    rng = random.Random(5566)
+    opaque_tx, blobs, blob_kzg_commitments, _ = get_sample_opaque_tx(spec, blob_count=2)
+    block = get_random_ssz_object(
+        rng,
+        spec.BeaconBlock,
+        max_bytes_length=2000,
+        max_list_length=2000,
+        mode=RandomizationMode,
+        chaos=True,
+    )
+    block.body.blob_kzg_commitments = blob_kzg_commitments
+    block.body.execution_payload.transactions = [opaque_tx]
+    block.body.execution_payload.block_hash = compute_el_block_hash(spec, block.body.execution_payload, state)
+    signed_block = sign_block(spec, state, block, proposer_index=0)
+    cells_and_kzg_proofs = [spec.compute_cells_and_kzg_proofs(blob) for blob in blobs]
+    return spec.get_data_column_sidecars(signed_block, cells_and_kzg_proofs)
+
+
+# Necessary to cache the result of compute_data_column_sidecars().
+# So multiple tests do not attempt to compute the sidecars at the same time.
+compute_data_column_sidecars_lock = threading.Lock()
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_kzg_proofs__valid(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        assert spec.verify_data_column_sidecar_kzg_proofs(sidecar)
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_kzg_proofs__invalid_zero_blobs(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        sidecar.column = []
+        sidecar.kzg_commitments = []
+        sidecar.kzg_proofs = []
+        expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_index(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        sidecar.index = 128
+        expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_mismatch_len_column(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        sidecar.column = sidecar.column[1:]
+        expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_mismatch_len_kzg_commitments(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        sidecar.kzg_commitments = sidecar.kzg_commitments[1:]
+        expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_kzg_proofs_invalid__invalid_mismatch_len_kzg_proofs(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        sidecar.kzg_proofs = sidecar.kzg_proofs[1:]
+        expect_assertion_error(lambda: spec.verify_data_column_sidecar_kzg_proofs(sidecar))
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_inclusion_proof__valid(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        assert spec.verify_data_column_sidecar_inclusion_proof(sidecar)
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_inclusion_proof__valid_but_missing_commitment(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        sidecar.kzg_commitments = sidecar.kzg_commitments[1:]
+        assert not spec.verify_data_column_sidecar_inclusion_proof(sidecar)
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_inclusion_proof__valid_but_duplicate_commitment(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        sidecar.kzg_commitments = sidecar.kzg_commitments + [sidecar.kzg_commitments[0]]
+        assert not spec.verify_data_column_sidecar_inclusion_proof(sidecar)
+
+
+@with_eip7594_and_later
+@spec_state_test
+@single_phase
+def test_verify_data_column_sidecar_inclusion_proof__invalid_zero_blobs(spec, state):
+    with compute_data_column_sidecars_lock:
+        sidecar = compute_data_column_sidecars(spec, state)[0]
+        sidecar.column = []
+        sidecar.kzg_commitments = []
+        sidecar.kzg_proofs = []
+        expect_assertion_error(lambda: spec.verify_data_column_sidecar_inclusion_proof(sidecar))


### PR DESCRIPTION
This PR adds an `assert len(sidecar.kzg_commitments) > 0` check for `DataColumnSidecar` objects. There should never be a situation where a `DataColumnSidecar` is propagated for a block with zero blobs.

In doing so, this PR creates a new `verify_data_column_sidecar` function and moves the asserts from `verify_data_column_sidecar_kzg_proofs` into it. Plus a bunch of tests.