### PR TITLE
Update `eth1_block_hash` type from Bytes32 to Hash32

### DIFF
--- a/tests/formats/genesis/initialization.md
+++ b/tests/formats/genesis/initialization.md
@@ -7,7 +7,7 @@ Tests the initialization of a genesis state based on Eth1 data.
 ### `eth1.yaml`
 
 ```yaml
-eth1_block_hash: Bytes32  -- A `Bytes32` hex encoded, with prefix 0x. The root of the Eth1 block. E.g. "0x4242424242424242424242424242424242424242424242424242424242424242"
+eth1_block_hash: Hash32  -- A `Hash32` hex encoded, with prefix 0x. The root of the Eth1 block. E.g. "0x4242424242424242424242424242424242424242424242424242424242424242"
 eth1_timestamp: int       -- An integer. The timestamp of the block, in seconds.
 ```
 


### PR DESCRIPTION
This PR updates the type specification for `eth1_block_hash` in `initialization.md` from `Bytes32` to `Hash32`, which is more accurate for representing Eth1 block hashes.

**Changes:**
- Changed type annotation from `Bytes32` to `Hash32` in the YAML specification
- Updated corresponding description to reflect the Hash32 type