### PR TITLE
Use SubnetID for sync committee

### DIFF
--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -295,7 +295,7 @@ The `subnet_id` is derived from the position in the sync committee such that the
 *Note*: This function returns multiple deduplicated subnets if a given validator index is included multiple times in a given sync committee across multiple subcommittees.
 
 ```python
-def compute_subnets_for_sync_committee(state: BeaconState, validator_index: ValidatorIndex) -> Set[uint64]:
+def compute_subnets_for_sync_committee(state: BeaconState, validator_index: ValidatorIndex) -> Set[SubnetID]:
     next_slot_epoch = compute_epoch_at_slot(Slot(state.slot + 1))
     if compute_sync_committee_period(get_current_epoch(state)) == compute_sync_committee_period(next_slot_epoch):
         sync_committee = state.current_sync_committee
@@ -305,7 +305,7 @@ def compute_subnets_for_sync_committee(state: BeaconState, validator_index: Vali
     target_pubkey = state.validators[validator_index].pubkey
     sync_committee_indices = [index for index, pubkey in enumerate(sync_committee.pubkeys) if pubkey == target_pubkey]
     return set([
-        uint64(index // (SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT))
+        SubnetID(index // (SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT))
         for index in sync_committee_indices
     ])
 ```


### PR DESCRIPTION
`SubnetID` is being used for computing for attestation and blob subnets. 

Updating sync committee subnet to use `SubnetID` type for consistency.