### PR TITLE
Fix typographical errors 

### DIFF
--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -221,7 +221,7 @@ Efficient algorithms for computing this object can be found in [the implementati
 We first define helper functions:
 
 * `size_of(B)`, where `B` is a basic type: the length, in bytes, of the serialized form of the basic type.
-* `chunk_count(type)`: calculate the amount of leafs for merkleization of the type.
+* `chunk_count(type)`: calculate the amount of leaves for merkleization of the type.
    * all basic types: `1`
    * `Bitlist[N]` and `Bitvector[N]`: `(N + 255) // 256` (dividing by chunk size, rounding up)
    * `List[B, N]` and `Vector[B, N]`, where `B` is a basic type: `(N * size_of(B) + 31) // 32` (dividing by chunk size, rounding up)

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_reorg.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_reorg.py
@@ -154,7 +154,7 @@ def test_simple_attempted_reorg_without_enough_ffg_votes(spec, state):
     yield 'steps', test_steps
 
 
-def _run_delayed_justification(spec, state, attemped_reorg, is_justifying_previous_epoch):
+def _run_delayed_justification(spec, state, attempted_reorg, is_justifying_previous_epoch):
     """
     """
     test_steps = []
@@ -224,7 +224,7 @@ def _run_delayed_justification(spec, state, attemped_reorg, is_justifying_previo
     yield from add_attestations(spec, store, attestations_for_y, test_steps)
     assert spec.get_head(store) == signed_block_y.message.hash_tree_root()
 
-    if attemped_reorg:
+    if attempted_reorg:
         # add chain z
         state = state_b.copy()
         slot = state.slot + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH) - 1
@@ -266,7 +266,7 @@ def test_simple_attempted_reorg_delayed_justification_current_epoch(spec, state)
     z: the child of block of x at the first slot of epoch 5.
     block z can reorg the chain from block y.
     """
-    yield from _run_delayed_justification(spec, state, attemped_reorg=True, is_justifying_previous_epoch=False)
+    yield from _run_delayed_justification(spec, state, attempted_reorg=True, is_justifying_previous_epoch=False)
 
 
 def _run_include_votes_of_another_empty_chain(spec, state, enough_ffg, is_justifying_previous_epoch):
@@ -496,7 +496,7 @@ def test_delayed_justification_current_epoch(spec, state):
 
     block_b: the block that can justify c4.
     """
-    yield from _run_delayed_justification(spec, state, attemped_reorg=False, is_justifying_previous_epoch=False)
+    yield from _run_delayed_justification(spec, state, attempted_reorg=False, is_justifying_previous_epoch=False)
 
 
 @with_altair_and_later
@@ -513,7 +513,7 @@ def test_delayed_justification_previous_epoch(spec, state):
     [c3]<---------------[c4]---[b]<---------------------------------[y]
 
     """
-    yield from _run_delayed_justification(spec, state, attemped_reorg=False, is_justifying_previous_epoch=True)
+    yield from _run_delayed_justification(spec, state, attempted_reorg=False, is_justifying_previous_epoch=True)
 
 
 @with_altair_and_later
@@ -536,7 +536,7 @@ def test_simple_attempted_reorg_delayed_justification_previous_epoch(spec, state
     z: the child of block of x at the first slot of epoch 5.
     block z can reorg the chain from block y.
     """
-    yield from _run_delayed_justification(spec, state, attemped_reorg=True, is_justifying_previous_epoch=True)
+    yield from _run_delayed_justification(spec, state, attempted_reorg=True, is_justifying_previous_epoch=True)
 
 
 @with_altair_and_later

--- a/tests/core/pyspec/eth2spec/utils/kzg.py
+++ b/tests/core/pyspec/eth2spec/utils/kzg.py
@@ -94,7 +94,7 @@ def dump_kzg_trusted_setup_files(secret: int, g1_length: int, g2_length: int, ou
     setup_g1_lagrange = get_lagrange(setup_g1)
     roots_of_unity = compute_roots_of_unity(g1_length)
 
-    serailized_setup_g1 = [encode_hex(bls.G1_to_bytes48(p)) for p in setup_g1]
+    serialized_setup_g1 = [encode_hex(bls.G1_to_bytes48(p)) for p in setup_g1]
     serialized_setup_g2 = [encode_hex(bls.G2_to_bytes96(p)) for p in setup_g2]
     serialized_setup_g1_lagrange = [encode_hex(x) for x in setup_g1_lagrange]
 
@@ -109,7 +109,7 @@ def dump_kzg_trusted_setup_files(secret: int, g1_length: int, g2_length: int, ou
     with open(file_path, 'w+') as f:
         json.dump(
             {
-                "setup_G1": serailized_setup_g1,
+                "setup_G1": serialized_setup_g1,
                 "setup_G2": serialized_setup_g2,
                 "setup_G1_lagrange": serialized_setup_g1_lagrange,
                 "roots_of_unity": roots_of_unity,


### PR DESCRIPTION
- Corrected the spelling of "endianess" to "endianness" in comments.
- Fixed other minor typos, including the miswritten "serailized" to "serialized" in code related to cryptographic functions.
- Ensured consistency in variable names and comments across multiple files.
