### PR TITLE
EIP-7251: Add check for target withdrawal credentials against source address

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1610,11 +1610,19 @@ def process_consolidation_request(
     target_validator = state.validators[target_index]
 
     # Verify source withdrawal credentials
-    has_correct_credential = has_execution_withdrawal_credential(source_validator)
+    has_correct_source_credential = has_execution_withdrawal_credential(source_validator)
     is_correct_source_address = (
         source_validator.withdrawal_credentials[12:] == consolidation_request.source_address
     )
-    if not (has_correct_credential and is_correct_source_address):
+    if not (has_correct_source_credential and is_correct_source_address):
+        return
+
+    # Verify target withdrawal credentials
+    has_correct_target_credential = has_execution_withdrawal_credential(target_validator)
+    is_correct_target_address = (
+        target_validator.withdrawal_credentials[12:] == consolidation_request.source_address
+    )
+    if not (has_correct_target_credential and is_correct_target_address):
         return
 
     # Verify that target has execution withdrawal credentials

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1625,10 +1625,6 @@ def process_consolidation_request(
     if not (has_correct_target_credential and is_correct_target_address):
         return
 
-    # Verify that target has execution withdrawal credentials
-    if not has_execution_withdrawal_credential(target_validator):
-        return
-
     # Verify the source and the target are active
     current_epoch = get_current_epoch(state)
     if not is_active_validator(source_validator, current_epoch):

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_consolidation_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_consolidation_request.py
@@ -40,15 +40,17 @@ def test_basic_consolidation_in_current_consolidation_epoch(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to eth1 credentials
-    set_eth1_withdrawal_credential_with_balance(spec, state, target_index)
 
     # Set earliest consolidation epoch to the expected exit epoch
     expected_exit_epoch = spec.compute_activation_exit_epoch(current_epoch)
@@ -89,15 +91,17 @@ def test_basic_consolidation_with_excess_target_balance(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to eth1 credentials
-    set_eth1_withdrawal_credential_with_balance(spec, state, target_index)
 
     # Set earliest consolidation epoch to the expected exit epoch
     expected_exit_epoch = spec.compute_activation_exit_epoch(current_epoch)
@@ -141,15 +145,17 @@ def test_basic_consolidation_with_excess_target_balance_and_compounding_credenti
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to eth1 credentials
-    set_compounding_withdrawal_credential(spec, state, target_index)
 
     # Set earliest consolidation epoch to the expected exit epoch
     expected_exit_epoch = spec.compute_activation_exit_epoch(current_epoch)
@@ -195,15 +201,17 @@ def test_basic_consolidation_in_new_consolidation_epoch(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to eth1 credentials
-    set_eth1_withdrawal_credential_with_balance(spec, state, target_index)
 
     yield from run_consolidation_processing(spec, state, consolidation)
 
@@ -240,15 +248,17 @@ def test_basic_consolidation_with_preexisting_churn(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to eth1 credentials
-    set_eth1_withdrawal_credential_with_balance(spec, state, target_index)
 
     # Set earliest consolidation epoch to the expected exit epoch
     expected_exit_epoch = spec.compute_activation_exit_epoch(current_epoch)
@@ -289,15 +299,17 @@ def test_basic_consolidation_with_insufficient_preexisting_churn(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to eth1 credentials
-    set_eth1_withdrawal_credential_with_balance(spec, state, target_index)
 
     # Set earliest consolidation epoch to the first available epoch
     state.earliest_consolidation_epoch = spec.compute_activation_exit_epoch(
@@ -342,15 +354,17 @@ def test_basic_consolidation_with_compounding_credentials(spec, state):
     set_compounding_withdrawal_credential(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_compounding_withdrawal_credential(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to compounding credentials
-    set_compounding_withdrawal_credential(spec, state, target_index)
 
     # Set the consolidation balance to consume equal to churn limit
     consolidation_churn_limit = spec.get_consolidation_churn_limit(state)
@@ -389,15 +403,17 @@ def test_consolidation_churn_limit_balance(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to eth1 credentials
-    set_eth1_withdrawal_credential_with_balance(spec, state, target_index)
 
     # Set source effective balance to consolidation churn limit
     consolidation_churn_limit = spec.get_consolidation_churn_limit(state)
@@ -439,15 +455,17 @@ def test_consolidation_balance_larger_than_churn_limit(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to eth1 credentials
-    set_eth1_withdrawal_credential_with_balance(spec, state, target_index)
 
     # Set source effective balance to 2 * consolidation churn limit
     consolidation_churn_limit = spec.get_consolidation_churn_limit(state)
@@ -488,15 +506,17 @@ def test_consolidation_balance_through_two_churn_epochs(spec, state):
     set_eth1_withdrawal_credential_with_balance(
         spec, state, source_index, address=source_address
     )
+    # Set target to eth1 credentials
+    target_address = source_address
+    set_eth1_withdrawal_credential_with_balance(
+        spec, state, target_index, address=target_address
+    )
     # Make consolidation with source address
     consolidation = spec.ConsolidationRequest(
         source_address=source_address,
         source_pubkey=state.validators[source_index].pubkey,
         target_pubkey=state.validators[target_index].pubkey,
     )
-
-    # Set target to eth1 credentials
-    set_eth1_withdrawal_credential_with_balance(spec, state, target_index)
 
     # Set source balance higher to 3 * consolidation churn limit
     consolidation_churn_limit = spec.get_consolidation_churn_limit(state)


### PR DESCRIPTION
This is a tentative PR to open discussions on the current semantics around consolidation and source/target withdrawal credentials under EIP-7251.

In the current specification, it is possible for an entity controlling a source stake to convert any target stake with eth1 credentials from 0x01 to 0x02, regardless of whether or not they own the target stake. The assumption is that it would likely be a stupid move as the source of the consolidation would effectively lose the amount staked on the source validator.

In some contexts/countries, owning an auto-compounding stake can have different legal implications, such that some actors will be willing to stay in 0x01. However, the possibility that arbitrarily external entities can convert their stakes to 0x02, without them having a say in it, can be a blocker.

This PR ensures that both the source withdrawal credentials and the target withdrawal credentials point to the source address of the consolidation request.

On the downside, such a constraint would prevent some stakers from changing their withdrawal credentials (i.e: by first staking something on a new validator with a new withdrawal credentials, then consolidating against it), this could however be addressed/make more sense via a future separate request type.