### PR TITLE
test: Improve test coverage for get_committee_assignment

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_registry_updates.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_registry_updates.py
@@ -31,6 +31,7 @@ def test_add_to_activation_queue(spec, state):
     assert state.validators[index].activation_eligibility_epoch != spec.FAR_FUTURE_EPOCH
     assert state.validators[index].activation_epoch == spec.FAR_FUTURE_EPOCH
     assert not spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
+    assert spec.get_committee_assignment(state, spec.get_current_epoch(state), index) is None
 
 
 @with_all_phases


### PR DESCRIPTION
Add assertion to test_add_to_activation_queue to verify that get_committee_assignment returns None for validators in the activation queue (inactive validators). This improves test coverage by explicitly checking the behavior of get_committee_assignment for inactive validators.