### PR TITLE
Align PeerDAS `sampling_size` comparison units

### DIFF
--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -237,7 +237,7 @@ The particular columns/groups that a node custodies are selected pseudo-randomly
 
 ## Custody sampling
 
-At each slot, a node advertising `custody_group_count` downloads a minimum of `sampling_size = max(SAMPLES_PER_SLOT, custody_group_count)` total custody groups. The corresponding set of columns is selected by `groups = get_custody_groups(node_id, sampling_size)` and `compute_columns_for_custody_group(group) for group in groups`, so that in particular the subset of columns to custody is consistent with the output of `get_custody_groups(node_id, custody_group_count)`. Sampling is considered successful if the node manages to retrieve all selected columns.
+At each slot, a node advertising `custody_group_count` downloads a minimum of `sampling_size = max(SAMPLES_PER_SLOT, custody_group_count * (NUMBER_OF_COLUMNS / NUMBER_OF_CUSTODY_GROUPS))` total columns. The corresponding set of columns is selected by `groups = get_custody_groups(node_id, sampling_size)` and `compute_columns_for_custody_group(group) for group in groups`, so that in particular the subset of columns to custody is consistent with the output of `get_custody_groups(node_id, custody_group_count)`. Sampling is considered successful if the node manages to retrieve all selected columns.
 
 ## Extended data
 

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -237,7 +237,7 @@ The particular columns/groups that a node custodies are selected pseudo-randomly
 
 ## Custody sampling
 
-At each slot, a node advertising `custody_group_count` downloads a minimum of `sampling_size = max(SAMPLES_PER_SLOT, custody_group_count * (NUMBER_OF_COLUMNS / NUMBER_OF_CUSTODY_GROUPS))` total columns. The corresponding set of columns is selected by `groups = get_custody_groups(node_id, sampling_size)` and `compute_columns_for_custody_group(group) for group in groups`, so that in particular the subset of columns to custody is consistent with the output of `get_custody_groups(node_id, custody_group_count)`. Sampling is considered successful if the node manages to retrieve all selected columns.
+At each slot, a node advertising `custody_group_count` downloads a minimum of `sampling_size = max(SAMPLES_PER_SLOT, custody_group_count * (NUMBER_OF_COLUMNS // NUMBER_OF_CUSTODY_GROUPS))` total columns. The corresponding set of columns is selected by `groups = get_custody_groups(node_id, sampling_size)` and `compute_columns_for_custody_group(group) for group in groups`, so that in particular the subset of columns to custody is consistent with the output of `get_custody_groups(node_id, custody_group_count)`. Sampling is considered successful if the node manages to retrieve all selected columns.
 
 ## Extended data
 

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -237,7 +237,7 @@ The particular columns/groups that a node custodies are selected pseudo-randomly
 
 ## Custody sampling
 
-At each slot, a node advertising `custody_group_count` downloads a minimum of `sampling_size = max(SAMPLES_PER_SLOT, custody_group_count * (NUMBER_OF_COLUMNS // NUMBER_OF_CUSTODY_GROUPS))` total columns. The corresponding set of columns is selected by `groups = get_custody_groups(node_id, sampling_size)` and `compute_columns_for_custody_group(group) for group in groups`, so that in particular the subset of columns to custody is consistent with the output of `get_custody_groups(node_id, custody_group_count)`. Sampling is considered successful if the node manages to retrieve all selected columns.
+At each slot, a node advertising `custody_group_count` downloads a minimum of `sampling_size = max(SAMPLES_PER_SLOT, custody_group_count * columns_per_group)` total columns, where `columns_per_group = NUMBER_OF_COLUMNS // NUMBER_OF_CUSTODY_GROUPS`. The corresponding set of columns is selected by `groups = get_custody_groups(node_id, sampling_size)` and `compute_columns_for_custody_group(group) for group in groups`, so that in particular the subset of columns to custody is consistent with the output of `get_custody_groups(node_id, custody_group_count)`. Sampling is considered successful if the node manages to retrieve all selected columns.
 
 ## Extended data
 


### PR DESCRIPTION
The current sampling size logic mixes different units - `SAMPLES_PER_SLOT` is measured in column samples, while `custody_group_count` refers to custody groups:

> At each slot, a node advertising `custody_group_count` downloads a minimum of `sampling_size = max(SAMPLES_PER_SLOT, custody_group_count)` total custody groups.

This discrepancy causes issues when `NUMBER_OF_COLUMNS` does not exactly match `NUMBER_OF_CUSTODY_GROUPS`, potentially leading to incorrect `sampling_size`. 

This PR converts the `custody_group_count` to column count.