### PR TITLE
Fix validator fields in `get_validator_from_deposit`

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -994,7 +994,7 @@ def notify_new_payload(self: ExecutionEngine,
                        parent_beacon_block_root: Root,
                        execution_requests_list: list[bytes]) -> bool:
     """
-    Return ``True`` if and only if ``execution_payload`` and ``execution_requests`` 
+    Return ``True`` if and only if ``execution_payload`` and ``execution_requests``
     are valid with respect to ``self.execution_state``.
     """
     ...
@@ -1290,11 +1290,12 @@ def get_validator_from_deposit(pubkey: BLSPubkey, withdrawal_credentials: Bytes3
     validator = Validator(
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
+        effective_balance=Gwei(0),
+        slashed=False,
         activation_eligibility_epoch=FAR_FUTURE_EPOCH,
         activation_epoch=FAR_FUTURE_EPOCH,
         exit_epoch=FAR_FUTURE_EPOCH,
         withdrawable_epoch=FAR_FUTURE_EPOCH,
-        effective_balance=Gwei(0),
     )
 
     # [Modified in Electra:EIP7251]

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1854,11 +1854,12 @@ def get_validator_from_deposit(pubkey: BLSPubkey, withdrawal_credentials: Bytes3
     return Validator(
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
+        effective_balance=effective_balance,
+        slashed=False,
         activation_eligibility_epoch=FAR_FUTURE_EPOCH,
         activation_epoch=FAR_FUTURE_EPOCH,
         exit_epoch=FAR_FUTURE_EPOCH,
         withdrawable_epoch=FAR_FUTURE_EPOCH,
-        effective_balance=effective_balance,
     )
 ```
 


### PR DESCRIPTION
When comparing the spec to Teku, I noticed that (1) `effective_balance` was in the wrong spot and (2) `slashed` wasn't being set. There's no bug here, just fixing for correctness & to make reviewing easier.

https://github.com/ethereum/consensus-specs/blob/a2e16c8e77875aeac328422adf22d87e540df521/specs/phase0/beacon-chain.md?plain=1#L358-L367