### PR TITLE
Add test with multiple deposit requests with same pubkey but different withdrawal credentials

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/fork/test_electra_fork_basic.py
+++ b/tests/core/pyspec/eth2spec/test/electra/fork/test_electra_fork_basic.py
@@ -1,4 +1,3 @@
-import random
 from eth2spec.test.context import (
     with_phases,
     with_custom_state,
@@ -150,33 +149,6 @@ def test_fork_has_compounding_withdrawal_credential(spec, phases, state):
         signature=spec.bls.G2_POINT_AT_INFINITY,
         slot=spec.GENESIS_SLOT,
     )]
-
-
-@with_phases(phases=[DENEB], other_phases=[ELECTRA])
-@spec_test
-@with_state
-@with_meta_tags(ELECTRA_FORK_TEST_META_TAGS)
-def test_fork_pending_deposits_with_same_pubkey_different_withdrawal_credentials(spec, phases, state):
-    post_spec = phases[ELECTRA]
-
-    num_validators = len(state.validators)
-    indexes_with_same_pubkey = random.sample(range(num_validators), min(10, num_validators))
-    constant_pubkey = b'\x11' * 48
-
-    for index in range(num_validators):
-        state.validators[index].activation_epoch = spec.FAR_FUTURE_EPOCH
-
-    for index in indexes_with_same_pubkey:
-        state.validators[index].pubkey = constant_pubkey
-
-    post_state = yield from run_fork_test(post_spec, state)
-
-    assert len(post_state.pending_deposits) == num_validators
-
-    for index in indexes_with_same_pubkey:
-        assert post_state.pending_deposits[index].pubkey == constant_pubkey
-        assert (post_state.pending_deposits[index].withdrawal_credentials
-                == state.validators[index].withdrawal_credentials)
 
 
 @with_phases(phases=[DENEB], other_phases=[ELECTRA])

--- a/tests/core/pyspec/eth2spec/test/electra/fork/test_electra_fork_basic.py
+++ b/tests/core/pyspec/eth2spec/test/electra/fork/test_electra_fork_basic.py
@@ -166,13 +166,8 @@ def test_fork_pending_deposits_with_same_pubkey_different_withdrawal_credentials
     for index in range(num_validators):
         state.validators[index].activation_epoch = spec.FAR_FUTURE_EPOCH
 
-    withdrawal_credentials = []
     for index in indexes_with_same_pubkey:
         state.validators[index].pubkey = constant_pubkey
-        withdrawal_credentials.append(state.validators[index].withdrawal_credentials)
-
-    # ensure that the withdrawal credentials are unique
-    assert len(set(withdrawal_credentials)) == len(withdrawal_credentials)
 
     post_state = yield from run_fork_test(post_spec, state)
 
@@ -180,8 +175,8 @@ def test_fork_pending_deposits_with_same_pubkey_different_withdrawal_credentials
 
     for index in indexes_with_same_pubkey:
         assert post_state.pending_deposits[index].pubkey == constant_pubkey
-        expected_withdrawal_credentials = state.validators[index].withdrawal_credentials
-        assert post_state.pending_deposits[index].withdrawal_credentials == expected_withdrawal_credentials
+        assert (post_state.pending_deposits[index].withdrawal_credentials
+                == state.validators[index].withdrawal_credentials)
 
 
 @with_phases(phases=[DENEB], other_phases=[ELECTRA])

--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
@@ -275,8 +275,8 @@ def test_deposit_transition__deposit_with_same_pubkey_different_withdrawal_crede
                                            deposit_request_cnt=deposit_request_count)
 
     # pick 2 indices among deposit requests to have the same pubkey as the deposit
-    indexes_with_same_pubkey = [1, 3]
-    for index in indexes_with_same_pubkey:
+    indices_with_same_pubkey = [1, 3]
+    for index in indices_with_same_pubkey:
         block.body.execution_requests.deposits[index].pubkey = block.body.deposits[0].data.pubkey
 
     block.body.execution_payload.block_hash = compute_el_block_hash_for_block(spec, block)
@@ -286,7 +286,7 @@ def test_deposit_transition__deposit_with_same_pubkey_different_withdrawal_crede
     yield from run_deposit_transition_block(spec, state, block)
 
     assert len(state.pending_deposits) == deposit_request_count + deposit_count
-    for index in indexes_with_same_pubkey:
+    for index in indices_with_same_pubkey:
         assert state.pending_deposits[deposit_count + index].pubkey == deposit_requests[index].pubkey
         assert (state.pending_deposits[deposit_count + index].withdrawal_credentials
                 == deposit_requests[index].withdrawal_credentials)

