### PR TITLE
Do not double build pyspec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,11 @@ PYSPEC_DIR = $(TEST_LIBS_DIR)/pyspec
 pyspec: $(VENV) setup.py pyproject.toml
 	@echo "Building eth2spec"
 	@$(PYTHON_VENV) -m uv pip install --reinstall-package=eth2spec .[docs,lint,test,generator]
-	@echo "Building all pyspecs"
-	@$(PYTHON_VENV) setup.py pyspecdev
+	@for dir in $(ALL_EXECUTABLE_SPEC_NAMES); do \
+	    mkdir -p "./tests/core/pyspec/eth2spec/$$dir"; \
+	    cp "./build/lib/eth2spec/$$dir/mainnet.py" "./tests/core/pyspec/eth2spec/$$dir/mainnet.py"; \
+	    cp "./build/lib/eth2spec/$$dir/minimal.py" "./tests/core/pyspec/eth2spec/$$dir/minimal.py"; \
+	done
 
 ###############################################################################
 # Testing

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ PYSPEC_DIR = $(TEST_LIBS_DIR)/pyspec
 
 # Create the pyspec for all phases.
 pyspec: $(VENV) setup.py pyproject.toml
-	@echo "Building eth2spec"
 	@$(PYTHON_VENV) -m uv pip install --reinstall-package=eth2spec .[docs,lint,test,generator]
 	@for dir in $(ALL_EXECUTABLE_SPEC_NAMES); do \
 	    mkdir -p "./tests/core/pyspec/eth2spec/$$dir"; \


### PR DESCRIPTION
A little something I've been wanting to do for a while. We have been doubly building the pyspec. When building `eth2spec`, it generates the `mainnet.py` and `minimal.py` file that tests use. And then `setup.py pyspecdev` would regenerate them but put them in a different directory. We could just copy them & save 3 seconds.