### PR TITLE
Add Electra `test_process_withdrawals` path to testgen

### DIFF
--- a/tests/generators/operations/main.py
+++ b/tests/generators/operations/main.py
@@ -49,6 +49,7 @@ if __name__ == "__main__":
         'deposit_request',
         'voluntary_exit',
         'withdrawal_request',
+        'withdrawals',
     ]}
     electra_mods = combine_mods(_new_electra_mods, deneb_mods)
 


### PR DESCRIPTION
Thank @ensi321  for reporting it.
It was a leftover of https://github.com/ethereum/consensus-specs/pull/3943 -- We forgot to add the test script file path.