### PR TITLE
fix: fix incorrect path separator in WORKDIR

### DIFF
--- a/scripts/build_run_docker_tests.sh
+++ b/scripts/build_run_docker_tests.sh
@@ -13,7 +13,7 @@
 ALL_EXECUTABLE_SPECS=("phase0" "altair" "bellatrix" "capella" "deneb" "electra" "fulu" "eip7441")
 TEST_PRESET_TYPE=minimal
 FORK_TO_TEST=phase0
-WORKDIR="//consensus-specs//tests//core//pyspec"
+WORKDIR="/consensus-specs/tests/core/pyspec"
 ETH2SPEC_FOLDER_NAME="eth2spec"
 CONTAINER_NAME="consensus-specs-tests"
 DATE=$(date +"%Y%m%d-%H-%M")


### PR DESCRIPTION
I’ve fixed an issue with the WORKDIR path. The original line used double slashes `//`, but it should use single slashes `/` as the correct path separator for Unix-like systems. Here's the updated line:

```bash
WORKDIR="/consensus-specs/tests/core/pyspec"
```

This change ensures the correct file path format.