### PR TITLE
Add a new consolidation test & two new pending deposit tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -154,7 +154,7 @@ def scaled_churn_balances_exceed_activation_churn_limit(spec: Spec):
 def scaled_churn_balances_exceed_activation_exit_churn_limit(spec: Spec):
     """
     Helper method to create enough validators to scale the churn limit.
-    (The number of validators is double the amount need for the max activation/exit  churn limit)
+    (The number of validators is double the amount need for the max activation/exit churn limit)
     Usage: `@with_custom_state(balances_fn=scaled_churn_balances_exceed_activation_churn_limit, ...)`
     """
     num_validators = (

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawal_request.py
@@ -271,7 +271,7 @@ def test_incorrect_withdrawal_credential_prefix(spec, state):
 
 @with_electra_and_later
 @spec_state_test
-def test_on_withdrawal_request_initiated_validator(spec, state):
+def test_on_withdrawal_request_initiated_exit_validator(spec, state):
     rng = random.Random(1342)
     # move state forward SHARD_COMMITTEE_PERIOD epochs to allow for exit
     state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
@@ -766,9 +766,7 @@ def test_insufficient_effective_balance(spec, state):
     address = b"\x22" * 20
     amount = spec.EFFECTIVE_BALANCE_INCREMENT
     # Make effective balance insufficient
-    state.validators[
-        validator_index
-    ].effective_balance -= spec.EFFECTIVE_BALANCE_INCREMENT
+    state.validators[validator_index].effective_balance -= spec.EFFECTIVE_BALANCE_INCREMENT
     # Make sure validator has enough balance to withdraw
     state.balances[validator_index] += spec.EFFECTIVE_BALANCE_INCREMENT
 

--- a/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_apply_pending_deposit.py
+++ b/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_apply_pending_deposit.py
@@ -16,7 +16,7 @@ from eth2spec.test.helpers.withdrawals import set_validator_fully_withdrawable
 def test_apply_pending_deposit_under_min_activation(spec, state):
     # fresh deposit = next validator index = validator appended to registry
     validator_index = len(state.validators)
-    # effective balance will be 1 EFFECTIVE_BALANCE_INCREMENT smaller because of this small decrement.
+    # effective balance will be 1 EFFECTIVE_BALANCE_INCREMENT smaller because of this small decrement
     amount = spec.MIN_ACTIVATION_BALANCE - 1
     pending_deposit = prepare_pending_deposit(spec, validator_index, amount, signed=True)
 
@@ -95,7 +95,7 @@ def test_apply_pending_deposit_compounding_withdrawal_credentials_under_max(spec
         + b'\x00' * 11  # specified 0s
         + b'\x59' * 20  # a 20-byte eth1 address
     )
-    # effective balance will be 1 EFFECTIVE_BALANCE_INCREMENT smaller because of this small decrement.
+    # effective balance will be 1 EFFECTIVE_BALANCE_INCREMENT smaller because of this small decrement
     amount = spec.MAX_EFFECTIVE_BALANCE_ELECTRA - 1
     pending_deposit = prepare_pending_deposit(
         spec,
@@ -118,7 +118,7 @@ def test_apply_pending_deposit_compounding_withdrawal_credentials_max(spec, stat
         + b'\x00' * 11  # specified 0s
         + b'\x59' * 20  # a 20-byte eth1 address
     )
-    # effective balance will be exactly the same as balance.
+    # effective balance will be exactly the same as balance
     amount = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
     pending_deposit = prepare_pending_deposit(
         spec,
@@ -390,7 +390,7 @@ def test_apply_pending_deposit_key_validate_invalid_subgroup(spec, state):
     validator_index = len(state.validators)
     amount = spec.MIN_ACTIVATION_BALANCE
 
-    # All-zero pubkey would not pass `bls.KeyValidate`, but `apply_pending_deposit` would not throw exception.
+    # All-zero pubkey would not pass `bls.KeyValidate`, but `apply_pending_deposit` would not throw exception
     pubkey = b'\x00' * 48
 
     pending_deposit = prepare_pending_deposit(spec, validator_index, amount, pubkey=pubkey, signed=True)
@@ -405,8 +405,8 @@ def test_apply_pending_deposit_key_validate_invalid_decompression(spec, state):
     validator_index = len(state.validators)
     amount = spec.MIN_ACTIVATION_BALANCE
 
-    # `deserialization_fails_infinity_with_true_b_flag` BLS G1 deserialization test case.
-    # This pubkey would not pass `bls.KeyValidate`, but `apply_pending_deposit` would not throw exception.
+    # `deserialization_fails_infinity_with_true_b_flag` BLS G1 deserialization test case
+    # This pubkey would not pass `bls.KeyValidate`, but `apply_pending_deposit` would not throw exception
     pubkey_hex = 'c01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
     pubkey = bytes.fromhex(pubkey_hex)
 
@@ -436,9 +436,9 @@ def test_apply_pending_deposit_ineffective_deposit_with_bad_fork_version(spec, s
 @spec_state_test
 @always_bls
 def test_apply_pending_deposit_with_previous_fork_version(spec, state):
-    # Since deposits are valid across forks, the domain is always set with `GENESIS_FORK_VERSION`.
-    # It's an ineffective deposit because it fails at BLS sig verification.
-    # NOTE: it was effective in Altair.
+    # Since deposits are valid across forks, the domain is always set with `GENESIS_FORK_VERSION`
+    # It's an ineffective deposit because it fails at BLS sig verification
+    # NOTE: it was effective in Altair
     assert state.fork.previous_version != state.fork.current_version
 
     validator_index = len(state.validators)

--- a/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_process_pending_deposits.py
+++ b/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_process_pending_deposits.py
@@ -438,12 +438,12 @@ def test_process_pending_deposits_multiple_pending_one_skipped(spec, state):
 @with_electra_and_later
 @spec_state_test
 def test_process_pending_deposits_mixture_of_skipped_and_above_churn(spec, state):
-    amount01 = spec.EFFECTIVE_BALANCE_INCREMENT
+    amount1 = spec.EFFECTIVE_BALANCE_INCREMENT
     amount2 = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
     # First two validators have small deposit, third validators a large one
     for i in [0, 1]:
         state.pending_deposits.append(
-            prepare_pending_deposit(spec, validator_index=i, amount=amount01)
+            prepare_pending_deposit(spec, validator_index=i, amount=amount1)
         )
     state.pending_deposits.append(
         prepare_pending_deposit(spec, validator_index=2, amount=amount2)
@@ -455,18 +455,18 @@ def test_process_pending_deposits_mixture_of_skipped_and_above_churn(spec, state
     yield from run_process_pending_deposits(spec, state)
 
     # First deposit is processed
-    assert state.balances[0] == pre_balances[0] + amount01
+    assert state.balances[0] == pre_balances[0] + amount1
     # Second deposit is postponed, third is above churn
     for i in [1, 2]:
         assert state.balances[i] == pre_balances[i]
     # First deposit consumes some deposit balance
     # Deposit is not processed
-    wanted_balance = spec.get_activation_exit_churn_limit(state) - amount01
+    wanted_balance = spec.get_activation_exit_churn_limit(state) - amount1
     assert state.deposit_balance_to_consume == wanted_balance
     # second and third deposit still in the queue
     assert state.pending_deposits == [
         prepare_pending_deposit(spec, validator_index=2, amount=amount2),
-        prepare_pending_deposit(spec, validator_index=1, amount=amount01)
+        prepare_pending_deposit(spec, validator_index=1, amount=amount1)
     ]
 
 


### PR DESCRIPTION
This PR will:

* Fix a few small nits (variable names, function names, spacing, punctuation).
* Add `test_basic_consolidation_source_has_less_than_max_effective_balance` -- a test where the source validator (with 0x01 creds) has an effective balance with less than 32 ETH. This shouldn't prevent the consolidation.
* Add `test_apply_pending_deposit_over_min_activation_next_increment ` -- a test where the deposit amount is 33 ETH. There's an existing test with a deposit amount of 32 ETH + 1 Gwei, but that only ensures the client mod's with the effective balance increment. It wouldn't catch a client that forgets to compare with the max effective balance.
* Add `test_apply_pending_deposit_compounding_withdrawal_credentials_over_max_next_increment` -- a test like the previous one, but it's a compounding validator and the values are bigger: 2049 ETH.