### PR TITLE
Fix typos

### DIFF
--- a/specs/_features/whisk/beacon-chain.md
+++ b/specs/_features/whisk/beacon-chain.md
@@ -54,7 +54,7 @@ This document details the beacon chain additions and changes of to support the W
 | `WHISK_PROPOSER_TRACKERS_COUNT`    | `uint64(2**13)` (= 8,192)  | number of proposer trackers                                 |
 | `WHISK_VALIDATORS_PER_SHUFFLE`     | `uint64(2**7 - 4)` (= 124) | number of validators shuffled per shuffle step              |
 | `WHISK_MAX_SHUFFLE_PROOF_SIZE`     | `uint64(2**15)`            | max size of a shuffle proof                                 |
-| `WHISK_MAX_OPENING_PROOF_SIZE`     | `uint64(2**10)`            | max size of a opening proof                                 |
+| `WHISK_MAX_OPENING_PROOF_SIZE`     | `uint64(2**10)`            | max size of an opening proof                                 |
 
 ## Configuration
 

--- a/specs/capella/validator.md
+++ b/specs/capella/validator.md
@@ -137,4 +137,4 @@ the withdrawal credential change takes effect. No further action is required for
 withdrawal process.
 
 *Note*: A node *should* prioritize locally received `BLSToExecutionChange` operations to ensure these changes make it on-chain
-through self published blocks even if the rest of the network censors.
+through self-published blocks even if the rest of the network censors.

--- a/tests/core/pyspec/eth2spec/gen_helpers/README.md
+++ b/tests/core/pyspec/eth2spec/gen_helpers/README.md
@@ -26,7 +26,7 @@ Options:
 
 ## `gen_from_tests`
 
-This is an util to derive tests from a tests source file.
+This is a util to derive tests from a tests source file.
 
 This requires the tests to yield test-case-part outputs. These outputs are then written to the test case directory.
 Yielding data is illegal in normal pytests, so it is only done when in "generator mode".

--- a/tests/formats/README.md
+++ b/tests/formats/README.md
@@ -136,7 +136,7 @@ Or to avoid large files, the SSZ can be compressed with Snappy.
 E.g. `pre.ssz_snappy`, `deposit.ssz_snappy`, `post.ssz_snappy`.
 
 Diffing a `pre.ssz_snappy` and `post.ssz_snappy` provides all the information for testing, when decompressed and decoded.
-Then the difference between pre and post can be compared to anything that changes the pre state, e.g. `deposit.ssz_snappy`
+Then the difference between pre and post can be compared to anything that changes the pre-state, e.g. `deposit.ssz_snappy`
 
 Note that by default, the SSZ data is in the given test case's <fork or phase name> version, e.g., if it's `altair` test case, use `altair.BeaconState` container to deserialize the given state.
 


### PR DESCRIPTION
This pull request fixes several typographical errors in the documentation files across multiple directories:

- **`beacon-chain.md`**: Corrected the use of "a" to "an" before "opening proof."
- **`validator.md`**: Added a hyphen to "self-published" to correct the spelling.
- **`README.md` (tests/core/pyspec/eth2spec/gen_helpers)**: Corrected "an util" to "a util" for grammatical accuracy.
- **`README.md` (tests/formats)**: Fixed the spelling of "pre-state" by adding the necessary hyphen.

These changes improve the clarity and correctness of the documentation.
