### PR TITLE
Rename PartialPendingWithdrawal field `index` to `validator_index`

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -586,7 +586,7 @@ def get_consolidation_churn_limit(state: BeaconState) -> Gwei:
 ```python
 def get_pending_balance_to_withdraw(state: BeaconState, validator_index: ValidatorIndex) -> Gwei:
     return sum(
-        withdrawal.amount for withdrawal in state.pending_partial_withdrawals 
+        withdrawal.amount for withdrawal in state.pending_partial_withdrawals
         if withdrawal.validator_index == validator_index
     )
 ```

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -586,8 +586,8 @@ def get_consolidation_churn_limit(state: BeaconState) -> Gwei:
 ```python
 def get_pending_balance_to_withdraw(state: BeaconState, validator_index: ValidatorIndex) -> Gwei:
     return sum(
-        withdrawal.amount for withdrawal in state.pending_partial_withdrawals if
-        withdrawal.validator_index == validator_index
+        withdrawal.amount for withdrawal in state.pending_partial_withdrawals 
+        if withdrawal.validator_index == validator_index
     )
 ```
 
@@ -1133,7 +1133,8 @@ def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], 
         has_excess_balance = state.balances[withdrawal.validator_index] > MIN_ACTIVATION_BALANCE
         if validator.exit_epoch == FAR_FUTURE_EPOCH and has_sufficient_effective_balance and has_excess_balance:
             withdrawable_balance = min(
-                state.balances[withdrawal.validator_index] - MIN_ACTIVATION_BALANCE, withdrawal.amount)
+                state.balances[withdrawal.validator_index] - MIN_ACTIVATION_BALANCE,
+                withdrawal.amount)
             withdrawals.append(Withdrawal(
                 index=withdrawal_index,
                 validator_index=withdrawal.validator_index,

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1571,7 +1571,7 @@ def process_withdrawal_request(
         exit_queue_epoch = compute_exit_epoch_and_update_churn(state, to_withdraw)
         withdrawable_epoch = Epoch(exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
         state.pending_partial_withdrawals.append(PendingPartialWithdrawal(
-            index=index,
+            validator_index=index,
             amount=to_withdraw,
             withdrawable_epoch=withdrawable_epoch,
         ))

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -239,7 +239,7 @@ class PendingDeposit(Container):
 
 ```python
 class PendingPartialWithdrawal(Container):
-    index: ValidatorIndex
+    validator_index: ValidatorIndex
     amount: Gwei
     withdrawable_epoch: Epoch
 ```
@@ -586,7 +586,8 @@ def get_consolidation_churn_limit(state: BeaconState) -> Gwei:
 ```python
 def get_pending_balance_to_withdraw(state: BeaconState, validator_index: ValidatorIndex) -> Gwei:
     return sum(
-        withdrawal.amount for withdrawal in state.pending_partial_withdrawals if withdrawal.index == validator_index
+        withdrawal.amount for withdrawal in state.pending_partial_withdrawals if
+        withdrawal.validator_index == validator_index
     )
 ```
 
@@ -1127,14 +1128,15 @@ def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], 
         if withdrawal.withdrawable_epoch > epoch or len(withdrawals) == MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP:
             break
 
-        validator = state.validators[withdrawal.index]
+        validator = state.validators[withdrawal.validator_index]
         has_sufficient_effective_balance = validator.effective_balance >= MIN_ACTIVATION_BALANCE
-        has_excess_balance = state.balances[withdrawal.index] > MIN_ACTIVATION_BALANCE
+        has_excess_balance = state.balances[withdrawal.validator_index] > MIN_ACTIVATION_BALANCE
         if validator.exit_epoch == FAR_FUTURE_EPOCH and has_sufficient_effective_balance and has_excess_balance:
-            withdrawable_balance = min(state.balances[withdrawal.index] - MIN_ACTIVATION_BALANCE, withdrawal.amount)
+            withdrawable_balance = min(
+                state.balances[withdrawal.validator_index] - MIN_ACTIVATION_BALANCE, withdrawal.amount)
             withdrawals.append(Withdrawal(
                 index=withdrawal_index,
-                validator_index=withdrawal.index,
+                validator_index=withdrawal.validator_index,
                 address=ExecutionAddress(validator.withdrawal_credentials[12:]),
                 amount=withdrawable_balance,
             ))

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_consolidation_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_consolidation_request.py
@@ -999,7 +999,7 @@ def test_incorrect_source_has_pending_withdrawal(spec, state):
 
     # Create pending withdrawal
     pending_withdrawal = spec.PendingPartialWithdrawal(
-        index=0, amount=excess_balance, withdrawable_epoch=current_epoch
+        validator_index=0, amount=excess_balance, withdrawable_epoch=current_epoch
     )
     state.pending_partial_withdrawals.append(pending_withdrawal)
 

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_voluntary_exit.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_voluntary_exit.py
@@ -401,7 +401,7 @@ def test_invalid_validator_has_pending_withdrawal(spec, state):
 
     state.pending_partial_withdrawals.append(
         spec.PendingPartialWithdrawal(
-            index=validator_index,
+            validator_index=validator_index,
             amount=1,
             withdrawable_epoch=spec.compute_activation_exit_epoch(current_epoch),
         )

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
@@ -81,7 +81,7 @@ def run_withdrawal_request_processing(
                 + spec.config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY
             )
             expected_partial_withdrawal = spec.PendingPartialWithdrawal(
-                index=validator_index,
+                validator_index=validator_index,
                 amount=expected_amount_to_withdraw,
                 withdrawable_epoch=expected_withdrawable_epoch,
             )
@@ -196,7 +196,7 @@ def test_basic_withdrawal_request_with_full_partial_withdrawal_queue(spec, state
 
     # Fill the partial withdrawal queue to the max (with a different validator index)
     partial_withdrawal = spec.PendingPartialWithdrawal(
-        index=1, amount=1, withdrawable_epoch=current_epoch
+        validator_index=1, amount=1, withdrawable_epoch=current_epoch
     )
     state.pending_partial_withdrawals = [
         partial_withdrawal
@@ -353,7 +353,7 @@ def test_unknown_pubkey(spec, state):
 @with_electra_and_later
 @spec_state_test
 @with_presets([MINIMAL])
-def test_basic_partial_withdrawal_request(spec, state):
+def  test_basic_partial_withdrawal_request(spec, state):
     rng = random.Random(1344)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)
@@ -471,7 +471,7 @@ def test_partial_withdrawal_request_with_pending_withdrawals(spec, state):
 
     # Add pending withdrawals
     partial_withdrawal = spec.PendingPartialWithdrawal(
-        index=validator_index, amount=amount, withdrawable_epoch=current_epoch
+        validator_index=validator_index, amount=amount, withdrawable_epoch=current_epoch
     )
     state.pending_partial_withdrawals = [partial_withdrawal] * 2
 
@@ -513,7 +513,7 @@ def test_partial_withdrawal_request_with_pending_withdrawals_and_high_amount(
 
     # Add many pending withdrawals
     partial_withdrawal = spec.PendingPartialWithdrawal(
-        index=validator_index,
+        validator_index=validator_index,
         amount=spec.EFFECTIVE_BALANCE_INCREMENT,
         withdrawable_epoch=current_epoch,
     )
@@ -661,7 +661,7 @@ def test_partial_withdrawal_queue_full(spec, state):
 
     # Fill the partial withdrawal queue to the max
     partial_withdrawal = spec.PendingPartialWithdrawal(
-        index=1, amount=1, withdrawable_epoch=current_epoch
+        validator_index=1, amount=1, withdrawable_epoch=current_epoch
     )
     state.pending_partial_withdrawals = [
         partial_withdrawal
@@ -746,7 +746,7 @@ def test_pending_withdrawals_consume_all_excess_balance(spec, state):
 
     # Add pending withdrawals totalling an amount equal to the excess balance
     partial_withdrawal = spec.PendingPartialWithdrawal(
-        index=validator_index, amount=amount, withdrawable_epoch=current_epoch
+        validator_index=validator_index, amount=amount, withdrawable_epoch=current_epoch
     )
     state.pending_partial_withdrawals = [partial_withdrawal] * 10
 
@@ -951,7 +951,7 @@ def test_full_exit_request_has_partial_withdrawal(spec, state):
     state.balances[validator_index] = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
     state.pending_partial_withdrawals.append(
         spec.PendingPartialWithdrawal(
-            index=validator_index,
+            validator_index=validator_index,
             amount=1,
             withdrawable_epoch=spec.compute_activation_exit_epoch(current_epoch),
         )

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
@@ -353,7 +353,7 @@ def test_unknown_pubkey(spec, state):
 @with_electra_and_later
 @spec_state_test
 @with_presets([MINIMAL])
-def  test_basic_partial_withdrawal_request(spec, state):
+def test_basic_partial_withdrawal_request(spec, state):
     rng = random.Random(1344)
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     current_epoch = spec.get_current_epoch(state)

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawals.py
@@ -91,14 +91,14 @@ def test_success_excess_balance_but_no_max_effective_balance_compounding(spec, s
 @with_electra_and_later
 @spec_state_test
 def test_pending_withdrawals_one_skipped_one_effective(spec, state):
-    index_0 = 3
-    index_1 = 5
+    validator_index_0 = 3
+    validator_index_1 = 5
 
-    pending_withdrawal_0 = prepare_pending_withdrawal(spec, state, index_0)
-    pending_withdrawal_1 = prepare_pending_withdrawal(spec, state, index_1)
+    pending_withdrawal_0 = prepare_pending_withdrawal(spec, state, validator_index_0)
+    pending_withdrawal_1 = prepare_pending_withdrawal(spec, state, validator_index_1)
 
     # If validator doesn't have an excess balance pending withdrawal is skipped
-    state.balances[index_0] = spec.MIN_ACTIVATION_BALANCE
+    state.balances[validator_index_0] = spec.MIN_ACTIVATION_BALANCE
 
     execution_payload = build_empty_execution_payload(spec, state)
     assert state.pending_partial_withdrawals == [pending_withdrawal_0, pending_withdrawal_1]
@@ -155,7 +155,7 @@ def test_pending_withdrawals_exiting_validator(spec, state):
     validator_index = len(state.validators) // 2
 
     pending_withdrawal = prepare_pending_withdrawal(spec, state, validator_index)
-    spec.initiate_validator_exit(state, pending_withdrawal.index)
+    spec.initiate_validator_exit(state, pending_withdrawal.validator_index)
 
     execution_payload = build_empty_execution_payload(spec, state)
     yield from run_withdrawals_processing(spec, state, execution_payload, num_expected_withdrawals=0)
@@ -169,7 +169,7 @@ def test_pending_withdrawals_low_effective_balance(spec, state):
     validator_index = len(state.validators) // 2
 
     pending_withdrawal = prepare_pending_withdrawal(spec, state, validator_index)
-    state.validators[pending_withdrawal.index].effective_balance = (
+    state.validators[pending_withdrawal.validator_index].effective_balance = (
         spec.MIN_ACTIVATION_BALANCE - spec.EFFECTIVE_BALANCE_INCREMENT
     )
 
@@ -185,7 +185,7 @@ def test_pending_withdrawals_no_excess_balance(spec, state):
     validator_index = len(state.validators) // 2
 
     pending_withdrawal = prepare_pending_withdrawal(spec, state, validator_index)
-    state.balances[pending_withdrawal.index] = spec.MIN_ACTIVATION_BALANCE
+    state.balances[pending_withdrawal.validator_index] = spec.MIN_ACTIVATION_BALANCE
 
     execution_payload = build_empty_execution_payload(spec, state)
     yield from run_withdrawals_processing(spec, state, execution_payload, num_expected_withdrawals=0)

--- a/tests/core/pyspec/eth2spec/test/helpers/withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/withdrawals.py
@@ -120,7 +120,7 @@ def prepare_pending_withdrawal(spec, state, validator_index,
     )
 
     withdrawal = spec.PendingPartialWithdrawal(
-        index=validator_index,
+        validator_index=validator_index,
         amount=amount,
         withdrawable_epoch=withdrawable_epoch,
     )
@@ -238,7 +238,7 @@ def run_withdrawals_processing(spec, state, execution_payload, num_expected_with
         assert len(pending_withdrawal_requests) <= len(execution_payload.withdrawals)
         for index, request in enumerate(pending_withdrawal_requests):
             withdrawal = execution_payload.withdrawals[index]
-            assert withdrawal.validator_index == request.index
+            assert withdrawal.validator_index == request.validator_index
             assert withdrawal.amount == request.amount
 
     return expected_withdrawals


### PR DESCRIPTION
### TLDR

This PR changes `PendingPartialWithdrawal.index` to `PendingPartialWithdrawal.validator_index`. This makes it more aligned with `Withdrawal` and other places where we refer to `ValidatorIndex` as `validator_index`.

### Justification

In Capella, we introduced `Withdrawal` with the following definition:
```
class Withdrawal(Container):
    index: WithdrawalIndex
    validator_index: ValidatorIndex
    address: ExecutionAddress
    amount: Gwei
```

And in Electra, we introduced `PendingPartialWithdrawal` as:
```
class PendingPartialWithdrawal(Container):
    index: ValidatorIndex
    amount: Gwei
    withdrawable_epoch: Epoch
```

The fact that we used `Withdrawal.validator_index` but `PendingPartialWithdrawal.index` is confusing. And can be misleading given we have `Withdrawal.index` with a complete different meaning.