### PR TITLE
test: add light client sync test for forced update before update timeout

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
@@ -359,28 +359,6 @@ def test_advance_finality_without_sync_committee(spec, state):
     yield from finish_lc_sync_test(test)
 
 
-def run_lc_sync_test_upgraded_store_with_legacy_data(spec, phases, state, fork):
-    # Start test (Legacy bootstrap with an upgraded store)
-    test = yield from setup_lc_sync_test(spec, state, phases[fork], phases)
-
-    # Initial `LightClientUpdate` (check that the upgraded store can process it)
-    finalized_block = spec.SignedBeaconBlock()
-    finalized_block.message.state_root = state.hash_tree_root()
-    finalized_state = state.copy()
-    attested_block = state_transition_with_full_block(spec, state, True, True)
-    attested_state = state.copy()
-    sync_aggregate, _ = get_sync_aggregate(spec, state)
-    block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
-    yield from emit_update(test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases)
-    assert test.store.finalized_header.beacon.slot == finalized_state.slot
-    assert test.store.next_sync_committee == finalized_state.next_sync_committee
-    assert test.store.best_valid_update is None
-    assert test.store.optimistic_header.beacon.slot == attested_state.slot
-
-    # Finish test
-    yield from finish_lc_sync_test(test)
-
-
 @with_light_client
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
@@ -447,6 +425,31 @@ def test_light_client_sync_no_force_update(spec, state):
     yield from emit_force_update(test, spec, state)
     # Store should remain unchanged since timeout wasn't reached
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
+
+    # Finish test
+    yield from finish_lc_sync_test(test)
+
+
+def run_lc_sync_test_upgraded_store_with_legacy_data(spec, phases, state, fork):
+    # Start test (Legacy bootstrap with an upgraded store)
+    test = yield from setup_lc_sync_test(spec, state, phases[fork], phases)
+
+    # Initial `LightClientUpdate` (check that the upgraded store can process it)
+    finalized_block = spec.SignedBeaconBlock()
+    finalized_block.message.state_root = state.hash_tree_root()
+    finalized_state = state.copy()
+    attested_block = state_transition_with_full_block(spec, state, True, True)
+    attested_state = state.copy()
+    sync_aggregate, _ = get_sync_aggregate(spec, state)
+    block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
+    yield from emit_update(test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases)
+    assert test.store.finalized_header.beacon.slot == finalized_state.slot
+    assert test.store.next_sync_committee == finalized_state.next_sync_committee
+    assert test.store.best_valid_update is None
+    assert test.store.optimistic_header.beacon.slot == attested_state.slot
+
+    # Finish test
+    yield from finish_lc_sync_test(test)
 
 
 @with_all_phases_from_to(ALTAIR, CAPELLA, other_phases=[CAPELLA])

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
@@ -381,6 +381,74 @@ def run_lc_sync_test_upgraded_store_with_legacy_data(spec, phases, state, fork):
     yield from finish_lc_sync_test(test)
 
 
+@with_light_client
+@spec_state_test_with_matching_config
+@with_presets([MINIMAL], reason="too slow")
+def test_light_client_sync_no_force_update(spec, state):
+    """Test that force update does not occur before timeout threshold is reached.
+
+    This test verifies that even with a best_valid_update present, the light client
+    will not perform a force update until sufficient time (UPDATE_TIMEOUT slots) has passed
+    since the last finalized header.
+
+    Test progression:
+    ```
+
+
+    +-----------+                   +----------+     +-----------+                  +---------+
+    | finalized | <-- (2 epochs) -- | attested | <-- | signature | <-- (N slots) -- | current |
+    +-----------+                   +----------+     +-----------+                  +---------+
+         ^                                                |                              ^
+         |                                                |                              |
+         |                                                V                              |
+         |                                           best_valid_update                   |
+         |                                                                               |
+         +------------------- (UPDATE_TIMEOUT) ------------------------------------------+
+
+    Delays:
+    * finalized to attested: 2 epochs
+    * attested to signature: 1 slot
+    * signature to current slot (N): UPDATE_TIMEOUT - (2 * SLOTS_PER_EPOCH + 1) slots
+    ```
+
+    Key points:
+    * best_valid_update created at signature block
+    * advance to just before timeout threshold
+    * verify force update does not occur
+    """
+    test = yield from setup_lc_sync_test(spec, state)
+
+    next_slots(spec, state, spec.SLOTS_PER_EPOCH - 1)
+    finalized_block = state_transition_with_full_block(spec, state, True, True)
+    finalized_state = state.copy()
+    _, _, state = next_slots_with_attestations(spec, state, 2 * spec.SLOTS_PER_EPOCH - 1, True, True)
+    attested_block = state_transition_with_full_block(spec, state, True, True)
+    attested_state = state.copy()
+    sync_aggregate, _ = get_sync_aggregate(spec, state)
+    block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
+
+    # Create initial update to set up store state
+    yield from emit_update(test, spec, state, block, attested_state, attested_block, finalized_block)
+    assert test.store.best_valid_update is None
+
+    # Create a best_valid_update by emitting an update without a finalized_header
+    update = yield from emit_update(test, spec, state, block, attested_state, attested_block, finalized_block=None)
+    assert test.store.best_valid_update == update
+
+    # Advance just short of timeout
+    next_slots(spec, state, spec.UPDATE_TIMEOUT - (2 * spec.SLOTS_PER_EPOCH + 1))
+
+    # Verify force update conditions
+    current_slot = state.slot
+    assert test.store.best_valid_update is not None
+    assert not (current_slot > test.store.finalized_header.beacon.slot + spec.UPDATE_TIMEOUT)
+
+    # Try force update
+    yield from emit_force_update(test, spec, state)
+    # Store should remain unchanged since timeout wasn't reached
+    assert test.store.finalized_header.beacon.slot == finalized_state.slot
+
+
 @with_all_phases_from_to(ALTAIR, CAPELLA, other_phases=[CAPELLA])
 @spec_test
 @with_state


### PR DESCRIPTION
This PR adds a test case `test_light_client_sync_no_force_update` that verifies light client force update behavior before timeout threshold is reached. The test:

- Creates a valid but partial update (missing finalized header)
- Advances state to just before UPDATE_TIMEOUT threshold
- Verifies force update does not occur prematurely

This complements existing timeout tests by explicitly covering the following negative case (first branch in process_light_client_store_force_update evaluates to False because current slot is at the timeout threshold) that was previously uncovered

```
def process_light_client_store_force_update(store: LightClientStore, current_slot: Slot) -> None:
    if (
        current_slot > store.finalized_header.beacon.slot + UPDATE_TIMEOUT
        and store.best_valid_update is not None
    ):
        # Forced best update when the update timeout has elapsed.
        # Because the apply logic waits for `finalized_header.beacon.slot` to indicate sync committee finality,
        # the `attested_header` may be treated as `finalized_header` in extended periods of non-finality
        # to guarantee progression into later sync committee periods according to `is_better_update`.
        if store.best_valid_update.finalized_header.beacon.slot <= store.finalized_header.beacon.slot:
            store.best_valid_update.finalized_header = store.best_valid_update.attested_header
        apply_light_client_update(store, store.best_valid_update)
        store.best_valid_update = None
```