### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ Handy commands:
 
 Ideally manual running of docker containers is for advanced users, we recommend the script based approach described below for most users.
 
-The `scripts/build_run_docker_tests.sh` script will cover most usecases. The script allows the user to configure the fork(altair/bellatrix/capella..), `$IMAGE_NAME` (specifies the container to use), preset type (mainnet/minimal), and test all forks flags. Ideally, this is the main way that users interact with the spec tests instead of running it locally with varying versions of dependencies.
+The `scripts/build_run_docker_tests.sh` script will cover most use cases. The script allows the user to configure the fork(altair/bellatrix/capella..), `$IMAGE_NAME` (specifies the container to use), preset type (mainnet/minimal), and test all forks flags. Ideally, this is the main way that users interact with the spec tests instead of running it locally with varying versions of dependencies.
 
 E.g:
 - `./build_run_docker_tests.sh --p mainnet` will run the mainnet preset tests

--- a/specs/_features/custody_game/beacon-chain.md
+++ b/specs/_features/custody_game/beacon-chain.md
@@ -124,12 +124,12 @@ building upon the [Sharding](../sharding/beacon-chain.md) specification.
 
 ```python
 class Validator(sharding.Validator):
-    # next_custody_secret_to_reveal is initialised to the custody period
+    # next_custody_secret_to_reveal is initialized to the custody period
     # (of the particular validator) in which the validator is activated
     # = get_custody_period_for_validator(...)
     next_custody_secret_to_reveal: uint64
     # TODO: The max_reveal_lateness doesn't really make sense anymore.
-    # So how do we incentivise early custody key reveals now?
+    # So how do we incentivize early custody key reveals now?
     all_custody_secrets_revealed_epoch: Epoch  # to be initialized to FAR_FUTURE_EPOCH
 ```
 
@@ -446,7 +446,7 @@ def process_chunk_challenge_response(state: BeaconState,
     challenge = matching_challenges[0]
     # Verify chunk index
     assert response.chunk_index == challenge.chunk_index
-    # Verify the chunk matches the crosslink data root
+    # Verify the chunk matches the cross link data root
     assert is_valid_merkle_branch(
         leaf=hash_tree_root(response.chunk),
         branch=response.branch,
@@ -619,7 +619,7 @@ def process_custody_slashing(state: BeaconState, signed_custody_slashing: Signed
         for attester_index in attesters:
             if attester_index != custody_slashing.malefactor_index:
                 increase_balance(state, attester_index, whistleblower_reward)
-        # No special whisteblower reward: it is expected to be an attester. Others are free to slash too however.
+        # No special whistleblower reward: it is expected to be an attester. Others are free to slash too however.
     else:
         # The claim was false, the custody bit was correct. Slash the whistleblower that induced this work.
         slash_validator(state, custody_slashing.whistleblower_index)

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -129,9 +129,9 @@ leaving the block tree without viable branches
 
 Let only a validator on an optimistic node be an *optimistic validator*.
 
-When this specification only defines behaviour for an optimistic
+When this specification only defines behavior for an optimistic
 node/validator, but *not* for the non-optimistic case, assume default
-behaviours without regard for optimistic sync.
+behaviors without regard for optimistic sync.
 
 ## Mechanisms
 
@@ -226,7 +226,7 @@ validity request for some block, a consensus engine:
 - MUST NOT apply the block to the fork choice store.
 - MAY queue the block for later processing.
 
-### Assumptions about Execution Engine Behaviour
+### Assumptions about Execution Engine Behavior
 
 This specification assumes execution engines will only return `NOT_VALIDATED` when
 there is insufficient information available to make a `VALID` or `INVALIDATED`
@@ -237,7 +237,7 @@ another chain.
 
 ### Re-Orgs
 
-The consensus engine MUST support any chain reorganisation which does *not*
+The consensus engine MUST support any chain reorganization which does *not*
 affect the justified checkpoint.
 
 If the justified checkpoint transitions from `NOT_VALIDATED` -> `INVALIDATED`, a
@@ -341,7 +341,7 @@ Optimistic sync is also an optimal strategy for execution engines using block ex
 sync mechanism (e.g. Erigon). Alternatively, a consensus engine may inform the execution engine with a payload
 obtained from a checkpoint block, then wait until the execution layer catches up with it and proceed
 in lock step after that. This alternative approach would keep user in limbo for several hours and
-would increase time of the sync process as batch sync has more opportunities for optimisation than the lock step.
+would increase time of the sync process as batch sync has more opportunities for optimization than the lock step.
 
 Aforementioned premises make optimistic sync a *generalized* solution for interaction between consensus and
 execution engines during the sync process.
@@ -426,4 +426,4 @@ retrospectively call [`validate_merge_block`](../specs/bellatrix/fork-choice.md#
 on a transition block that
 matches `TERMINAL_BLOCK_HASH` after an optimistic sync, doing so will have no
 effect. For simplicity, the optimistic sync specification does not define
-edge-case behaviour for when `TERMINAL_BLOCK_HASH` is used.
+edge-case behavior for when `TERMINAL_BLOCK_HASH` is used.


### PR DESCRIPTION
Corrected `usecases` to `use cases`
Corrected `initialised` to `initialized`
Corrected `incentivise` to `incentivize`
Corrected `crosslink` to `cross link`
Corrected `whisteblower` to `whistleblower`
Corrected `behaviour` to `behavior` x4
Corrected `reorganisation` to `reorganization`
Corrected `optimisation` to `optimization`