### PR TITLE
Simplify validator activation flow

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -422,7 +422,7 @@ def compute_proposer_index(state: BeaconState, indices: Sequence[ValidatorIndex]
 #### Modified `is_eligible_for_activation`
 
 *Note*: The function `is_eligible_for_activation` is modified to directly use `effective_balance`
-instead of `activation_eligibility_epoch` as one of the elgibility criteria.
+instead of `activation_eligibility_epoch` as one of the eligibility criteria.
 
 ```python
 def is_eligible_for_activation(state: BeaconState, validator: Validator) -> bool:

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -782,7 +782,7 @@ def process_epoch(state: BeaconState) -> None:
 #### Modified `process_registry_updates`
 
 *Note*: The function `process_registry_updates` is modified to use the updated definition of `initiate_validator_exit`,
-changes how `activation_epoch` is computed for an eligible validator and removes the usage of `activation_eligibility_epoch`.
+changes how `activation_epoch` and `activation_eligibility_epoch` are computed for an eligible validator.
 
 ```python
 def process_registry_updates(state: BeaconState) -> None:
@@ -796,9 +796,13 @@ def process_registry_updates(state: BeaconState) -> None:
 
     # Activate all eligible validators [Modified in Electra:EIP7251]
     activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
+    activation_eligibility_epoch = get_current_epoch(state) + 1
     for validator in state.validators:
         if is_eligible_for_activation(state, validator):
             validator.activation_epoch = activation_epoch
+            # Set activation eligibility epoch for backwards compatibility,
+            # to be deprecated in one of the future upgrades
+            validator.activation_eligibility_epoch = activation_eligibility_epoch
 ```
 
 #### Modified `process_slashings`

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -425,7 +425,7 @@ def compute_proposer_index(state: BeaconState, indices: Sequence[ValidatorIndex]
 instead of `activation_eligibility_epoch` as one of the eligibility criteria.
 
 ```python
-def is_eligible_for_activation(state: BeaconState, validator: Validator) -> bool:
+def is_eligible_for_activation(validator: Validator) -> bool:
     """
     Check if ``validator`` is eligible for activation.
     """
@@ -798,7 +798,7 @@ def process_registry_updates(state: BeaconState) -> None:
     activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
     activation_eligibility_epoch = get_current_epoch(state) + 1
     for validator in state.validators:
-        if is_eligible_for_activation(state, validator):
+        if is_eligible_for_activation(validator):
             validator.activation_epoch = activation_epoch
             # Set activation eligibility epoch for backwards compatibility,
             # to be deprecated in one of the future upgrades


### PR DESCRIPTION
Deposit queue finalization proposed in https://github.com/ethereum/consensus-specs/pull/3818 allows for the following simplification in the validator activation flow:
* Do not use `activation_eligibility_epoch` which is currently used by the protocol to finalize new validators before activating them — this is now done by finalizing the deposit queue
* Activate new validator once it has sufficient effective balance
* Set `activation_eligibility_epoch` for backwards compatibility

In future upgrades `activation_eligibility_epoch` can be deprecated and re-purposed for any other usage e.g. custom EB ceiling etc

### ToDo
* [ ] Fix tests