### PR TITLE
Clean up markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Documentation on the different components used during spec writing can be found 
 
 Conformance tests built from the executable python spec are available in the [Ethereum Proof-of-Stake Consensus Spec Tests](https://github.com/ethereum/consensus-spec-tests) repo. Compressed tarballs are available in [releases](https://github.com/ethereum/consensus-spec-tests/releases).
 
-
 ## Installation and Usage
 The consensus-specs repo can be used by running the tests locally or inside a docker container.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Features are researched and developed in parallel, and then consolidated into se
 | 4 | **Deneb** | `269568` | <ul><li>Core</li><ul><li>[Beacon Chain changes](specs/deneb/beacon-chain.md)</li><li>[Deneb fork](specs/deneb/fork.md)</li><li>[Polynomial commitments](specs/deneb/polynomial-commitments.md)</li><li>[Fork choice changes](specs/deneb/fork-choice.md)</li></ul><li>Additions</li><ul><li>[Light client sync protocol changes](specs/deneb/light-client/sync-protocol.md) ([fork](specs/deneb/light-client/fork.md), [full node](specs/deneb/light-client/full-node.md), [networking](specs/deneb/light-client/p2p-interface.md))</li></ul><ul><li>[Honest validator guide changes](specs/deneb/validator.md)</li><li>[P2P networking](specs/deneb/p2p-interface.md)</li></ul></ul> |
 
 ### In-development Specifications
+
 | Code Name or Topic | Specs | Notes |
 | - | - | - |
 | Electra | <ul><li>Core</li><ul><li>[Beacon Chain changes](specs/electra/beacon-chain.md)</li><li>[EIP-6110 fork](specs/electra/fork.md)</li></ul><li>Additions</li><ul><li>[Light client sync protocol changes](specs/electra/light-client/sync-protocol.md) ([fork](specs/electra/light-client/fork.md), [full node](specs/electra/light-client/full-node.md), [networking](specs/electra/light-client/p2p-interface.md))</li></ul><ul><li>[Honest validator guide changes](specs/electra/validator.md)</li></ul></ul> |
@@ -75,6 +76,7 @@ Documentation on the different components used during spec writing can be found 
 Conformance tests built from the executable python spec are available in the [Ethereum Proof-of-Stake Consensus Spec Tests](https://github.com/ethereum/consensus-spec-tests) repo. Compressed tarballs are available in [releases](https://github.com/ethereum/consensus-spec-tests/releases).
 
 ## Installation and Usage
+
 The consensus-specs repo can be used by running the tests locally or inside a docker container.
 
 To run the tests locally:

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,7 +1,7 @@
 # Configurations
 
 This directory contains a set of configurations used for testing, testnets, and mainnet.
-A client binary may be compiled for a specific `PRESET_BASE`, 
+A client binary may be compiled for a specific `PRESET_BASE`,
 and then load different configurations around that preset to participate in different networks or tests.
 
 Standard configs:
@@ -24,7 +24,7 @@ In this case, the suffix on the new variable may be removed, and the old variabl
 
 A previous iteration of forking made use of "timelines", but this collides with the definitions used in the spec (variables for special forking slots, etc.), and was not integrated sufficiently in any of the spec tools or implementations.
 Instead, the config essentially doubles as fork definition now, e.g. changing the value for `ALTAIR_FORK_EPOCH` changes the fork.
- 
+
 ## Format
 
 Each preset and configuration is a key-value mapping.

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,6 @@
 This dockerfile sets up the dependencies required to run consensus-spec tests. The docker image can be locally built with:
 - `docker build ./ -t $IMAGE_NAME -f ./docker/Dockerfile`
 
-
 Handy commands:
 - `docker run -it $IMAGE_NAME /bin/sh` will give you a shell inside the docker container to manually run any tests
 - `docker run $IMAGE_NAME make citest` will run the make citest command inside the docker container

--- a/docs/docs/new-feature.md
+++ b/docs/docs/new-feature.md
@@ -23,7 +23,6 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-
 ## A. Make it executable for linter checks
 
 ### 1. Create a folder under `./specs/_features`

--- a/docs/docs/new-feature.md
+++ b/docs/docs/new-feature.md
@@ -34,6 +34,7 @@ For example, if it's an `EIP-9999` CL spec, you can create a `./specs/_features/
 For example, if the latest fork is Capella, use `./specs/capella` content as your "previous fork".
 
 ### 3. Write down your proposed `beacon-chain.md` change
+
 - You can either use [Beacon Chain Spec Template](./templates/beacon-chain-template.md), or make a copy of the latest fork content and then edit it.
 - Tips:
     - We use [`doctoc`](https://www.npmjs.com/package/doctoc) tool to generate the table of content.
@@ -49,8 +50,11 @@ For example, if the latest fork is Capella, use `./specs/capella` content as you
         - Use simple Python rather than the fancy Python dark magic.
 
 ### 4. Add `fork.md`
+
 You can refer to the previous fork's `fork.md` file.
+
 ### 5. Make it executable
+
 - Update Pyspec [`constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/constants.py) with the new feature name.
 - Update helpers for [`setup.py`](https://github.com/ethereum/consensus-specs/blob/dev/setup.py) for building the spec:
     - Update [`pysetup/constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/pysetup/constants.py) with the new feature name as Pyspec `constants.py` defined.
@@ -62,17 +66,21 @@ You can refer to the previous fork's `fork.md` file.
 ## B: Make it executable for pytest and test generator
 
 ### 1. [Optional] Add `light-client/*` docs if you updated the content of `BeaconBlock`
+
 - You can refer to the previous fork's `light-client/*` file.
 - Add the path of the new markdown files in [`pysetup/md_doc_paths.py`](https://github.com/ethereum/consensus-specs/blob/dev/pysetup/md_doc_paths.py)'s `get_md_doc_paths` function.
 
 ### 2. Add the mainnet and minimal presets and update the configs
+
 - Add presets: `presets/mainnet/<new-feature-name>.yaml` and `presets/minimal/<new-feature-name>.yaml`
 - Update configs: `configs/mainnet.yaml` and `configs/minimal.yaml`
 
 ### 3. Update [`context.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/context.py)
+
 - [Optional] Add `with_<new-feature-name>_and_later` decorator for writing pytest cases. e.g., `with_capella_and_later`.
 
 ### 4. Update [`constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/constants.py)
+
 - Add `<NEW_FEATURE>` to `ALL_PHASES` and `TESTGEN_FORKS`
 
 ### 5. Update [`genesis.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/genesis.py):
@@ -93,6 +101,7 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 - If the given feature changes `ExecutionPayload` fields, you have to set the initial values by updating `get_sample_genesis_execution_payload_header` helper.
 
 ### 6. Update CI configurations
+
 - Update [GitHub Actions config](https://github.com/ethereum/consensus-specs/blob/dev/.github/workflows/run-tests.yml)
     - Update `pyspec-tests.strategy.matrix.version` list by adding new feature to it
 - Update [CircleCI config](https://github.com/ethereum/consensus-specs/blob/dev/.circleci/config.yml)
@@ -101,7 +110,9 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 ## Others
 
 ### Bonus
+
 - Add `validator.md` if honest validator behavior changes with the new feature.
 
 ### Need help?
+
 You can tag spec elves for cleaning up your PR. 🧚

--- a/docs/docs/templates/beacon-chain-template.md
+++ b/docs/docs/templates/beacon-chain-template.md
@@ -3,14 +3,13 @@
 # <FORK_NAME> -- The Beacon Chain
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
-
-
 
 ## Introduction
 
@@ -27,7 +26,6 @@
 | `<CONSTANT_NAME>` | `<VALUE>`` |
 
 ## Preset
-
 
 ### [CATEGORY OF PRESETS]
 
@@ -64,12 +62,8 @@ class CONTAINER_NAME(Container):
 
 ### Epoch processing
 
-
 ### Block processing
 
-    
-
-    
 ## Testing
 
 *Note*: The function `initialize_beacon_state_from_eth1` is modified for pure <FORK_NAME> testing only.

--- a/fork_choice/safe-block.md
+++ b/fork_choice/safe-block.md
@@ -1,6 +1,7 @@
 # Fork Choice -- Safe Block
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/_features/custody_game/beacon-chain.md
+++ b/specs/_features/custody_game/beacon-chain.md
@@ -55,7 +55,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
 
 This document details the beacon chain additions and changes of to support the shard data custody game,
@@ -100,7 +99,6 @@ building upon the [Sharding](../sharding/beacon-chain.md) specification.
 | `MAX_CUSTODY_CHUNK_CHALLENGES` | `uint64(2**2)` (= 4) |
 | `MAX_CUSTODY_CHUNK_CHALLENGE_RESPONSES` | `uint64(2**4)` (= 16) |
 | `MAX_CUSTODY_SLASHINGS` | `uint64(2**0)` (= 1) |
-
 
 ### Size parameters
 
@@ -355,7 +353,6 @@ def get_custody_period_for_validator(validator_index: ValidatorIndex, epoch: Epo
     return (epoch + validator_index % EPOCHS_PER_CUSTODY_PERIOD) // EPOCHS_PER_CUSTODY_PERIOD
 ```
 
-
 ## Per-block processing
 
 ### Block processing
@@ -573,7 +570,7 @@ def process_custody_slashing(state: BeaconState, signed_custody_slashing: Signed
 
     # Any signed custody-slashing should result in at least one slashing.
     # If the custody bits are valid, then the claim itself is slashed.
-    malefactor = state.validators[custody_slashing.malefactor_index] 
+    malefactor = state.validators[custody_slashing.malefactor_index]
     whistleblower = state.validators[custody_slashing.whistleblower_index]
     domain = get_domain(state, DOMAIN_CUSTODY_BIT_SLASHING, get_current_epoch(state))
     signing_root = compute_signing_root(custody_slashing, domain)
@@ -596,7 +593,7 @@ def process_custody_slashing(state: BeaconState, signed_custody_slashing: Signed
     # Verify existence and participation of claimed malefactor
     attesters = get_attesting_indices(state, attestation)
     assert custody_slashing.malefactor_index in attesters
-    
+
     # Verify the malefactor custody key
     epoch_to_sign = get_randao_epoch_for_custody_period(
         get_custody_period_for_validator(custody_slashing.malefactor_index, attestation.data.target.epoch),
@@ -619,7 +616,7 @@ def process_custody_slashing(state: BeaconState, signed_custody_slashing: Signed
         for attester_index in attesters:
             if attester_index != custody_slashing.malefactor_index:
                 increase_balance(state, attester_index, whistleblower_reward)
-        # No special whisteblower reward: it is expected to be an attester. Others are free to slash too however. 
+        # No special whisteblower reward: it is expected to be an attester. Others are free to slash too however.
     else:
         # The claim was false, the custody bit was correct. Slash the whistleblower that induced this work.
         slash_validator(state, custody_slashing.whistleblower_index)

--- a/specs/_features/custody_game/validator.md
+++ b/specs/_features/custody_game/validator.md
@@ -24,7 +24,6 @@ participating in the shard data Custody Game.
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
 
 ## Prerequisites
@@ -57,7 +56,6 @@ Up to `MAX_EARLY_DERIVED_SECRET_REVEALS`, [`EarlyDerivedSecretReveal`](./beacon-
 #### Construct attestation
 
 `attestation.data`, `attestation.aggregation_bits`, and `attestation.signature` are unchanged from Phase 0. But safety/validity in signing the message is premised upon calculation of the "custody bit" [TODO].
-
 
 ## How to avoid slashing
 

--- a/specs/_features/das/das-core.md
+++ b/specs/_features/das/das-core.md
@@ -24,7 +24,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Custom types
 
 We define the following Python custom types for type hinting and readability:
@@ -33,7 +32,6 @@ We define the following Python custom types for type hinting and readability:
 | - | - | - |
 | `SampleIndex` | `uint64` | A sample index, corresponding to chunk of extended data |
 
-
 ## Configuration
 
 ### Misc
@@ -41,7 +39,6 @@ We define the following Python custom types for type hinting and readability:
 | Name | Value | Notes |
 | - | - | - |
 | `MAX_RESAMPLE_TIME` | `TODO` (= TODO) | Time window to sample a shard blob and put it on vertical subnets |
-
 
 ## New containers
 

--- a/specs/_features/das/fork-choice.md
+++ b/specs/_features/das/fork-choice.md
@@ -14,7 +14,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
 
 This document is the beacon chain fork choice spec for Data Availability Sampling. The only change that we add from phase 0 is that we add a concept of "data dependencies";

--- a/specs/_features/das/p2p-interface.md
+++ b/specs/_features/das/p2p-interface.md
@@ -28,12 +28,10 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
-
 ## Introduction
 
 For an introduction about DAS itself, see [the DAS participation spec](sampling.md#data-availability-sampling).
-This is not a pre-requisite for the network layer, but will give you valuable context. 
+This is not a pre-requisite for the network layer, but will give you valuable context.
 
 For sampling, all nodes need to query for `k` random samples each slot.
 
@@ -55,13 +53,13 @@ The push model does not aim to serve "historical" queries (anything older than t
 Historical queries are still required for the unhappy case, where messages are not pushed quick enough,
 and missing samples are not reconstructed by other nodes on the horizontal subnet quick enough.
 
-The main challenge in supporting historical queries is to target the right nodes, 
+The main challenge in supporting historical queries is to target the right nodes,
 without concentrating too many requests on a single node, or breaking the network/consensus identity separation.
 
 ## DAS Subnets
 
 On a high level, the push-model roles are divided into:
-- Sources: create blobs of shard block data, and transformed into many tiny samples. 
+- Sources: create blobs of shard block data, and transformed into many tiny samples.
 - Sinks: continuously look for samples
 
 At full operation, the network has one proposer, per shard, per slot.
@@ -93,15 +91,14 @@ Peers on the horizontal subnet are expected to at least perform regular propagat
 Nodes on this same subnet can replicate the sampling efficiently (including a proof for each sample),
 and distribute it to any vertical networks that are available to them.
 
-Since the messages are content-addressed (instead of origin-stamped), 
-multiple publishers of the same samples on a vertical subnet do not hurt performance, 
+Since the messages are content-addressed (instead of origin-stamped),
+multiple publishers of the same samples on a vertical subnet do not hurt performance,
 but actually improve it by shortcutting regular propagation on the vertical subnet, and thus lowering the latency to a sample.
-
 
 ### Vertical subnets
 
 Vertical subnets propagate the samples to every peer that is interested.
-These interests are randomly sampled and rotate quickly: although not perfect, 
+These interests are randomly sampled and rotate quickly: although not perfect,
 sufficient to avoid any significant amount of nodes from being 100% predictable.
 
 As soon as a sample is missing after the expected propagation time window,
@@ -163,10 +160,9 @@ Take `blob = signed_blob.blob`:
 
 The [DAS participation spec](sampling.md#horizontal-subnets) outlines when and where to participate in DAS on horizontal subnets.
 
-
 #### Vertical subnets: `das_sample_{subnet_index}`
 
-Shard blob samples can be verified with just a 48 byte KZG proof (commitment quotient polynomial), 
+Shard blob samples can be verified with just a 48 byte KZG proof (commitment quotient polynomial),
 against the commitment to blob polynomial, specific to that `(shard, slot)` key.
 
 The following validations MUST pass before forwarding the `sample` on the vertical subnet.
@@ -187,12 +183,11 @@ The following validations MUST pass before forwarding the `sample` on the vertic
 Upon receiving a valid sample, it SHOULD be retained for a buffer period if the local node is part of the backbone that covers this sample.
 This is to serve other peers that may have missed it.
 
-
 ## DAS in the Req-Resp domain: Pull
 
 To pull samples from nodes, in case of network instability when samples are unavailable, a new query method is added to the Req-Resp domain.
 
-This builds on top of the protocol identification and encoding spec which was introduced in [the Phase0 network spec](../../phase0/p2p-interface.md). 
+This builds on top of the protocol identification and encoding spec which was introduced in [the Phase0 network spec](../../phase0/p2p-interface.md).
 
 Note that DAS networking uses a different protocol prefix: `/eth2/das/req`
 

--- a/specs/_features/das/sampling.md
+++ b/specs/_features/das/sampling.md
@@ -22,7 +22,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Data Availability Sampling
 
 TODO: Summary of Data Availability problem
@@ -44,7 +43,6 @@ TODO
 #### Quick rotation: Sampling
 
 TODO
-
 
 ### DAS during network instability
 

--- a/specs/_features/eip6800/fork.md
+++ b/specs/_features/eip6800/fork.md
@@ -29,7 +29,6 @@ Warning: this configuration is not definitive.
 | `EIP6800_FORK_VERSION` | `Version('0x05000000')` |
 | `EIP6800_FORK_EPOCH` | `Epoch(18446744073709551615)` **TBD** |
 
-
 ## Helper functions
 
 ### Misc

--- a/specs/_features/eip7594/fork-choice.md
+++ b/specs/_features/eip7594/fork-choice.md
@@ -1,6 +1,7 @@
 # EIP-7594 -- Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -25,10 +26,10 @@ This is the modification of the fork choice accompanying EIP-7594.
 ```python
 def is_data_available(beacon_block_root: Root) -> bool:
     # `retrieve_column_sidecars` is implementation and context dependent, replacing
-    # `retrieve_blobs_and_proofs`. For the given block root, it returns all column 
-    # sidecars to sample, or raises an exception if they are not available. 
-    # The p2p network does not guarantee sidecar retrieval outside of 
-    # `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs.  
+    # `retrieve_blobs_and_proofs`. For the given block root, it returns all column
+    # sidecars to sample, or raises an exception if they are not available.
+    # The p2p network does not guarantee sidecar retrieval outside of
+    # `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs.
     column_sidecars = retrieve_column_sidecars(beacon_block_root)
     return all(
         verify_data_column_sidecar(column_sidecar)

--- a/specs/_features/eip7594/peer-sampling.md
+++ b/specs/_features/eip7594/peer-sampling.md
@@ -1,4 +1,4 @@
-# EIP-7594 -- Peer Sampling 
+# EIP-7594 -- Peer Sampling
 
 **Notice**: This document is a work-in-progress for researchers and implementers.
 

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -613,6 +613,7 @@ def is_merge_transition_complete(state: BeaconState) -> bool:
 ```
 
 #### Modified `validate_merge_block`
+
 `validate_merge_block` is modified to use the new `signed_execution_payload_header` message in the Beacon Block Body
 
 ```python

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -61,34 +61,34 @@
 
 ## Introduction
 
-This is the beacon chain specification of the enshrined proposer builder separation feature. 
+This is the beacon chain specification of the enshrined proposer builder separation feature.
 
 *Note:* This specification is built upon [Electra](../../electra/beacon-chain.md) and is under active development.
 
 This feature adds new staked consensus participants called *Builders* and new honest validators duties called *payload timeliness attestations*. The slot is divided in **four** intervals. Honest validators gather *signed bids* (a `SignedExecutionPayloadHeader`) from builders and submit their consensus blocks (a `SignedBeaconBlock`) including these bids at the beginning of the slot. At the start of the second interval, honest validators submit attestations just as they do previous to this feature). At the  start of the third interval, aggregators aggregate these attestations and the builder broadcasts either a full payload or a message indicating that they are withholding the payload (a `SignedExecutionPayloadEnvelope`). At the start of the fourth interval, some validators selected to be members of the new **Payload Timeliness Committee** (PTC) attest to the presence and timeliness of the builder's payload.
 
-At any given slot, the status of the blockchain's head may be either 
-- A block from a previous slot (e.g. the current slot's proposer did not submit its block). 
-- An *empty* block from the current slot (e.g. the proposer submitted a timely block, but the builder did not reveal the payload on time). 
-- A full block for the current slot (both the proposer and the builder revealed on time). 
+At any given slot, the status of the blockchain's head may be either
+- A block from a previous slot (e.g. the current slot's proposer did not submit its block).
+- An *empty* block from the current slot (e.g. the proposer submitted a timely block, but the builder did not reveal the payload on time).
+- A full block for the current slot (both the proposer and the builder revealed on time).
 
 ## Constants
 
 ### Payload status
 
-| Name | Value | 
-| - | - | 
+| Name | Value |
+| - | - |
 | `PAYLOAD_ABSENT` | `uint8(0)` |
-| `PAYLOAD_PRESENT` | `uint8(1)` | 
-| `PAYLOAD_WITHHELD` | `uint8(2)` | 
+| `PAYLOAD_PRESENT` | `uint8(1)` |
+| `PAYLOAD_WITHHELD` | `uint8(2)` |
 | `PAYLOAD_INVALID_STATUS` | `uint8(3)` |
 
 ## Preset
 
 ### Misc
 
-| Name | Value | 
-| - | - | 
+| Name | Value |
+| - | - |
 | `PTC_SIZE` | `uint64(2**9)` (=512)  # (New in EIP-7732) |
 
 ### Domain types
@@ -151,7 +151,7 @@ class SignedExecutionPayloadHeader(Container):
     message: ExecutionPayloadHeader
     signature: BLSSignature
 ```
-    
+
 #### `ExecutionPayloadEnvelope`
 
 ```python
@@ -177,7 +177,7 @@ class SignedExecutionPayloadEnvelope(Container):
 
 #### `BeaconBlockBody`
 
-**Note:** The Beacon Block body is modified to contain a `Signed ExecutionPayloadHeader`. The containers `BeaconBlock` and `SignedBeaconBlock` are modified indirectly. The field `execution_requests` is removed from the beacon block body and moved into the signed execution payload envelope. 
+**Note:** The Beacon Block body is modified to contain a `Signed ExecutionPayloadHeader`. The containers `BeaconBlock` and `SignedBeaconBlock` are modified indirectly. The field `execution_requests` is removed from the beacon block body and moved into the signed execution payload envelope.
 
 ```python
 class BeaconBlockBody(Container):
@@ -203,7 +203,7 @@ class BeaconBlockBody(Container):
 
 #### `ExecutionPayloadHeader`
 
-**Note:** The `ExecutionPayloadHeader` is modified to only contain the block hash of the committed `ExecutionPayload` in addition to the builder's payment information, gas limit and KZG commitments root to verify the inclusion proofs. 
+**Note:** The `ExecutionPayloadHeader` is modified to only contain the block hash of the committed `ExecutionPayload` in addition to the builder's payment information, gas limit and KZG commitments root to verify the inclusion proofs.
 
 ```python
 class ExecutionPayloadHeader(Container):
@@ -219,7 +219,7 @@ class ExecutionPayloadHeader(Container):
 
 #### `BeaconState`
 
-*Note*: The `BeaconState` is modified to track the last withdrawals honored in the CL. The `latest_execution_payload_header` is modified semantically to refer not to a past committed `ExecutionPayload` but instead it corresponds to the state's slot builder's bid. Another addition is to track the last committed block hash and the last slot that was full, that is in which there were both consensus and execution blocks included. 
+*Note*: The `BeaconState` is modified to track the last withdrawals honored in the CL. The `latest_execution_payload_header` is modified semantically to refer not to a past committed `ExecutionPayload` but instead it corresponds to the state's slot builder's bid. Another addition is to track the last committed block hash and the last slot that was full, that is in which there were both consensus and execution blocks included.
 
 ```python
 class BeaconState(Container):
@@ -311,7 +311,7 @@ def remove_flag(flags: ParticipationFlags, flag_index: int) -> ParticipationFlag
 
 ```python
 def is_valid_indexed_payload_attestation(
-        state: BeaconState, 
+        state: BeaconState,
         indexed_payload_attestation: IndexedPayloadAttestation) -> bool:
     """
     Check if ``indexed_payload_attestation`` is not empty, has sorted and unique indices and has
@@ -335,7 +335,7 @@ def is_valid_indexed_payload_attestation(
 
 #### `is_parent_block_full`
 
-This function returns true if the last committed payload header was fulfilled with a payload, this can only happen when both beacon block and payload were present. This function must be called on a beacon state before processing the execution payload header in the block. 
+This function returns true if the last committed payload header was fulfilled with a payload, this can only happen when both beacon block and payload were present. This function must be called on a beacon state before processing the execution payload header in the block.
 
 ```python
 def is_parent_block_full(state: BeaconState) -> bool:
@@ -354,8 +354,8 @@ def get_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
     epoch = compute_epoch_at_slot(slot)
     committees_per_slot = bit_floor(min(get_committee_count_per_slot(state, epoch), PTC_SIZE))
     members_per_committee = PTC_SIZE // committees_per_slot
-    
-    validator_indices: List[ValidatorIndex] = [] 
+
+    validator_indices: List[ValidatorIndex] = []
     for idx in range(committees_per_slot):
         beacon_committee = get_beacon_committee(state, slot, CommitteeIndex(idx))
         validator_indices += beacon_committee[:members_per_committee]
@@ -390,7 +390,7 @@ def get_attesting_indices(state: BeaconState, attestation: Attestation) -> Set[V
 #### `get_payload_attesting_indices`
 
 ```python
-def get_payload_attesting_indices(state: BeaconState, slot: Slot, 
+def get_payload_attesting_indices(state: BeaconState, slot: Slot,
                                   payload_attestation: PayloadAttestation) -> Set[ValidatorIndex]:
     """
     Return the set of attesting indices corresponding to ``payload_attestation``.
@@ -402,7 +402,7 @@ def get_payload_attesting_indices(state: BeaconState, slot: Slot,
 #### `get_indexed_payload_attestation`
 
 ```python
-def get_indexed_payload_attestation(state: BeaconState, slot: Slot, 
+def get_indexed_payload_attestation(state: BeaconState, slot: Slot,
                                     payload_attestation: PayloadAttestation) -> IndexedPayloadAttestation:
     """
     Return the indexed payload attestation corresponding to ``payload_attestation``.
@@ -442,7 +442,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 ##### Modified `process_withdrawals`
 
-**Note:** This is modified to take only the `state` as parameter. Withdrawals are deterministic given the beacon state, any execution payload that has the corresponding block as parent beacon block is required to honor these withdrawals in the execution layer. This function must be called before `process_execution_payload_header` as this latter function affects validator balances. 
+**Note:** This is modified to take only the `state` as parameter. Withdrawals are deterministic given the beacon state, any execution payload that has the corresponding block as parent beacon block is required to honor these withdrawals in the execution layer. This function must be called before `process_execution_payload_header` as this latter function affects validator balances.
 
 ```python
 def process_withdrawals(state: BeaconState) -> None:
@@ -481,7 +481,7 @@ def process_withdrawals(state: BeaconState) -> None:
 ##### New `verify_execution_payload_header_signature`
 
 ```python
-def verify_execution_payload_header_signature(state: BeaconState, 
+def verify_execution_payload_header_signature(state: BeaconState,
                                               signed_header: SignedExecutionPayloadHeader) -> bool:
     # Check the signature
     builder = state.validators[signed_header.message.builder_index]
@@ -516,7 +516,7 @@ def process_execution_payload_header(state: BeaconState, block: BeaconBlock) -> 
     decrease_balance(state, builder_index, amount)
     increase_balance(state, block.proposer_index, amount)
 
-    # Cache the signed execution payload header 
+    # Cache the signed execution payload header
     state.latest_execution_payload_header = header
 ```
 
@@ -557,7 +557,7 @@ def process_payload_attestation(state: BeaconState, payload_attestation: Payload
     data = payload_attestation.data
     assert data.beacon_block_root == state.latest_block_header.parent_root
     # Check that the attestation is for the previous slot
-    assert data.slot + 1 == state.slot 
+    assert data.slot + 1 == state.slot
 
     # Verify signature
     indexed_payload_attestation = get_indexed_payload_attestation(state, data.slot, payload_attestation)
@@ -658,11 +658,11 @@ def verify_execution_payload_envelope_signature(
 *Note*: `process_execution_payload` is now an independent check in state transition. It is called when importing a signed execution payload proposed by the builder of the current slot.
 
 ```python
-def process_execution_payload(state: BeaconState, 
-                              signed_envelope: SignedExecutionPayloadEnvelope, 
+def process_execution_payload(state: BeaconState,
+                              signed_envelope: SignedExecutionPayloadEnvelope,
                               execution_engine: ExecutionEngine, verify: bool = True) -> None:
     # Verify signature
-    if verify: 
+    if verify:
         assert verify_execution_payload_envelope_signature(state, signed_envelope)
     envelope = signed_envelope.message
     payload = envelope.payload
@@ -670,7 +670,7 @@ def process_execution_payload(state: BeaconState,
     previous_state_root = hash_tree_root(state)
     if state.latest_block_header.state_root == Root():
         state.latest_block_header.state_root = previous_state_root
-    
+
     # Verify consistency with the beacon block
     assert envelope.beacon_block_root == hash_tree_root(state.latest_block_header)
 
@@ -679,14 +679,14 @@ def process_execution_payload(state: BeaconState,
     assert envelope.builder_index == committed_header.builder_index
     assert committed_header.blob_kzg_commitments_root == hash_tree_root(envelope.blob_kzg_commitments)
 
-    if not envelope.payload_withheld: 
+    if not envelope.payload_withheld:
         # Verify the withdrawals root
         assert hash_tree_root(payload.withdrawals) == state.latest_withdrawals_root
 
         # Verify the gas_limit
         assert committed_header.gas_limit == payload.gas_limit
 
-        assert committed_header.block_hash == payload.block_hash 
+        assert committed_header.block_hash == payload.block_hash
         # Verify consistency of the parent hash with respect to the previous execution payload
         assert payload.parent_hash == state.latest_block_hash
         # Verify prev_randao
@@ -696,7 +696,7 @@ def process_execution_payload(state: BeaconState,
         # Verify commitments are under limit
         assert len(envelope.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
         # Verify the execution payload is valid
-        versioned_hashes = [kzg_commitment_to_versioned_hash(commitment) 
+        versioned_hashes = [kzg_commitment_to_versioned_hash(commitment)
                             for commitment in envelope.blob_kzg_commitments]
         requests = envelope.execution_requests
         assert execution_engine.verify_and_notify_new_payload(
@@ -722,6 +722,6 @@ def process_execution_payload(state: BeaconState,
         state.latest_full_slot = state.slot
 
     # Verify the state root
-    if verify: 
+    if verify:
         assert envelope.state_root == hash_tree_root(state)
 ```

--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -16,20 +16,20 @@ This is an accompanying document which describes the expected actions of a "buil
 
 ## Introduction
 
-With the EIP-7732 Fork, the protocol includes new staked participants of the protocol called *Builders*. While Builders are a subset of the validator set, they have extra attributions that are optional. Validators may opt to not be builders and as such we collect the set of guidelines for those validators that want to act as builders in this document. 
+With the EIP-7732 Fork, the protocol includes new staked participants of the protocol called *Builders*. While Builders are a subset of the validator set, they have extra attributions that are optional. Validators may opt to not be builders and as such we collect the set of guidelines for those validators that want to act as builders in this document.
 
 ## Builders attributions
 
-Builders can submit bids to produce execution payloads. They can broadcast these bids in the form of `SignedExecutionPayloadHeader` objects, these objects encode a commitment to reveal an execution payload in exchange for a payment. When their bids are chosen by the corresponding proposer, builders are expected to broadcast an accompanying `SignedExecutionPayloadEnvelope` object honoring the commitment. 
+Builders can submit bids to produce execution payloads. They can broadcast these bids in the form of `SignedExecutionPayloadHeader` objects, these objects encode a commitment to reveal an execution payload in exchange for a payment. When their bids are chosen by the corresponding proposer, builders are expected to broadcast an accompanying `SignedExecutionPayloadEnvelope` object honoring the commitment.
 
-Thus, builders tasks are divided in two, submitting bids, and submitting payloads. 
+Thus, builders tasks are divided in two, submitting bids, and submitting payloads.
 
 ### Constructing the payload bid
 
-Builders can broadcast a payload bid for the current or the next slot's proposer to include. They produce a `SignedExecutionPayloadHeader` as follows. 
+Builders can broadcast a payload bid for the current or the next slot's proposer to include. They produce a `SignedExecutionPayloadHeader` as follows.
 
 1. Set `header.parent_block_hash` to the current head of the execution chain (this can be obtained from the beacon state as `state.last_block_hash`).
-2. Set `header.parent_block_root` to be the head of the consensus chain (this can be obtained from the beacon state as `hash_tree_root(state.latest_block_header)`. The `parent_block_root` and `parent_block_hash` must be compatible, in the sense that they both should come from the same `state` by the method described in this and the previous point. 
+2. Set `header.parent_block_root` to be the head of the consensus chain (this can be obtained from the beacon state as `hash_tree_root(state.latest_block_header)`. The `parent_block_root` and `parent_block_hash` must be compatible, in the sense that they both should come from the same `state` by the method described in this and the previous point.
 3. Construct an execution payload. This can be performed with an external execution engine with a call to `engine_getPayloadV4`.
 4. Set `header.block_hash` to be the block hash of the constructed payload, that is `payload.block_hash`.
 5. Set `header.gas_limit` to be the gas limit of the constructed payload, that is `payload.gas_limit`.
@@ -48,13 +48,13 @@ def get_execution_payload_header_signature(
     return bls.Sign(privkey, signing_root)
 ```
 
-The builder assembles then `signed_execution_payload_header = SignedExecutionPayloadHeader(message=header, signature=signature)` and broadcasts it on the `execution_payload_header` global gossip topic. 
+The builder assembles then `signed_execution_payload_header = SignedExecutionPayloadHeader(message=header, signature=signature)` and broadcasts it on the `execution_payload_header` global gossip topic.
 
 ### Constructing the `BlobSidecar`s
 
 [Modified in EIP-7732]
 
-The `BlobSidecar` container is modified indirectly because the constant `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH` is modified. The function `get_blob_sidecars` is modified because the KZG commitments are no longer included in the beacon block but rather in the `ExecutionPayloadEnvelope`, the builder has to send the commitments as parameters to this function. 
+The `BlobSidecar` container is modified indirectly because the constant `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH` is modified. The function `get_blob_sidecars` is modified because the KZG commitments are no longer included in the beacon block but rather in the `ExecutionPayloadEnvelope`, the builder has to send the commitments as parameters to this function.
 
 ```python
 def get_blob_sidecars(signed_block: SignedBeaconBlock,
@@ -100,19 +100,19 @@ def get_blob_sidecars(signed_block: SignedBeaconBlock,
 
 ### Constructing the execution payload envelope
 
-When the proposer publishes a valid `SignedBeaconBlock` containing a signed commitment by the builder, the builder is later expected to broadcast the corresponding `SignedExecutionPayloadEnvelope`  that fulfills this commitment. See below for a special case of an *honestly withheld payload*. 
+When the proposer publishes a valid `SignedBeaconBlock` containing a signed commitment by the builder, the builder is later expected to broadcast the corresponding `SignedExecutionPayloadEnvelope`  that fulfills this commitment. See below for a special case of an *honestly withheld payload*.
 
-To construct the `execution_payload_envelope` the builder must perform the following steps, we alias `header` to be the committed `ExecutionPayloadHeader` in the beacon block. 
+To construct the `execution_payload_envelope` the builder must perform the following steps, we alias `header` to be the committed `ExecutionPayloadHeader` in the beacon block.
 
-1. Set the `payload` field to be the `ExecutionPayload` constructed when creating the corresponding bid. This payload **MUST** have the same block hash as `header.block_hash`. 
-2. Set the `builder_index` field to be the validator index of the builder performing these steps. This field **MUST** be `header.builder_index`. 
+1. Set the `payload` field to be the `ExecutionPayload` constructed when creating the corresponding bid. This payload **MUST** have the same block hash as `header.block_hash`.
+2. Set the `builder_index` field to be the validator index of the builder performing these steps. This field **MUST** be `header.builder_index`.
 3. Set `beacon_block_root` to be the `hash_tree_root` of the corresponding beacon block.
 4. Set `blob_kzg_commitments` to be the `commitments` field of the blobs bundle constructed when constructing the bid. This field **MUST** have a `hash_tree_root` equal to `header.blob_kzg_commitments_root`.
 5. Set `payload_witheld` to `False`.
 
 After setting these parameters, the builder should run `process_execution_payload(state, signed_envelope, verify=False)` and this function should not trigger an exception.
 
-6. Set `state_root` to `hash_tree_root(state)`. 
+6. Set `state_root` to `hash_tree_root(state)`.
 After preparing the `envelope` the builder should sign the envelope using:
 ```python
 def get_execution_payload_envelope_signature(
@@ -121,8 +121,8 @@ def get_execution_payload_envelope_signature(
     signing_root = compute_signing_root(envelope, domain)
     return bls.Sign(privkey, signing_root)
 ```
-The builder assembles then `signed_execution_payload_envelope = SignedExecutionPayloadEnvelope(message=envelope, signature=signature)` and broadcasts it on the `execution_payload` global gossip topic. 
+The builder assembles then `signed_execution_payload_envelope = SignedExecutionPayloadEnvelope(message=envelope, signature=signature)` and broadcasts it on the `execution_payload` global gossip topic.
 
 ### Honest payload withheld messages
 
-An honest builder that has seen a `SignedBeaconBlock` referencing his signed bid, but that block was not timely and thus it is not the head of the builder's chain, may choose to withhold their execution payload. For this the builder should simply act as if it were building an empty payload, without any transactions, withdrawals, etc. The `payload.block_hash` may not be equal to `header.block_hash`. The builder may then sets `payload_withheld` to `True`. If the PTC sees this message and votes for it, validators will attribute a *withholding boost* to the builder, which would increase the forkchoice weight of the parent block, favoring it and preventing the builder from being charged for the bid by not revealing. 
+An honest builder that has seen a `SignedBeaconBlock` referencing his signed bid, but that block was not timely and thus it is not the head of the builder's chain, may choose to withhold their execution payload. For this the builder should simply act as if it were building an empty payload, without any transactions, withdrawals, etc. The `payload.block_hash` may not be equal to `header.block_hash`. The builder may then sets `payload_withheld` to `True`. If the PTC sees this message and votes for it, validators will attribute a *withholding boost* to the builder, which would increase the forkchoice weight of the parent block, favoring it and preventing the builder from being charged for the bid by not revealing.

--- a/specs/_features/eip7732/fork-choice.md
+++ b/specs/_features/eip7732/fork-choice.md
@@ -54,6 +54,7 @@ This is the modification of the fork choice accompanying the EIP-7732 upgrade.
 ## Containers
 
 ### New `ChildNode`
+
 Auxiliary class to consider `(block, slot, bool)` LMD voting
 
 ```python
@@ -66,6 +67,7 @@ class ChildNode(Container):
 ## Helpers
 
 ### Modified `LatestMessage`
+
 **Note:** The class is modified to keep track of the slot instead of the epoch.
 
 ```python
@@ -76,6 +78,7 @@ class LatestMessage(object):
 ```
 
 ### Modified `update_latest_messages`
+
 **Note:** the function `update_latest_messages` is updated to use the attestation slot instead of target. Notice that this function is only called on validated attestations and validators cannot attest twice in the same epoch without equivocating. Notice also that target epoch number and slot number are validated on `validate_on_attestation`.
 
 ```python
@@ -89,6 +92,7 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
 ```
 
 ### Modified `Store`
+
 **Note:** `Store` is modified to track the intermediate states of "empty" consensus blocks, that is, those consensus blocks for which the corresponding execution payload has not been revealed or has not been included on chain.
 
 ```python
@@ -194,6 +198,7 @@ def is_parent_node_full(store: Store, block: BeaconBlock) -> bool:
 ```
 
 ### Modified `get_ancestor`
+
 **Note:** `get_ancestor` is modified to return whether the chain is based on an *empty* or *full* block.
 
 ```python
@@ -214,6 +219,7 @@ def get_ancestor(store: Store, root: Root, slot: Slot) -> ChildNode:
 ```
 
 ### Modified `get_checkpoint_block`
+
 **Note:** `get_checkpoint_block` is modified to use the new `get_ancestor`
 
 ```python
@@ -245,7 +251,9 @@ def is_supporting_vote(store: Store, node: ChildNode, message: LatestMessage) ->
 ```
 
 ### New `compute_proposer_boost`
+
 This is a helper to compute the proposer boost. It applies the proposer boost to any ancestor of the proposer boost root taking into account the payload presence. There is one exception: if the requested node has the same root and slot as the block with the proposer boost root, then the proposer boost is applied to both empty and full versions of the node.
+
 ```python
 def compute_proposer_boost(store: Store, state: BeaconState, node: ChildNode) -> Gwei:
     if store.proposer_boost_root == Root():
@@ -264,6 +272,7 @@ def compute_proposer_boost(store: Store, state: BeaconState, node: ChildNode) ->
 ```
 
 ### New `compute_withhold_boost`
+
 This is a similar helper that applies for the withhold boost. In this case this always takes into account the reveal status.
 
 ```python
@@ -283,6 +292,7 @@ def compute_withhold_boost(store: Store, state: BeaconState, node: ChildNode) ->
 ```
 
 ### New `compute_reveal_boost`
+
 This is a similar helper to the last two, the only difference is that the reveal boost is only applied to the full version of the node when querying for the same slot as the revealed payload.
 
 ```python

--- a/specs/_features/eip7732/fork-choice.md
+++ b/specs/_features/eip7732/fork-choice.md
@@ -1,6 +1,7 @@
 # EIP-7732 -- Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -44,15 +45,15 @@ This is the modification of the fork choice accompanying the EIP-7732 upgrade.
 
 | Name                 | Value       |
 | -------------------- | ----------- |
-| `PAYLOAD_TIMELY_THRESHOLD` | `PTC_SIZE / 2` (=`uint64(256)`) | 
+| `PAYLOAD_TIMELY_THRESHOLD` | `PTC_SIZE / 2` (=`uint64(256)`) |
 | `INTERVALS_PER_SLOT` | `4` # [modified in EIP-7732] |
-| `PROPOSER_SCORE_BOOST` | `20` # [modified in EIP-7732] | 
-| `PAYLOAD_WITHHOLD_BOOST` | `40` | 
-| `PAYLOAD_REVEAL_BOOST` | `40` | 
+| `PROPOSER_SCORE_BOOST` | `20` # [modified in EIP-7732] |
+| `PAYLOAD_WITHHOLD_BOOST` | `40` |
+| `PAYLOAD_REVEAL_BOOST` | `40` |
 
 ## Containers
 
-### New `ChildNode` 
+### New `ChildNode`
 Auxiliary class to consider `(block, slot, bool)` LMD voting
 
 ```python
@@ -75,7 +76,7 @@ class LatestMessage(object):
 ```
 
 ### Modified `update_latest_messages`
-**Note:** the function `update_latest_messages` is updated to use the attestation slot instead of target. Notice that this function is only called on validated attestations and validators cannot attest twice in the same epoch without equivocating. Notice also that target epoch number and slot number are validated on `validate_on_attestation`. 
+**Note:** the function `update_latest_messages` is updated to use the attestation slot instead of target. Notice that this function is only called on validated attestations and validators cannot attest twice in the same epoch without equivocating. Notice also that target epoch number and slot number are validated on `validate_on_attestation`.
 
 ```python
 def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIndex], attestation: Attestation) -> None:
@@ -87,8 +88,8 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
             store.latest_messages[i] = LatestMessage(slot=slot, root=beacon_block_root)
 ```
 
-### Modified `Store` 
-**Note:** `Store` is modified to track the intermediate states of "empty" consensus blocks, that is, those consensus blocks for which the corresponding execution payload has not been revealed or has not been included on chain. 
+### Modified `Store`
+**Note:** `Store` is modified to track the intermediate states of "empty" consensus blocks, that is, those consensus blocks for which the corresponding execution payload has not been revealed or has not been included on chain.
 
 ```python
 @dataclass
@@ -114,7 +115,7 @@ class Store(object):
     ptc_vote: Dict[Root, Vector[uint8, PTC_SIZE]] = field(default_factory=dict)  # [New in EIP-7732]
 ```
 
-### Modified `get_forkchoice_store` 
+### Modified `get_forkchoice_store`
 
 ```python
 def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
@@ -162,8 +163,8 @@ def notify_ptc_messages(store: Store, state: BeaconState, payload_attestations: 
                 store,
                 PayloadAttestationMessage(
                     validator_index=idx,
-                    data=payload_attestation.data, 
-                    signature=BLSSignature(), 
+                    data=payload_attestation.data,
+                    signature=BLSSignature(),
                     is_from_block=True
                 )
             )
@@ -174,7 +175,7 @@ def notify_ptc_messages(store: Store, state: BeaconState, payload_attestations: 
 ```python
 def is_payload_present(store: Store, beacon_block_root: Root) -> bool:
     """
-    Return whether the execution payload for the beacon block with root ``beacon_block_root`` was voted as present 
+    Return whether the execution payload for the beacon block with root ``beacon_block_root`` was voted as present
     by the PTC
     """
     # The beacon block root must be known
@@ -192,15 +193,15 @@ def is_parent_node_full(store: Store, block: BeaconBlock) -> bool:
     return parent_block_hash == message_block_hash
 ```
 
-### Modified `get_ancestor` 
-**Note:** `get_ancestor` is modified to return whether the chain is based on an *empty* or *full* block. 
+### Modified `get_ancestor`
+**Note:** `get_ancestor` is modified to return whether the chain is based on an *empty* or *full* block.
 
 ```python
 def get_ancestor(store: Store, root: Root, slot: Slot) -> ChildNode:
     """
-    Returns the beacon block root, the slot and the payload status of the ancestor of the beacon block 
-    with ``root`` at ``slot``. If the beacon block with ``root`` is already at ``slot`` or we are 
-    requesting an ancestor "in the future" it returns its PTC status instead of the actual payload content. 
+    Returns the beacon block root, the slot and the payload status of the ancestor of the beacon block
+    with ``root`` at ``slot``. If the beacon block with ``root`` is already at ``slot`` or we are
+    requesting an ancestor "in the future" it returns its PTC status instead of the actual payload content.
     """
     block = store.blocks[root]
     if block.slot <= slot:
@@ -224,7 +225,6 @@ def get_checkpoint_block(store: Store, root: Root, epoch: Epoch) -> Root:
     return get_ancestor(store, root, epoch_first_slot).root
 ```
 
-
 ### `is_supporting_vote`
 
 ```python
@@ -235,7 +235,7 @@ def is_supporting_vote(store: Store, node: ChildNode, message: LatestMessage) ->
     """
     if node.root == message.root:
         # an attestation for a given root always counts for that root regardless if full or empty
-        # as long as the attestation happened after the requested slot. 
+        # as long as the attestation happened after the requested slot.
         return node.slot <= message.slot
     message_block = store.blocks[message.root]
     if node.slot >= message_block.slot:
@@ -245,7 +245,7 @@ def is_supporting_vote(store: Store, node: ChildNode, message: LatestMessage) ->
 ```
 
 ### New `compute_proposer_boost`
-This is a helper to compute the proposer boost. It applies the proposer boost to any ancestor of the proposer boost root taking into account the payload presence. There is one exception: if the requested node has the same root and slot as the block with the proposer boost root, then the proposer boost is applied to both empty and full versions of the node. 
+This is a helper to compute the proposer boost. It applies the proposer boost to any ancestor of the proposer boost root taking into account the payload presence. There is one exception: if the requested node has the same root and slot as the block with the proposer boost root, then the proposer boost is applied to both empty and full versions of the node.
 ```python
 def compute_proposer_boost(store: Store, state: BeaconState, node: ChildNode) -> Gwei:
     if store.proposer_boost_root == Root():
@@ -283,7 +283,7 @@ def compute_withhold_boost(store: Store, state: BeaconState, node: ChildNode) ->
 ```
 
 ### New `compute_reveal_boost`
-This is a similar helper to the last two, the only difference is that the reveal boost is only applied to the full version of the node when querying for the same slot as the revealed payload. 
+This is a similar helper to the last two, the only difference is that the reveal boost is only applied to the full version of the node when querying for the same slot as the revealed payload.
 
 ```python
 def compute_reveal_boost(store: Store, state: BeaconState, node: ChildNode) -> Gwei:
@@ -302,7 +302,7 @@ def compute_reveal_boost(store: Store, state: BeaconState, node: ChildNode) -> G
 
 ### Modified `get_weight`
 
-**Note:** `get_weight` is modified to only count votes for descending chains that support the status of a triple `Root, Slot, bool`, where the `bool` indicates if the block was full or not. `Slot` is needed for a correct implementation of `(Block, Slot)` voting. 
+**Note:** `get_weight` is modified to only count votes for descending chains that support the status of a triple `Root, Slot, bool`, where the `bool` indicates if the block was full or not. `Slot` is needed for a correct implementation of `(Block, Slot)` voting.
 
 ```python
 def get_weight(store: Store, node: ChildNode) -> Gwei:
@@ -326,7 +326,7 @@ def get_weight(store: Store, node: ChildNode) -> Gwei:
     return attestation_score + proposer_score + builder_reveal_score + builder_withhold_score
 ```
 
-### Modified `get_head` 
+### Modified `get_head`
 
 **Note:** `get_head` is a modified to use the new `get_weight` function. It returns the `ChildNode` object corresponidng to the head block.
 
@@ -343,13 +343,13 @@ def get_head(store: Store) -> ChildNode:
     while True:
         children = [
             ChildNode(root=root, slot=block.slot, is_payload_present=present) for (root, block) in blocks.items()
-            if block.parent_root == best_child.root and block.slot > best_child.slot and 
+            if block.parent_root == best_child.root and block.slot > best_child.slot and
             (best_child.root == justified_root or is_parent_node_full(store, block) == best_child.is_payload_present)
             for present in (True, False) if root in store.execution_payload_states or not present
         ]
         if len(children) == 0:
             return best_child
-        # if we have children we consider the current head advanced as a possible head 
+        # if we have children we consider the current head advanced as a possible head
         highest_child_slot = max(child.slot for child in children)
         children += [
             ChildNode(root=best_child.root, slot=best_child.slot + 1, is_payload_present=best_child.is_payload_present)
@@ -360,10 +360,10 @@ def get_head(store: Store) -> ChildNode:
         # Ties are then broken by favoring full blocks
         # Ties then broken by favoring block with lexicographically higher root
         new_best_child = max(children, key=lambda child: (
-            get_weight(store, child), 
+            get_weight(store, child),
             blocks[child.root].slot,
-            is_payload_present(store, child.root), 
-            child.is_payload_present, 
+            is_payload_present(store, child.root),
+            child.is_payload_present,
             child.root
         )
         )
@@ -376,7 +376,7 @@ def get_head(store: Store) -> ChildNode:
 
 ### Modified `on_block`
 
-*Note*: The handler `on_block` is modified to consider the pre `state` of the given consensus beacon block depending not only on the parent block root, but also on the parent blockhash. In addition we delay the checking of blob data availability until the processing of the execution payload. 
+*Note*: The handler `on_block` is modified to consider the pre `state` of the given consensus beacon block depending not only on the parent block root, but also on the parent blockhash. In addition we delay the checking of blob data availability until the processing of the execution payload.
 
 ```python
 def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
@@ -449,14 +449,14 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
 
 ### New `on_execution_payload`
 
-The handler `on_execution_payload` is called when the node receives a `SignedExecutionPayloadEnvelope` to sync. 
+The handler `on_execution_payload` is called when the node receives a `SignedExecutionPayloadEnvelope` to sync.
 
 ```python
 def on_execution_payload(store: Store, signed_envelope: SignedExecutionPayloadEnvelope) -> None:
     """
     Run ``on_execution_payload`` upon receiving a new execution payload.
     """
-    envelope = signed_envelope.message 
+    envelope = signed_envelope.message
     # The corresponding beacon block root needs to be known
     assert envelope.beacon_block_root in store.block_states
 
@@ -472,7 +472,7 @@ def on_execution_payload(store: Store, signed_envelope: SignedExecutionPayloadEn
 
     # Add new state for this payload to the store
     store.execution_payload_states[envelope.beacon_block_root] = state
-```   
+```
 
 ### `seconds_into_slot`
 
@@ -497,7 +497,7 @@ def on_tick_per_slot(store: Store, time: uint64) -> None:
     # If this is a new slot, reset store.proposer_boost_root
     if current_slot > previous_slot:
         store.proposer_boost_root = Root()
-    else: 
+    else:
         # Reset the payload boost if this is the attestation time
         if seconds_into_slot(store) >= SECONDS_PER_SLOT // INTERVALS_PER_SLOT:
             store.payload_withhold_boost_root = Root()
@@ -534,7 +534,7 @@ def on_payload_attestation_message(
         assert data.slot == get_current_slot(store)
         # Verify the signature
         assert is_valid_indexed_payload_attestation(
-            state, 
+            state,
             IndexedPayloadAttestation(
                 attesting_indices=[ptc_message.validator_index],
                 data=data,
@@ -545,7 +545,7 @@ def on_payload_attestation_message(
     ptc_index = ptc.index(ptc_message.validator_index)
     ptc_vote = store.ptc_vote[data.beacon_block_root]
     ptc_vote[ptc_index] = data.payload_status
-    
+
     # Only update payload boosts with attestations from a block if the block is for the current slot and it's early
     if is_from_block and data.slot + 1 != get_current_slot(store):
         return

--- a/specs/_features/eip7732/fork.md
+++ b/specs/_features/eip7732/fork.md
@@ -61,7 +61,7 @@ def compute_fork_version(epoch: Epoch) -> Version:
 
 ### Fork trigger
 
-TBD. This fork is defined for testing purposes, the EIP may be combined with other 
+TBD. This fork is defined for testing purposes, the EIP may be combined with other
 consensus-layer upgrade.
 For now, we assume the condition will be triggered at epoch `EIP7732_FORK_EPOCH`.
 

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -46,7 +46,6 @@ This document contains the consensus-layer networking specification for EIP7732.
 |------------------------|----------------|-------------------------------------------------------------------|
 | `MAX_REQUEST_PAYLOADS` | `2**7` (= 128) | Maximum number of execution payload envelopes in a single request |
 
-
 ### Containers
 
 #### `BlobSidecar`
@@ -67,7 +66,7 @@ class BlobSidecar(Container):
 
 ##### Modified `verify_blob_sidecar_inclusion_proof`
 
-`verify_blob_sidecar_inclusion_proof` is modified in EIP-7732 to account for the fact that the KZG commitments are included in the `ExecutionPayloadEnvelope` and no longer in the beacon block body. 
+`verify_blob_sidecar_inclusion_proof` is modified in EIP-7732 to account for the fact that the KZG commitments are included in the `ExecutionPayloadEnvelope` and no longer in the beacon block body.
 
 ```python
 def verify_blob_sidecar_inclusion_proof(blob_sidecar: BlobSidecar) -> bool:
@@ -121,7 +120,7 @@ EIP-7732 introduces new global topics for execution header, execution payload an
 
 [Modified in EIP-7732]
 
-The *type* of the payload of this topic changes to the (modified) `SignedBeaconBlock` found in [the Beacon Chain changes](./beacon-chain.md). 
+The *type* of the payload of this topic changes to the (modified) `SignedBeaconBlock` found in [the Beacon Chain changes](./beacon-chain.md).
 
 There are no new validations for this topic. However, all validations with regards to the `ExecutionPayload` are removed:
 
@@ -137,7 +136,7 @@ There are no new validations for this topic. However, all validations with regar
 And instead the following validations are set in place with the alias `header = signed_execution_payload_header.message`:
 
 - If `execution_payload` verification of block's execution payload parent by an execution node **is complete**:
-    - [REJECT] The block's execution payload parent (defined by `header.parent_block_hash`) passes all validation. 
+    - [REJECT] The block's execution payload parent (defined by `header.parent_block_hash`) passes all validation.
 - [REJECT] The block's parent (defined by `block.parent_root`) passes validation.
 
 ###### `execution_payload`
@@ -148,12 +147,12 @@ The following validations MUST pass before forwarding the `signed_execution_payl
 
 - _[IGNORE]_ The envelope's block root `envelope.block_root` has been seen (via both gossip and non-gossip sources) (a client MAY queue payload for processing once the block is retrieved).
 - _[IGNORE]_ The node has not seen another valid `SignedExecutionPayloadEnvelope` for this block root from this builder.
- 
-Let `block` be the block with `envelope.beacon_block_root`. 
+
+Let `block` be the block with `envelope.beacon_block_root`.
 Let `header` alias `block.body.signed_execution_payload_header.message` (notice that this can be obtained from the `state.signed_execution_payload_header`)
-- _[REJECT]_ `block` passes validation. 
-- _[REJECT]_ `envelope.builder_index == header.builder_index` 
-- if `envelope.payload_withheld == False` then 
+- _[REJECT]_ `block` passes validation.
+- _[REJECT]_ `envelope.builder_index == header.builder_index`
+- if `envelope.payload_withheld == False` then
     - _[REJECT]_ `payload.block_hash == header.block_hash`
 - _[REJECT]_ The builder signature, `signed_execution_payload_envelope.signature`, is valid with respect to the builder's public key.
 
@@ -163,14 +162,14 @@ This topic is used to propagate signed payload attestation message.
 
 The following validations MUST pass before forwarding the `payload_attestation_message` on the network, assuming the alias `data = payload_attestation_message.data`:
 
-- _[IGNORE]_ The message's slot is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e. `data.slot == current_slot`. 
-- _[REJECT]_ The message's payload status is a valid status, i.e. `data.payload_status < PAYLOAD_INVALID_STATUS`. 
-- _[IGNORE]_ The `payload_attestation_message` is the first valid message received from the validator with index `payload_attestation_message.validate_index`. 
-- _[IGNORE]_ The message's block `data.beacon_block_root` has been seen (via both gossip and non-gossip sources) (a client MAY queue attestation for processing once the block is retrieved. Note a client might want to request payload after). 
-- _[REJECT]_ The message's block `data.beacon_block_root` passes validation. 
-- _[REJECT]_ The message's validator index is within the payload committee in `get_ptc(state, data.slot)`. The `state` is the head state corresponding to processing the block up to the current slot as determined by the fork choice. 
-- _[REJECT]_ The message's signature of `payload_attestation_message.signature` is valid with respect to the validator index. 
-    
+- _[IGNORE]_ The message's slot is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e. `data.slot == current_slot`.
+- _[REJECT]_ The message's payload status is a valid status, i.e. `data.payload_status < PAYLOAD_INVALID_STATUS`.
+- _[IGNORE]_ The `payload_attestation_message` is the first valid message received from the validator with index `payload_attestation_message.validate_index`.
+- _[IGNORE]_ The message's block `data.beacon_block_root` has been seen (via both gossip and non-gossip sources) (a client MAY queue attestation for processing once the block is retrieved. Note a client might want to request payload after).
+- _[REJECT]_ The message's block `data.beacon_block_root` passes validation.
+- _[REJECT]_ The message's validator index is within the payload committee in `get_ptc(state, data.slot)`. The `state` is the head state corresponding to processing the block up to the current slot as determined by the fork choice.
+- _[REJECT]_ The message's signature of `payload_attestation_message.signature` is valid with respect to the validator index.
+
 ###### `execution_payload_header`
 
 This topic is used to propagate signed bids as `SignedExecutionPayloadHeader`.
@@ -182,8 +181,8 @@ The following validations MUST pass before forwarding the `signed_execution_payl
 - _[REJECT]_ The signed builder bid, `header.builder_index` is a valid, active, and non-slashed builder index in state.
 - _[IGNORE]_ The signed builder bid value, `header.value`, is less or equal than the builder's balance in state.  i.e. `MIN_BUILDER_BALANCE + header.value < state.builder_balances[header.builder_index]`.
 - _[IGNORE]_ `header.parent_block_hash` is the block hash of a known execution payload in fork choice.
-_ _[IGNORE]_ `header.parent_block_root` is the hash tree root of a known beacon block in fork choice. 
-- _[IGNORE]_ `header.slot` is the current slot or the next slot. 
+_ _[IGNORE]_ `header.parent_block_root` is the hash tree root of a known beacon block in fork choice.
+- _[IGNORE]_ `header.slot` is the current slot or the next slot.
 - _[REJECT]_ The builder signature, `signed_execution_payload_header_envelope.signature`, is valid with respect to the `header_envelope.builder_index`.
 
 ### The Req/Resp domain
@@ -220,8 +219,7 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 | `BELLATRIX_FORK_VERSION` | `bellatrix.SignedBeaconBlock` |
 | `CAPELLA_FORK_VERSION`   | `capella.SignedBeaconBlock`   |
 | `DENEB_FORK_VERSION`     | `deneb.SignedBeaconBlock`     |
-| `EIP7732_FORK_VERSION`   | `eip7732.SignedBeaconBlock`   | 
-
+| `EIP7732_FORK_VERSION`   | `eip7732.SignedBeaconBlock`   |
 
 ##### BlobSidecarsByRoot v2
 
@@ -233,7 +231,6 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 |--------------------------|-------------------------------|
 | `DENEB_FORK_VERSION`     | `deneb.BlobSidecar`           |
 | `EIP7732_FORK_VERSION`   | `eip7732.BlobSidecar`         |
-
 
 ##### ExecutionPayloadEnvelopesByRoot v1
 

--- a/specs/_features/eip7732/validator.md
+++ b/specs/_features/eip7732/validator.md
@@ -1,10 +1,10 @@
 # EIP-7732 -- Honest Validator
 
-This document represents the changes and additions to the Honest validator guide included in the EIP-7732 fork. 
+This document represents the changes and additions to the Honest validator guide included in the EIP-7732 fork.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents** 
+**Table of Contents**
 
 - [Validator assignment](#validator-assignment)
   - [Lookahead](#lookahead)
@@ -33,7 +33,7 @@ def get_ptc_assignment(
         validator_index: ValidatorIndex) -> Optional[Slot]:
     """
     Returns the slot during the requested epoch in which the validator with index `validator_index`
-    is a member of the PTC. Returns None if no assignment is found. 
+    is a member of the PTC. Returns None if no assignment is found.
     """
     next_epoch = Epoch(get_current_epoch(state) + 1)
     assert epoch <= next_epoch
@@ -49,23 +49,22 @@ def get_ptc_assignment(
 
 [New in EIP-7732]
 
-`get_ptc_assignment` should be called at the start of each epoch to get the assignment for the next epoch (`current_epoch + 1`). A validator should plan for future assignments by noting their assigned PTC slot. 
+`get_ptc_assignment` should be called at the start of each epoch to get the assignment for the next epoch (`current_epoch + 1`). A validator should plan for future assignments by noting their assigned PTC slot.
 
 ## Beacon chain responsibilities
 
 All validator responsibilities remain unchanged other than the following:
 
-- Proposers are no longer required to broadcast `BlobSidecar` objects, as this becomes a builder's duty. 
-- Some validators are selected per slot to become PTC members, these validators must broadcast `PayloadAttestationMessage` objects during the assigned slot before the deadline of `3 * SECONDS_PER_SLOT // INTERVALS_PER_SLOT` seconds into the slot. 
+- Proposers are no longer required to broadcast `BlobSidecar` objects, as this becomes a builder's duty.
+- Some validators are selected per slot to become PTC members, these validators must broadcast `PayloadAttestationMessage` objects during the assigned slot before the deadline of `3 * SECONDS_PER_SLOT // INTERVALS_PER_SLOT` seconds into the slot.
 
 ### Attestation
 
-Attestation duties are not changed for validators, however the attestation deadline is implicitly changed by the change in `INTERVALS_PER_SLOT`. 
+Attestation duties are not changed for validators, however the attestation deadline is implicitly changed by the change in `INTERVALS_PER_SLOT`.
 
 ### Sync Committee participations
 
-Sync committee duties are not changed for validators, however the submission deadline is implicitly changed by the change in `INTERVALS_PER_SLOT`. 
-
+Sync committee duties are not changed for validators, however the submission deadline is implicitly changed by the change in `INTERVALS_PER_SLOT`.
 
 ### Block proposal
 
@@ -74,32 +73,32 @@ Validators are still expected to propose `SignedBeaconBlock` at the beginning of
 #### Constructing the new `signed_execution_payload_header` field in  `BeaconBlockBody`
 
 To obtain `signed_execution_payload_header`, a block proposer building a block on top of a `state` must take the following actions:
-* Listen to the `execution_payload_header` gossip global topic and save an accepted `signed_execution_payload_header` from a builder. Proposer MAY obtain these signed messages by other off-protocol means. 
-* The `signed_execution_payload_header` must satisfy the verification conditions found in `process_execution_payload_header`, that is 
+* Listen to the `execution_payload_header` gossip global topic and save an accepted `signed_execution_payload_header` from a builder. Proposer MAY obtain these signed messages by other off-protocol means.
+* The `signed_execution_payload_header` must satisfy the verification conditions found in `process_execution_payload_header`, that is
     - The header signature must be valid
     - The builder balance can cover the header value
     - The header slot is for the proposal block slot
-    - The header parent block hash equals the state's `latest_block_hash`. 
+    - The header parent block hash equals the state's `latest_block_hash`.
     - The header parent block root equals the current block's `parent_root`.
 * Select one bid and set `body.signed_execution_payload_header = signed_execution_payload_header`
 
 #### Constructing the new `payload_attestations` field in  `BeaconBlockBody`
 
-Up to `MAX_PAYLOAD_ATTESTATIONS`, aggregate payload attestations can be included in the block. The validator will have to 
-* Listen to the `payload_attestation_message` gossip global topic 
+Up to `MAX_PAYLOAD_ATTESTATIONS`, aggregate payload attestations can be included in the block. The validator will have to
+* Listen to the `payload_attestation_message` gossip global topic
 * The payload attestations added must satisfy the verification conditions found in payload attestation gossip validation and payload attestation processing. This means
     - The `data.beacon_block_root` corresponds to `block.parent_root`.
-    - The slot of the parent block is exactly one slot before the proposing slot. 
-    - The signature of the payload attestation data message verifies correctly. 
-* The proposer needs to aggregate all payload attestations with the same data into a given `PayloadAttestation` object. For this it needs to fill the `aggregation_bits` field by using the relative position of the validator indices with respect to the PTC that is obtained from `get_ptc(state, block_slot - 1)`. 
-* The proposer should only include payload attestations that are consistent with the current block they are proposing. That is, if the previous block had a payload, they should only include attestations with `payload_status = PAYLOAD_PRESENT`. Proposers are penalized for attestations that are not-consistent with their view. 
+    - The slot of the parent block is exactly one slot before the proposing slot.
+    - The signature of the payload attestation data message verifies correctly.
+* The proposer needs to aggregate all payload attestations with the same data into a given `PayloadAttestation` object. For this it needs to fill the `aggregation_bits` field by using the relative position of the validator indices with respect to the PTC that is obtained from `get_ptc(state, block_slot - 1)`.
+* The proposer should only include payload attestations that are consistent with the current block they are proposing. That is, if the previous block had a payload, they should only include attestations with `payload_status = PAYLOAD_PRESENT`. Proposers are penalized for attestations that are not-consistent with their view.
 
 #### Blob sidecars
 The blob sidecars are no longer broadcast by the validator, and thus their construction is not necessary. This deprecates the corresponding sections from the honest validator guide in the Electra fork, moving them, albeit with some modifications, to the [honest Builder guide](./builder.md)
 
 ### Payload timeliness attestation
 
-Some validators are selected to submit payload timeliness attestations. Validators should call `get_ptc_assignment` at the beginning of an epoch to be prepared to submit their PTC attestations during the next epoch. 
+Some validators are selected to submit payload timeliness attestations. Validators should call `get_ptc_assignment` at the beginning of an epoch to be prepared to submit their PTC attestations during the next epoch.
 
 A validator should create and broadcast the `payload_attestation_message` to the global execution attestation subnet not after `SECONDS_PER_SLOT * 3 / INTERVALS_PER_SLOT` seconds since the start of `slot`
 
@@ -109,9 +108,9 @@ If a validator is in the payload attestation committee for the current slot (as 
 according to the logic in `get_payload_attestation_message` below and broadcast it not after  `SECONDS_PER_SLOT * 3 / INTERVALS_PER_SLOT` seconds since the start of the slot, to the global `payload_attestation_message` pubsub topic.
 
 The validator creates `payload_attestation_message` as follows:
-* If the validator has not seen any beacon block for the assigned slot, do not submit a payload attestation. It will be ignored anyway. 
+* If the validator has not seen any beacon block for the assigned slot, do not submit a payload attestation. It will be ignored anyway.
 * Set `data.beacon_block_root` be the HTR of the beacon block seen for the assigned slot
-* Set `data.slot` to be the assigned slot. 
+* Set `data.slot` to be the assigned slot.
 * Set `data.payload_status` as follows
     - If a `SignedExecutionPayloadEnvelope` has been seen referencing the block `data.beacon_block_root` and the envelope has `payload_withheld = False`,  set to `PAYLOAD_PRESENT`.
     - If a `SignedExecutionPayloadEnvelope` has been seen referencing the block `data.beacon_block_root` and the envelope has `payload_withheld = True`,  set to `PAYLOAD_WITHHELD`.
@@ -119,7 +118,7 @@ The validator creates `payload_attestation_message` as follows:
 * Set `payload_attestation_message.validator_index = validator_index` where `validator_index` is the validator chosen to submit. The private key mapping to `state.validators[validator_index].pubkey` is used to sign the payload timeliness attestation.
 * Sign the `payload_attestation_message.data` using the helper `get_payload_attestation_message_signature`.
 
-Notice that the attester only signs the `PayloadAttestationData` and not the `validator_index` field in the message. Proposers need to aggregate these attestations as described above. 
+Notice that the attester only signs the `PayloadAttestationData` and not the `validator_index` field in the message. Proposers need to aggregate these attestations as described above.
 
 ```python
 def get_payload_attestation_message_signature(
@@ -129,6 +128,4 @@ def get_payload_attestation_message_signature(
     return bls.Sign(privkey, signing_root)
 ```
 
-**Remark** Validators do not need to check the full validity of the `ExecutionPayload` contained in within the envelope, but the checks in the [P2P guide](./p2p-interface.md) should pass for the `SignedExecutionPayloadEnvelope`. 
-
-
+**Remark** Validators do not need to check the full validity of the `ExecutionPayload` contained in within the envelope, but the checks in the [P2P guide](./p2p-interface.md) should pass for the `SignedExecutionPayloadEnvelope`.

--- a/specs/_features/eip7732/validator.md
+++ b/specs/_features/eip7732/validator.md
@@ -94,6 +94,7 @@ Up to `MAX_PAYLOAD_ATTESTATIONS`, aggregate payload attestations can be included
 * The proposer should only include payload attestations that are consistent with the current block they are proposing. That is, if the previous block had a payload, they should only include attestations with `payload_status = PAYLOAD_PRESENT`. Proposers are penalized for attestations that are not-consistent with their view.
 
 #### Blob sidecars
+
 The blob sidecars are no longer broadcast by the validator, and thus their construction is not necessary. This deprecates the corresponding sections from the honest validator guide in the Electra fork, moving them, albeit with some modifications, to the [honest Builder guide](./builder.md)
 
 ### Payload timeliness attestation

--- a/specs/_features/sharding/beacon-chain.md
+++ b/specs/_features/sharding/beacon-chain.md
@@ -45,7 +45,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
 
 This document describes the extensions made to the Phase 0 design of The Beacon Chain to support data sharding,
@@ -56,7 +55,6 @@ using KZG10 commitments to commit to data to remove any need for fraud proofs (a
 
 - **Data**: A list of KZG points, to translate a byte string into
 - **Blob**: Data with commitments and meta-data, like a flattened bundle of L2 transactions.
-
 
 ## Constants
 
@@ -82,7 +80,7 @@ The following values are (non-configurable) constants used throughout the specif
 | - | - | - |
 | `MAX_SHARDS` | `uint64(2**12)` (= 4,096) | Theoretical max shard count (used to determine data structure sizes) |
 | `ACTIVE_SHARDS` | `uint64(2**8)` (= 256) | Initial shard count |
-| `MAX_PROPOSER_BLOCKS_BETWEEN_BUILDER_BLOCKS` | `uint64(2**4)` (= 16) | TODO: Need to define what happens if there were more blocks without builder blocks | 
+| `MAX_PROPOSER_BLOCKS_BETWEEN_BUILDER_BLOCKS` | `uint64(2**4)` (= 16) | TODO: Need to define what happens if there were more blocks without builder blocks |
 
 ### Time parameters
 
@@ -100,7 +98,7 @@ With the introduction of builder blocks the number of slots per epoch is doubled
 
 ## Configuration
 
-Note: Some preset variables may become run-time configurable for testnets, but default to a preset while the spec is unstable.  
+Note: Some preset variables may become run-time configurable for testnets, but default to a preset while the spec is unstable.
 E.g. `ACTIVE_SHARDS` and `SAMPLES_PER_BLOB`.
 
 ### Time parameters
@@ -129,12 +127,12 @@ class BuilderBlockBid(Container):
     bid: Gwei # Block builder bid paid to proposer
 
     validator_index: ValidatorIndex # Validator index for this bid
-    
+
     # Block builders use an Eth1 address -- need signature as
     # block bid and data gas base fees will be charged to this address
     signature_y_parity: bool
     signature_r: uint256
-    signature_s: uint256    
+    signature_s: uint256
 ```
 
 #### `BuilderBlockBidWithRecipientAddress`
@@ -156,7 +154,7 @@ class ShardedCommitmentsContainer(Container):
 
     # The sizes of the blocks encoded in the commitments (last builder and all beacon blocks since)
     included_block_sizes: List[uint64, MAX_PROPOSER_BLOCKS_BETWEEN_BUILDER_BLOCKS + 1]
-    
+
     # Number of commitments that are for sharded data (no blocks)
     included_sharded_data_commitments: uint64
 
@@ -192,7 +190,7 @@ class BeaconState(bellatrix.BeaconState):
 class BuilderBlockData(Container):
     execution_payload: ExecutionPayload
     sharded_commitments_container: ShardedCommitmentsContainer
-```    
+```
 
 #### `BeaconBlockBody`
 

--- a/specs/_features/sharding/polynomial-commitments.md
+++ b/specs/_features/sharding/polynomial-commitments.md
@@ -44,7 +44,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
 
 This document specifies basic polynomial operations and KZG polynomial commitment operations as they are needed for the sharding specification. The implementations are not optimized for performance, but readability. All practical implementations should optimize the polynomial operations, and hints what the best known algorithms for these implementations are included below.
@@ -57,7 +56,6 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 | - | - | - |
 | `BLS_MODULUS` | `0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001` (curve order of BLS12_381) |
 | `PRIMITIVE_ROOT_OF_UNITY` | `7` | Primitive root of unity of the BLS12_381 (inner) BLS_MODULUS |
-
 
 ### KZG Trusted setup
 
@@ -203,7 +201,7 @@ def low_degree_check(commitments: List[KZGCommitment]):
         coefs.append( - (r_to_K - 1) * bls_modular_inverse(K * roots[i * (K - 1) % K] * (r - roots[i])) % BLS_MODULUS)
     for i in range(d + 1):
         coefs[i] = (coefs[i] + B(r) * bls_modular_inverse(Bprime(r) * (r - roots[i]))) % BLS_MODULUS
-    
+
     assert elliptic_curve_lincomb(commitments, coefs) == bls.inf_G1()
 ```
 
@@ -259,7 +257,6 @@ def multiply_polynomials(a: BLSPolynomialByCoefficients, b: BLSPolynomialByCoeff
     return r
 ```
 
-
 #### `interpolate_polynomial`
 
 ```python
@@ -279,7 +276,7 @@ def interpolate_polynomial(xs: List[BLSFieldElement], ys: List[BLSFieldElement])
                     summand, [weight_adjustment, ((BLS_MODULUS - weight_adjustment) * xs[i])]
                 )
         r = add_polynomials(r, summand)
-    
+
     return r
 ```
 
@@ -300,7 +297,7 @@ def evaluate_polynomial_in_evaluation_form(poly: BLSPolynomialByEvaluations, x: 
         return r
 
     def Aprime(z):
-        return field_elements_per_blob * pow(z, field_elements_per_blob - 1, BLS_MODULUS) 
+        return field_elements_per_blob * pow(z, field_elements_per_blob - 1, BLS_MODULUS)
 
     r = 0
     inverses = [bls_modular_inverse(z - x) for z in roots]
@@ -312,7 +309,7 @@ def evaluate_polynomial_in_evaluation_form(poly: BLSPolynomialByEvaluations, x: 
 
 ## KZG Operations
 
-We are using the KZG10 polynomial commitment scheme (Kate, Zaverucha and Goldberg, 2010: https://www.iacr.org/archive/asiacrypt2010/6477178/6477178.pdf).  
+We are using the KZG10 polynomial commitment scheme (Kate, Zaverucha and Goldberg, 2010: https://www.iacr.org/archive/asiacrypt2010/6477178/6477178.pdf).
 
 ### Elliptic curve helper functions
 
@@ -387,7 +384,7 @@ def verify_kzg_multiproof(commitment: KZGCommitment,
 ```python
 def verify_degree_proof(commitment: KZGCommitment, degree_bound: uint64, proof: KZGCommitment):
     """
-    Verifies that the commitment is of polynomial degree < degree_bound. 
+    Verifies that the commitment is of polynomial degree < degree_bound.
     """
 
     assert (

--- a/specs/_features/whisk/beacon-chain.md
+++ b/specs/_features/whisk/beacon-chain.md
@@ -96,7 +96,7 @@ def bytes_to_bls_field(b: Bytes32) -> BLSFieldElement:
 | --------------------- | ------------------------------------------------------------------------------- |
 | `BLS_G1_GENERATOR`    | `BLSG1Point('0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb')  # noqa: E501` |
 | `BLS_MODULUS`         | `52435875175126190479447740508185965837690552500527637822603658699938581184513` |
-| `CURDLEPROOFS_CRS`    | TBD | 
+| `CURDLEPROOFS_CRS`    | TBD |
 
 ### Curdleproofs and opening proofs
 
@@ -423,7 +423,7 @@ def add_validator_to_registry(state: BeaconState,
     # [New in Whisk]
     k = get_unique_whisk_k(state, ValidatorIndex(len(state.validators) - 1))
     state.whisk_trackers.append(get_initial_tracker(k))
-    state.whisk_k_commitments.append(get_k_commitment(k)) 
+    state.whisk_k_commitments.append(get_k_commitment(k))
 ```
 
 ### `get_beacon_proposer_index`

--- a/specs/_features/whisk/fork.md
+++ b/specs/_features/whisk/fork.md
@@ -19,7 +19,6 @@
 
 This document describes the process of Whisk upgrade.
 
-
 ```
 """
     WHISK_FORK_EPOCH

--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -1,7 +1,5 @@
 # Altair Light Client -- Full Node
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/altair/light-client/light-client.md
+++ b/specs/altair/light-client/light-client.md
@@ -1,7 +1,5 @@
 # Altair Light Client -- Light Client
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/altair/light-client/p2p-interface.md
+++ b/specs/altair/light-client/p2p-interface.md
@@ -1,7 +1,5 @@
 # Altair Light Client -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -1,7 +1,5 @@
 # Altair Light Client -- Sync Protocol
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -1,12 +1,5 @@
 # Altair -- Networking
 
-This document contains the networking specification for Altair.
-This document should be viewed as additive to the [document from Phase 0](../phase0/p2p-interface.md) and will be referred to as the "Phase 0 document" hereafter.
-Readers should understand the Phase 0 document and use it as a basis to understand the changes outlined in this document.
-
-Altair adds new messages, topics and data to the Req-Resp, Gossip and Discovery domain. Some Phase 0 features will be deprecated, but not removed immediately.
-
-
 ## Table of contents
 
 <!-- TOC -->
@@ -38,6 +31,14 @@ Altair adds new messages, topics and data to the Req-Resp, Gossip and Discovery 
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
+
+## Introduction
+
+This document contains the networking specification for Altair.
+This document should be viewed as additive to the [document from Phase 0](../phase0/p2p-interface.md) and will be referred to as the "Phase 0 document" hereafter.
+Readers should understand the Phase 0 document and use it as a basis to understand the changes outlined in this document.
+
+Altair adds new messages, topics and data to the Req-Resp, Gossip and Discovery domain. Some Phase 0 features will be deprecated, but not removed immediately.
 
 ## Modifications in Altair
 

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -1,6 +1,7 @@
 # Bellatrix -- Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -1,11 +1,5 @@
 # Bellatrix -- Networking
 
-This document contains the networking specification for the Bellatrix.
-
-The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite. This document should be viewed as additive to the documents from [Phase 0](../phase0/p2p-interface.md) and from [Altair](../altair/p2p-interface.md)
-and will be referred to as the "Phase 0 document" and "Altair document" respectively, hereafter.
-Readers should understand the Phase 0 and Altair documents and use them as a basis to understand the changes outlined in this document.
-
 ## Table of contents
 
 <!-- TOC -->
@@ -31,6 +25,14 @@ Readers should understand the Phase 0 and Altair documents and use them as a bas
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
+
+## Introduction
+
+This document contains the networking specification for the Bellatrix.
+
+The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite. This document should be viewed as additive to the documents from [Phase 0](../phase0/p2p-interface.md) and from [Altair](../altair/p2p-interface.md)
+and will be referred to as the "Phase 0 document" and "Altair document" respectively, hereafter.
+Readers should understand the Phase 0 and Altair documents and use them as a basis to understand the changes outlined in this document.
 
 ## Modifications in Bellatrix
 
@@ -146,7 +148,7 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 
 With the addition of `ExecutionPayload` to `BeaconBlock`s, there is a dynamic
 field -- `transactions` -- which can validly exceed the `GOSSIP_MAX_SIZE` limit (1 MiB) put in
-place at Phase 0, so GOSSIP_MAX_SIZE has increased to 10 Mib on the network. 
+place at Phase 0, so GOSSIP_MAX_SIZE has increased to 10 Mib on the network.
 At the `GAS_LIMIT` (~30M) currently seen on mainnet in 2021, a single transaction
 filled entirely with data at a cost of 16 gas per byte can create a valid
 `ExecutionPayload` of ~2 MiB. Thus we need a size limit to at least account for

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -124,7 +124,6 @@ To obtain an execution payload, a block proposer building a block on top of a `s
     * `finalized_block_hash` is the block hash of the latest finalized execution payload (`Hash32()` if none yet finalized)
     * `suggested_fee_recipient` is the value suggested to be used for the `fee_recipient` field of the execution payload
 
-
 ```python
 def prepare_execution_payload(state: BeaconState,
                               safe_block_hash: Hash32,

--- a/specs/capella/fork-choice.md
+++ b/specs/capella/fork-choice.md
@@ -1,6 +1,7 @@
 # Capella -- Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/capella/fork.md
+++ b/specs/capella/fork.md
@@ -27,7 +27,6 @@ This document describes the process of the Capella upgrade.
 | `CAPELLA_FORK_VERSION` | `Version('0x03000000')` |
 | `CAPELLA_FORK_EPOCH` | `Epoch(194048)` (April 12, 2023, 10:27:35pm UTC) |
 
-
 ## Helper functions
 
 ### Misc

--- a/specs/capella/light-client/full-node.md
+++ b/specs/capella/light-client/full-node.md
@@ -1,7 +1,5 @@
 # Capella Light Client -- Full Node
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/capella/light-client/p2p-interface.md
+++ b/specs/capella/light-client/p2p-interface.md
@@ -1,7 +1,5 @@
 # Capella Light Client -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/capella/light-client/sync-protocol.md
+++ b/specs/capella/light-client/sync-protocol.md
@@ -1,7 +1,5 @@
 # Capella Light Client -- Sync Protocol
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -1,10 +1,6 @@
 # Capella -- Networking
 
-This document contains the networking specification for Capella.
-
-The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite.
-
-### Table of contents
+## Table of contents
 
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -25,6 +21,11 @@ The specification of these changes continues in the same format as the network s
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
+## Introduction
+
+This document contains the networking specification for Capella.
+
+The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite.
 
 ## Modifications in Capella
 

--- a/specs/capella/validator.md
+++ b/specs/capella/validator.md
@@ -110,7 +110,7 @@ Validator balances are withdrawn periodically via an automatic process. For exit
 There is one prerequisite for this automated process:
 the validator's withdrawal credentials pointing to an execution layer address, i.e. having an `ETH1_ADDRESS_WITHDRAWAL_PREFIX`.
 
-If a validator has a `BLS_WITHDRAWAL_PREFIX` withdrawal credential prefix, to participate in withdrawals the validator must 
+If a validator has a `BLS_WITHDRAWAL_PREFIX` withdrawal credential prefix, to participate in withdrawals the validator must
 create a one-time message to change their withdrawal credential from the version authenticated with a BLS key to the
 version compatible with the execution layer. This message -- a `BLSToExecutionChange` -- is available starting in Capella
 

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -1,6 +1,7 @@
 # Deneb -- Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/deneb/light-client/full-node.md
+++ b/specs/deneb/light-client/full-node.md
@@ -1,7 +1,5 @@
 # Deneb Light Client -- Full Node
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/deneb/light-client/p2p-interface.md
+++ b/specs/deneb/light-client/p2p-interface.md
@@ -1,7 +1,5 @@
 # Deneb Light Client -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/deneb/light-client/sync-protocol.md
+++ b/specs/deneb/light-client/sync-protocol.md
@@ -1,7 +1,5 @@
 # Deneb Light Client -- Sync Protocol
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -1,9 +1,5 @@
 # Deneb -- Networking
 
-This document contains the consensus-layer networking specification for Deneb.
-
-The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite.
-
 ## Table of contents
 
 <!-- TOC -->
@@ -40,6 +36,12 @@ The specification of these changes continues in the same format as the network s
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
+
+## Introduction
+
+This document contains the consensus-layer networking specification for Deneb.
+
+The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite.
 
 ## Modifications in Deneb
 

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -150,7 +150,6 @@ def bit_reversal_permutation(sequence: Sequence[T]) -> Sequence[T]:
 
 ### BLS12-381 helpers
 
-
 #### `multi_exp`
 
 This function performs a multi-scalar multiplication between `points` and `integers`. `points` can either be in G1 or G2.
@@ -381,7 +380,6 @@ def verify_kzg_proof(commitment_bytes: Bytes48,
                                  bytes_to_kzg_proof(proof_bytes))
 ```
 
-
 #### `verify_kzg_proof_impl`
 
 ```python
@@ -438,7 +436,7 @@ def verify_kzg_proof_batch(commitments: Sequence[KZGCommitment],
                   for commitment, y in zip(commitments, ys)]
     C_minus_y_as_KZGCommitments = [KZGCommitment(bls.G1_to_bytes48(x)) for x in C_minus_ys]
     C_minus_y_lincomb = g1_lincomb(C_minus_y_as_KZGCommitments, r_powers)
-    
+
     return bls.pairing_check([
         [bls.bytes48_to_G1(proof_lincomb), bls.neg(bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[1]))],
         [bls.add(bls.bytes48_to_G1(C_minus_y_lincomb), bls.bytes48_to_G1(proof_z_lincomb)), bls.G2()]

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -994,7 +994,7 @@ def notify_new_payload(self: ExecutionEngine,
                        parent_beacon_block_root: Root,
                        execution_requests_list: list[bytes]) -> bool:
     """
-    Return ``True`` if and only if ``execution_payload`` and ``execution_requests`` 
+    Return ``True`` if and only if ``execution_payload`` and ``execution_requests``
     are valid with respect to ``self.execution_state``.
     """
     ...

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -1,8 +1,6 @@
 # Electra -- Networking
 
-This document contains the consensus-layer networking specification for Electra.
-
-The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite.
+**Notice**: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -20,6 +18,12 @@ The specification of these changes continues in the same format as the network s
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
+
+## Introduction
+
+This document contains the consensus-layer networking specification for Electra.
+
+The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite.
 
 ## Modifications in Electra
 

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1,6 +1,7 @@
 # Phase 0 -- The Beacon Chain
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -1420,24 +1421,20 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
     return Gwei(effective_balance * BASE_REWARD_FACTOR // integer_squareroot(total_balance) // BASE_REWARDS_PER_EPOCH)
 ```
 
-
 ```python
 def get_proposer_reward(state: BeaconState, attesting_index: ValidatorIndex) -> Gwei:
     return Gwei(get_base_reward(state, attesting_index) // PROPOSER_REWARD_QUOTIENT)
 ```
-
 
 ```python
 def get_finality_delay(state: BeaconState) -> uint64:
     return get_previous_epoch(state) - state.finalized_checkpoint.epoch
 ```
 
-
 ```python
 def is_in_inactivity_leak(state: BeaconState) -> bool:
     return get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
 ```
-
 
 ```python
 def get_eligible_validator_indices(state: BeaconState) -> Sequence[ValidatorIndex]:

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1627,6 +1627,7 @@ def process_slashings(state: BeaconState) -> None:
 ```
 
 #### Eth1 data votes updates
+
 ```python
 def process_eth1_data_reset(state: BeaconState) -> None:
     next_epoch = Epoch(get_current_epoch(state) + 1)
@@ -1672,6 +1673,7 @@ def process_randao_mixes_reset(state: BeaconState) -> None:
 ```
 
 #### Historical roots updates
+
 ```python
 def process_historical_roots_update(state: BeaconState) -> None:
     # Set historical root accumulator

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -1,6 +1,7 @@
 # Phase 0 -- Deposit Contract
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -1,6 +1,7 @@
 # Phase 0 -- Beacon Chain Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -78,7 +79,6 @@ Any of the above handlers that trigger an unhandled exception (e.g. a failed ass
 3) **Eth1 data**: The large `ETH1_FOLLOW_DISTANCE` specified in the [honest validator document](./validator.md) should ensure that `state.latest_eth1_data` of the canonical beacon chain remains consistent with the canonical Ethereum proof-of-work chain. If not, emergency manual intervention will be required.
 4) **Manual forks**: Manual forks may arbitrarily change the fork choice rule but are expected to be enacted at epoch transitions, with the fork details reflected in `state.fork`.
 5) **Implementation**: The implementation found in this specification is constructed for ease of understanding rather than for optimization in computation, space, or any other resource. A number of optimized alternatives can be found [here](https://github.com/protolambda/lmd-ghost).
-
 
 ### Constant
 
@@ -559,7 +559,6 @@ def on_tick_per_slot(store: Store, time: uint64) -> None:
 
 #### `on_attestation` helpers
 
-
 ##### `validate_target_epoch_against_current_time`
 
 ```python
@@ -626,7 +625,6 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
         if i not in store.latest_messages or target.epoch > store.latest_messages[i].epoch:
             store.latest_messages[i] = LatestMessage(epoch=target.epoch, root=beacon_block_root)
 ```
-
 
 ### Handlers
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -412,12 +412,14 @@ def update_unrealized_checkpoints(store: Store, unrealized_justified_checkpoint:
 _Implementing these helpers is optional_.
 
 ##### `is_head_late`
+
 ```python
 def is_head_late(store: Store, head_root: Root) -> bool:
     return not store.block_timeliness[head_root]
 ```
 
 ##### `is_shuffling_stable`
+
 ```python
 def is_shuffling_stable(slot: Slot) -> bool:
     return slot % SLOTS_PER_EPOCH != 0

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1,15 +1,7 @@
 # Phase 0 -- Networking
 
-This document contains the networking specification for Phase 0.
-
-It consists of four main sections:
-
-1. A specification of the network fundamentals.
-2. A specification of the three network interaction *domains* of the proof-of-stake consensus layer: (a) the gossip domain, (b) the discovery domain, and (c) the Req/Resp domain.
-3. The rationale and further explanation for the design choices made in the previous two sections.
-4. An analysis of the maturity/state of the libp2p features required by this spec across the languages in which clients are being developed.
-
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -113,6 +105,17 @@ It consists of four main sections:
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
+
+## Introduction
+
+This document contains the networking specification for Phase 0.
+
+It consists of four main sections:
+
+1. A specification of the network fundamentals.
+2. A specification of the three network interaction *domains* of the proof-of-stake consensus layer: (a) the gossip domain, (b) the discovery domain, and (c) the Req/Resp domain.
+3. The rationale and further explanation for the design choices made in the previous two sections.
+4. An analysis of the maturity/state of the libp2p features required by this spec across the languages in which clients are being developed.
 
 ## Network fundamentals
 
@@ -393,7 +396,6 @@ The following validations MUST pass before forwarding the `signed_aggregate_and_
   `get_checkpoint_block(store, aggregate.data.beacon_block_root, finalized_checkpoint.epoch)
   == store.finalized_checkpoint.root`
 
-
 ###### `voluntary_exit`
 
 The `voluntary_exit` topic is used solely for propagating signed voluntary validator exits to proposers on the network.
@@ -467,8 +469,6 @@ The following validations MUST pass before forwarding the `attestation` on the s
 - _[IGNORE]_ The current `finalized_checkpoint` is an ancestor of the `block` defined by `attestation.data.beacon_block_root` -- i.e.
   `get_checkpoint_block(store, attestation.data.beacon_block_root, store.finalized_checkpoint.epoch)
   == store.finalized_checkpoint.root`
-
-
 
 ##### Attestations and Aggregation
 
@@ -1300,7 +1300,6 @@ Some examples of where messages could be duplicated:
   does not provide enough responsiveness during adverse conditions.
 - `seen_ttl`: `SLOTS_PER_EPOCH * SECONDS_PER_SLOT / heartbeat_interval = approx. 550`.
   Attestation gossip validity is bounded by an epoch, so this is the safe max bound.
-
 
 #### Why is there `MAXIMUM_GOSSIP_CLOCK_DISPARITY` when validating slot ranges of messages in gossip subnets?
 

--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -86,9 +86,9 @@ A detailed analysis of the calculation of the weak subjectivity period is made i
 ```python
 def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
     """
-    Returns the weak subjectivity period for the current ``state``. 
+    Returns the weak subjectivity period for the current ``state``.
     This computation takes into account the effect of:
-        - validator set churn (bounded by ``get_validator_churn_limit()`` per epoch), and 
+        - validator set churn (bounded by ``get_validator_churn_limit()`` per epoch), and
         - validator balance top-ups (bounded by ``MAX_DEPOSITS * SLOTS_PER_EPOCH`` per epoch).
     A detailed calculation can be found at:
     https://github.com/runtimeverification/beacon-chain-verification/blob/master/weak-subjectivity/weak-subjectivity-analysis.pdf
@@ -113,7 +113,7 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
         ws_period += (
             3 * N * D * t // (200 * Delta * (T - t))
         )
-    
+
     return ws_period
 ```
 

--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -3,6 +3,7 @@
 **Notice**: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -71,7 +72,7 @@ Note that the generalized index has the convenient property that the two childre
 ```python
 def merkle_tree(leaves: Sequence[Bytes32]) -> Sequence[Bytes32]:
     """
-    Return an array representing the tree nodes by generalized index: 
+    Return an array representing the tree nodes by generalized index:
     [0, 1, 2, 3, 4, 5, 6, 7], where each layer is a power of 2. The 0 index is ignored. The 1 index is the root.
     The result will be twice the size as the padded bottom layer for the input leaves.
     """

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -41,6 +41,7 @@
 | `BITS_PER_BYTE` | `8` | Number of bits per byte. |
 
 ## Typing
+
 ### Basic types
 
 * `uintN`: `N`-bit unsigned integer (where `N in [8, 16, 32, 64, 128, 256]`)
@@ -88,6 +89,7 @@ For convenience we alias:
 Aliases are semantically equivalent to their underlying type and therefore share canonical representations both in SSZ and in related formats.
 
 ### Default values
+
 Assuming a helper function `default(type)` which returns the default value for `type`, we can recursively define the default value for all types.
 
 | Type | Default Value |

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -1,6 +1,7 @@
 # SimpleSerialize (SSZ)
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -1,6 +1,7 @@
 # Optimistic Sync
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -326,7 +327,7 @@ optimistic blocks (and vice-versa).
 
 ### Why sync optimistically?
 
-Most execution engines use state sync as a default sync mechanism on Ethereum Mainnet 
+Most execution engines use state sync as a default sync mechanism on Ethereum Mainnet
 because executing blocks from genesis takes several weeks on commodity hardware.
 
 State sync requires the knowledge of the current head of the chain to converge eventually.

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,7 +15,7 @@ Use an OS that has Python 3.8 or above. For example, Debian 11 (bullseye)
    git clone https://github.com/ethereum/consensus-specs.git
    cd consensus-specs
    ```
-3. Create the specifications and tests:   
+3. Create the specifications and tests:
    ```sh
    make install_test
    make pyspec
@@ -25,14 +25,13 @@ To read more about creating the environment, [see here](core/pyspec/README.md).
 
 ### Running your first test
 
-
 1. Enter the virtual Python environment:
    ```sh
    cd ~/consensus-specs
    . venv/bin/activate
    ```
 2. Run a sanity check test against Altair fork:
-   ```sh 
+   ```sh
    cd tests/core/pyspec
    python -m pytest -k test_empty_block_transition --fork altair eth2spec
    ```
@@ -49,21 +48,20 @@ To read more about creating the environment, [see here](core/pyspec/README.md).
 
    =============================== warnings summary ===============================
    ../../../venv/lib/python3.9/site-packages/cytoolz/compatibility.py:2
-     /home/qbzzt1/consensus-specs/venv/lib/python3.9/site-packages/cytoolz/compatibility.py:2: 
-   DeprecationWarning: The toolz.compatibility module is no longer needed in Python 3 and has 
-   been deprecated. Please import these utilities directly from the standard library. This 
+     /home/qbzzt1/consensus-specs/venv/lib/python3.9/site-packages/cytoolz/compatibility.py:2:
+   DeprecationWarning: The toolz.compatibility module is no longer needed in Python 3 and has
+   been deprecated. Please import these utilities directly from the standard library. This
    module will be removed in a future release.
        warnings.warn("The toolz.compatibility module is no longer "
 
    -- Docs: https://docs.pytest.org/en/stable/warnings.html
-   ================ 3 passed, 626 deselected, 1 warning in 16.81s =================   
+   ================ 3 passed, 626 deselected, 1 warning in 16.81s =================
    ```
-
 
 ## The "Hello, World" of Consensus Spec Tests
 
 One of the `test_empty_block_transition` tests is implemented by a function with the same
-name located in 
+name located in
 [`~/consensus-specs/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py).
 To learn how consensus spec tests are written, let's go over the code:
 
@@ -94,10 +92,10 @@ This type of test receives two parameters:
 
 ```python
     pre_slot = state.slot
-```    
+```
 
 A slot is a unit of time (every 12 seconds in mainnet), for which a specific validator (selected randomly but in a
-deterministic manner) is a proposer. The proposer can propose a block during that slot. 
+deterministic manner) is a proposer. The proposer can propose a block during that slot.
 
 ```python
     pre_eth1_votes = len(state.eth1_data_votes)
@@ -143,15 +141,13 @@ More `yield` statements. The output of a consensus test is:
 5. `'post'`
 6. The state after the test
 
-
-
 ```python
     # One vote for the eth1
     assert len(state.eth1_data_votes) == pre_eth1_votes + 1
 
     # Check that the new parent root is correct
     assert spec.get_block_root_at_slot(state, pre_slot) == signed_block.message.parent_root
-    
+
     # Random data changed
     assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != pre_mix
 ```
@@ -160,16 +156,15 @@ Finally we assertions that test the transition was legitimate. In this case we h
 
 1. One item was added to `eth1_data_votes`
 2. The new block's `parent_root` is the same as the block in the previous location
-3. The random data that every block includes was changed. 
-
+3. The random data that every block includes was changed.
 
 ## New Tests
 
 The easiest way to write a new test is to copy and modify an existing one. For example,
-lets write a test where the first slot of the beacon chain is empty (because the assigned 
+lets write a test where the first slot of the beacon chain is empty (because the assigned
 proposer is offline, for example), and then there's an empty block in the second slot.
 
-We already know how to accomplish most of what we need for this test, but the only way we know 
+We already know how to accomplish most of what we need for this test, but the only way we know
 to advance the state is `state_transition_and_sign_block`, a function that also puts a block
 into the slot. So let's see if the function's definition tells us how to advance the state without
 a block.
@@ -180,7 +175,7 @@ First, we need to find out where the function is located. Run:
 find . -name '*.py' -exec grep 'def state_transition_and_sign_block' {} \; -print
 ```
 
-And you'll find that the function is defined in 
+And you'll find that the function is defined in
 [`eth2spec/test/helpers/state.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/state.py). Looking
 in that file, we see that the second function is:
 
@@ -193,7 +188,6 @@ def next_slot(spec, state):
 ```
 
 This looks like exactly what we need. So we add this call before we create the empty block:
-
 
 ```python
 .
@@ -209,16 +203,14 @@ This looks like exactly what we need. So we add this call before we create the e
 .
 ```
 
-That's it. Our new test works (copy `test_empty_block_transition`, rename it, add the `next_slot` call, and then run it to 
+That's it. Our new test works (copy `test_empty_block_transition`, rename it, add the `next_slot` call, and then run it to
 verify this).
-
-
 
 ## Tests Designed to Fail
 
 It is important to make sure that the system rejects invalid input, so our next step is to deal with cases where the protocol
 is supposed to reject something. To see such a test, look at `test_prev_slot_block_transition` (in the same
-file we used previously, 
+file we used previously,
 [`~/consensus-specs/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py)).
 
 ```python
@@ -249,7 +241,7 @@ Transition to the new slot, which naturally has a different proposer.
 ```
 
 Specify that the function `transition_unsigned_block` will cause an assertion error.
-You can see this function in 
+You can see this function in
 [`~/consensus-specs/tests/core/pyspec/eth2spec/test/helpers/block.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/block.py),
 and one of the tests is that the block must be for this slot:
 > ```python
@@ -265,14 +257,14 @@ be called later.
 ```
 
 Set the block's state root to the current state hash tree root, which identifies this block as
-belonging to this slot (even though it was created for the previous slot). 
+belonging to this slot (even though it was created for the previous slot).
 
-```python    
+```python
     signed_block = sign_block(spec, state, block, proposer_index=proposer_index)
 ```
 
 Notice that `proposer_index` is the variable we set earlier, *before* we advanced
-the slot with `spec.process_slots(state, state.slot + 1)`. It is not the proposer 
+the slot with `spec.process_slots(state, state.slot + 1)`. It is not the proposer
 for the current state.
 
 ```python
@@ -282,7 +274,6 @@ for the current state.
 
 This is the way we specify that a test is designed to fail - failed tests have no post state,
 because the processing mechanism errors out before creating it.
-
 
 ## Attestation Tests
 
@@ -296,13 +287,12 @@ includes the block hash of the proposed new head of the execution layer.
 
 For every slot there is also a randomly selected committee of validators that needs to vote whether
 the new consensus layer block is valid, which requires the proposed head of the execution chain to
-also be a valid block. These votes are called [attestations](https://notes.ethereum.org/@hww/aggregation#112-Attestation), 
-and they are sent as independent messages. The proposer for a block is able to include attestations from previous slots, 
+also be a valid block. These votes are called [attestations](https://notes.ethereum.org/@hww/aggregation#112-Attestation),
+and they are sent as independent messages. The proposer for a block is able to include attestations from previous slots,
 which is how they get on chain to form consensus, reward honest validators, etc.
 
 [You can see a simple successful attestation test here](https://github.com/ethereum/consensus-specs/blob/926e5a3d722df973b9a12f12c015783de35cafa9/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attestation.py#L26-L30):
 Lets go over it line by line.
-
 
 ```python
 @with_all_phases
@@ -315,7 +305,6 @@ def test_success(spec, state):
 creates a valid attestation (which can then be modified to make it invalid if needed).
 To see an attestion "from the inside" we need to follow it.
 
-
 > ```python
 >  def get_valid_attestation(spec,
 >                           state,
@@ -326,8 +315,8 @@ To see an attestion "from the inside" we need to follow it.
 > ```
 >
 > Only two parameters, `spec` and `state` are required. However, there are four other parameters that can affect
-> the attestation created by this function. 
-> 
+> the attestation created by this function.
+>
 >
 > ```python
 >     # If filter_participant_set filters everything, the attestation has 0 participants, and cannot be signed.
@@ -345,10 +334,10 @@ To see an attestion "from the inside" we need to follow it.
 >     attestation_data = build_attestation_data(
 >         spec, state, slot=slot, index=index
 >     )
-> ```   
+> ```
 >
-> Build the actual attestation. You can see this function 
-> [here](https://github.com/ethereum/consensus-specs/blob/30fe7ba1107d976100eb0c3252ca7637b791e43a/tests/core/pyspec/eth2spec/test/helpers/attestations.py#L53-L85) 
+> Build the actual attestation. You can see this function
+> [here](https://github.com/ethereum/consensus-specs/blob/30fe7ba1107d976100eb0c3252ca7637b791e43a/tests/core/pyspec/eth2spec/test/helpers/attestations.py#L53-L85)
 > to see the exact data in an attestation.
 >
 >  ```python
@@ -358,17 +347,17 @@ To see an attestion "from the inside" we need to follow it.
 >         attestation_data.index,
 >     )
 > ```
-> 
+>
 > This is the committee that is supposed to approve or reject the proposed block.
-> 
-> ```python    
-> 
+>
+> ```python
+>
 >     committee_size = len(beacon_committee)
 >     aggregation_bits = Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*([0] * committee_size))
 > ```
-> 
+>
 > There's a bit for every committee member to see if it approves or not.
-> 
+>
 > ```python
 >     attestation = spec.Attestation(
 >         aggregation_bits=aggregation_bits,
@@ -376,15 +365,15 @@ To see an attestion "from the inside" we need to follow it.
 >     )
 >     # fill the attestation with (optionally filtered) participants, and optionally sign it
 >     fill_aggregate_attestation(spec, state, attestation, signed=signed, filter_participant_set=filter_participant_set)
-> 
->    return attestation  
+>
+>    return attestation
 >  ```
 
 ```python
     next_slots(spec, state, spec.MIN_ATTESTATION_INCLUSION_DELAY)
 ```
 
-Attestations have to appear after the block they attest for, so we advance 
+Attestations have to appear after the block they attest for, so we advance
 `spec.MIN_ATTESTATION_INCLUSION_DELAY` slots before creating the block that includes the attestation.
 Currently a single block is sufficient, but that may change in the future.
 
@@ -392,9 +381,8 @@ Currently a single block is sufficient, but that may change in the future.
     yield from run_attestation_processing(spec, state, attestation)
 ```
 
-[This function](https://github.com/ethereum/consensus-specs/blob/30fe7ba1107d976100eb0c3252ca7637b791e43a/tests/core/pyspec/eth2spec/test/helpers/attestations.py#L13-L50) 
+[This function](https://github.com/ethereum/consensus-specs/blob/30fe7ba1107d976100eb0c3252ca7637b791e43a/tests/core/pyspec/eth2spec/test/helpers/attestations.py#L13-L50)
 processes the attestation and returns the result.
-
 
 ### Adding an Attestation Test
 
@@ -402,7 +390,6 @@ Attestations can't happen in the same block as the one about which they are atte
 after the block is finalized. This is specified as part of the specs, in the `process_attestation` function
 (which is created from the spec by the `make pyspec` command you ran earlier). Here is the relevant code
 fragment:
-
 
 ```python
 def process_attestation(state: BeaconState, attestation: Attestation) -> None:
@@ -419,15 +406,15 @@ In the last line you can see two conditions being asserted:
    arrive too early.
 2. `state.slot <= data.slot + SLOTS_PER_EPOCH` which verifies that the attestation doesn't
    arrive too late.
-   
+
 This is how the consensus layer tests deal with edge cases, by asserting the conditions required for the
-values to be legitimate. In the case of these particular conditions, they are tested 
+values to be legitimate. In the case of these particular conditions, they are tested
 [here](https://github.com/ethereum/consensus-specs/blob/926e5a3d722df973b9a12f12c015783de35cafa9/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attestation.py#L87-L104).
 One test checks what happens if the attestation is too early, and another if it is too late.
 
 However, it is not enough to ensure we reject invalid blocks. It is also necessary to ensure we accept all valid blocks. You saw earlier
-a test (`test_success`) that tested that being `MIN_ATTESTATION_INCLUSION_DELAY` after the data for which we attest is enough. 
-Now we'll write a similar test that verifies that being `SLOTS_PER_EPOCH` away is still valid. To do this, we modify the 
+a test (`test_success`) that tested that being `MIN_ATTESTATION_INCLUSION_DELAY` after the data for which we attest is enough.
+Now we'll write a similar test that verifies that being `SLOTS_PER_EPOCH` away is still valid. To do this, we modify the
 `test_after_epoch_slots` function. We need two changes:
 
 1. Call `transition_to_slot_via_block` with one less slot to advance
@@ -445,7 +432,7 @@ def test_almost_after_epoch_slots(spec, state):
     transition_to_slot_via_block(spec, state, state.slot + spec.SLOTS_PER_EPOCH)
 
     yield from run_attestation_processing(spec, state, attestation)
-```    
+```
 
 Add this function to the file `consensus-specs/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attestation.py`,
 and run the test against Altair fork:
@@ -463,7 +450,7 @@ You should see it ran successfully (although you might get a warning, you can ig
 
 So far we've ran tests against the formal specifications. This is a way to check the specifications
 are what we expect, but it doesn't actually check the beacon chain clients. The way these tests get applied
-by clients is that every few weeks 
+by clients is that every few weeks
 [new test specifications are released](https://github.com/ethereum/consensus-spec-tests/releases),
 in a format [documented here](https://github.com/ethereum/consensus-specs/tree/dev/tests/formats).
 All the consensus layer clients implement test-runners that consume the test vectors in this standard format.

--- a/tests/core/pyspec/README.md
+++ b/tests/core/pyspec/README.md
@@ -29,7 +29,6 @@ the distutils implementation of the `setup` runs `build`, which is extended to r
 but outputs into the standard `./build/lib` output.
 This enables the `consensus-specs` repository to be installed like any other python package.
 
-
 ## Py-tests
 
 These tests are not intended for client-consumption.
@@ -91,7 +90,6 @@ Building spec files from any markdown sources, to a custom location:
 
 Contributions are welcome, but consider implementing your idea as part of the spec itself first.
 The pyspec is not a replacement.
-
 
 ## License
 

--- a/tests/core/pyspec/eth2spec/config/README.md
+++ b/tests/core/pyspec/eth2spec/config/README.md
@@ -19,5 +19,5 @@ spec.config = spec.Configuration(**config_util.load_config_file(Path('mytestnet.
 ```
 
 Note: previously the testnet config files included both preset and runtime-configuration data.
-The new config loader is compatible with this: all config vars are loaded from the file, 
-but those that have become presets can be ignored. 
+The new config loader is compatible with this: all config vars are loaded from the file,
+but those that have become presets can be ignored.

--- a/tests/core/pyspec/eth2spec/gen_helpers/README.md
+++ b/tests/core/pyspec/eth2spec/gen_helpers/README.md
@@ -17,10 +17,10 @@ Options:
                    If true, all cases will run regardless, and files will be overwritten.
                    Other existing files are not deleted.
 
--c CONFIGS_PATH   -- The directory to load configs for pyspec from. A config is a simple key-value yaml file. 
+-c CONFIGS_PATH   -- The directory to load configs for pyspec from. A config is a simple key-value yaml file.
     Use `../../configs/` when running from the root dir of a generator, and requiring the standard spec configs.
 
-[-l [CONFIG_LIST [CONFIG_LIST ...]]]   -- Optional. Define which configs to run. 
+[-l [CONFIG_LIST [CONFIG_LIST ...]]]   -- Optional. Define which configs to run.
     Test providers loading other configs will be ignored. If none are specified, no config will be ignored.
 ```
 
@@ -45,10 +45,10 @@ The yielding pattern is:
 Test part output kinds:
 - `ssz`: value is expected to be a `bytes`, and the raw data is written to a `<key name>.ssz_snappy` file.
 - `data`: value is expected to be any Python object that can be dumped as YAML. Output is written to `<key name>.yaml`
-- `meta`: these key-value pairs are collected into a dict, and then collectively written to a metadata 
+- `meta`: these key-value pairs are collected into a dict, and then collectively written to a metadata
           file named `meta.yaml`, if anything is yielded with `meta` empty.
 
 The `vector_test()` decorator can detect pyspec SSZ types, and output them both as `data` and `ssz`, for the test consumer to choose.
 
-Note that the yielded outputs are processed before the test continues. It is safe to yield information that later mutates, 
+Note that the yielded outputs are processed before the test continues. It is safe to yield information that later mutates,
  as the output will already be encoded to yaml or ssz bytes. This avoids the need to deep-copy the whole object.

--- a/tests/formats/README.md
+++ b/tests/formats/README.md
@@ -3,6 +3,7 @@
 This document defines the YAML format and structure used for consensus spec testing.
 
 ## Table of contents
+
 <!-- TOC -->
 
 * [About](#about)
@@ -46,11 +47,10 @@ Test formats:
 - [`ssz_static`](./ssz_static/README.md)
 - More formats are planned, see tracking issues for CI/testing
 
-
 ## Glossary
 
 - `generator`: a program that outputs one or more test-cases, each organized into a `config > runner > handler > suite` hierarchy.
-- `config`: tests are grouped by configuration used for spec presets. In addition to the standard configurations, 
+- `config`: tests are grouped by configuration used for spec presets. In addition to the standard configurations,
   `general` may be used as a catch-all for tests not restricted to one configuration. (E.g. BLS).
 - `type`: the specialization of one single `generator`. E.g. epoch processing.
 - `runner`: where a generator is a *"producer"*, this is the *"consumer"*.
@@ -59,10 +59,10 @@ Test formats:
   To facilitate this, you specify a `handler`: the runner can deal with the format by using the specified handler.
 - `suite`: a directory containing test cases that are coherent. Each `suite` under the same `handler` shares the same format.
   This is an organizational/cosmetic hierarchy layer.
-- `case`: a test case, a directory in a `suite`. A case can be anything in general, 
+- `case`: a test case, a directory in a `suite`. A case can be anything in general,
   but its format should be well-defined in the documentation corresponding to the `type` (and `handler`).
 - `case part`: a test case consists of different files, possibly in different formats, to facilitate the specific test case format better.
-  Optionally, a `meta.yaml` is included to declare meta-data for the test, e.g. BLS requirements. 
+  Optionally, a `meta.yaml` is included to declare meta-data for the test, e.g. BLS requirements.
 
 ## Test format philosophy
 
@@ -70,12 +70,12 @@ Test formats:
 
 The configuration constant types are:
 - Never changing: genesis data.
-- Changing, but reliant on old value: e.g. an epoch time may change, but if you want to do the conversion 
+- Changing, but reliant on old value: e.g. an epoch time may change, but if you want to do the conversion
   `(genesis data, timestamp) -> epoch number`, you end up needing both constants.
 - Changing, but kept around during fork transition: finalization may take a while,
   e.g. an executable has to deal with new deposits and old deposits at the same time. Another example may be economic constants.
 - Additional, backwards compatible: new constants are introduced for later phases.
-- Changing: there is a very small chance some constant may really be *replaced*. 
+- Changing: there is a very small chance some constant may really be *replaced*.
   In this off-chance, it is likely better to include it as an additional variable,
   and some clients may simply stop supporting the old one if they do not want to sync from genesis.
   The change of functionality goes through a phase of deprecation of the old constant, and eventually only the new constant is kept around in the config (when old state is not supported anymore).
@@ -92,7 +92,6 @@ The aim is to provide clients with a well-defined scope of work to run a particu
 - Clients that are complete are expected to contribute to testing, seeking for better resources to get conformance with the spec, and other clients.
 - Clients that are not complete in functionality can choose to ignore suites that use certain test-runners, or specific handlers of these test-runners.
 - Clients that are on older versions can test their work based on older releases of the generated tests, and catch up with newer releases when possible.
-
 
 ## Test structure
 
@@ -152,12 +151,11 @@ Between all types of tests, a few formats are common:
 - **`.ssz_snappy`**: Like `.ssz`, but compressed with Snappy block compression.
   Snappy block compression is already applied to SSZ in consensus-layer gossip, available in client implementations, and thus chosen as compression method.
 
-
 #### Special output parts
 
 ##### `meta.yaml`
 
-If present (it is optional), the test is enhanced with extra data to describe usage. Specialized data is described in the documentation of the specific test format. 
+If present (it is optional), the test is enhanced with extra data to describe usage. Specialized data is described in the documentation of the specific test format.
 
 Common data is documented here:
 
@@ -181,7 +179,6 @@ The format matches that of the `mainnet_config.yaml` and `minimal_config.yaml`,
 see the [`/configs`](../../configs/README.md#format) documentation.
 Config values that are introduced at a later fork may be omitted from tests of previous forks.
 
-
 ## Config sourcing
 
 The constants configurations are located in:
@@ -198,14 +195,13 @@ And copied by CI for testing purposes to:
 
 The first `<config name>` is a directory, which contains exactly all tests that make use of the given config.
 
-
 ## Note for implementers
 
 The basic pattern for test-suite loading and running is:
 
 1. For a specific config, load it first (and only need to do so once),
     then continue with the tests defined in the config folder.
-2. Select a fork. Repeat for each fork if running tests for multiple forks.  
+2. Select a fork. Repeat for each fork if running tests for multiple forks.
 3. Select the category and specialization of interest (e.g. `operations > deposits`). Again, repeat for each if running all.
 4. Select a test suite. Or repeat for each.
 5. Select a test case. Or repeat for each.
@@ -213,4 +209,4 @@ The basic pattern for test-suite loading and running is:
 7. Run the test, as defined by the test format.
 
 Step 1 may be a step with compile time selection of a configuration, if desired for optimization.
-The base requirement is just to use the same set of constants, independent of the loading process. 
+The base requirement is just to use the same set of constants, independent of the loading process.

--- a/tests/formats/epoch_processing/README.md
+++ b/tests/formats/epoch_processing/README.md
@@ -25,7 +25,7 @@ An SSZ-snappy encoded `BeaconState`, the state after applying the epoch sub-tran
 
 ## Condition
 
-A handler of the `epoch_processing` test-runner should process these cases, 
+A handler of the `epoch_processing` test-runner should process these cases,
  calling the corresponding processing implementation (same name, prefixed with `process_`).
 This excludes the other parts of the epoch-transition.
 The provided pre-state is already transitioned to just before the specific sub-transition of focus of the handler.

--- a/tests/formats/finality/README.md
+++ b/tests/formats/finality/README.md
@@ -20,7 +20,6 @@ An SSZ-snappy encoded `BeaconState`, the state before running the block transiti
 
 Also available as `pre.ssz_snappy`.
 
-
 ### `blocks_<index>.yaml`
 
 A series of files, with `<index>` in range `[0, blocks_count)`. Blocks need to be processed in order,
@@ -33,7 +32,6 @@ Each block is also available as `blocks_<index>.ssz_snappy`
 ### `post.ssz_snappy`
 
 An SSZ-snappy encoded `BeaconState`, the state after applying the block transitions.
-
 
 ## Condition
 

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -3,6 +3,7 @@
 The aim of the fork choice tests is to provide test coverage of the various components of the fork choice.
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -90,7 +91,7 @@ The parameter that is required for executing `on_block(store, block)`.
     proofs: array of byte48 hex string -- optional, the proofs of blob commitments.
     valid: bool             -- optional, default to `true`.
                                If it's `false`, this execution step is expected to be invalid.
-}  
+}
 ```
 
 The file is located in the same folder (see below).

--- a/tests/formats/genesis/initialization.md
+++ b/tests/formats/genesis/initialization.md
@@ -11,7 +11,6 @@ eth1_block_hash: Bytes32  -- A `Bytes32` hex encoded, with prefix 0x. The root o
 eth1_timestamp: int       -- An integer. The timestamp of the block, in seconds.
 ```
 
-
 ### `meta.yaml`
 
 A yaml file to help read the deposit count:

--- a/tests/formats/genesis/validity.md
+++ b/tests/formats/genesis/validity.md
@@ -16,16 +16,13 @@ description: string    -- Optional. Description of test case, purely for debuggi
 
 An SSZ-snappy encoded `BeaconState`, the state to validate as genesis candidate.
 
-
 ### `is_valid.yaml`
 
 A boolean, true if the genesis state is deemed valid as to launch with, false otherwise.
 
-
 ## Processing
 
 To process the data, call `is_valid_genesis_state(genesis)`.
-
 
 ## Condition
 

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -24,7 +24,6 @@ An SSZ-snappy encoded operation object, e.g. a `ProposerSlashing`, or `Deposit`.
 
 An SSZ-snappy encoded `BeaconState`, the state after applying the operation. No value if operation processing is aborted.
 
-
 ## Condition
 
 A handler of the `operations` test-runner should process these cases,

--- a/tests/formats/rewards/README.md
+++ b/tests/formats/rewards/README.md
@@ -49,7 +49,7 @@ An SSZ-snappy encoded `Deltas` representing the rewards and penalties returned b
 
 ## Condition
 
-A handler of the `rewards` test-runner should process these cases, 
+A handler of the `rewards` test-runner should process these cases,
  calling the corresponding rewards deltas function for each set of deltas.
 
 The provided pre-state is ready to be input into each rewards deltas function.

--- a/tests/formats/sanity/blocks.md
+++ b/tests/formats/sanity/blocks.md
@@ -13,11 +13,9 @@ reveal_deadlines_setting: int  -- see general test-format spec.
 blocks_count: int              -- the number of blocks processed in this test.
 ```
 
-
 ### `pre.ssz_snappy`
 
 An SSZ-snappy encoded `BeaconState`, the state before running the block transitions.
-
 
 ### `blocks_<index>.ssz_snappy`
 
@@ -29,7 +27,6 @@ Each file is a SSZ-snappy encoded `SignedBeaconBlock`.
 ### `post.ssz_snappy`
 
 An SSZ-snappy encoded `BeaconState`, the state after applying the block transitions.
-
 
 ## Condition
 

--- a/tests/formats/sanity/slots.md
+++ b/tests/formats/sanity/slots.md
@@ -11,13 +11,11 @@ description: string    -- Optional. Description of test case, purely for debuggi
 bls_setting: int       -- see general test-format spec.
 ```
 
-
 ### `pre.ssz_snappy`
 
 An SSZ-snappy `BeaconState`, the state before running the transitions.
 
 Also available as `pre.ssz_snappy`.
-
 
 ### `slots.yaml`
 
@@ -28,7 +26,6 @@ An integer. The amount of slots to process (i.e. the difference in slots between
 An SSZ-snappy `BeaconState`, the state after applying the transitions.
 
 Also available as `post.ssz_snappy`.
-
 
 ### Processing
 

--- a/tests/formats/shuffling/README.md
+++ b/tests/formats/shuffling/README.md
@@ -35,4 +35,4 @@ I.e. `mapping[i]` is the shuffled location of `i`.
 ## Condition
 
 The resulting list should match the expected output after shuffling the implied input, using the given `seed`.
-The output is checked using the `mapping`, based on the shuffling test type (e.g. can be backwards shuffling). 
+The output is checked using the `mapping`, based on the shuffling test type (e.g. can be backwards shuffling).

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -23,7 +23,6 @@ The `ssz_generic` tests are split up into different handler, each specialized in
 - Containers
     - `containers`
 
-
 ## Format
 
 For each type, a `valid` and an `invalid` suite is implemented.
@@ -59,7 +58,7 @@ The object, encoded as a YAML structure. Using the same familiar encoding as YAM
 The conditions are the same for each type:
 
 - Encoding: After encoding the given `value` object, the output should match `serialized`.
-- Decoding: After decoding the given `serialized` bytes, it should match the `value` object. 
+- Decoding: After decoding the given `serialized` bytes, it should match the `value` object.
 - Hash-tree-root: the root should match the root declared in the metadata.
 
 ## `invalid`
@@ -73,7 +72,6 @@ The `serialized` data should simply not be decoded without raising an error.
 
 Note that for some type declarations in the invalid suite, the type itself may technically be invalid.
 This is a valid way of detecting `invalid` data too. E.g. a 0-length basic vector.
-
 
 ## Type declarations
 
@@ -97,7 +95,6 @@ Data:
 {length}: an unsigned integer
 ```
 
-
 ### `bitlist`
 
 ```
@@ -109,7 +106,6 @@ Data:
 
 {limit}: the list limit, in bits, of the bitlist. Does not include the length-delimiting bit in the serialized form.
 ```
-
 
 ### `bitvector`
 
@@ -154,7 +150,6 @@ Data:
 ```
 
 ```python
-
 class SingleFieldTestStruct(Container):
     A: byte
 

--- a/tests/formats/ssz_static/core.md
+++ b/tests/formats/ssz_static/core.md
@@ -34,7 +34,6 @@ The SSZ-snappy encoded bytes.
 
 The same value as `serialized.ssz_snappy`, represented as YAML.
 
-
 ## Condition
 
 A test-runner can implement the following assertions:
@@ -42,10 +41,9 @@ A test-runner can implement the following assertions:
     - Serialization: After parsing the `value`, SSZ-serialize it: the output should match `serialized`
     - Deserialization: SSZ-deserialize the `serialized` value, and see if it matches the parsed `value`
 - If YAML decoding of SSZ objects is not supported by the implementation:
-    - Serialization in 2 steps: deserialize `serialized`, then serialize the result, 
+    - Serialization in 2 steps: deserialize `serialized`, then serialize the result,
        and verify if the bytes match the original `serialized`.
 - Hash-tree-root: After parsing the `value` (or deserializing `serialized`), Hash-tree-root it: the output should match `root`
-
 
 ## References
 

--- a/tests/generators/README.md
+++ b/tests/generators/README.md
@@ -7,13 +7,12 @@ Any issues with the generators and/or generated tests should be filed in the rep
 
 On releases, test generators are run by the release manager. Test-generation of mainnet tests can take a significant amount of time, and is better left out of a CI setup.
 
-An automated nightly tests release system, with a config filter applied, is being considered as implementation needs mature.  
+An automated nightly tests release system, with a config filter applied, is being considered as implementation needs mature.
 
 ## Table of contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 
 - [How to run generators](#how-to-run-generators)
   - [Cleaning](#cleaning)
@@ -24,8 +23,6 @@ An automated nightly tests release system, with a config filter applied, is bein
 - [How to remove a test generator](#how-to-remove-a-test-generator)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-
 
 ## How to run generators
 
@@ -39,7 +36,7 @@ Prerequisites:
 This removes the existing virtual environments (`/tests/generators/<generator>/venv`) and generated tests (`../consensus-spec-tests/tests`).
 
 ```bash
-make clean 
+make clean
 ```
 
 ### Running all test generators
@@ -51,7 +48,6 @@ make -j 4 generate_tests
 ```
 
 The `-j N` flag makes the generators run in parallel, with `N` being the amount of cores.
-
 
 ### Running a single generator
 
@@ -195,9 +191,9 @@ Recommendations:
 - You can have more than just one test provider.
 - Your test provider is free to output any configuration and combination of runner/handler/fork/case name.
 - You can split your test case generators into different Python files/packages; this is good for code organization.
-- Use config `minimal` for performance and simplicity, but also implement a suite with the `mainnet` config where necessary. 
+- Use config `minimal` for performance and simplicity, but also implement a suite with the `mainnet` config where necessary.
 - You may be able to write your test case provider in a way where it does not make assumptions on constants.
-  If so, you can generate test cases with different configurations for the same scenario (see example). 
+  If so, you can generate test cases with different configurations for the same scenario (see example).
 - See [`tests/core/gen_helpers/README.md`](../core/pyspec/eth2spec/gen_helpers/README.md) for command line options for generators.
 
 ## How to add a new test generator
@@ -219,7 +215,6 @@ To add a new test generator that builds `New Tests`:
 *Note*: You do not have to change the makefile.
 However, if necessary (e.g. not using Python, or mixing in other languages), submit an issue, and it can be a special case.
 Do note that generators should be easy to maintain, lean, and based on the spec.
-
 
 ## How to remove a test generator
 

--- a/tests/generators/epoch_processing/README.md
+++ b/tests/generators/epoch_processing/README.md
@@ -6,6 +6,3 @@ An epoch-processing test-runner can consume these sub-transition test-suites,
  and handle different kinds of epoch sub-transitions by processing the cases using the specified test handler.
 
 Information on the format of the tests can be found in the [epoch-processing test formats documentation](../../formats/epoch_processing/README.md).
-
- 
-

--- a/tests/generators/operations/README.md
+++ b/tests/generators/operations/README.md
@@ -7,6 +7,3 @@ An operation test-runner can consume these operation test-suites,
  and handle different kinds of operations by processing the cases using the specified test handler.
 
 Information on the format of the tests can be found in the [operations test formats documentation](../../formats/operations/README.md).
-
- 
-

--- a/tests/generators/sanity/README.md
+++ b/tests/generators/sanity/README.md
@@ -3,6 +3,3 @@
 Sanity tests cover regular state-transitions in a common block-list format, to ensure the basics work.
 
 Information on the format of the tests can be found in the [sanity test formats documentation](../../formats/sanity/README.md).
-
- 
-


### PR DESCRIPTION
Sorry in advance, I didn't intend to touch so many files. The changes should be pretty simple though.

This PR does the following to markdown files:

* Remove "This document is a work-in-progress" from stable specs.
* Add "This document is a work-in-progress" to unstable specs.
* Delete double blank lines (not in Python code chunks).
* Add blank line after headers.
* Remove trailing whitespace.