### PR TITLE
Fix all pytest warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -572,7 +572,7 @@ setup(
         "py_ecc==6.0.0",
         "milagro_bls_binding==1.9.0",
         "remerkleable==0.1.28",
-        "trie==2.0.2",
+        "trie>=3,<4",
         RUAMEL_YAML_VERSION,
         "lru-dict==1.2.0",
         MARKO_VERSION,


### PR DESCRIPTION
This PR fixes these warnings that show up when running `pytest`. These two:

> ../../../venv/lib/python3.10/site-packages/trie/__init__.py:1
  /Users/specs/venv/lib/python3.10/site-packages/trie/__init__.py:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

> ../../../venv/lib/python3.10/site-packages/pkg_resources/__init__.py:3154
  /Users/specs/venv/lib/python3.10/site-packages/pkg_resources/__init__.py:3154: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('ruamel')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

The solution is to update the `trie` package. It fixes both.