### PR TITLE
4091: add test for empty blob

### DIFF
--- a/tests/core/pyspec/eth2spec/test/deneb/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/block_processing/test_process_execution_payload.py
@@ -261,3 +261,23 @@ def test_invalid_exceed_max_blobs_per_block(spec, state):
     execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments, valid=False)
+
+
+@with_deneb_and_later
+@spec_state_test
+def test_empty_blob(spec, state):
+    """
+    The blob is empty but commitment is valid
+    """
+
+    execution_payload = build_empty_execution_payload(spec, state)
+
+    opaque_tx, _, blob_kzg_commitments, _ = get_sample_blob_tx(spec, blob_count=1)
+
+    empty_blob = b'\x00' * spec.BYTES_PER_BLOB
+    blob_kzg_commitments[0] = spec.blob_to_kzg_commitment(empty_blob)
+
+    execution_payload.transactions = [opaque_tx]
+    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
+
+    yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments, valid=True)


### PR DESCRIPTION
This PR provides examples of a test for checking the behaviour of empty blobs. However, while writing this test, I spotted some strange behaviour. when i set empty_blob as =b'' i got error like
`    def blob_to_kzg_commitment(blob: Blob) -> KZGCommitment:
        """
        Public method.
        """
>       assert len(blob) == BYTES_PER_BLOB
`
so i tried with     empty_blob = b'\x00' * spec.BYTES_PER_BLOB
 , and now the test is passing. I don't know if it should be like that.
 
 About future improvements:
 1. Introduce `pytest.mark.parametrize`  in the test. It could simplify test structure and reduce code duplication (especially for tests that differ only in minor details) for example:
 
`This PR provides examples of a test for checking the behaviour of empty blobs. However, while writing this test, I spotted some strange behaviour. when i set empty_blob as =b'' i got error like
`    def blob_to_kzg_commitment(blob: Blob) -> KZGCommitment:
        """
        Public method.
        """
>       assert len(blob) == BYTES_PER_BLOB
`
so i tried with     empty_blob = b'\x00' * spec.BYTES_PER_BLOB
 , and now the test is passing. I don't know if it should be like that.
 
 About future improvements:
 1. Introduce `pytest.mark.parametrize`  in the test. It could simplify test structure and reduce code duplication (especially for tests that differ only in minor details) for example:
 `@pytest.mark.parametrize(
    "modify_tx, valid",
    [
        (lambda tx: tx + b'\x12', False),  # 1 byte longer
        (lambda tx: tx[:-1], False),      # 1 byte shorter
        (lambda tx: b'', False),          # Empty transaction
        (lambda tx: tx + b'\x12' * 32, False),  # 32 bytes longer
    ]
)
@with_deneb_and_later
@spec_state_test
def test_transaction_length_variations(spec, state, modify_tx, valid):
    """
    Tests various cases of invalid transaction lengths.
    """
    execution_payload = build_empty_execution_payload(spec, state)
    opaque_tx, _, blob_kzg_commitments, _ = get_sample_blob_tx(spec)
    opaque_tx = modify_tx(opaque_tx)  # Modify the transaction according to the parameter
    execution_payload.transactions = [opaque_tx]
    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
    yield from run_execution_payload_processing(spec, state, execution_payload, blob_kzg_commitments, valid=valid)
  
 `
 
 2. Stop using `yield from run_execution_payload_processing()` at least in some cases. I would suggest using pytest.fixture and pytest assertions, and for negative scenarios with pytest.raises(AssertionError),  Using fixtures  make it easy to share setup logic across tests, keeping the test functions focused on the actual test logic. Test logic is explicit and easy to follow. So on the end we can have something like:
 `@pytest.fixture
def sample_payload(spec, state):
    execution_payload = build_empty_execution_payload(spec, state)
    opaque_tx, _, blob_kzg_commitments, _ = get_sample_blob_tx(spec, blob_count=1)
    return execution_payload, opaque_tx, blob_kzg_commitments

@pytest.mark.parametrize(
    "modify_tx, modify_commitments, valid",
    [
        (lambda tx: tx, lambda commitments: commitments, True),
        (lambda tx: b'', lambda commitments: commitments, False),
    ]
)
def test_blob_processing(spec, state, sample_payload, modify_tx, modify_commitments, valid):
    execution_payload, opaque_tx, blob_kzg_commitments = sample_payload

    opaque_tx = modify_tx(opaque_tx)
    blob_kzg_commitments = modify_commitments(blob_kzg_commitments)
    execution_payload.transactions = [opaque_tx]
    execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)

    if valid:
        process_execution_payload(spec, state, execution_payload, blob_kzg_commitments)
    else:
        with pytest.raises(AssertionError):
            process_execution_payload(spec, state, execution_payload, blob_kzg_commitments)`
 
 
 