### PR TITLE
add new test test_random_data_empty_block_transition to test_blocks.py file

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -109,6 +109,26 @@ def test_empty_block_transition(spec, state):
     assert spec.get_block_root_at_slot(state, pre_slot) == signed_block.message.parent_root
     assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != pre_mix
 
+@with_all_phases
+@spec_state_test
+def test_random_data_empty_block_transition(spec, state):
+    pre_slot = state.slot
+    pre_eth1_votes = len(state.eth1_data_votes)
+    pre_mix = spec.get_randao_mix(state, spec.get_current_epoch(state))
+
+    yield 'pre', state
+
+    block = build_empty_block_for_next_slot(spec, state)
+
+    signed_block = state_transition_and_sign_block(spec, state, block)
+
+    yield 'blocks', [signed_block]
+    yield 'post', state
+
+    assert len(state.eth1_data_votes) == pre_eth1_votes + 1
+    assert spec.get_block_root_at_slot(state, pre_slot) == signed_block.message.parent_root
+    # test for negative condition - random data in new block cannot be same as previous block
+    assert not spec.get_randao_mix(state, spec.get_current_epoch(state)) == pre_mix
 
 @with_all_phases
 @with_presets([MINIMAL],


### PR DESCRIPTION
 A new PR to add a new test in test_blocks.py

This adds a new (negative) test called test_random_data_empty_block_transition:
- this checks that  random data in a new proposed block cannot equal the data in the previous block.

If this is true (ie not equal) then the test will pass.

##########################################################

In addition, I would like to propose some changes to  the repo. 

- The README (consensus-specs/tree/dev/tests) could be updated. eg using 'make' to create specs and tests does not work.  'make   pyspec' needs to be run to create the specifications. Also if 'make tests' is run, the whole test framework runs and this  can take 1.5 to  2 hours. 

- In addition to running just 1 test, maybe similar feature tests or tests for a particular release can be grouped to run together, rather than the whole  framework. As a result a regression (or base collection) suite of tests could be defined.

- When a test(s) is run, the results  are written to  'tests/core/pyspec/test-reports/test_results.xml'. Any subsequent test runs will overwrite this local  results file. It may be an idea to append a timestamp to this file so previous results are not  overwritten or append a text description of the test run to the results  filename.

- Also although a summary  of the tests passed/failed/skipped is written to the console  after a test has run, only the failed/skipped stats are written to the above test results file. It would be nice to have the passed stats added to the results file.
 