### PR TITLE
In get_custody_groups, don't skip 0 value

### DIFF
--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -105,19 +105,20 @@ class MatrixEntry(Container):
 def get_custody_groups(node_id: NodeID, custody_group_count: uint64) -> Sequence[CustodyIndex]:
     assert custody_group_count <= NUMBER_OF_CUSTODY_GROUPS
 
-    custody_groups: List[uint64] = []
     current_id = uint256(node_id)
+    custody_groups: List[CustodyIndex] = []
     while len(custody_groups) < custody_group_count:
         custody_group = CustodyIndex(
-            bytes_to_uint64(hash(uint_to_bytes(uint256(current_id)))[0:8])
+            bytes_to_uint64(hash(uint_to_bytes(current_id))[0:8])
             % NUMBER_OF_CUSTODY_GROUPS
         )
         if custody_group not in custody_groups:
             custody_groups.append(custody_group)
         if current_id == UINT256_MAX:
             # Overflow prevention
-            current_id = NodeID(0)
-        current_id += 1
+            current_id = uint256(0)
+        else:
+            current_id += 1
 
     assert len(custody_groups) == len(set(custody_groups))
     return sorted(custody_groups)


### PR DESCRIPTION
This PR does the following:

* If there's an overflow, don't skip the zero value.
  * Previously this would set it to zero THEN increment.
  * Instead we should set to zero OR increment.
* Use more strict type annotations for explicit clarity.
* Remove unnecessary uint256 cast.
* When there's an overflow, cast zero to uint256 not NodeID. 

Thanks to @tersec for pointing this out on Discord.

> is it intentional that https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#get_custody_groups in the name of "Overflow prevention" skips the zero NodeID? That's not just overflow protection, that's conceptually, the NodeID sequence it iterates through is 115792089237316195423570985008687907853269984665640564039457584007913129639934, 115792089237316195423570985008687907853269984665640564039457584007913129639935, not 0, 1, 2, ...