### PR TITLE
Replace pip with uv pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,13 @@ commands:
     description: "Restore the cache with pyspec keys"
     steps:
       - restore_cached_venv:
-          venv_name: v32-pyspec
+          venv_name: v33-pyspec
           reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}
   save_pyspec_cached_venv:
     description: Save a venv into a cache with pyspec keys"
     steps:
       - save_cached_venv:
-          venv_name: v32-pyspec
+          venv_name: v33-pyspec
           reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}
           venv_path: ./venv
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - restore_pyspec_cached_venv
       - run:
           name: Install pyspec requirements
-          command: make eth2spec
+          command: make pyspec
       - save_pyspec_cached_venv
   test-phase0:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ CODESPELL_VENV = $(VENV)/bin/codespell
 $(VENV):
 	@echo "Creating virtual environment"
 	@python3 -m venv $(VENV)
+	@$(PIP_VENV) install --quiet uv==0.5.24
 
 ###############################################################################
 # Specification
@@ -73,7 +74,7 @@ PYSPEC_DIR = $(TEST_LIBS_DIR)/pyspec
 # Create the pyspec for all phases.
 pyspec: $(VENV) setup.py pyproject.toml
 	@echo "Building eth2spec"
-	@$(PIP_VENV) install --quiet --upgrade .[docs,lint,test,generator]
+	@$(PYTHON_VENV) -m uv pip install .[docs,lint,test,generator]
 	@echo "Building all pyspecs"
 	@$(PYTHON_VENV) setup.py pyspecdev
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ ALL_EXECUTABLE_SPEC_NAMES = \
 	clean         \
 	coverage      \
 	detect_errors \
-	eth2spec      \
 	gen_all       \
 	gen_list      \
 	help          \
@@ -41,7 +40,6 @@ help:
 	@echo "make $(BOLD)clean$(NORM)         -- delete all untracked files"
 	@echo "make $(BOLD)coverage$(NORM)      -- run pyspec tests with coverage"
 	@echo "make $(BOLD)detect_errors$(NORM) -- detect generator errors"
-	@echo "make $(BOLD)eth2spec$(NORM)      -- force rebuild eth2spec package"
 	@echo "make $(BOLD)gen_<gen>$(NORM)     -- run a single generator"
 	@echo "make $(BOLD)gen_all$(NORM)       -- run all generators"
 	@echo "make $(BOLD)gen_list$(NORM)      -- list all generator targets"
@@ -60,8 +58,8 @@ PYTHON_VENV = $(VENV)/bin/python3
 PIP_VENV = $(VENV)/bin/pip3
 CODESPELL_VENV = $(VENV)/bin/codespell
 
-# Make a virtual environment will all of the necessary dependencies.
-$(VENV): pyproject.toml
+# Make a virtual environment.
+$(VENV):
 	@echo "Creating virtual environment"
 	@python3 -m venv $(VENV)
 
@@ -71,21 +69,11 @@ $(VENV): pyproject.toml
 
 TEST_LIBS_DIR = $(CURDIR)/tests/core
 PYSPEC_DIR = $(TEST_LIBS_DIR)/pyspec
-SITE_PACKAGES := $(wildcard $(VENV)/lib/python*/site-packages)
-ETH2SPEC := $(SITE_PACKAGES)/eth2spec
-
-# Install the eth2spec package.
-# The pipe indicates that venv is an order-only prerequisite.
-# When restoring venv cache, its timestamp is newer than eth2spec.
-$(ETH2SPEC): setup.py | $(VENV)
-	@$(PIP_VENV) install .[docs,lint,test,generator]
-
-# Force rebuild/install the eth2spec package.
-eth2spec:
-	@$(MAKE) --always-make $(ETH2SPEC)
 
 # Create the pyspec for all phases.
-pyspec: $(VENV) setup.py
+pyspec: $(VENV) setup.py pyproject.toml
+	@echo "Building eth2spec"
+	@$(PIP_VENV) install --quiet --upgrade .[docs,lint,test,generator]
 	@echo "Building all pyspecs"
 	@$(PYTHON_VENV) setup.py pyspecdev
 
