### PR TITLE
eip7251: Limit consolidating balance by validator.effective_balance

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -957,8 +957,8 @@ def process_pending_consolidations(state: BeaconState) -> None:
             break
 
         # Calculate the consolidated balance
-        max_effective_balance = get_max_effective_balance(source_validator)
-        source_effective_balance = min(state.balances[pending_consolidation.source_index], max_effective_balance)
+        source_effective_balance = min(
+            state.balances[pending_consolidation.source_index], source_validator.effective_balance)
 
         # Move active balance to target. Excess balance is withdrawable.
         decrease_balance(state, pending_consolidation.source_index, source_effective_balance)

--- a/tests/core/pyspec/eth2spec/test/electra/epoch_processing/test_process_pending_consolidations.py
+++ b/tests/core/pyspec/eth2spec/test/electra/epoch_processing/test_process_pending_consolidations.py
@@ -461,7 +461,7 @@ def prepare_consolidation_and_state(spec, state, source_index, target_index,
     )
     # Set withdrawable epoch to current epoch to allow processing
     state.validators[source_index].withdrawable_epoch = current_epoch
-    
+
     # Set source and target withdrawal credentials
     if creds_type == 'eth1':
         set_eth1_withdrawal_credential_with_balance(spec, state, source_index)
@@ -477,9 +477,10 @@ def prepare_consolidation_and_state(spec, state, source_index, target_index,
     elif eb_to_min_ab == '=':
         source.effective_balance = spec.MIN_ACTIVATION_BALANCE
     elif eb_to_max_eb == '<':
-        source.effective_balance = (spec.MAX_EFFECTIVE_BALANCE_ELECTRA - spec.MIN_ACTIVATION_BALANCE) // 2
+        source.effective_balance = (max_eb - spec.MIN_ACTIVATION_BALANCE) // 2
     else:
-        source.effective_balance = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
+        # eb_to_max_eb == '='
+        source.effective_balance = max_eb
 
     if balance_to_eb == '<':
         state.balances[source_index] = source.effective_balance - spec.EFFECTIVE_BALANCE_INCREMENT // 2
@@ -511,7 +512,6 @@ def run_balance_computation_test(spec, state, instance_tuples):
         )
         assert state.balances[source_index] == pre_state.balances[source_index] - consolidated_balance
         assert state.balances[target_index] == pre_state.balances[target_index] + consolidated_balance
-
 
 
 @with_electra_and_later

--- a/tests/core/pyspec/eth2spec/test/electra/epoch_processing/test_process_pending_consolidations.py
+++ b/tests/core/pyspec/eth2spec/test/electra/epoch_processing/test_process_pending_consolidations.py
@@ -244,7 +244,8 @@ def test_pending_consolidation_compounding_creds(spec, state):
     assert state.balances[target_index] == expected_target_balance
     # All source balance is active and moved to the target,
     # because the source validator has compounding credentials
-    assert state.balances[source_index] == state_before_consolidation.balances[source_index] - spec.MIN_ACTIVATION_BALANCE
+    assert state.balances[source_index] == (
+        state_before_consolidation.balances[source_index] - spec.MIN_ACTIVATION_BALANCE)
     assert state.pending_consolidations == []
 
     # Pending balance deposit to the target is not created,
@@ -300,7 +301,8 @@ def test_pending_consolidation_with_pending_deposit(spec, state):
         spec.MIN_ACTIVATION_BALANCE + state_before_consolidation.balances[target_index]
     )
     assert state.balances[target_index] == expected_target_balance
-    assert state.balances[source_index] == state_before_consolidation.balances[source_index] - spec.MIN_ACTIVATION_BALANCE
+    assert state.balances[source_index] == (
+        state_before_consolidation.balances[source_index] - spec.MIN_ACTIVATION_BALANCE)
     assert state.pending_consolidations == []
 
     # Pending deposit to the source was not processed.

--- a/tests/core/pyspec/eth2spec/test/electra/epoch_processing/test_process_pending_consolidations.py
+++ b/tests/core/pyspec/eth2spec/test/electra/epoch_processing/test_process_pending_consolidations.py
@@ -239,12 +239,12 @@ def test_pending_consolidation_compounding_creds(spec, state):
 
     # Pending consolidation was successfully processed
     expected_target_balance = (
-        state_before_consolidation.balances[source_index] + state_before_consolidation.balances[target_index]
+        spec.MIN_ACTIVATION_BALANCE + state_before_consolidation.balances[target_index]
     )
     assert state.balances[target_index] == expected_target_balance
     # All source balance is active and moved to the target,
     # because the source validator has compounding credentials
-    assert state.balances[source_index] == 0
+    assert state.balances[source_index] == state_before_consolidation.balances[source_index] - spec.MIN_ACTIVATION_BALANCE
     assert state.pending_consolidations == []
 
     # Pending balance deposit to the target is not created,
@@ -297,10 +297,10 @@ def test_pending_consolidation_with_pending_deposit(spec, state):
 
     # Pending consolidation was successfully processed
     expected_target_balance = (
-        state_before_consolidation.balances[source_index] + state_before_consolidation.balances[target_index]
+        spec.MIN_ACTIVATION_BALANCE + state_before_consolidation.balances[target_index]
     )
     assert state.balances[target_index] == expected_target_balance
-    assert state.balances[source_index] == 0
+    assert state.balances[source_index] == state_before_consolidation.balances[source_index] - spec.MIN_ACTIVATION_BALANCE
     assert state.pending_consolidations == []
 
     # Pending deposit to the source was not processed.


### PR DESCRIPTION
Proposes to use `source.effective_balance` as the limitation of the source’s balance moved upon consolidation.

Ensures that in the most of the cases the newly activated balance is not higher than the amount passed through the consolidation churn. Relying on `source.max_effective_balance` as it is today allows to activate more balance than it was churned, although up to a limited extent (`<= 1.25 ETH`).

After this fix there still the case when an excess balance can be activated. It can happen if `source.effective_balance` has been bumped due to accrued rewards after consolidation has been initiated. But that increase would happen regardless of consolidation and is allowed by the protocol.

The other quirk addressed by this fix is the dependency of the amount of activated balance on the withdrawal credential type. Suppose there is a validator with `32.05 ETH` balance. If it had compounding credentials, entire `32.05 ETH` would be moved to the target upon consolidation, while if it had eth1 credentials, only `32 ETH` would be moved leaving `0.05 ETH` for the sweep.

cc @fradamt

### ToDo
* [x] write more exhaustive balance tests for consolidation