### PR TITLE
docs: fix broken link in `polynomial-commitments-sampling.md`

### DIFF
--- a/specs/fulu/polynomial-commitments-sampling.md
+++ b/specs/fulu/polynomial-commitments-sampling.md
@@ -54,7 +54,7 @@
 
 ## Introduction
 
-This document extends [polynomial-commitments.md](../../deneb/polynomial-commitments.md) with the functions required for data availability sampling (DAS). It is not part of the core Deneb spec but an extension that can be optionally implemented to allow nodes to reduce their load using DAS.
+This document extends [polynomial-commitments.md](../deneb/polynomial-commitments.md) with the functions required for data availability sampling (DAS). It is not part of the core Deneb spec but an extension that can be optionally implemented to allow nodes to reduce their load using DAS.
 
 ## Public Methods
 


### PR DESCRIPTION
Hey! I fixed a broken link in `polynomial-commitments-sampling.md`. The relative path was incorrect, causing navigation issues. Updated it to the correct reference.
