### PR TITLE
refactor: Simplify get_execution_requests type check

### DIFF
--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -265,7 +265,7 @@ def get_execution_requests(execution_requests_list: Sequence[bytes]) -> Executio
                 List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD],
                 request_data
             )
-        elif request_type == CONSOLIDATION_REQUEST_TYPE:
+        else:
             consolidations = ssz_deserialize(
                 List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD],
                 request_data


### PR DESCRIPTION
The get_execution_requests function already asserts that request_type must be one of DEPOSIT_REQUEST_TYPE, WITHDRAWAL_REQUEST_TYPE, or CONSOLIDATION_REQUEST_TYPE. After handling deposits and withdrawals, consolidation is the only remaining possibility, making the explicit type check redundant.

This change:
- Replaces `elif request_type == CONSOLIDATION_REQUEST_TYPE` with `else`
- Improves branch coverage by removing an unreachable condition
- Maintains the same behavior since request_type validity is checked upfront