### PR TITLE
Add test cases with blocks containing several withdrawal requests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
@@ -174,6 +174,7 @@ def test_cl_exit_and_el_withdrawal_request_in_same_block(spec, state):
 
     assert state.validators[validator_index].exit_epoch < spec.FAR_FUTURE_EPOCH
 
+
 @with_electra_and_later
 @spec_state_test
 def test_multiple_el_partial_withdrawal_requests_same_validator(spec, state):
@@ -210,6 +211,7 @@ def test_multiple_el_partial_withdrawal_requests_same_validator(spec, state):
 
     assert len(state.pending_partial_withdrawals) == 2
     assert state.validators[validator_index].exit_epoch == spec.FAR_FUTURE_EPOCH
+
 
 @with_electra_and_later
 @spec_state_test


### PR DESCRIPTION
A bug was discovered in devnet-5 by @pk910 in [discord](https://discord.com/channels/595666850260713488/1330516498724421692/1330615860766965973) regarding Lodestar's inability to process a block that contains multiple **valid** withdrawal requests.

Likely a gap we've missed in the spec test, as the only tests I have seen which generates multiple withdrawal requests are from `random_block_electra()` which the requests are not valid.

Adding test cases in sanity blocks to cover this scenario. Have tested locally with pre-patched Lodestar failing and post-patched Lodestar passing.