### PR TITLE
Move `execution_requests` after `parent_beacon_block_root`

### DIFF
--- a/pysetup/spec_builders/electra.py
+++ b/pysetup/spec_builders/electra.py
@@ -28,8 +28,8 @@ class NoopExecutionEngine(ExecutionEngine):
 
     def notify_new_payload(self: ExecutionEngine,
                            execution_payload: ExecutionPayload,
-                           execution_requests: ExecutionRequests,
-                           parent_beacon_block_root: Root) -> bool:
+                           parent_beacon_block_root: Root,
+                           execution_requests: ExecutionRequests) -> bool:
         return True
 
     def notify_forkchoice_updated(self: ExecutionEngine,

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -990,8 +990,8 @@ class NewPayloadRequest(object):
 ```python
 def notify_new_payload(self: ExecutionEngine,
                        execution_payload: ExecutionPayload,
-                       execution_requests: ExecutionRequests,
-                       parent_beacon_block_root: Root) -> bool:
+                       parent_beacon_block_root: Root,
+                       execution_requests: ExecutionRequests) -> bool:
     """
     Return ``True`` if and only if ``execution_payload`` and ``execution_requests`` 
     are valid with respect to ``self.execution_state``.
@@ -1011,8 +1011,8 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
     Return ``True`` if and only if ``new_payload_request`` is valid with respect to ``self.execution_state``.
     """
     execution_payload = new_payload_request.execution_payload
-    execution_requests = new_payload_request.execution_requests  # [New in Electra]
     parent_beacon_block_root = new_payload_request.parent_beacon_block_root
+    execution_requests = new_payload_request.execution_requests  # [New in Electra]
 
     if not self.is_valid_block_hash(execution_payload, parent_beacon_block_root):
         return False
@@ -1022,9 +1022,8 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
 
     # [Modified in Electra]
     if not self.notify_new_payload(
-            execution_payload, 
-            execution_requests, 
-            parent_beacon_block_root):
+            parent_beacon_block_root,
+            execution_requests):
         return False
 
     return True
@@ -1160,9 +1159,9 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
     assert execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(
             execution_payload=payload,
-            execution_requests=body.execution_requests,  # [New in Electra]
             versioned_hashes=versioned_hashes,
             parent_beacon_block_root=state.latest_block_header.parent_root,
+            execution_requests=body.execution_requests,  # [New in Electra]
         )
     )
     # Cache execution payload header


### PR DESCRIPTION
We decided to close #3950, but it also included a change which moved `execution_requests` after `parent_beacon_block_root`. I think we should keep that change. New fields should be at the bottom.