### PR TITLE
Standardize DAS data store in the fork-choice store

### DIFF
--- a/specs/_features/eip7594/fork-choice.md
+++ b/specs/_features/eip7594/fork-choice.md
@@ -7,7 +7,11 @@
 
 - [Introduction](#introduction)
 - [Helpers](#helpers)
+  - [New `Config`](#new-config)
+  - [Modified `Store`](#modified-store)
   - [Modified `is_data_available`](#modified-is_data_available)
+- [New fork-choice handlers](#new-fork-choice-handlers)
+  - [New `on_data_column_sidecar`](#new-on_data_column_sidecar)
 - [Updated fork-choice handlers](#updated-fork-choice-handlers)
   - [Modified `on_block`](#modified-on_block)
 
@@ -20,21 +24,113 @@ This is the modification of the fork choice accompanying EIP-7594.
 
 ## Helpers
 
+### New `Config`
+
+*Note*: `Config` is supposed to be pre-populated with configurations specific to each node.
+
+```python
+@dataclass
+class Config(object):
+    metadata: MetaData
+    node_id: NodeID
+```
+
+### Modified `Store`
+
+*Note*: There are two modifications to `Store`:
+1. Config is added to keep node-specific configurations.
+2. Data column sidecar store is added to keep track the data column sidecars that have been seen.
+
+```python
+@dataclass
+class Store(object):
+    config: Config # [New in EIP7594]
+    time: uint64
+    genesis_time: uint64
+    justified_checkpoint: Checkpoint
+    finalized_checkpoint: Checkpoint
+    unrealized_justified_checkpoint: Checkpoint
+    unrealized_finalized_checkpoint: Checkpoint
+    proposer_boost_root: Root
+    equivocating_indices: Set[ValidatorIndex]
+    blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
+    block_states: Dict[Root, BeaconState] = field(default_factory=dict)
+    block_timeliness: Dict[Root, boolean] = field(default_factory=dict)
+    checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
+    latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
+    unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
+    data_column_sidecars: Dict[DataColumnIdentifier, DataColumnSidecar] = field(default_factory=dict) # [New in EIP7594]
+```
+
 ### Modified `is_data_available`
 
 ```python
-def is_data_available(beacon_block_root: Root) -> bool:
-    # `retrieve_column_sidecars` is implementation and context dependent, replacing
-    # `retrieve_blobs_and_proofs`. For the given block root, it returns all column 
-    # sidecars to sample, or raises an exception if they are not available. 
-    # The p2p network does not guarantee sidecar retrieval outside of 
-    # `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs.  
-    column_sidecars = retrieve_column_sidecars(beacon_block_root)
+def is_data_available(store: Store, beacon_block_root: Root) -> bool:
+    # The p2p network does not guarantee sidecar retrieval outside of
+    # `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs.
+    custody_columns = get_custody_columns(store.config.node_id, store.config.metadata.custody_subnet_count)
     return all(
-        verify_data_column_sidecar(column_sidecar)
-        and verify_data_column_sidecar_kzg_proofs(column_sidecar)
-        for column_sidecar in column_sidecars
+        DataColumnIdentifier(block_root=beacon_block_root, index=column_index) in store.data_column_sidecars
+        for column_index in custody_columns
     )
+```
+
+## New fork-choice handlers
+
+### New `on_data_column_sidecar`
+
+*Note*: `on_data_column_sidecar` is triggered whenever a data column sidecar is received (either through Gossipsub topics or Req/Resp).
+
+```python
+def on_data_column_sidecar(store: Store, sidecar: DataColumnSidecar) -> None:
+    """
+    Run ``on_data_column_sidecar`` upon receiving a data column sidecar.
+    """
+    block_header = sidecar.signed_block_header.message
+    # Verify data column sidecar
+    assert verify_data_column_sidecar(sidecar)
+    # Data column sidecars cannot be in the future. If they are, their consideration must be delayed until they are in the past.
+    assert get_current_slot(store) >= block_header.slot
+
+    # Check that the sidecar is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
+    finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+    assert block_header.slot > finalized_slot
+
+    # Parent block must be known
+    assert block_header.parent_root in store.block_states
+    # Make a copy of the state to avoid mutability issues
+    state = copy(store.block_states[block_header.parent_root])
+
+    # The block header signature is valid with respect to the proposer pubkey
+    proposer = state.validators[block_header.proposer_index]
+    domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block_header.slot))
+    signing_root = compute_signing_root(block_header, domain)
+    assert bls.Verify(proposer.pubkey, signing_root, sidecar.signed_block_header.signature)
+
+    # The sidecar is from a higher slot than the sidecar's block's parent
+    assert block_header.slot > store.blocks[block_header.parent_root].slot
+
+    # Check block is a descendant of the finalized block at the checkpoint finalized slot
+    finalized_checkpoint_block = get_checkpoint_block(
+        store,
+        block_header.parent_root,
+        store.finalized_checkpoint.epoch,
+    )
+    assert store.finalized_checkpoint.root == finalized_checkpoint_block
+
+    # The sidecar's inclusion proof is valid
+    assert verify_data_column_sidecar_inclusion_proof(sidecar)
+
+    # The sidecar's column data is valid
+    assert verify_data_column_sidecar_kzg_proofs(sidecar)
+
+    # Check block is proposed by the expected proposer
+    process_slots(state, block.slot)
+    assert block.proposer_index == get_beacon_proposer_index(state)
+
+    # Save the data column sidecar
+    data_column_identifier = DataColumnIdentifier(block_root=hash_tree_root(block_header), index=sidecar.index)
+    store.data_column_sidecars[data_column_identifier] = sidecar
 ```
 
 ## Updated fork-choice handlers

--- a/specs/_features/eip7594/fork-choice.md
+++ b/specs/_features/eip7594/fork-choice.md
@@ -59,6 +59,7 @@ class Store(object):
     checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
     latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
     unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
+    # blob_sidecars: Dict[BlobIdentifier, BlobSidecar] = field(default_factory=dict) # [Removed in EIP7594]
     data_column_sidecars: Dict[DataColumnIdentifier, DataColumnSidecar] = field(default_factory=dict) # [New in EIP7594]
 ```
 


### PR DESCRIPTION
Previously we left the DAS data store (blob store in Deneb and data column store in PeerDAS)  implementation-dependent. I noticed that that left many issues on the specification.

### Currently, a sidecar is verified using only the GossipSub rules

This strictly disallows us to receive sidecars using alternative methods other than GossipSub. This has a bad effect on PeerDAS because it's explicitly stated that you can get a data column sidecar using Req/Resp as well. So. I decided to propose `on_blob_sidecar` and `on_data_column_sidecar` to be entry points for respective sidecars and all the verification will be done there before importing them to the store, in addition to the GossipSub rules.

You can think of the GossipSub rules as rules to decide whether to forward a message further or not, while the fork-choice handlers, like `on_blob_sidecar` and `on_data_column_sidecar`, are used to decide whether to import an object to the store or not.

You will probably notice that the verification done in the fork-choice handlers is the same as the one in the GossipSub rules. Yes, they are mostly the same and we did that since the beginning of the beacon chain (look at `on_block` for an example). It's not trivial to refactor this duplicate because the expected result of the fork-choice handlers is ACCEPT or FAIL, while the expected result of the Gossipsub is ACCEPT, IGNORE, or REJECT.

### If the DAS data store is implementation-dependent, it's hard to make assumptions on what is inside the store and extend the spec further

Let's look at `is_data_available` from both Deneb and PeerDAS.

In PeerDAS `is_data_available`, we are doing some verification using `verify_data_column_sidecar` and `verify_data_column_sidecar_kzg_proofs`. I'm not sure why we do some verification here because we already did the whole verification using the GossipSub rules which are more comprehensive.

It's probably because we assume that `retrieve_column_sidecars` probably will return some invalid sidecars. If that's the case, why do we do only two verification rules instead of doing the whole bunch again.

If we assume that `retrieve_column_sidecars` will return only valid sidecars, why bother doing verification at all?

The same argument can be applied to `verify_blob_kzg_proof_batch` in Deneb `is_data_available` as well.

So I think the solution is to standardize the data store.

### Some notes

1. `verify_blob_kzg_proof_batch` can be completely removed from the Deneb crypto library which is interesting.
2. I will do the test after the idea is accepted.