### PR TITLE
fix: typos in documentation files

### DIFF
--- a/tests/core/pyspec/eth2spec/test/eip7441/block_processing/test_process_eip7441_registration.py
+++ b/tests/core/pyspec/eth2spec/test/eip7441/block_processing/test_process_eip7441_registration.py
@@ -50,7 +50,7 @@ def test_first_proposal_ok(spec, state):
 
 @with_eip7441_and_later
 @spec_state_test
-def test_first_proposal_indentity_tracker(spec, state):
+def test_first_proposal_identity_tracker(spec, state):
     body = empty_block_body(spec)
     set_as_first_proposal_and_proposer(spec, state, PROPOSER_INDEX)
     set_registration(body, OTHER_K, IDENTITY_R)

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_reorg.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_reorg.py
@@ -154,7 +154,7 @@ def test_simple_attempted_reorg_without_enough_ffg_votes(spec, state):
     yield 'steps', test_steps
 
 
-def _run_delayed_justification(spec, state, attemped_reorg, is_justifying_previous_epoch):
+def _run_delayed_justification(spec, state, attempted_reorg, is_justifying_previous_epoch):
     """
     """
     test_steps = []
@@ -224,7 +224,7 @@ def _run_delayed_justification(spec, state, attemped_reorg, is_justifying_previo
     yield from add_attestations(spec, store, attestations_for_y, test_steps)
     assert spec.get_head(store) == signed_block_y.message.hash_tree_root()
 
-    if attemped_reorg:
+    if attempted_reorg:
         # add chain z
         state = state_b.copy()
         slot = state.slot + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH) - 1
@@ -266,7 +266,7 @@ def test_simple_attempted_reorg_delayed_justification_current_epoch(spec, state)
     z: the child of block of x at the first slot of epoch 5.
     block z can reorg the chain from block y.
     """
-    yield from _run_delayed_justification(spec, state, attemped_reorg=True, is_justifying_previous_epoch=False)
+    yield from _run_delayed_justification(spec, state, attempted_reorg=True, is_justifying_previous_epoch=False)
 
 
 def _run_include_votes_of_another_empty_chain(spec, state, enough_ffg, is_justifying_previous_epoch):
@@ -496,7 +496,7 @@ def test_delayed_justification_current_epoch(spec, state):
 
     block_b: the block that can justify c4.
     """
-    yield from _run_delayed_justification(spec, state, attemped_reorg=False, is_justifying_previous_epoch=False)
+    yield from _run_delayed_justification(spec, state, attempted_reorg=False, is_justifying_previous_epoch=False)
 
 
 @with_altair_and_later
@@ -513,7 +513,7 @@ def test_delayed_justification_previous_epoch(spec, state):
     [c3]<---------------[c4]---[b]<---------------------------------[y]
 
     """
-    yield from _run_delayed_justification(spec, state, attemped_reorg=False, is_justifying_previous_epoch=True)
+    yield from _run_delayed_justification(spec, state, attempted_reorg=False, is_justifying_previous_epoch=True)
 
 
 @with_altair_and_later
@@ -536,7 +536,7 @@ def test_simple_attempted_reorg_delayed_justification_previous_epoch(spec, state
     z: the child of block of x at the first slot of epoch 5.
     block z can reorg the chain from block y.
     """
-    yield from _run_delayed_justification(spec, state, attemped_reorg=True, is_justifying_previous_epoch=True)
+    yield from _run_delayed_justification(spec, state, attempted_reorg=True, is_justifying_previous_epoch=True)
 
 
 @with_altair_and_later


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "indentity" to "identity"
Corrected "attemped" to "attempted"
