### PR TITLE
Add back `compute_cells` function

### DIFF
--- a/specs/fulu/polynomial-commitments-sampling.md
+++ b/specs/fulu/polynomial-commitments-sampling.md
@@ -526,7 +526,7 @@ def coset_for_cell(cell_index: CellIndex) -> Coset:
 ```python
 def compute_cells(blob: Blob) -> Vector[Cell, CELLS_PER_EXT_BLOB]:
     """
-    Compute all the cells for an extended blob.
+    Given a blob, extend it and return all the cells of the extended blob.
 
     Public method.
     """

--- a/specs/fulu/polynomial-commitments-sampling.md
+++ b/specs/fulu/polynomial-commitments-sampling.md
@@ -39,6 +39,7 @@
     - [`coset_for_cell`](#coset_for_cell)
 - [Cells](#cells-1)
   - [Cell computation](#cell-computation)
+    - [`compute_cells`](#compute_cells)
     - [`compute_cells_and_kzg_proofs_polynomialcoeff`](#compute_cells_and_kzg_proofs_polynomialcoeff)
     - [`compute_cells_and_kzg_proofs`](#compute_cells_and_kzg_proofs)
   - [Cell verification](#cell-verification)
@@ -519,6 +520,28 @@ def coset_for_cell(cell_index: CellIndex) -> Coset:
 ## Cells
 
 ### Cell computation
+
+#### `compute_cells`
+
+```python
+def compute_cells(blob: Blob) -> Vector[Cell, CELLS_PER_EXT_BLOB]:
+    """
+    Compute all the cells for an extended blob.
+
+    Public method.
+    """
+    assert len(blob) == BYTES_PER_BLOB
+
+    polynomial = blob_to_polynomial(blob)
+    polynomial_coeff = polynomial_eval_to_coeff(polynomial)
+
+    cells = []
+    for i in range(CELLS_PER_EXT_BLOB):
+        coset = coset_for_cell(CellIndex(i))
+        ys = CosetEvals([evaluate_polynomialcoeff(polynomial_coeff, z) for z in coset])
+        cells.append(coset_evals_to_cell(CosetEvals(ys)))
+    return cells
+```
 
 #### `compute_cells_and_kzg_proofs_polynomialcoeff`
 

--- a/tests/formats/kzg_7594/compute_cells.md
+++ b/tests/formats/kzg_7594/compute_cells.md
@@ -1,0 +1,22 @@
+# Test format: Compute cells
+
+Compute the cells for a given `blob`.
+
+## Test case format
+
+The test data is declared in a `data.yaml` file:
+
+```yaml
+input:
+  blob: Blob -- the data blob
+output: List[Cell] -- the cells
+```
+
+- `Blob` is a 131072-byte hexadecimal string, prefixed with `0x`.
+- `Cell` is a 2048-byte hexadecimal string, prefixed with `0x`.
+
+All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with `0x`.
+
+## Condition
+
+The `compute_cells` handler should compute the cells (chunks of an extended blob) for `blob`, and the result should match the expected `output`. If the blob is invalid (e.g. incorrect length or one of the 32-byte blocks does not represent a BLS field element) it should error, i.e. the output should be `null`.

--- a/tests/generators/kzg_7594/main.py
+++ b/tests/generators/kzg_7594/main.py
@@ -28,6 +28,34 @@ from eth2spec.utils import bls
 
 
 ###############################################################################
+# Test cases for compute_cells
+###############################################################################
+
+def case_compute_cells():
+    # Valid cases
+    for blob in VALID_BLOBS:
+        cells = spec.compute_cells(blob)
+        identifier = make_id(blob)
+        yield f'compute_cells_case_valid_{identifier}', {
+            'input': {
+                'blob': encode_hex(blob),
+            },
+            'output': encode_hex_list(cells)
+        }
+
+    # Edge case: Invalid blobs
+    for blob in INVALID_BLOBS:
+        expect_exception(spec.compute_cells, blob)
+        identifier = make_id(blob)
+        yield f'compute_cells_invalid_blob_{identifier}', {
+            'input': {
+                'blob': encode_hex(blob)
+            },
+            'output': None
+        }
+
+
+###############################################################################
 # Test cases for compute_cells_and_kzg_proofs
 ###############################################################################
 
@@ -565,6 +593,7 @@ def create_provider(fork_name: SpecForkName,
 if __name__ == "__main__":
     bls.use_arkworks()
     gen_runner.run_generator("kzg_7594", [
+        create_provider(FULU, 'compute_cells', case_compute_cells),
         create_provider(FULU, 'compute_cells_and_kzg_proofs', case_compute_cells_and_kzg_proofs),
         create_provider(FULU, 'verify_cell_kzg_proof_batch', case_verify_cell_kzg_proof_batch),
         create_provider(FULU, 'recover_cells_and_kzg_proofs', case_recover_cells_and_kzg_proofs),


### PR DESCRIPTION
For PeerDAS, we are going to add cell proofs to the blob transaction. Instead of sending the cells in the transaction, we can quickly compute the cells given the blob. For this, we need the `compute_cells` function again.

@kevaundray & @asn-d6, please review 🙂