### PR TITLE
Fix modcheck CI test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -136,4 +136,10 @@ jobs:
       - name: Install pyspec requirements
         run: make install_test
       - name: Run generators with --modcheck
-        run: make generate_tests modcheck=true
+        run: make generate_tests modcheck=true 2>&1 | tee consensustestgen.log
+      - name: Check for errors
+        run: |
+          if grep -q "\[ERROR\]" consensustestgen.log; then
+            echo "There is an error in the log"
+            exit 1
+          fi

--- a/tests/generators/genesis/main.py
+++ b/tests/generators/genesis/main.py
@@ -1,4 +1,4 @@
-from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators, combine_mods, check_mods
+from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators, check_mods
 from eth2spec.test.helpers.constants import PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA
 
 

--- a/tests/generators/genesis/main.py
+++ b/tests/generators/genesis/main.py
@@ -8,13 +8,8 @@ if __name__ == "__main__":
         'validity',
     ]}
 
-    altair_mods = phase_0_mods
-
-    # we have new unconditional lines in `initialize_beacon_state_from_eth1` and we want to test it
-    _new_bellatrix_mods = {key: 'eth2spec.test.bellatrix.genesis.test_' + key for key in [
-        'initialization',
-    ]}
-    bellatrix_mods = combine_mods(_new_bellatrix_mods, altair_mods)
+    altair_mods = phase_0_mods  # No additional Altair specific genesis tests
+    bellatrix_mods = altair_mods  #  No additional Bellatrix specific genesis tests
     capella_mods = bellatrix_mods  # No additional Capella specific genesis tests
     deneb_mods = capella_mods  # No additional Deneb specific genesis tests
     electra_mods = deneb_mods  # No additional Electra specific genesis tests

--- a/tests/generators/genesis/main.py
+++ b/tests/generators/genesis/main.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
     ]}
 
     altair_mods = phase_0_mods  # No additional Altair specific genesis tests
-    bellatrix_mods = altair_mods  #  No additional Bellatrix specific genesis tests
+    bellatrix_mods = altair_mods  # No additional Bellatrix specific genesis tests
     capella_mods = bellatrix_mods  # No additional Capella specific genesis tests
     deneb_mods = capella_mods  # No additional Deneb specific genesis tests
     electra_mods = deneb_mods  # No additional Electra specific genesis tests


### PR DESCRIPTION
The nightly test vector generator has been failing for a few days because the modcheck CI test had a bug (my fault). We forgot to check if there were errors in the log. This PR also fixes a generator oversight due to another recent change.