### PR TITLE
Update blob sidecar subnet computation for EIP-7691

### DIFF
--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -24,6 +24,8 @@
     - [Deposits](#deposits)
     - [Execution payload](#execution-payload)
     - [Execution Requests](#execution-requests)
+  - [Constructing the `BlobSidecar`s](#constructing-the-blobsidecars)
+    - [Sidecar](#sidecar)
 - [Attesting](#attesting)
   - [Construct attestation](#construct-attestation)
 - [Attestation aggregation](#attestation-aggregation)
@@ -238,6 +240,17 @@ def get_execution_requests(execution_requests_list: Sequence[bytes]) -> Executio
         withdrawals=withdrawals,
         consolidations=consolidations,
     )
+```
+
+### Constructing the `BlobSidecar`s
+
+#### Sidecar
+
+*[Modified in Electra:EIP7691]*
+
+```python
+def compute_subnet_for_blob_sidecar(blob_index: BlobIndex) -> SubnetID:
+    return SubnetID(blob_index % BLOB_SIDECAR_SUBNET_COUNT_ELECTRA)
 ```
 
 ## Attesting


### PR DESCRIPTION
Follow up on https://github.com/ethereum/consensus-specs/pull/4056 to update the blob sidecar subnet computation for EIP-7691 which does not use `MAX_BLOBS_PER_BLOCK` but `BLOB_SIDECAR_SUBNET_COUNT`, so I don't think it's covered by the previous PR.

Closes https://github.com/ethereum/consensus-specs/issues/4066