### PR TITLE
Pass execution requests to Engine API as a list of bytes

### DIFF
--- a/pysetup/spec_builders/electra.py
+++ b/pysetup/spec_builders/electra.py
@@ -10,6 +10,7 @@ class ElectraSpecBuilder(BaseSpecBuilder):
     def imports(cls, preset_name: str):
         return f'''
 from eth2spec.deneb import {preset_name} as deneb
+from eth2spec.utils.ssz.ssz_impl import serialize
 '''
 
     @classmethod
@@ -28,7 +29,7 @@ class NoopExecutionEngine(ExecutionEngine):
 
     def notify_new_payload(self: ExecutionEngine,
                            execution_payload: ExecutionPayload,
-                           execution_requests: ExecutionRequests,
+                           execution_requests_list: list[bytes],
                            parent_beacon_block_root: Root) -> bool:
         return True
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -84,6 +84,7 @@
       - [Modified `get_expected_withdrawals`](#modified-get_expected_withdrawals)
       - [Modified `process_withdrawals`](#modified-process_withdrawals)
     - [Execution payload](#execution-payload)
+      - [New `get_execution_requests_list`](#new-get_execution_requests_list)
       - [Modified `process_execution_payload`](#modified-process_execution_payload)
     - [Operations](#operations)
       - [Modified `process_operations`](#modified-process_operations)

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -990,7 +990,7 @@ class NewPayloadRequest(object):
 ```python
 def notify_new_payload(self: ExecutionEngine,
                        execution_payload: ExecutionPayload,
-                       execution_requests: ExecutionRequests,
+                       execution_requests_list: list[bytes],
                        parent_beacon_block_root: Root) -> bool:
     """
     Return ``True`` if and only if ``execution_payload`` and ``execution_requests`` 
@@ -1011,7 +1011,7 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
     Return ``True`` if and only if ``new_payload_request`` is valid with respect to ``self.execution_state``.
     """
     execution_payload = new_payload_request.execution_payload
-    execution_requests = new_payload_request.execution_requests  # [New in Electra]
+    execution_requests_list = get_execution_requests_list(new_payload_request.execution_requests)  # [New in Electra]
     parent_beacon_block_root = new_payload_request.parent_beacon_block_root
 
     if not self.is_valid_block_hash(execution_payload, parent_beacon_block_root):
@@ -1023,7 +1023,7 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
     # [Modified in Electra]
     if not self.notify_new_payload(
             execution_payload, 
-            execution_requests, 
+            execution_requests_list, 
             parent_beacon_block_root):
         return False
 
@@ -1138,6 +1138,19 @@ def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
 ```
 
 #### Execution payload
+
+##### New `get_execution_requests_list`
+
+*Note*: Encodes execution requests as defined by [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685).
+
+```python
+def get_execution_requests_list(execution_requests: ExecutionRequests) -> list[bytes]:
+    deposit_bytes = serialize(execution_requests.deposits)
+    withdrawal_bytes = serialize(execution_requests.withdrawals)
+    consolidation_bytes = serialize(execution_requests.consolidations)
+
+    return [deposit_bytes, withdrawal_bytes, consolidation_bytes]
+```
 
 ##### Modified `process_execution_payload`
 


### PR DESCRIPTION
As defined here:

* https://github.com/ethereum/execution-apis/pull/591

This was essentially copied from this [commit](https://github.com/ethereum/consensus-specs/pull/3950/commits/601631fa898caf5d68cccf0b4b608ad06835d1b9) in #3950. Thanks @mkalinin.