### PR TITLE
Do not checkout tests repo in nightly tests action

### DIFF
--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -25,12 +25,6 @@ jobs:
           repository: 'ethereum/consensus-specs'
           path: 'consensus-specs'
           ref: ${{ inputs.ref || 'dev' }}
-      - name: Checkout consensus-spec-tests repository
-        uses: actions/checkout@v4
-        with:
-          repository: 'ethereum/consensus-spec-tests'
-          path: 'consensus-spec-tests'
-          fetch-depth: 1
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
For some reason, the nightly test vectors generator action is packaging files like this:

```
version https://git-lfs.github.com/spec/v1
oid sha256:a2cf780b8dc8fe675a7b2f5a133dcf1331e7739032fb10dfab20a68a652a15e6
size 19
```

When reviewing the workflow, I noticed that we checkout this repo (which takes forever!) unnecessarily. And I think that's the cause of the problem, because it's configured with Git LFS support.