### PR TITLE
Group pending types & request types

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -24,12 +24,12 @@
   - [Validator cycle](#validator-cycle)
 - [Containers](#containers)
   - [New containers](#new-containers)
-    - [`DepositRequest`](#depositrequest)
     - [`PendingDeposit`](#pendingdeposit)
     - [`PendingPartialWithdrawal`](#pendingpartialwithdrawal)
+    - [`PendingConsolidation`](#pendingconsolidation)
+    - [`DepositRequest`](#depositrequest)
     - [`WithdrawalRequest`](#withdrawalrequest)
     - [`ConsolidationRequest`](#consolidationrequest)
-    - [`PendingConsolidation`](#pendingconsolidation)
     - [`ExecutionRequests`](#executionrequests)
   - [Modified Containers](#modified-containers)
     - [`AttesterSlashing`](#attesterslashing)
@@ -201,19 +201,6 @@ The following values are (non-configurable) constants used throughout the specif
 
 ### New containers
 
-#### `DepositRequest`
-
-*Note*: The container is new in EIP6110.
-
-```python
-class DepositRequest(Container):
-    pubkey: BLSPubkey
-    withdrawal_credentials: Bytes32
-    amount: Gwei
-    signature: BLSSignature
-    index: uint64
-```
-
 #### `PendingDeposit`
 
 *Note*: The container is new in EIP7251.
@@ -237,6 +224,30 @@ class PendingPartialWithdrawal(Container):
     amount: Gwei
     withdrawable_epoch: Epoch
 ```
+
+#### `PendingConsolidation`
+
+*Note*: The container is new in EIP7251.
+
+```python
+class PendingConsolidation(Container):
+    source_index: ValidatorIndex
+    target_index: ValidatorIndex
+```
+
+#### `DepositRequest`
+
+*Note*: The container is new in EIP6110.
+
+```python
+class DepositRequest(Container):
+    pubkey: BLSPubkey
+    withdrawal_credentials: Bytes32
+    amount: Gwei
+    signature: BLSSignature
+    index: uint64
+```
+
 #### `WithdrawalRequest`
 
 *Note*: The container is new in EIP7251:EIP7002.
@@ -257,16 +268,6 @@ class ConsolidationRequest(Container):
     source_address: ExecutionAddress
     source_pubkey: BLSPubkey
     target_pubkey: BLSPubkey
-```
-
-#### `PendingConsolidation`
-
-*Note*: The container is new in EIP7251.
-
-```python
-class PendingConsolidation(Container):
-    source_index: ValidatorIndex
-    target_index: ValidatorIndex
 ```
 
 #### `ExecutionRequests`


### PR DESCRIPTION
This PR groups the three `Pending*` types and the three `*Request` types together.

In my opinion, it makes sense for the request types to be immediately above the `ExecutionRequests` type.