### PR TITLE
Add a test with a consolidation and deposit request in the same block

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/sanity/test_slots.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/test_slots.py
@@ -153,18 +153,24 @@ def test_deposit_then_consolidation_does_not_update_effective_balance(spec, stat
     assert state.validators[target_index].effective_balance == spec.MIN_ACTIVATION_BALANCE
 
     # 2) Create deposit request
-    deposit = prepare_pending_deposit(spec, validator_index=source_index, amount=spec.MIN_ACTIVATION_BALANCE, signed=True) # So that it should have MIN_ACTIVATION_BALANCE * 2
+    deposit = prepare_pending_deposit(
+        spec, validator_index=source_index,
+        amount=spec.MIN_ACTIVATION_BALANCE, signed=True
+    )
     pending_deposits = [deposit]
-    
+
     # 3) Create consolidation request
     pending_consolidations = [spec.PendingConsolidation(
         source_index=source_index,
         target_index=target_index
     )]
-    
+
     # 4) Process requests, as seen from the CL
-    yield from run_epoch_processing(spec, state, pending_deposits=pending_deposits, pending_consolidations=pending_consolidations)
-    
+    yield from run_epoch_processing(
+        spec, state, pending_deposits=pending_deposits,
+        pending_consolidations=pending_consolidations
+    )
+
     # 5) Check that balance increased but effective balance remained unchanged
     assert state.balances[source_index] == spec.MIN_ACTIVATION_BALANCE
     assert state.validators[source_index].effective_balance == spec.MIN_ACTIVATION_BALANCE


### PR DESCRIPTION
This PR adds a test to check that the effective balance of a validator does not change if such a validator on the EL sent two requests on the same block, namely a deposit and a consolidation request (which in theory would allow him to increase his effective balance). However, this is not the case, so the test proves this behavior.