### PR TITLE
Revert BlobSidecarsByRoot/Range version bump

### DIFF
--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -19,8 +19,8 @@
         - [`beacon_attestation_{subnet_id}`](#beacon_attestation_subnet_id)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
-      - [BlobSidecarsByRoot v2](#blobsidecarsbyroot-v2)
-      - [BlobSidecarsByRange v2](#blobsidecarsbyrange-v2)
+      - [BlobSidecarsByRoot v1](#blobsidecarsbyroot-v1)
+      - [BlobSidecarsByRange v1](#blobsidecarsbyrange-v1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -110,9 +110,9 @@ The following validations are removed:
 
 #### Messages
 
-##### BlobSidecarsByRoot v2
+##### BlobSidecarsByRoot v1
 
-**Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/2/`
+**Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/1/`
 
 *[Modified in Electra:EIP7691]*
 
@@ -136,9 +136,9 @@ Response Content:
 
 No more than `MAX_REQUEST_BLOB_SIDECARS_ELECTRA` may be requested at a time.
 
-##### BlobSidecarsByRange v2
+##### BlobSidecarsByRange v1
 
-**Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/2/`
+**Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/1/`
 
 *[Modified in Electra:EIP7691]*
 


### PR DESCRIPTION
This PR changes `BlobSidecarsByRoot` and `BlobSidecarsByRange` from v2 back to v1. This was an unnecessary change since only the request/response list lengths have changed. Thank you for noticing this @pawanjay176!

For reference, please see the Eth R&D messages here:

https://discord.com/channels/595666850260713488/598292067260825641/1326382390397898803

> Have other clients implemented the v2 blobsbyrange/root rpc protocol for electra https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/p2p-interface.md#blobsidecarsbyroot-v2 ?
 seems like the only difference between v1 and v2 versions is the length of the list. Not sure when we typically bump rpc protocol versions but doing this for a length increase seems unnecessary imo. Do other clients think this is good to have?