### PR TITLE
Add python3 version check to cache requirements checksum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ commands:
     steps:
       - restore_cached_venv:
           venv_name: v34-pyspec
-          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}
+          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}-{{ python3 --version }}
   save_pyspec_cached_venv:
     description: "Save a venv into a cache with pyspec keys"
     steps:
       - save_cached_venv:
           venv_name: v34-pyspec
-          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}
+          reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "pyproject.toml" }}-{{ python3 --version }}
           venv_path: ./venv
 jobs:
   checkout_specs:


### PR DESCRIPTION
This PR updates the `config.yml` file to include `python3` version in the cache key for requirements checksum. This change ensures proper cache invalidation when python version changes.

**Changes made:**
- Added python3 --version to the cache key in `restore_cached_venv` step
- Added python3 --version to the cache key in `save_pyspec_cached_venv` step