### PR TITLE
Pass `max_blobs_per_block` into Engine API methods

### DIFF
--- a/pysetup/spec_builders/electra.py
+++ b/pysetup/spec_builders/electra.py
@@ -31,7 +31,8 @@ class NoopExecutionEngine(ExecutionEngine):
                            execution_payload: ExecutionPayload,
                            parent_beacon_block_root: Root,
                            execution_requests_list: Sequence[bytes],
-                           target_blobs_per_block: uint64) -> bool:
+                           target_blobs_per_block: uint64,
+                           max_blobs_per_block: uint64) -> bool:
         return True
 
     def notify_forkchoice_updated(self: ExecutionEngine,
@@ -49,7 +50,8 @@ class NoopExecutionEngine(ExecutionEngine):
                             execution_payload: ExecutionPayload,
                             parent_beacon_block_root: Root,
                             execution_requests_list: Sequence[bytes],
-                            target_blobs_per_block: uint64) -> bool:
+                            target_blobs_per_block: uint64,
+                            max_blobs_per_block: uint64) -> bool:
         return True
 
     def is_valid_versioned_hashes(self: ExecutionEngine, new_payload_request: NewPayloadRequest) -> bool:

--- a/specs/_features/eip7594/beacon-chain.md
+++ b/specs/_features/eip7594/beacon-chain.md
@@ -55,6 +55,7 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
             parent_beacon_block_root=state.latest_block_header.parent_root,
             execution_requests=body.execution_requests,
             target_blobs_per_block=TARGET_BLOBS_PER_BLOCK_EIP7594,  # [Modified in EIP7594]
+            max_blobs_per_block=MAX_BLOBS_PER_BLOCK_EIP7594,  # [Modified in EIP7594]
         )
     )
     # Cache execution payload header

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -706,6 +706,7 @@ def process_execution_payload(state: BeaconState,
                 parent_beacon_block_root=state.latest_block_header.parent_root,
                 execution_requests=requests,
                 target_blobs_per_block=TARGET_BLOBS_PER_BLOCK_ELECTRA,
+                max_blobs_per_block=MAX_BLOBS_PER_BLOCK_ELECTRA,
             )
         )
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1014,6 +1014,7 @@ class NewPayloadRequest(object):
     parent_beacon_block_root: Root
     execution_requests: ExecutionRequests  # [New in Electra]
     target_blobs_per_block: uint64  # [New in Electra:EIP7742]
+    max_blobs_per_block: uint64  # [New in Electra:EIP7742]
 ```
 
 #### Engine APIs
@@ -1028,7 +1029,8 @@ def is_valid_block_hash(self: ExecutionEngine,
                         execution_payload: ExecutionPayload,
                         parent_beacon_block_root: Root,
                         execution_requests_list: Sequence[bytes],
-                        target_blobs_per_block: uint64) -> bool:
+                        target_blobs_per_block: uint64,
+                        max_blobs_per_block: uint64) -> bool:
     """
     Return ``True`` if and only if ``execution_payload.block_hash`` is computed correctly.
     """
@@ -1045,7 +1047,8 @@ def notify_new_payload(self: ExecutionEngine,
                        execution_payload: ExecutionPayload,
                        parent_beacon_block_root: Root,
                        execution_requests_list: Sequence[bytes],
-                       target_blobs_per_block: uint64) -> bool:
+                       target_blobs_per_block: uint64,
+                       max_blobs_per_block: uint64) -> bool:
     """
     Return ``True`` if and only if ``execution_payload`` and ``execution_requests_list``
     are valid with respect to ``self.execution_state``.
@@ -1069,6 +1072,7 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
     parent_beacon_block_root = new_payload_request.parent_beacon_block_root
     execution_requests_list = get_execution_requests_list(new_payload_request.execution_requests)  # [New in Electra]
     target_blobs_per_block = new_payload_request.target_blobs_per_block  # [New in Electra:EIP7742]
+    max_blobs_per_block = new_payload_request.max_blobs_per_block  # [New in Electra:EIP7742]
 
     if b'' in execution_payload.transactions:
         return False
@@ -1078,7 +1082,8 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
             execution_payload,
             parent_beacon_block_root,
             execution_requests_list,
-            target_blobs_per_block):
+            target_blobs_per_block,
+            max_blobs_per_block):
         return False
 
     if not self.is_valid_versioned_hashes(new_payload_request):
@@ -1089,7 +1094,8 @@ def verify_and_notify_new_payload(self: ExecutionEngine,
             execution_payload,
             parent_beacon_block_root,
             execution_requests_list,
-            target_blobs_per_block):
+            target_blobs_per_block,
+            max_blobs_per_block):
         return False
 
     return True
@@ -1252,6 +1258,7 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody, executi
             parent_beacon_block_root=state.latest_block_header.parent_root,
             execution_requests=body.execution_requests,  # [New in Electra]
             target_blobs_per_block=TARGET_BLOBS_PER_BLOCK_ELECTRA,  # [New in Electra:EIP7691:EIP7742]
+            max_blobs_per_block=MAX_BLOBS_PER_BLOCK_ELECTRA,  # [New in Electra:EIP7691:EIP7742]
         )
     )
     # Cache execution payload header


### PR DESCRIPTION
Discussed on Discord [here](https://discord.com/channels/595666850260713488/688075293562503241/1314326254656426075). We might need to pass `max_blobs_per_block` (not just `target_blobs_per_block`) to the EL. Without it, the EL is unable to do certain tasks (eg `eth_feeHistory`) due to a lack of information. This is a follow up to:

* #3800 