### PR TITLE
Remove reference to electra.BlobSidecar in EIP-7691

### DIFF
--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -116,15 +116,6 @@ The following validations are removed:
 
 *[Modified in Electra:EIP7691]*
 
-The `<context-bytes>` field is calculated as `context = compute_fork_digest(fork_version, genesis_validators_root)`:
-
-[1]: # (eth2spec: skip)
-
-| `fork_version`         | Chunk SSZ type        |
-|------------------------|-----------------------|
-| `DENEB_FORK_VERSION`   | `deneb.BlobSidecar`   |
-| `ELECTRA_FORK_VERSION` | `electra.BlobSidecar` |
-
 Request Content:
 
 ```
@@ -150,15 +141,6 @@ No more than `MAX_REQUEST_BLOB_SIDECARS_ELECTRA` may be requested at a time.
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/2/`
 
 *[Modified in Electra:EIP7691]*
-
-The `<context-bytes>` field is calculated as `context = compute_fork_digest(fork_version, genesis_validators_root)`:
-
-[1]: # (eth2spec: skip)
-
-| `fork_version`         | Chunk SSZ type        |
-|------------------------|-----------------------|
-| `DENEB_FORK_VERSION`   | `deneb.BlobSidecar`   |
-| `ELECTRA_FORK_VERSION` | `electra.BlobSidecar` |
 
 Request Content:
 


### PR DESCRIPTION
Removing reference to `electra.BlobSidecar` as there is no change to `BlobSidecar`'s ssz type definition in Electra.


Alternatively we can define `electra.BlobSidecar` by defining `MAX_BLOB_COMMITMENTS_PER_BLOCK_ELECTRA` and `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH` and revert changes to `MAX_BLOB_COMMITMENTS_PER_BLOCK` and `KZG_COMMITMENT_INCLUSION_PROOF` [here](https://github.com/ethereum/consensus-specs/pull/4023/files#diff-105bcf56c68ccee23f29448d8cad7a9376736382b9ab9b39de28fcadd35625c0R8).