### PR TITLE
test: Ignore --disable-bls for test_process_pending_deposits_multiple_for_new_validator

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_process_pending_deposits.py
+++ b/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_process_pending_deposits.py
@@ -8,6 +8,7 @@ from eth2spec.test.context import (
     with_custom_state,
     scaled_churn_balances_exceed_activation_exit_churn_limit,
     default_activation_threshold,
+    always_bls,
 )
 from eth2spec.test.helpers.deposits import prepare_pending_deposit
 from eth2spec.test.helpers.state import (
@@ -335,6 +336,7 @@ def test_process_pending_deposits_multiple_pending_deposits_above_churn(spec, st
 
 @with_electra_and_later
 @spec_state_test
+@always_bls
 def test_process_pending_deposits_multiple_for_new_validator(spec, state):
     """
     - There are three pending deposits in the state, all pointing to the same public key.


### PR DESCRIPTION
The test_process_pending_deposits_multiple_for_new_validator test verifies that unsigned deposits are rejected for new validators. Add @always_bls decorator to ensure BLS signature verification remains enabled even when tests are run with --disable-bls flag for coverage reporting.

Without this change, running with --disable-bls (set by `make coverage`) causes all deposits to be processed regardless of signature validity, which does not match the spec behavior where the first deposit for a new validator must be signed.