@@ -112,7 +100,7 @@ test: MAYBE_TEST := $(if $(k),-k=$(k))
 test: MAYBE_FORK := $(if $(fork),--fork=$(fork))
 test: PRESET := --preset=$(if $(preset),$(preset),minimal)
 test: BLS := --bls-type=$(if $(bls),$(bls),fastest)
-test: $(ETH2SPEC) pyspec
+test: pyspec
 	@mkdir -p $(TEST_REPORT_DIR)
 	@$(PYTHON_VENV) -m pytest \
 		-n auto \
@@ -136,7 +124,7 @@ COVERAGE_SCOPE := $(foreach S,$(ALL_EXECUTABLE_SPEC_NAMES), --cov=eth2spec.$S.$(
 # Run pytest with coverage tracking
 _test_with_coverage: MAYBE_TEST := $(if $(k),-k=$(k))
 _test_with_coverage: MAYBE_FORK := $(if $(fork),--fork=$(fork))
-_test_with_coverage: $(ETH2SPEC) pyspec
+_test_with_coverage: pyspec
 	@$(PYTHON_VENV) -m pytest \
 		-n auto \
 		$(MAYBE_TEST) \
@@ -210,7 +198,7 @@ _check_toc: $(MARKDOWN_FILES:=.toc)
 	@[ "$$(find . -name '*.md.tmp' -print -quit)" ] && exit 1 || exit 0
 
 # Check for mistakes.
-lint: $(ETH2SPEC) pyspec _check_toc
+lint: pyspec _check_toc
 	@$(CODESPELL_VENV) . --skip "./.git,$(VENV),$(PYSPEC_DIR)/.mypy_cache" -I .codespell-whitelist
 	@$(PYTHON_VENV) -m flake8 --config $(FLAKE8_CONFIG) $(PYSPEC_DIR)/eth2spec
 	@$(PYTHON_VENV) -m flake8 --config $(FLAKE8_CONFIG) $(TEST_GENERATORS_DIR)
@@ -235,11 +223,11 @@ gen_list:
 	done
 
 # Run one generator.
-# This will forcibly rebuild eth2spec just in case.
+# This will forcibly rebuild pyspec just in case.
 # To check modules for a generator, append modcheck=true, eg:
 #   make gen_genesis modcheck=true
 gen_%: MAYBE_MODCHECK := $(if $(filter true,$(modcheck)),--modcheck)
-gen_%: eth2spec
+gen_%: pyspec
 	@mkdir -p $(TEST_VECTOR_DIR)
 	@$(PYTHON_VENV) $(GENERATOR_DIR)/$*/main.py \
 		--output $(TEST_VECTOR_DIR) \
@@ -259,7 +247,7 @@ detect_errors: $(TEST_VECTOR_DIR)
 	fi
 
 # Generate KZG trusted setups for testing.
-kzg_setups: $(ETH2SPEC)
+kzg_setups: pyspec
 	@for preset in minimal mainnet; do \
 		$(PYTHON_VENV) $(SCRIPTS_DIR)/gen_kzg_trusted_setups.py \
 			--secret=1337 \


### PR DESCRIPTION
I've been wanting to switch to `uv pip` for a while now. It's a lot faster. This will `pip install uv` (in the venv) once when creating the virtual environment. It also rebuilds `eth2spec` now everytime we build the pyspec, because it's so fast.

Some screenshots with numbers:

Before:

From clean build:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/73b3d368-15b3-4e43-9b84-4148033c8da4" />

From existing build:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/c2c11eb2-e4e5-4097-9022-8a2ed9b98a33" />


After:

From clean build:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/6dd166b7-a97a-4713-8bdf-9444d05b6137" />

From existing build:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/d16dc4c6-58d6-4bad-b4a9-f02fca60873e" />