### PR TITLE
Clean up dead link and typo in LC docs for Electra

### DIFF
--- a/specs/electra/light-client/fork.md
+++ b/specs/electra/light-client/fork.md
@@ -33,7 +33,7 @@ def normalize_merkle_branch(branch: Sequence[Bytes32],
 
 ## Upgrading light client data
 
-A Electra `LightClientStore` can still process earlier light client data. In order to do so, that pre-Electra data needs to be locally upgraded to Electra before processing.
+An Electra `LightClientStore` can still process earlier light client data. In order to do so, that pre-Electra data needs to be locally upgraded to Electra before processing.
 
 ```python
 def upgrade_lc_header_to_electra(pre: deneb.LightClientHeader) -> LightClientHeader:

--- a/specs/electra/light-client/sync-protocol.md
+++ b/specs/electra/light-client/sync-protocol.md
@@ -27,7 +27,6 @@
 This upgrade updates light client data to include the Electra changes to the [`ExecutionPayload`](../beacon-chain.md) structure and to the generalized indices of surrounding containers. It extends the [Deneb Light Client specifications](../../deneb/light-client/sync-protocol.md). The [fork document](./fork.md) explains how to upgrade existing Deneb based deployments to Electra.
 
 Additional documents describes the impact of the upgrade on certain roles:
-- [Full node](./full-node.md)
 - [Networking](./p2p-interface.md)
 
 ## Custom types


### PR DESCRIPTION
Followup from #3987 to remove references to the deleted document.