### PR TITLE
Rename index vars in `get_attesting_indices()`

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -572,10 +572,12 @@ def get_attesting_indices(state: BeaconState, attestation: Attestation) -> Set[V
     output: Set[ValidatorIndex] = set()
     committee_indices = get_committee_indices(attestation.committee_bits)
     committee_offset = 0
-    for index in committee_indices:
-        committee = get_beacon_committee(state, attestation.data.slot, index)
+    for committee_index in committee_indices:
+        committee = get_beacon_committee(state, attestation.data.slot, committee_index)
         committee_attesters = set(
-            index for i, index in enumerate(committee) if attestation.aggregation_bits[committee_offset + i])
+            attester_index for i, attester_index in enumerate(committee)
+            if attestation.aggregation_bits[committee_offset + i]
+        )
         output = output.union(committee_attesters)
 
         committee_offset += len(committee)


### PR DESCRIPTION
I found this function a little confusing because the `index` variable is shadowed.

1. `for index in committee_indices:`
2. `for i, index in enumerate(committee)`

I think it would be good to rename this so it's clear which index is used.