### PR TITLE
In process_registry_updates, change two ifs to elifs

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -830,11 +830,9 @@ def process_registry_updates(state: BeaconState) -> None:
     for index, validator in enumerate(state.validators):
         if is_eligible_for_activation_queue(validator):  # [Modified in Electra:EIP7251]
             validator.activation_eligibility_epoch = current_epoch + 1
-
-        if is_active_validator(validator, current_epoch) and validator.effective_balance <= EJECTION_BALANCE:
+        elif is_active_validator(validator, current_epoch) and validator.effective_balance <= EJECTION_BALANCE:
             initiate_validator_exit(state, ValidatorIndex(index))  # [Modified in Electra:EIP7251]
-
-        if is_eligible_for_activation(state, validator):
+        elif is_eligible_for_activation(state, validator):
             validator.activation_epoch = activation_epoch
 ```
 


### PR DESCRIPTION
This PR is a little optimization. It changes two `if` conditions to `elif` in `process_registry_updates`.

This idea was suggested here:

* https://github.com/ethereum/consensus-specs/pull/4081#discussion_r1931374564

These are mutually exclusive checks (ie only one should be true), so this should be safe.