### PR TITLE
Add python version to circleci venv key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ commands:
     steps:
       - restore_cached_venv:
           venv_name: v33-pyspec
-          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}
+          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}-{{ python3 --version }}
   save_pyspec_cached_venv:
     description: Save a venv into a cache with pyspec keys"
     steps:
       - save_cached_venv:
           venv_name: v33-pyspec
-          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}
+          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}-{{ python3 --version }}
           venv_path: ./venv
 jobs:
   checkout_specs:


### PR DESCRIPTION
In the most recent PR, the circeci tests fail because it says "python3: not found"...
<img width="512" alt="image" src="https://github.com/user-attachments/assets/3599a7f5-866b-4678-b1df-c4cc7fcbed12" />

This is because a new python 3.12 release came out & the old version no longer exists.
<img width="774" alt="image" src="https://github.com/user-attachments/assets/7589f77f-194b-4340-b813-dc4da8bed2f9" />

See the new one:
<img width="774" alt="image" src="https://github.com/user-attachments/assets/e4e0a96c-bb3a-4ba3-8797-4648986d52d5" />

One solution would be to include the python version in the cached venv key, so this doesn't happen again.