### PR TITLE
Fix various nits in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Documentation on the different components used during spec writing can be found 
 
 Conformance tests built from the executable python spec are available in the [Ethereum Proof-of-Stake Consensus Spec Tests](https://github.com/ethereum/consensus-spec-tests) repo. Compressed tarballs are available in [releases](https://github.com/ethereum/consensus-spec-tests/releases).
 
-
 ## Installation and Usage
 The consensus-specs repo can be used by running the tests locally or inside a docker container.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,11 @@
 ## Docker related information
 
 This dockerfile sets up the dependencies required to run consensus-spec tests. The docker image can be locally built with:
+
 - `docker build ./ -t $IMAGE_NAME -f ./docker/Dockerfile`
 
-
 Handy commands:
+
 - `docker run -it $IMAGE_NAME /bin/sh` will give you a shell inside the docker container to manually run any tests
 - `docker run $IMAGE_NAME make test` will run the make test command inside the docker container
 
@@ -13,6 +14,7 @@ Ideally manual running of docker containers is for advanced users, we recommend 
 The `scripts/build_run_docker_tests.sh` script will cover most use cases. The script allows the user to configure the fork(altair/bellatrix/capella..), `$IMAGE_NAME` (specifies the container to use), preset type (mainnet/minimal), and test all forks flags. Ideally, this is the main way that users interact with the spec tests instead of running it locally with varying versions of dependencies.
 
 E.g:
+
 - `./build_run_docker_tests.sh --p mainnet` will run the mainnet preset tests
 - `./build_run_docker_tests.sh --a` will run all the tests across all the forks
 - `./build_run_docker_tests.sh --f deneb` will only run deneb tests

--- a/docs/docs/new-feature.md
+++ b/docs/docs/new-feature.md
@@ -1,8 +1,9 @@
 # How to add a new feature proposal in consensus-specs
 
+## Table of contents
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-## Table of Contents
 
 - [A. Make it executable for linter checks](#a-make-it-executable-for-linter-checks)
   - [1. Create a folder under `./specs/_features`](#1-create-a-folder-under-specs_features)
@@ -23,7 +24,6 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-
 ## A. Make it executable for linter checks
 
 ### 1. Create a folder under `./specs/_features`
@@ -35,6 +35,7 @@ For example, if it's an `EIP-9999` CL spec, you can create a `./specs/_features/
 For example, if the latest fork is Capella, use `./specs/capella` content as your "previous fork".
 
 ### 3. Write down your proposed `beacon-chain.md` change
+
 - You can either use [Beacon Chain Spec Template](./templates/beacon-chain-template.md), or make a copy of the latest fork content and then edit it.
 - Tips:
     - We use [`doctoc`](https://www.npmjs.com/package/doctoc) tool to generate the table of content.
@@ -50,8 +51,11 @@ For example, if the latest fork is Capella, use `./specs/capella` content as you
         - Use simple Python rather than the fancy Python dark magic.
 
 ### 4. Add `fork.md`
+
 You can refer to the previous fork's `fork.md` file.
+
 ### 5. Make it executable
+
 - Update Pyspec [`constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/constants.py) with the new feature name.
 - Update helpers for [`setup.py`](https://github.com/ethereum/consensus-specs/blob/dev/setup.py) for building the spec:
     - Update [`pysetup/constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/pysetup/constants.py) with the new feature name as Pyspec `constants.py` defined.
@@ -63,17 +67,21 @@ You can refer to the previous fork's `fork.md` file.
 ## B: Make it executable for pytest and test generator
 
 ### 1. [Optional] Add `light-client/*` docs if you updated the content of `BeaconBlock`
+
 - You can refer to the previous fork's `light-client/*` file.
 - Add the path of the new markdown files in [`pysetup/md_doc_paths.py`](https://github.com/ethereum/consensus-specs/blob/dev/pysetup/md_doc_paths.py)'s `get_md_doc_paths` function.
 
 ### 2. Add the mainnet and minimal presets and update the configs
+
 - Add presets: `presets/mainnet/<new-feature-name>.yaml` and `presets/minimal/<new-feature-name>.yaml`
 - Update configs: `configs/mainnet.yaml` and `configs/minimal.yaml`
 
 ### 3. Update [`context.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/context.py)
+
 - [Optional] Add `with_<new-feature-name>_and_later` decorator for writing pytest cases. e.g., `with_capella_and_later`.
 
 ### 4. Update [`constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/constants.py)
+
 - Add `<NEW_FEATURE>` to `ALL_PHASES` and `TESTGEN_FORKS`
 
 ### 5. Update [`genesis.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/genesis.py):
@@ -94,6 +102,7 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 - If the given feature changes `ExecutionPayload` fields, you have to set the initial values by updating `get_sample_genesis_execution_payload_header` helper.
 
 ### 6. Update CI configurations
+
 - Update [GitHub Actions config](https://github.com/ethereum/consensus-specs/blob/dev/.github/workflows/run-tests.yml)
     - Update `pyspec-tests.strategy.matrix.version` list by adding new feature to it
 - Update [CircleCI config](https://github.com/ethereum/consensus-specs/blob/dev/.circleci/config.yml)
@@ -102,7 +111,9 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 ## Others
 
 ### Bonus
+
 - Add `validator.md` if honest validator behavior changes with the new feature.
 
 ### Need help?
+
 You can tag spec elves for cleaning up your PR. 🧚

--- a/docs/docs/templates/beacon-chain-template.md
+++ b/docs/docs/templates/beacon-chain-template.md
@@ -3,14 +3,13 @@
 # <FORK_NAME> -- The Beacon Chain
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
-
-
 
 ## Introduction
 
@@ -27,7 +26,6 @@
 | `<CONSTANT_NAME>` | `<VALUE>`` |
 
 ## Preset
-
 
 ### [CATEGORY OF PRESETS]
 
@@ -63,6 +61,5 @@ class CONTAINER_NAME(Container):
 ```
 
 ### Epoch processing
-
 
 ### Block processing

--- a/fork_choice/safe-block.md
+++ b/fork_choice/safe-block.md
@@ -1,6 +1,7 @@
 # Fork Choice -- Safe Block
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/solidity_deposit_contract/README.md
+++ b/solidity_deposit_contract/README.md
@@ -14,6 +14,7 @@ In August 2020, version `r2` was released with metadata modifications and relice
 ## Compiling solidity deposit contract
 
 In this directory run:
+
 ```sh
 make compile_deposit_contract
 ```

--- a/specs/_features/custody_game/beacon-chain.md
+++ b/specs/_features/custody_game/beacon-chain.md
@@ -55,7 +55,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
 
 This document details the beacon chain additions and changes of to support the shard data custody game,
@@ -100,7 +99,6 @@ building upon the [Sharding](../sharding/beacon-chain.md) specification.
 | `MAX_CUSTODY_CHUNK_CHALLENGES` | `uint64(2**2)` (= 4) |
 | `MAX_CUSTODY_CHUNK_CHALLENGE_RESPONSES` | `uint64(2**4)` (= 16) |
 | `MAX_CUSTODY_SLASHINGS` | `uint64(2**0)` (= 1) |
-
 
 ### Size parameters
 
@@ -354,7 +352,6 @@ def get_custody_period_for_validator(validator_index: ValidatorIndex, epoch: Epo
     '''
     return (epoch + validator_index % EPOCHS_PER_CUSTODY_PERIOD) // EPOCHS_PER_CUSTODY_PERIOD
 ```
-
 
 ## Per-block processing
 

--- a/specs/_features/custody_game/validator.md
+++ b/specs/_features/custody_game/validator.md
@@ -1,8 +1,6 @@
 # Custody Game -- Honest Validator
 
 **Notice**: This document is a work-in-progress for researchers and implementers.
-This is an accompanying document to [Custody Game -- The Beacon Chain](./beacon-chain.md), which describes the expected actions of a "validator"
-participating in the shard data Custody Game.
 
 ## Table of contents
 
@@ -24,8 +22,10 @@ participating in the shard data Custody Game.
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
+
+This is an accompanying document to [Custody Game -- The Beacon Chain](./beacon-chain.md), which describes the expected actions of a "validator"
+participating in the shard data Custody Game.
 
 ## Prerequisites
 
@@ -57,7 +57,6 @@ Up to `MAX_EARLY_DERIVED_SECRET_REVEALS`, [`EarlyDerivedSecretReveal`](./beacon-
 #### Construct attestation
 
 `attestation.data`, `attestation.aggregation_bits`, and `attestation.signature` are unchanged from Phase 0. But safety/validity in signing the message is premised upon calculation of the "custody bit" [TODO].
-
 
 ## How to avoid slashing
 

--- a/specs/_features/das/das-core.md
+++ b/specs/_features/das/das-core.md
@@ -24,7 +24,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Custom types
 
 We define the following Python custom types for type hinting and readability:
@@ -33,7 +32,6 @@ We define the following Python custom types for type hinting and readability:
 | - | - | - |
 | `SampleIndex` | `uint64` | A sample index, corresponding to chunk of extended data |
 
-
 ## Configuration
 
 ### Misc
@@ -41,7 +39,6 @@ We define the following Python custom types for type hinting and readability:
 | Name | Value | Notes |
 | - | - | - |
 | `MAX_RESAMPLE_TIME` | `TODO` (= TODO) | Time window to sample a shard blob and put it on vertical subnets |
-
 
 ## New containers
 

--- a/specs/_features/das/fork-choice.md
+++ b/specs/_features/das/fork-choice.md
@@ -14,7 +14,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
 
 This document is the beacon chain fork choice spec for Data Availability Sampling. The only change that we add from phase 0 is that we add a concept of "data dependencies";

--- a/specs/_features/das/p2p-interface.md
+++ b/specs/_features/das/p2p-interface.md
@@ -95,7 +95,6 @@ Since the messages are content-addressed (instead of origin-stamped),
 multiple publishers of the same samples on a vertical subnet do not hurt performance,
 but actually improve it by shortcutting regular propagation on the vertical subnet, and thus lowering the latency to a sample.
 
-
 ### Vertical subnets
 
 Vertical subnets propagate the samples to every peer that is interested.
@@ -161,7 +160,6 @@ Take `blob = signed_blob.blob`:
 
 The [DAS participation spec](sampling.md#horizontal-subnets) outlines when and where to participate in DAS on horizontal subnets.
 
-
 #### Vertical subnets: `das_sample_{subnet_index}`
 
 Shard blob samples can be verified with just a 48 byte KZG proof (commitment quotient polynomial),
@@ -185,7 +183,6 @@ The following validations MUST pass before forwarding the `sample` on the vertic
 Upon receiving a valid sample, it SHOULD be retained for a buffer period if the local node is part of the backbone that covers this sample.
 This is to serve other peers that may have missed it.
 
-
 ## DAS in the Req-Resp domain: Pull
 
 To pull samples from nodes, in case of network instability when samples are unavailable, a new query method is added to the Req-Resp domain.
@@ -201,6 +198,7 @@ Note that DAS networking uses a different protocol prefix: `/eth2/das/req`
 **Protocol ID:** `/eth2/das/req/query/1/`
 
 Request Content:
+
 ```
 (
   sample_index: SampleIndex
@@ -208,6 +206,7 @@ Request Content:
 ```
 
 Response Content:
+
 ```
 (
   DASSample

--- a/specs/_features/das/sampling.md
+++ b/specs/_features/das/sampling.md
@@ -22,7 +22,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Data Availability Sampling
 
 TODO: Summary of Data Availability problem
@@ -44,7 +43,6 @@ TODO
 #### Quick rotation: Sampling
 
 TODO
-
 
 ### DAS during network instability
 

--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -1,5 +1,7 @@
 # EIP6800 -- The Beacon Chain
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/_features/eip6800/fork.md
+++ b/specs/_features/eip6800/fork.md
@@ -1,7 +1,10 @@
 # EIP-6800 -- Fork Logic
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
 
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -15,6 +18,7 @@
   - [Upgrading the state](#upgrading-the-state)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
 
@@ -28,7 +32,6 @@ Warning: this configuration is not definitive.
 | - | - |
 | `EIP6800_FORK_VERSION` | `Version('0x05000000')` |
 | `EIP6800_FORK_EPOCH` | `Epoch(18446744073709551615)` **TBD** |
-
 
 ## Helper functions
 

--- a/specs/_features/eip6914/beacon-chain.md
+++ b/specs/_features/eip6914/beacon-chain.md
@@ -1,5 +1,7 @@
 # EIP-6914 -- The Beacon Chain
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/_features/eip6914/fork-choice.md
+++ b/specs/_features/eip6914/fork-choice.md
@@ -1,5 +1,7 @@
 # EIP-6914 -- Fork Choice
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -1,5 +1,7 @@
 # EIP-7732 -- The Beacon Chain
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -1,7 +1,10 @@
 # EIP-7732 -- Honest Builder
 
-This is an accompanying document which describes the expected actions of a "builder" participating in the Ethereum proof-of-stake protocol.
+**Notice**: This document is a work-in-progress for researchers and implementers.
 
+## Table of contents
+
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -13,8 +16,11 @@ This is an accompanying document which describes the expected actions of a "buil
   - [Honest payload withheld messages](#honest-payload-withheld-messages)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
+
+This is an accompanying document which describes the expected actions of a "builder" participating in the Ethereum proof-of-stake protocol.
 
 With the EIP-7732 Fork, the protocol includes new staked participants of the protocol called *Builders*. While Builders are a subset of the validator set, they have extra attributions that are optional. Validators may opt to not be builders and as such we collect the set of guidelines for those validators that want to act as builders in this document.
 
@@ -113,7 +119,9 @@ To construct the `execution_payload_envelope` the builder must perform the follo
 After setting these parameters, the builder should run `process_execution_payload(state, signed_envelope, verify=False)` and this function should not trigger an exception.
 
 6. Set `state_root` to `hash_tree_root(state)`.
+
 After preparing the `envelope` the builder should sign the envelope using:
+
 ```python
 def get_execution_payload_envelope_signature(
         state: BeaconState, envelope: ExecutionPayloadEnvelope, privkey: int) -> BLSSignature:
@@ -121,6 +129,7 @@ def get_execution_payload_envelope_signature(
     signing_root = compute_signing_root(envelope, domain)
     return bls.Sign(privkey, signing_root)
 ```
+
 The builder assembles then `signed_execution_payload_envelope = SignedExecutionPayloadEnvelope(message=envelope, signature=signature)` and broadcasts it on the `execution_payload` global gossip topic.
 
 ### Honest payload withheld messages

--- a/specs/_features/eip7732/fork-choice.md
+++ b/specs/_features/eip7732/fork-choice.md
@@ -1,6 +1,9 @@
 # EIP-7732 -- Fork Choice
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -53,6 +56,7 @@ This is the modification of the fork choice accompanying the EIP-7732 upgrade.
 ## Containers
 
 ### New `ChildNode`
+
 Auxiliary class to consider `(block, slot, bool)` LMD voting
 
 ```python
@@ -65,6 +69,7 @@ class ChildNode(Container):
 ## Helpers
 
 ### Modified `LatestMessage`
+
 **Note:** The class is modified to keep track of the slot instead of the epoch.
 
 ```python
@@ -75,6 +80,7 @@ class LatestMessage(object):
 ```
 
 ### Modified `update_latest_messages`
+
 **Note:** the function `update_latest_messages` is updated to use the attestation slot instead of target. Notice that this function is only called on validated attestations and validators cannot attest twice in the same epoch without equivocating. Notice also that target epoch number and slot number are validated on `validate_on_attestation`.
 
 ```python
@@ -88,6 +94,7 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
 ```
 
 ### Modified `Store`
+
 **Note:** `Store` is modified to track the intermediate states of "empty" consensus blocks, that is, those consensus blocks for which the corresponding execution payload has not been revealed or has not been included on chain.
 
 ```python
@@ -193,6 +200,7 @@ def is_parent_node_full(store: Store, block: BeaconBlock) -> bool:
 ```
 
 ### Modified `get_ancestor`
+
 **Note:** `get_ancestor` is modified to return whether the chain is based on an *empty* or *full* block.
 
 ```python
@@ -213,6 +221,7 @@ def get_ancestor(store: Store, root: Root, slot: Slot) -> ChildNode:
 ```
 
 ### Modified `get_checkpoint_block`
+
 **Note:** `get_checkpoint_block` is modified to use the new `get_ancestor`
 
 ```python
@@ -223,7 +232,6 @@ def get_checkpoint_block(store: Store, root: Root, epoch: Epoch) -> Root:
     epoch_first_slot = compute_start_slot_at_epoch(epoch)
     return get_ancestor(store, root, epoch_first_slot).root
 ```
-
 
 ### `is_supporting_vote`
 
@@ -245,7 +253,9 @@ def is_supporting_vote(store: Store, node: ChildNode, message: LatestMessage) ->
 ```
 
 ### New `compute_proposer_boost`
+
 This is a helper to compute the proposer boost. It applies the proposer boost to any ancestor of the proposer boost root taking into account the payload presence. There is one exception: if the requested node has the same root and slot as the block with the proposer boost root, then the proposer boost is applied to both empty and full versions of the node.
+
 ```python
 def compute_proposer_boost(store: Store, state: BeaconState, node: ChildNode) -> Gwei:
     if store.proposer_boost_root == Root():
@@ -264,6 +274,7 @@ def compute_proposer_boost(store: Store, state: BeaconState, node: ChildNode) ->
 ```
 
 ### New `compute_withhold_boost`
+
 This is a similar helper that applies for the withhold boost. In this case this always takes into account the reveal status.
 
 ```python
@@ -283,6 +294,7 @@ def compute_withhold_boost(store: Store, state: BeaconState, node: ChildNode) ->
 ```
 
 ### New `compute_reveal_boost`
+
 This is a similar helper to the last two, the only difference is that the reveal boost is only applied to the full version of the node when querying for the same slot as the revealed payload.
 
 ```python

--- a/specs/_features/eip7732/fork.md
+++ b/specs/_features/eip7732/fork.md
@@ -4,6 +4,7 @@
 
 ## Table of contents
 
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -17,6 +18,7 @@
   - [Upgrading the state](#upgrading-the-state)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
 

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -1,5 +1,10 @@
 # EIP-7732 -- Networking
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
+## Table of contents
+
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -26,6 +31,7 @@
       - [ExecutionPayloadEnvelopesByRoot v1](#executionpayloadenvelopesbyroot-v1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
 
@@ -39,9 +45,9 @@ The specification of these changes continues in the same format as the network s
 
 *[Modified in EIP-7732]*
 
-| Name                                     | Value                             | Description                                                         |
-|------------------------------------------|-----------------------------------|---------------------------------------------------------------------|
-| `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH_EIP7732`   | `13` # TODO: Compute it when the spec stabilizes | Merkle proof depth for the `blob_kzg_commitments` list item |
+| Name                                           | Value        | Description                                                 |
+|------------------------------------------------|--------------|-------------------------------------------------------------|
+| `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH_EIP7732` | `13` **TBD** | Merkle proof depth for the `blob_kzg_commitments` list item |
 
 ### Configuration
 
@@ -50,7 +56,6 @@ The specification of these changes continues in the same format as the network s
 | Name                   | Value          | Description                                                       |
 |------------------------|----------------|-------------------------------------------------------------------|
 | `MAX_REQUEST_PAYLOADS` | `2**7` (= 128) | Maximum number of execution payload envelopes in a single request |
-
 
 ### Containers
 
@@ -227,7 +232,6 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 | `DENEB_FORK_VERSION`     | `deneb.SignedBeaconBlock`     |
 | `EIP7732_FORK_VERSION`   | `eip7732.SignedBeaconBlock`   |
 
-
 ##### BlobSidecarsByRoot v2
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/2/`
@@ -238,7 +242,6 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 |--------------------------|-------------------------------|
 | `DENEB_FORK_VERSION`     | `deneb.BlobSidecar`           |
 | `EIP7732_FORK_VERSION`   | `eip7732.BlobSidecar`         |
-
 
 ##### ExecutionPayloadEnvelopesByRoot v1
 
@@ -267,6 +270,7 @@ Response Content:
   List[SignedExecutionPayloadEnvelope, MAX_REQUEST_PAYLOADS]
 )
 ```
+
 Requests execution payload envelopes by `signed_execution_payload_envelope.message.block_root`. The response is a list of `SignedExecutionPayloadEnvelope` whose length is less than or equal to the number of requested execution payload envelopes. It may be less in the case that the responding peer is missing payload envelopes.
 
 No more than `MAX_REQUEST_PAYLOADS` may be requested at a time.

--- a/specs/_features/eip7732/validator.md
+++ b/specs/_features/eip7732/validator.md
@@ -1,11 +1,14 @@
 # EIP-7732 -- Honest Validator
 
-This document represents the changes and additions to the Honest validator guide included in the EIP-7732 fork.
+**Notice**: This document is a work-in-progress for researchers and implementers.
 
+## Table of contents
+
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
 
+- [Introduction](#introduction)
 - [Validator assignment](#validator-assignment)
   - [Lookahead](#lookahead)
 - [Beacon chain responsibilities](#beacon-chain-responsibilities)
@@ -19,6 +22,11 @@ This document represents the changes and additions to the Honest validator guide
     - [Constructing a payload attestation](#constructing-a-payload-attestation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+## Introduction
+
+This document represents the changes and additions to the Honest validator guide included in the EIP-7732 fork.
 
 ## Validator assignment
 
@@ -65,7 +73,6 @@ Attestation duties are not changed for validators, however the attestation deadl
 ### Sync Committee participations
 
 Sync committee duties are not changed for validators, however the submission deadline is implicitly changed by the change in `INTERVALS_PER_SLOT`.
-
 
 ### Block proposal
 
@@ -130,5 +137,3 @@ def get_payload_attestation_message_signature(
 ```
 
 **Remark** Validators do not need to check the full validity of the `ExecutionPayload` contained in within the envelope, but the checks in the [P2P guide](./p2p-interface.md) should pass for the `SignedExecutionPayloadEnvelope`.
-
-

--- a/specs/_features/sharding/beacon-chain.md
+++ b/specs/_features/sharding/beacon-chain.md
@@ -45,7 +45,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
 
 This document describes the extensions made to the Phase 0 design of The Beacon Chain to support data sharding,
@@ -56,7 +55,6 @@ using KZG10 commitments to commit to data to remove any need for fraud proofs (a
 
 - **Data**: A list of KZG points, to translate a byte string into
 - **Blob**: Data with commitments and meta-data, like a flattened bundle of L2 transactions.
-
 
 ## Constants
 
@@ -72,7 +70,7 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value |
 | - | - |
-| `DOMAIN_SHARD_SAMPLE`     | `DomainType('0x10000000')` |
+| `DOMAIN_SHARD_SAMPLE` | `DomainType('0x10000000')` |
 
 ## Preset
 

--- a/specs/_features/sharding/polynomial-commitments.md
+++ b/specs/_features/sharding/polynomial-commitments.md
@@ -44,7 +44,6 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
 
-
 ## Introduction
 
 This document specifies basic polynomial operations and KZG polynomial commitment operations as they are needed for the sharding specification. The implementations are not optimized for performance, but readability. All practical implementations should optimize the polynomial operations, and hints what the best known algorithms for these implementations are included below.
@@ -57,7 +56,6 @@ This document specifies basic polynomial operations and KZG polynomial commitmen
 | - | - | - |
 | `BLS_MODULUS` | `0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001` (curve order of BLS12_381) |
 | `PRIMITIVE_ROOT_OF_UNITY` | `7` | Primitive root of unity of the BLS12_381 (inner) BLS_MODULUS |
-
 
 ### KZG Trusted setup
 
@@ -258,7 +256,6 @@ def multiply_polynomials(a: BLSPolynomialByCoefficients, b: BLSPolynomialByCoeff
         r = add_polynomials(r, summand)
     return r
 ```
-
 
 #### `interpolate_polynomial`
 

--- a/specs/_features/whisk/fork.md
+++ b/specs/_features/whisk/fork.md
@@ -19,7 +19,6 @@
 
 This document describes the process of Whisk upgrade.
 
-
 ```
 """
     WHISK_FORK_EPOCH

--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -2,6 +2,7 @@
 
 ## Table of contents
 
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -15,6 +16,7 @@
   - [Upgrading the state](#upgrading-the-state)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
 

--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -1,7 +1,5 @@
 # Altair Light Client -- Full Node
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/altair/light-client/light-client.md
+++ b/specs/altair/light-client/light-client.md
@@ -1,7 +1,5 @@
 # Altair Light Client -- Light Client
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/altair/light-client/p2p-interface.md
+++ b/specs/altair/light-client/p2p-interface.md
@@ -1,7 +1,5 @@
 # Altair Light Client -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->
@@ -158,6 +156,7 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 **Protocol ID:** `/eth2/beacon_chain/req/light_client_updates_by_range/1/`
 
 Request Content:
+
 ```
 (
   start_period: uint64
@@ -166,6 +165,7 @@ Request Content:
 ```
 
 Response Content:
+
 ```
 (
   List[LightClientUpdate, MAX_REQUEST_LIGHT_CLIENT_UPDATES]

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -1,7 +1,5 @@
 # Altair Light Client -- Sync Protocol
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -1,6 +1,7 @@
 # Bellatrix -- Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/bellatrix/fork.md
+++ b/specs/bellatrix/fork.md
@@ -2,6 +2,7 @@
 
 ## Table of contents
 
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -15,6 +16,7 @@
   - [Upgrading the state](#upgrading-the-state)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
 

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -124,7 +124,6 @@ To obtain an execution payload, a block proposer building a block on top of a `s
     * `finalized_block_hash` is the block hash of the latest finalized execution payload (`Hash32()` if none yet finalized)
     * `suggested_fee_recipient` is the value suggested to be used for the `fee_recipient` field of the execution payload
 
-
 ```python
 def prepare_execution_payload(state: BeaconState,
                               safe_block_hash: Hash32,

--- a/specs/capella/fork-choice.md
+++ b/specs/capella/fork-choice.md
@@ -1,6 +1,7 @@
 # Capella -- Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/capella/fork.md
+++ b/specs/capella/fork.md
@@ -2,6 +2,7 @@
 
 ## Table of contents
 
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -15,6 +16,7 @@
   - [Upgrading the state](#upgrading-the-state)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
 
@@ -26,7 +28,6 @@ This document describes the process of the Capella upgrade.
 | - | - |
 | `CAPELLA_FORK_VERSION` | `Version('0x03000000')` |
 | `CAPELLA_FORK_EPOCH` | `Epoch(194048)` (April 12, 2023, 10:27:35pm UTC) |
-
 
 ## Helper functions
 

--- a/specs/capella/light-client/full-node.md
+++ b/specs/capella/light-client/full-node.md
@@ -1,7 +1,5 @@
 # Capella Light Client -- Full Node
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/capella/light-client/p2p-interface.md
+++ b/specs/capella/light-client/p2p-interface.md
@@ -1,7 +1,5 @@
 # Capella Light Client -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/capella/light-client/sync-protocol.md
+++ b/specs/capella/light-client/sync-protocol.md
@@ -1,7 +1,5 @@
 # Capella Light Client -- Sync Protocol
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -1,6 +1,7 @@
 # Deneb -- Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/deneb/fork.md
+++ b/specs/deneb/fork.md
@@ -2,6 +2,7 @@
 
 ## Table of contents
 
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -15,6 +16,7 @@
   - [Upgrading the state](#upgrading-the-state)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
 

--- a/specs/deneb/light-client/full-node.md
+++ b/specs/deneb/light-client/full-node.md
@@ -1,7 +1,5 @@
 # Deneb Light Client -- Full Node
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/deneb/light-client/p2p-interface.md
+++ b/specs/deneb/light-client/p2p-interface.md
@@ -1,7 +1,5 @@
 # Deneb Light Client -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/deneb/light-client/sync-protocol.md
+++ b/specs/deneb/light-client/sync-protocol.md
@@ -1,7 +1,5 @@
 # Deneb Light Client -- Sync Protocol
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -341,6 +341,7 @@ When clients use the local execution layer to retrieve blobs, they MUST behave a
 *[New in Deneb:EIP4844]*
 
 Request Content:
+
 ```
 (
   start_slot: Slot
@@ -349,6 +350,7 @@ Request Content:
 ```
 
 Response Content:
+
 ```
 (
   List[BlobSidecar, MAX_REQUEST_BLOB_SIDECARS]

--- a/specs/deneb/polynomial-commitments.md
+++ b/specs/deneb/polynomial-commitments.md
@@ -150,7 +150,6 @@ def bit_reversal_permutation(sequence: Sequence[T]) -> Sequence[T]:
 
 ### BLS12-381 helpers
 
-
 #### `multi_exp`
 
 This function performs a multi-scalar multiplication between `points` and `integers`. `points` can either be in G1 or G2.
@@ -380,7 +379,6 @@ def verify_kzg_proof(commitment_bytes: Bytes48,
                                  bytes_to_bls_field(y_bytes),
                                  bytes_to_kzg_proof(proof_bytes))
 ```
-
 
 #### `verify_kzg_proof_impl`
 

--- a/specs/deneb/validator.md
+++ b/specs/deneb/validator.md
@@ -153,6 +153,7 @@ To construct a `BlobSidecar`, a `blob_sidecar` is defined with the necessary con
 Blobs associated with a block are packaged into sidecar objects for distribution to the associated sidecar topic, the `blob_sidecar_{subnet_id}` pubsub topic.
 
 Each `sidecar` is obtained from:
+
 ```python
 def get_blob_sidecars(signed_block: SignedBeaconBlock,
                       blobs: Sequence[Blob],

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -168,7 +168,7 @@ The following values are (non-configurable) constants used throughout the specif
 ### State list lengths
 
 | Name | Value | Unit |
-| - | - | :-: |
+| - | - | - |
 | `PENDING_DEPOSITS_LIMIT` | `uint64(2**27)` (= 134,217,728) | pending deposits |
 | `PENDING_PARTIAL_WITHDRAWALS_LIMIT` | `uint64(2**27)` (= 134,217,728) | pending partial withdrawals |
 | `PENDING_CONSOLIDATIONS_LIMIT` | `uint64(2**18)` (= 262,144) | pending consolidations |

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -4,6 +4,7 @@
 
 ## Table of contents
 
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -17,6 +18,7 @@
   - [Upgrading the state](#upgrading-the-state)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
 

--- a/specs/electra/light-client/fork.md
+++ b/specs/electra/light-client/fork.md
@@ -1,5 +1,7 @@
 # Electra Light Client -- Fork Logic
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -1,5 +1,7 @@
 # Electra -- Networking
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -1,5 +1,7 @@
 # Electra -- Honest Validator
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -1,6 +1,9 @@
 # Fulu -- Fork Choice
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/fulu/fork.md
+++ b/specs/fulu/fork.md
@@ -4,6 +4,7 @@
 
 ## Table of contents
 
+<!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -17,6 +18,7 @@
   - [Upgrading the state](#upgrading-the-state)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
 
 ## Introduction
 

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -234,7 +234,7 @@ Response Content:
 
 ```
 (
-    List[DataColumnSidecar, MAX_REQUEST_DATA_COLUMN_SIDECARS]
+  List[DataColumnSidecar, MAX_REQUEST_DATA_COLUMN_SIDECARS]
 )
 ```
 

--- a/specs/fulu/polynomial-commitments-sampling.md
+++ b/specs/fulu/polynomial-commitments-sampling.md
@@ -1,5 +1,7 @@
 # Fulu -- Polynomial Commitments Sampling
 
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
 ## Table of contents
 
 <!-- TOC -->

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1,6 +1,7 @@
 # Phase 0 -- The Beacon Chain
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -1420,24 +1421,20 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
     return Gwei(effective_balance * BASE_REWARD_FACTOR // integer_squareroot(total_balance) // BASE_REWARDS_PER_EPOCH)
 ```
 
-
 ```python
 def get_proposer_reward(state: BeaconState, attesting_index: ValidatorIndex) -> Gwei:
     return Gwei(get_base_reward(state, attesting_index) // PROPOSER_REWARD_QUOTIENT)
 ```
-
 
 ```python
 def get_finality_delay(state: BeaconState) -> uint64:
     return get_previous_epoch(state) - state.finalized_checkpoint.epoch
 ```
 
-
 ```python
 def is_in_inactivity_leak(state: BeaconState) -> bool:
     return get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
 ```
-
 
 ```python
 def get_eligible_validator_indices(state: BeaconState) -> Sequence[ValidatorIndex]:

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -1,6 +1,7 @@
 # Phase 0 -- Deposit Contract
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -1,6 +1,7 @@
 # Phase 0 -- Beacon Chain Fork Choice
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -78,7 +79,6 @@ Any of the above handlers that trigger an unhandled exception (e.g. a failed ass
 3) **Eth1 data**: The large `ETH1_FOLLOW_DISTANCE` specified in the [honest validator document](./validator.md) should ensure that `state.latest_eth1_data` of the canonical beacon chain remains consistent with the canonical Ethereum proof-of-work chain. If not, emergency manual intervention will be required.
 4) **Manual forks**: Manual forks may arbitrarily change the fork choice rule but are expected to be enacted at epoch transitions, with the fork details reflected in `state.fork`.
 5) **Implementation**: The implementation found in this specification is constructed for ease of understanding rather than for optimization in computation, space, or any other resource. A number of optimized alternatives can be found [here](https://github.com/protolambda/lmd-ghost).
-
 
 ### Constant
 
@@ -559,7 +559,6 @@ def on_tick_per_slot(store: Store, time: uint64) -> None:
 
 #### `on_attestation` helpers
 
-
 ##### `validate_target_epoch_against_current_time`
 
 ```python
@@ -626,7 +625,6 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
         if i not in store.latest_messages or target.epoch > store.latest_messages[i].epoch:
             store.latest_messages[i] = LatestMessage(epoch=target.epoch, root=beacon_block_root)
 ```
-
 
 ### Handlers
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1,6 +1,7 @@
 # Phase 0 -- Networking
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -184,8 +185,8 @@ We define the following Python custom types for type hinting and readability:
 
 | Name | SSZ equivalent | Description |
 | - | - | - |
-| `NodeID`   | `uint256` | node identifier   |
-| `SubnetID` | `uint64`  | subnet identifier |
+| `NodeID` | `uint256` | node identifier |
+| `SubnetID` | `uint64` | subnet identifier |
 
 ### Constants
 
@@ -198,16 +199,16 @@ We define the following Python custom types for type hinting and readability:
 This section outlines configurations that are used in this spec.
 
 | Name | Value | Description |
-|---|---|---|
+| - | - | - |
 | `MAX_PAYLOAD_SIZE` | `10 * 2**20` (= 10485760, 10 MiB) | The maximum allowed size of uncompressed payload in gossipsub messages and RPC chunks |
 | `MAX_REQUEST_BLOCKS` | `2**10` (= 1024) | Maximum number of blocks in a single request |
 | `EPOCHS_PER_SUBNET_SUBSCRIPTION` | `2**8` (= 256) | Number of epochs on a subnet subscription (~27 hours) |
 | `MIN_EPOCHS_FOR_BLOCK_REQUESTS` | `MIN_VALIDATOR_WITHDRAWABILITY_DELAY + CHURN_LIMIT_QUOTIENT // 2` (= 33024, ~5 months) | The minimum epoch range over which a node must serve blocks |
-| `ATTESTATION_PROPAGATION_SLOT_RANGE` | `32` | The maximum number of slots during which an attestation can be propagated. |
-| `MAXIMUM_GOSSIP_CLOCK_DISPARITY` | `500` | The maximum **milliseconds** of clock disparity assumed between honest nodes. |
+| `ATTESTATION_PROPAGATION_SLOT_RANGE` | `32` | The maximum number of slots during which an attestation can be propagated |
+| `MAXIMUM_GOSSIP_CLOCK_DISPARITY` | `500` | The maximum **milliseconds** of clock disparity assumed between honest nodes |
 | `MESSAGE_DOMAIN_INVALID_SNAPPY` | `DomainType('0x00000000')` | 4-byte domain for gossip message-id isolation of *invalid* snappy messages |
 | `MESSAGE_DOMAIN_VALID_SNAPPY`  | `DomainType('0x01000000')` | 4-byte domain for gossip message-id isolation of *valid* snappy messages |
-| `SUBNETS_PER_NODE` | `2` | The number of long-lived subnets a beacon node should be subscribed to. |
+| `SUBNETS_PER_NODE` | `2` | The number of long-lived subnets a beacon node should be subscribed to |
 | `ATTESTATION_SUBNET_COUNT` | `2**6` (= 64) | The number of attestation subnets used in the gossipsub protocol. |
 | `ATTESTATION_SUBNET_EXTRA_BITS` | `0` | The number of extra bits of a NodeId to use when mapping to a subscribed subnet |
 | `ATTESTATION_SUBNET_PREFIX_BITS` | `int(ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS)` | |
@@ -422,7 +423,6 @@ The following validations MUST pass before forwarding the `signed_aggregate_and_
   `get_checkpoint_block(store, aggregate.data.beacon_block_root, finalized_checkpoint.epoch)
   == store.finalized_checkpoint.root`
 
-
 ###### `voluntary_exit`
 
 The `voluntary_exit` topic is used solely for propagating signed voluntary validator exits to proposers on the network.
@@ -496,8 +496,6 @@ The following validations MUST pass before forwarding the `attestation` on the s
 - _[IGNORE]_ The current `finalized_checkpoint` is an ancestor of the `block` defined by `attestation.data.beacon_block_root` -- i.e.
   `get_checkpoint_block(store, attestation.data.beacon_block_root, store.finalized_checkpoint.epoch)
   == store.finalized_checkpoint.root`
-
-
 
 ##### Attestations and Aggregation
 
@@ -729,6 +727,7 @@ Each _successful_ `response_chunk` contains a single `SignedBeaconBlock` payload
 **Protocol ID:** ``/eth2/beacon_chain/req/status/1/``
 
 Request, Response Content:
+
 ```
 (
   fork_digest: ForkDigest
@@ -738,6 +737,7 @@ Request, Response Content:
   head_slot: Slot
 )
 ```
+
 The fields are, as seen by the client at the time of sending the message:
 
 - `fork_digest`: The node's `ForkDigest` (`compute_fork_digest(current_fork_version, genesis_validators_root)`) where
@@ -775,11 +775,13 @@ Implementers are free to implement such behavior in their own way.
 **Protocol ID:** ``/eth2/beacon_chain/req/goodbye/1/``
 
 Request, Response Content:
+
 ```
 (
   uint64
 )
 ```
+
 Client MAY send goodbye messages upon disconnection. The reason field MAY be one of the following values:
 
 - 1: Client shut down.
@@ -799,6 +801,7 @@ The response MUST consist of a single `response_chunk`.
 **Protocol ID:** `/eth2/beacon_chain/req/beacon_blocks_by_range/1/`
 
 Request Content:
+
 ```
 (
   start_slot: Slot
@@ -808,6 +811,7 @@ Request Content:
 ```
 
 Response Content:
+
 ```
 (
   List[SignedBeaconBlock, MAX_REQUEST_BLOCKS]
@@ -1008,9 +1012,9 @@ Specifications of these parameters can be found in the [ENR Specification](http:
 The ENR `attnets` entry signifies the attestation subnet bitfield with the following form
 to more easily discover peers participating in particular attestation gossip subnets.
 
-| Key          | Value                                            |
-|:-------------|:-------------------------------------------------|
-| `attnets`    | SSZ `Bitvector[ATTESTATION_SUBNET_COUNT]`        |
+| Key       | Value                                     |
+|:----------|:------------------------------------------|
+| `attnets` | SSZ `Bitvector[ATTESTATION_SUBNET_COUNT]` |
 
 If a node's `MetaData.attnets` has any non-zero bit, the ENR MUST include the `attnets` entry with the same value as `MetaData.attnets`.
 
@@ -1021,17 +1025,17 @@ If a node's `MetaData.attnets` is composed of all zeros, the ENR MAY optionally 
 ENRs MUST carry a generic `eth2` key with an 16-byte value of the node's current fork digest, next fork version,
 and next fork epoch to ensure connections are made with peers on the intended Ethereum network.
 
-| Key          | Value               |
-|:-------------|:--------------------|
-| `eth2`       | SSZ `ENRForkID`        |
+| Key    | Value           |
+|:-------|:----------------|
+| `eth2` | SSZ `ENRForkID` |
 
 Specifically, the value of the `eth2` key MUST be the following SSZ encoded object (`ENRForkID`)
 
 ```
 (
-    fork_digest: ForkDigest
-    next_fork_version: Version
-    next_fork_epoch: Epoch
+  fork_digest: ForkDigest
+  next_fork_version: Version
+  next_fork_epoch: Epoch
 )
 ```
 
@@ -1339,7 +1343,6 @@ Some examples of where messages could be duplicated:
   does not provide enough responsiveness during adverse conditions.
 - `seen_ttl`: `SLOTS_PER_EPOCH * SECONDS_PER_SLOT / heartbeat_interval = approx. 550`.
   Attestation gossip validity is bounded by an epoch, so this is the safe max bound.
-
 
 #### Why is there `MAXIMUM_GOSSIP_CLOCK_DISPARITY` when validating slot ranges of messages in gossip subnets?
 

--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -41,19 +41,19 @@ This document uses data structures, constants, functions, and terminology from
 ## Custom Types
 
 | Name | SSZ Equivalent | Description |
-|---|---|---|
+| - | - | - |
 | `Ether` | `uint64` | an amount in Ether |
 
 ## Constants
 
 | Name | Value |
-|---|---|
+| - | - |
 | `ETH_TO_GWEI` | `uint64(10**9)` |
 
 ## Configuration
 
 | Name | Value |
-|---|---|
+| - | - |
 | `SAFETY_DECAY` | `uint64(10)` |
 
 ## Weak Subjectivity Checkpoint

--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -1,8 +1,7 @@
 # Merkle proof formats
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
-
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -1,6 +1,7 @@
 # SimpleSerialize (SSZ)
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -34,7 +35,7 @@
 ## Constants
 
 | Name | Value | Description |
-|-|-|-|
+| - | - | - |
 | `BYTES_PER_CHUNK` | `32` | Number of bytes per chunk. |
 | `BYTES_PER_LENGTH_OFFSET` | `4` | Number of bytes per serialized length offset. |
 | `BITS_PER_BYTE` | `8` | Number of bits per byte. |

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -1,6 +1,7 @@
 # Optimistic Sync
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/tests/README.md
+++ b/tests/README.md
@@ -123,8 +123,6 @@ More `yield` statements. The output of a consensus test is:
 5. `'post'`
 6. The state after the test
 
-
-
 ```python
     # One vote for the eth1
     assert len(state.eth1_data_votes) == pre_eth1_votes + 1
@@ -141,7 +139,6 @@ Finally we assertions that test the transition was legitimate. In this case we h
 1. One item was added to `eth1_data_votes`
 2. The new block's `parent_root` is the same as the block in the previous location
 3. The random data that every block includes was changed.
-
 
 ## New Tests
 
@@ -173,7 +170,6 @@ def next_slot(spec, state):
 
 This looks like exactly what we need. So we add this call before we create the empty block:
 
-
 ```python
 .
 .
@@ -190,8 +186,6 @@ This looks like exactly what we need. So we add this call before we create the e
 
 That's it. Our new test works (copy `test_empty_block_transition`, rename it, add the `next_slot` call, and then run it to
 verify this).
-
-
 
 ## Tests Designed to Fail
 
@@ -260,7 +254,6 @@ for the current state.
 This is the way we specify that a test is designed to fail - failed tests have no post state,
 because the processing mechanism errors out before creating it.
 
-
 ## Attestation Tests
 
 The consensus layer doesn't provide any direct functionality to end users. It does
@@ -280,7 +273,6 @@ which is how they get on chain to form consensus, reward honest validators, etc.
 [You can see a simple successful attestation test here](https://github.com/ethereum/consensus-specs/blob/926e5a3d722df973b9a12f12c015783de35cafa9/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attestation.py#L26-L30):
 Lets go over it line by line.
 
-
 ```python
 @with_all_phases
 @spec_state_test
@@ -291,7 +283,6 @@ def test_success(spec, state):
 [This function](https://github.com/ethereum/consensus-specs/blob/30fe7ba1107d976100eb0c3252ca7637b791e43a/tests/core/pyspec/eth2spec/test/helpers/attestations.py#L88-L120)
 creates a valid attestation (which can then be modified to make it invalid if needed).
 To see an attestion "from the inside" we need to follow it.
-
 
 > ```python
 >  def get_valid_attestation(spec,
@@ -372,14 +363,12 @@ Currently a single block is sufficient, but that may change in the future.
 [This function](https://github.com/ethereum/consensus-specs/blob/30fe7ba1107d976100eb0c3252ca7637b791e43a/tests/core/pyspec/eth2spec/test/helpers/attestations.py#L13-L50)
 processes the attestation and returns the result.
 
-
 ### Adding an Attestation Test
 
 Attestations can't happen in the same block as the one about which they are attesting, or in a block that is
 after the block is finalized. This is specified as part of the specs, in the `process_attestation` function
 (which is created from the spec by the `make pyspec` command you ran earlier). Here is the relevant code
 fragment:
-
 
 ```python
 def process_attestation(state: BeaconState, attestation: Attestation) -> None:

--- a/tests/core/pyspec/README.md
+++ b/tests/core/pyspec/README.md
@@ -16,21 +16,25 @@ However, most of the tests can be run in generator-mode, to output test vectors 
 ### How to run tests
 
 To run all tests:
+
 ```shell
 make test
 ```
 
 To run all tests under the minimal preset:
+
 ```shell
 make test preset=minimal
 ```
 
 Or, to run a specific test function specify `k=<test-name>`:
+
 ```shell
 make test k=test_verify_kzg_proof
 ```
 
 Or, to run a specific test function under a single fork specify `k=<test-name>`:
+
 ```shell
 make test fork=phase0
 ```

--- a/tests/formats/README.md
+++ b/tests/formats/README.md
@@ -3,6 +3,7 @@
 This document defines the YAML format and structure used for consensus spec testing.
 
 ## Table of contents
+
 <!-- TOC -->
 
 * [About](#about)
@@ -45,7 +46,6 @@ Test formats:
 - [`ssz_generic`](./ssz_generic/README.md)
 - [`ssz_static`](./ssz_static/README.md)
 - More formats are planned, see tracking issues for CI/testing
-
 
 ## Glossary
 
@@ -92,7 +92,6 @@ The aim is to provide clients with a well-defined scope of work to run a particu
 - Clients that are complete are expected to contribute to testing, seeking for better resources to get conformance with the spec, and other clients.
 - Clients that are not complete in functionality can choose to ignore suites that use certain test-runners, or specific handlers of these test-runners.
 - Clients that are on older versions can test their work based on older releases of the generated tests, and catch up with newer releases when possible.
-
 
 ## Test structure
 
@@ -152,7 +151,6 @@ Between all types of tests, a few formats are common:
 - **`.ssz_snappy`**: Like `.ssz`, but compressed with Snappy block compression.
   Snappy block compression is already applied to SSZ in consensus-layer gossip, available in client implementations, and thus chosen as compression method.
 
-
 #### Special output parts
 
 ##### `meta.yaml`
@@ -181,7 +179,6 @@ The format matches that of the `mainnet_config.yaml` and `minimal_config.yaml`,
 see the [`/configs`](../../configs/README.md#format) documentation.
 Config values that are introduced at a later fork may be omitted from tests of previous forks.
 
-
 ## Config sourcing
 
 The constants configurations are located in:
@@ -197,7 +194,6 @@ And copied by CI for testing purposes to:
 ```
 
 The first `<config name>` is a directory, which contains exactly all tests that make use of the given config.
-
 
 ## Note for implementers
 

--- a/tests/formats/finality/README.md
+++ b/tests/formats/finality/README.md
@@ -20,7 +20,6 @@ An SSZ-snappy encoded `BeaconState`, the state before running the block transiti
 
 Also available as `pre.ssz_snappy`.
 
-
 ### `blocks_<index>.yaml`
 
 A series of files, with `<index>` in range `[0, blocks_count)`. Blocks need to be processed in order,
@@ -33,7 +32,6 @@ Each block is also available as `blocks_<index>.ssz_snappy`
 ### `post.ssz_snappy`
 
 An SSZ-snappy encoded `BeaconState`, the state after applying the block transitions.
-
 
 ## Condition
 

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -3,6 +3,7 @@
 The aim of the fork choice tests is to provide test coverage of the various components of the fork choice.
 
 ## Table of contents
+
 <!-- TOC -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -190,6 +191,7 @@ should_override_forkchoice_update: {  -- [New in Bellatrix]
 ```
 
 For example:
+
 ```yaml
 - checks:
     time: 192

--- a/tests/formats/genesis/initialization.md
+++ b/tests/formats/genesis/initialization.md
@@ -11,7 +11,6 @@ eth1_block_hash: Bytes32  -- A `Bytes32` hex encoded, with prefix 0x. The root o
 eth1_timestamp: int       -- An integer. The timestamp of the block, in seconds.
 ```
 
-
 ### `meta.yaml`
 
 A yaml file to help read the deposit count:

--- a/tests/formats/genesis/validity.md
+++ b/tests/formats/genesis/validity.md
@@ -16,16 +16,13 @@ description: string    -- Optional. Description of test case, purely for debuggi
 
 An SSZ-snappy encoded `BeaconState`, the state to validate as genesis candidate.
 
-
 ### `is_valid.yaml`
 
 A boolean, true if the genesis state is deemed valid as to launch with, false otherwise.
 
-
 ## Processing
 
 To process the data, call `is_valid_genesis_state(genesis)`.
-
 
 ## Condition
 

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -24,7 +24,6 @@ An SSZ-snappy encoded operation object, e.g. a `ProposerSlashing`, or `Deposit`.
 
 An SSZ-snappy encoded `BeaconState`, the state after applying the operation. No value if operation processing is aborted.
 
-
 ## Condition
 
 A handler of the `operations` test-runner should process these cases,

--- a/tests/formats/rewards/README.md
+++ b/tests/formats/rewards/README.md
@@ -5,6 +5,7 @@ There is no "change" factor, the rewards/penalties outputs are pure functions wi
 (See test condition documentation on how to run the tests.)
 
 `Deltas` is defined as:
+
 ```python
 class Deltas(Container):
     rewards: List[Gwei, VALIDATOR_REGISTRY_LIMIT]

--- a/tests/formats/sanity/blocks.md
+++ b/tests/formats/sanity/blocks.md
@@ -13,11 +13,9 @@ reveal_deadlines_setting: int  -- see general test-format spec.
 blocks_count: int              -- the number of blocks processed in this test.
 ```
 
-
 ### `pre.ssz_snappy`
 
 An SSZ-snappy encoded `BeaconState`, the state before running the block transitions.
-
 
 ### `blocks_<index>.ssz_snappy`
 
@@ -29,7 +27,6 @@ Each file is a SSZ-snappy encoded `SignedBeaconBlock`.
 ### `post.ssz_snappy`
 
 An SSZ-snappy encoded `BeaconState`, the state after applying the block transitions.
-
 
 ## Condition
 

--- a/tests/formats/sanity/slots.md
+++ b/tests/formats/sanity/slots.md
@@ -11,13 +11,11 @@ description: string    -- Optional. Description of test case, purely for debuggi
 bls_setting: int       -- see general test-format spec.
 ```
 
-
 ### `pre.ssz_snappy`
 
 An SSZ-snappy `BeaconState`, the state before running the transitions.
 
 Also available as `pre.ssz_snappy`.
-
 
 ### `slots.yaml`
 
@@ -28,7 +26,6 @@ An integer. The amount of slots to process (i.e. the difference in slots between
 An SSZ-snappy `BeaconState`, the state after applying the transitions.
 
 Also available as `post.ssz_snappy`.
-
 
 ### Processing
 

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -23,7 +23,6 @@ The `ssz_generic` tests are split up into different handler, each specialized in
 - Containers
     - `containers`
 
-
 ## Format
 
 For each type, a `valid` and an `invalid` suite is implemented.
@@ -74,7 +73,6 @@ The `serialized` data should simply not be decoded without raising an error.
 Note that for some type declarations in the invalid suite, the type itself may technically be invalid.
 This is a valid way of detecting `invalid` data too. E.g. a 0-length basic vector.
 
-
 ## Type declarations
 
 Most types are not as static, and can reasonably be constructed during test runtime from the test case name.
@@ -97,7 +95,6 @@ Data:
 {length}: an unsigned integer
 ```
 
-
 ### `bitlist`
 
 ```
@@ -109,7 +106,6 @@ Data:
 
 {limit}: the list limit, in bits, of the bitlist. Does not include the length-delimiting bit in the serialized form.
 ```
-
 
 ### `bitvector`
 

--- a/tests/formats/ssz_static/core.md
+++ b/tests/formats/ssz_static/core.md
@@ -34,7 +34,6 @@ The SSZ-snappy encoded bytes.
 
 The same value as `serialized.ssz_snappy`, represented as YAML.
 
-
 ## Condition
 
 A test-runner can implement the following assertions:
@@ -45,7 +44,6 @@ A test-runner can implement the following assertions:
     - Serialization in 2 steps: deserialize `serialized`, then serialize the result,
        and verify if the bytes match the original `serialized`.
 - Hash-tree-root: After parsing the `value` (or deserializing `serialized`), Hash-tree-root it: the output should match `root`
-
 
 ## References
 

--- a/tests/generators/README.md
+++ b/tests/generators/README.md
@@ -14,7 +14,6 @@ An automated nightly tests release system, with a config filter applied, is bein
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [How to run generators](#how-to-run-generators)
   - [Cleaning](#cleaning)
   - [Running all test generators](#running-all-test-generators)
@@ -24,8 +23,6 @@ An automated nightly tests release system, with a config filter applied, is bein
 - [How to remove a test generator](#how-to-remove-a-test-generator)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-
 
 ## How to run generators
 
@@ -51,7 +48,6 @@ make -j 4 gen_all
 ```
 
 The `-j N` flag makes the generators run in parallel, with `N` being the amount of cores.
-
 
 ### Running a single generator
 
@@ -193,7 +189,6 @@ To add a new test generator that builds `New Tests`:
 *Note*: You do not have to change the makefile.
 However, if necessary (e.g. not using Python, or mixing in other languages), submit an issue, and it can be a special case.
 Do note that generators should be easy to maintain, lean, and based on the spec.
-
 
 ## How to remove a test generator
 

--- a/tests/generators/epoch_processing/README.md
+++ b/tests/generators/epoch_processing/README.md
@@ -6,6 +6,3 @@ An epoch-processing test-runner can consume these sub-transition test-suites,
  and handle different kinds of epoch sub-transitions by processing the cases using the specified test handler.
 
 Information on the format of the tests can be found in the [epoch-processing test formats documentation](../../formats/epoch_processing/README.md).
-
-
-

--- a/tests/generators/operations/README.md
+++ b/tests/generators/operations/README.md
@@ -7,6 +7,3 @@ An operation test-runner can consume these operation test-suites,
  and handle different kinds of operations by processing the cases using the specified test handler.
 
 Information on the format of the tests can be found in the [operations test formats documentation](../../formats/operations/README.md).
-
-
-

--- a/tests/generators/sanity/README.md
+++ b/tests/generators/sanity/README.md
@@ -3,6 +3,3 @@
 Sanity tests cover regular state-transitions in a common block-list format, to ensure the basics work.
 
 Information on the format of the tests can be found in the [sanity test formats documentation](../../formats/sanity/README.md).
-
-
-


### PR DESCRIPTION
This PR touches a lot of files, but these were found somewhat organically and breaking it up into multiple commits and/or PRs would be very time consuming. This PR makes these notable changes:

* Delete unnecessary blank lines.
* Add blank line before code block or line, or between a header and a paragraph.
* Add missing table of contents headers.
* Move ToC headers to the correct location, out of doctoc section.
* Add work-in-progress notices to in-development specs.
* Remove work-in-progress notices from stable specs.
* Fix table whitespace/alignment issues.
* Left justify electra state list length unit fields.
* Where missing, add `<!-- TOC -->` comments for consistency.