--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
@@ -274,7 +274,7 @@ def test_deposit_transition__deposit_with_same_pubkey_different_withdrawal_crede
     state, block = prepare_state_and_block(spec, state,
                                            deposit_cnt=deposit_count,
                                            deposit_request_cnt=deposit_request_count)
-    
+
     # pick 2 indices among deposit requests to have the same pubkey as the deposit
     indexes_with_same_pubkey = random.sample(range(deposit_count, deposit_request_count), 2)
     for index in indexes_with_same_pubkey:

--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
@@ -1,4 +1,3 @@
-import random
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
@@ -276,7 +275,7 @@ def test_deposit_transition__deposit_with_same_pubkey_different_withdrawal_crede
                                            deposit_request_cnt=deposit_request_count)
 
     # pick 2 indices among deposit requests to have the same pubkey as the deposit
-    indexes_with_same_pubkey = random.sample(range(deposit_count, deposit_request_count), 2)
+    indexes_with_same_pubkey = [1, 3]
     for index in indexes_with_same_pubkey:
         block.body.execution_requests.deposits[index].pubkey = block.body.deposits[0].data.pubkey
 

--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
@@ -278,6 +278,9 @@ def test_deposit_transition__deposit_with_same_pubkey_different_withdrawal_crede
     indices_with_same_pubkey = [1, 3]
     for index in indices_with_same_pubkey:
         block.body.execution_requests.deposits[index].pubkey = block.body.deposits[0].data.pubkey
+        # ensure top-up deposit request withdrawal credentials are different than the deposit
+        assert (block.body.execution_requests.deposits[index].withdrawal_credentials
+                != block.body.deposits[0].data.withdrawal_credentials)
 
     block.body.execution_payload.block_hash = compute_el_block_hash_for_block(spec, block)
 
@@ -288,5 +291,6 @@ def test_deposit_transition__deposit_with_same_pubkey_different_withdrawal_crede
     assert len(state.pending_deposits) == deposit_request_count + deposit_count
     for index in indices_with_same_pubkey:
         assert state.pending_deposits[deposit_count + index].pubkey == deposit_requests[index].pubkey
+        # ensure withdrawal credentials are retained, rather than being made the same
         assert (state.pending_deposits[deposit_count + index].withdrawal_credentials
                 == deposit_requests[index].withdrawal_credentials)

--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_deposit_transition.py
@@ -1,3 +1,4 @@
+import random
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
@@ -262,3 +263,31 @@ def test_deposit_transition__deposit_and_top_up_same_block(spec, state):
     assert state.pending_deposits[pre_pending_deposits].amount == block.body.deposits[0].data.amount
     amount_from_deposit = block.body.execution_requests.deposits[0].amount
     assert state.pending_deposits[pre_pending_deposits + 1].amount == amount_from_deposit
+
+
+@with_phases([ELECTRA])
+@spec_state_test
+def test_deposit_transition__deposit_with_same_pubkey_different_withdrawal_credentials(spec, state):
+    deposit_count = 1
+    deposit_request_count = 4
+
+    state, block = prepare_state_and_block(spec, state,
+                                           deposit_cnt=deposit_count,
+                                           deposit_request_cnt=deposit_request_count)
+    
+    # pick 2 indices among deposit requests to have the same pubkey as the deposit
+    indexes_with_same_pubkey = random.sample(range(deposit_count, deposit_request_count), 2)
+    for index in indexes_with_same_pubkey:
+        block.body.execution_requests.deposits[index].pubkey = block.body.deposits[0].data.pubkey
+
+    block.body.execution_payload.block_hash = compute_el_block_hash_for_block(spec, block)
+
+    deposit_requests = block.body.execution_requests.deposits.copy()
+
+    yield from run_deposit_transition_block(spec, state, block)
+
+    assert len(state.pending_deposits) == deposit_request_count + deposit_count
+    for index in indexes_with_same_pubkey:
+        assert state.pending_deposits[deposit_count + index].pubkey == deposit_requests[index].pubkey
+        assert (state.pending_deposits[deposit_count + index].withdrawal_credentials
+                == deposit_requests[index].withdrawal_credentials)


### PR DESCRIPTION
> If a block contained multiple deposits with the same pubkey, Grandine would add them to BeaconState.pending_deposits with the same withdrawal credentials. [link](https://github.com/ethereum/consensus-specs/issues/4054#:~:text=If%20a%20block%20contained%20multiple%20deposits%20with%20the%20same%20pubkey%2C%20Grandine%20would%20add%20them%20to%20BeaconState.pending_deposits%20with%20the%20same%20withdrawal%20credentials.)

This PR adds a test which checks that the withdrawal credentials associated with the same pubkey are retained, rather than being made the same. It randomly picks 2 deposit requests and their pubkeys are made the same as the top deposit.

fixes partially: #4054 