### PR TITLE
test: validator merkle proof 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venv
 /.pytest_cache
 *.swp
 .eth2spec
+.idea
 
 build/
 output/

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
@@ -73,6 +73,7 @@ def test_finality_root_merkle_proof(spec, state):
         root=state.hash_tree_root(),
     )
 
+
 @with_test_suite_name("BeaconState")
 @with_light_client
 @spec_state_test

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
@@ -84,13 +84,7 @@ def test_validator_merkle_proof(spec, state):
     (for example, to verify the validator's public key or effective balance).
     """
     yield "object", state
-
-    validator_0_gindex = spec.get_generalized_index(
-        state,
-        'validators',
-        0
-    )
-
+    validator_0_gindex = spec.get_generalized_index(state, 'validators', 0)
     branch = spec.compute_merkle_proof(state, validator_0_gindex)
 
     yield "proof", {

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
@@ -72,3 +72,36 @@ def test_finality_root_merkle_proof(spec, state):
         index=spec.get_subtree_index(gindex),
         root=state.hash_tree_root(),
     )
+
+@with_test_suite_name("BeaconState")
+@with_light_client
+@spec_state_test
+def test_validator_merkle_proof(spec, state):
+    """
+    Demonstrates the validity of a Merkle proof for state.validators[0] in the BeaconState.
+    Ensures that a client can prove inclusion of a single validator record.
+    (for example, to verify the validator's public key or effective balance).
+    """
+    yield "object", state
+
+    validator_0_gindex = spec.get_generalized_index(
+        state,
+        'validators',
+        0
+    )
+
+    branch = spec.compute_merkle_proof(state, validator_0_gindex)
+
+    yield "proof", {
+        "leaf": "0x" + state.validators[0].hash_tree_root().hex(),
+        "leaf_index": validator_0_gindex,
+        "branch": ['0x' + root.hex() for root in branch]
+    }
+
+    assert spec.is_valid_merkle_branch(
+        leaf=state.validators[0].hash_tree_root(),
+        branch=branch,
+        depth=spec.floorlog2(validator_0_gindex),
+        index=spec.get_subtree_index(validator_0_gindex),
+        root=state.hash_tree_root(),
+    )


### PR DESCRIPTION
This PR adds a test to the Altair light-client tests in `test_single_merkle_proof.py`, in order to test the generation and validation of a merkle proof for a validator in the beacon state. This is a functionality usually used by light clients in order to prove some information about a validator.

This PR also adds the `.idea` path to the list of `gitignore` files. 

The following are a number of potential ways to improve this repository and the testing framework in general:

1. **PR/Issue templates:**
    It would be beneficial to have templates for PRs and Issues. some examples:
    - Having an issue template for test coverage would allow creating a number of issues that specify places that lack tests, and then by encouraging contributors to work on those issues we could reach better coverage in the repo.
    - Defining a PR checklist would help the contributors to provide all the needed information in the PR, add sufficient tests, check for linter errors, and ... before publishing their PRs. This would help to have clearer PRs and decreases the work needed by maintainers to review them.

2. **Aggregated Specs:**
    Having the aggregated specs instead of per fork, would allow client developers to see the latest specs in one place, and not to be forced to implement changes incrementally. check out [light client agg specs](https://github.com/Inspector-Butters/light-client-consensus-specs) as an example.

3. **Only Build eth2sepc for specified forks:**
    If possible, don't build the whole eth2specs if a `fork=X` is provided in the `make test` command. there is no need to build the package for newer phases than the targeted phase.

4. **Cache for builds and test runs:**
    If possible, add caching to the testing framework. It can be helpful to rebuild only parts of the package that have changed, and not the whole package. It can also be used for running tests, to cache test results instead of running them every time. this might be tricky. `pytest` offers a few ways to improve this, like `--lf` or `--ff` flags, or if worth it, use build systems like Bazel that automatically help with this.

5. **Provide documentation on test decorators and their ordering:**
    It is not obvious that what decorators are available and what their usecases are. specifically it's not visible in what order you can use them on a test case. An explanation on this would help contributors to use the decorators efficiently.