### PR TITLE
Fulu: Remove V3 of blob sidecar by root/range RPC

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -29,8 +29,6 @@
         - [`data_column_sidecar_{subnet_id}`](#data_column_sidecar_subnet_id)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
-      - [BlobSidecarsByRoot v3](#blobsidecarsbyroot-v3)
-      - [BlobSidecarsByRange v3](#blobsidecarsbyrange-v3)
       - [DataColumnSidecarsByRoot v1](#datacolumnsidecarsbyroot-v1)
       - [DataColumnSidecarsByRange v1](#datacolumnsidecarsbyrange-v1)
       - [GetMetaData v3](#getmetadata-v3)
@@ -64,7 +62,6 @@ The specification of these changes continues in the same format as the network s
 | `DATA_COLUMN_SIDECAR_SUBNET_COUNT`             | `128`                                                 | The number of data column sidecar subnets used in the gossipsub protocol  |
 | `MAX_REQUEST_DATA_COLUMN_SIDECARS`             | `MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS`        | Maximum number of data column sidecars in a single request                |
 | `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` | `2**12` (= 4096 epochs, ~18 days)                     | The minimum epoch range over which a node must serve data column sidecars |
-| `MAX_REQUEST_BLOB_SIDECARS_FULU`               | `MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK_FULU` | Maximum number of blob sidecars in a single request                       |
 
 ### Containers
 
@@ -210,75 +207,6 @@ The following validations MUST pass before forwarding the `sidecar: DataColumnSi
 ### The Req/Resp domain
 
 #### Messages
-
-##### BlobSidecarsByRoot v3
-
-**Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/3/`
-
-*[Modified in Fulu:EIP7594]*
-
-The `<context-bytes>` field is calculated as `context = compute_fork_digest(fork_version, genesis_validators_root)`:
-
-[1]: # (eth2spec: skip)
-
-| `fork_version`      | Chunk SSZ type     |
-|---------------------|--------------------|
-| `FULU_FORK_VERSION` | `fulu.BlobSidecar` |
-
-Request Content:
-
-```
-(
-  List[BlobIdentifier, MAX_REQUEST_BLOB_SIDECARS_FULU]
-)
-```
-
-Response Content:
-
-```
-(
-  List[BlobSidecar, MAX_REQUEST_BLOB_SIDECARS_FULU]
-)
-```
-
-*Updated validation*
-
-No more than `MAX_REQUEST_BLOB_SIDECARS_FULU` may be requested at a time.
-
-##### BlobSidecarsByRange v3
-
-**Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/3/`
-
-*[Modified in Fulu:EIP7594]*
-
-The `<context-bytes>` field is calculated as `context = compute_fork_digest(fork_version, genesis_validators_root)`:
-
-[1]: # (eth2spec: skip)
-
-| `fork_version`      | Chunk SSZ type     |
-|---------------------|--------------------|
-| `FULU_FORK_VERSION` | `fulu.BlobSidecar` |
-
-Request Content:
-
-```
-(
-  start_slot: Slot
-  count: uint64
-)
-```
-
-Response Content:
-
-```
-(
-  List[BlobSidecar, MAX_REQUEST_BLOB_SIDECARS_FULU]
-)
-```
-
-*Updated validation*
-
-Clients MUST respond with at least the blob sidecars of the first blob-carrying block that exists in the range, if they have it, and no more than `MAX_REQUEST_BLOB_SIDECARS_FULU` sidecars.
 
 ##### DataColumnSidecarsByRoot v1
 

--- a/tests/core/pyspec/eth2spec/test/fulu/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/unittests/test_config_invariants.py
@@ -32,7 +32,3 @@ def test_polynomical_commitments_sampling(spec):
 @single_phase
 def test_networking(spec):
     assert spec.config.MAX_BLOBS_PER_BLOCK_FULU <= spec.MAX_BLOB_COMMITMENTS_PER_BLOCK
-    assert (
-        spec.config.MAX_REQUEST_BLOB_SIDECARS_FULU ==
-        spec.config.MAX_REQUEST_BLOCKS_DENEB * spec.config.MAX_BLOBS_PER_BLOCK_FULU
-    )


### PR DESCRIPTION
The Fulu fork introduces peerDAS, replacing blob sidecars by data columns sidecars.

After the Fulu fork epoch, clients still need to be able to request blob sidecars by root/range, at least for the blobs retention period after the Fulu fork epoch.

Blob sidecars will be retrieved at most up to the Electra epoch, so the V2 version (Electra) for blob sidecars by range/root is enough. There is no need to retrieve blob sidecars after the Fulu fork where data column sidecars will be used instead, so there is no need to introduce the V3 version (Fulu) for blob sidecars by range/root.