### PR TITLE
Simplify/optimize `process_registry_updates`

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -816,27 +816,24 @@ def process_epoch(state: BeaconState) -> None:
 
 #### Modified `process_registry_updates`
 
-*Note*: The function `process_registry_updates` is modified to
-use the updated definitions of `initiate_validator_exit` and `is_eligible_for_activation_queue`
-and changes how the activation epochs are computed for eligible validators.
+*Note*: The function `process_registry_updates` is modified to use the updated definitions of
+`initiate_validator_exit` and `is_eligible_for_activation_queue`, changes how the activation epochs
+are computed for eligible validators, and processes activations in the same loop as activation
+eligibility updates and ejections.
 
 ```python
 def process_registry_updates(state: BeaconState) -> None:
-    # Process activation eligibility and ejections
+    current_epoch = get_current_epoch(state)
+    activation_epoch = compute_activation_exit_epoch(current_epoch)
+
+    # Process activation eligibility, ejections, and activations
     for index, validator in enumerate(state.validators):
         if is_eligible_for_activation_queue(validator):  # [Modified in Electra:EIP7251]
-            validator.activation_eligibility_epoch = get_current_epoch(state) + 1
+            validator.activation_eligibility_epoch = current_epoch + 1
 
-        if (
-            is_active_validator(validator, get_current_epoch(state))
-            and validator.effective_balance <= EJECTION_BALANCE
-        ):
+        if is_active_validator(validator, current_epoch) and validator.effective_balance <= EJECTION_BALANCE:
             initiate_validator_exit(state, ValidatorIndex(index))  # [Modified in Electra:EIP7251]
 
-    # Activate all eligible validators
-    # [Modified in Electra:EIP7251]
-    activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
-    for validator in state.validators:
         if is_eligible_for_activation(state, validator):
             validator.activation_epoch = activation_epoch
 ```


### PR DESCRIPTION
When reviewing Prysm's implementation of [`process_registry_updates`](https://github.com/prysmaticlabs/prysm/blob/e5784d09f040c4788ad83659d0c8e06b5fbfc142/beacon-chain/core/electra/registry_updates.go#L39-L107) I noticed that they were processing registry changes in a single loop, rather than two like the spec does. After evaluating it, I came to the conclusion that it is safe. Since this is a simplification and an optimization that clients should implement, it would be best to include it in the specifications.

These operations can be done in the same loop because they do not impact each other. For example, if a validator is added to the activation queue (`validator.activation_eligibility_epoch = current_epoch + 1`) it will not be eligible for activation until `validator.activation_eligibility_epoch` is finalized, which is not this epoch.

https://github.com/ethereum/consensus-specs/blob/da1746124cd5a492a58e53bbddd609c5fc539dc8/specs/phase0/beacon-chain.md?plain=1#L699-L708

This PR makes the following changes:

* Compute the current epoch once at the beginning of the function.
* Replace instances of `get_current_epoch(state)` with `current_epoch`.
* Combine the two loops into one.