### PR TITLE
Re-add `execution_payload` to `notify_new_payload` call

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1022,6 +1022,7 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
 
     # [Modified in Electra]
     if not self.notify_new_payload(
+            execution_payload,
             parent_beacon_block_root,
             execution_requests):
         return False


### PR DESCRIPTION
I made a mistake in this PR. I accidentally deleted `execution_payload` here.

* https://github.com/ethereum/consensus-specs/pull/3967