### PR TITLE
make validator custody static for beacon node run session

### DIFF
--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -235,17 +235,17 @@ A node stores the custodied columns for the duration of the pruning period and r
 
 ### Validator custody
 
-A node with validators attached downloads and custodies a higher minimum of custody groups per slot which is dependent on the validator stake node needs to support determined by `get_validators_custody_requirement(supported_validator_stake)`. This `supported_validator_stake` upper bound it is provided while starting the node which syncs any missing custody (if the custody requirement has gone up) in last `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs before being ready to serve the validator duties.
+A node with validators attached downloads and custodies a higher minimum of custody groups per slot which is dependent on the validator stake node needs to support determined by `get_validators_custody_requirement(supported_validator_stake)`. This `supported_validator_stake` upper bound is provided while starting the node which syncs any missing custody (if the custody requirement has gone up) in last `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs before being ready to serve the validator duties.
 
 ```python
 def get_stake_custody_requirement(supported_validator_stake: uint64) -> uint64:
-  count = attached_validator_stake // BALANCE_PER_ADDITIONAL_CUSTODY_GROUP
+  count = supported_validator_stake // BALANCE_PER_ADDITIONAL_CUSTODY_GROUP
   return min(max(count, VALIDATOR_CUSTODY_REQUIREMENT), NUMBER_OF_CUSTODY_GROUPS)
 ```
 
 This higher custody is now advertised in the node's Metadata by setting a higher `custody_group_count` and in the node's ENR by setting a higher `cgc`. As with the regular custody requirement, a node with validators *may* still choose to custody, advertise and serve more than this minimum. As with the regular custody requirement, a node MUST backfill columns when syncing. In addition, when the validator custody requirement increases, due to an increase in the total balance of the attached validators, a node MUST backfill columns from the new custody groups. However, a node *may* wait to advertise a higher custody in its Metadata and ENR until backfilling is complete.
 
-The node keepts a registery of attached validators, determine the validators it can support and reject duties of the validators whose stake go above the `supported_validator_stake` cumulative cutoff which can be determined in the following way:
+The node keeps a registry of attached validators, determines the validators it can support and rejects duties of the validators whose stake go above the supported_validator_stake cumulative cutoff, which can be determined in the following way:
 
 ```python
 def get_custody_supported_validators(state: BeaconState, supported_validator_stake: uint64, validator_indices: Sequence[ValidatorIndex]) -> Sequence[ValidatorIndex]:

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -253,7 +253,7 @@ def get_custody_supported_validators(state: BeaconState, supported_validator_sta
     supported_validator_stake = 0
 
     for index in validator_indices:
-      if (supported_validator_stake + state.balances[index] < supported_validator_stake):
+      if (supported_validator_stake + state.balances[index] <= supported_validator_stake):
         supported_validator_stake += state.balances[index]
       elif
         break

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -245,7 +245,7 @@ def get_stake_custody_requirement(supported_validator_stake: uint64) -> uint64:
 
 This higher custody is now advertised in the node's Metadata by setting a higher `custody_group_count` and in the node's ENR by setting a higher `cgc`. As with the regular custody requirement, a node with validators *may* still choose to custody, advertise and serve more than this minimum. As with the regular custody requirement, a node MUST backfill columns when syncing. In addition, when the validator custody requirement increases, due to an increase in the total balance of the attached validators, a node MUST backfill columns from the new custody groups. However, a node *may* wait to advertise a higher custody in its Metadata and ENR until backfilling is complete.
 
-The node keeps a registry of attached validators, determines the validators it can support and rejects duties of the validators whose stake go above the supported_validator_stake cumulative cutoff, which can be determined in the following way:
+Additionally now the node keeps a registry of attached validators, determines the validators it can support and rejects duties of the validators whose stake go above the supported_validator_stake cumulative cutoff, which can be determined in the following way:
 
 ```python
 def get_custody_supported_validators(state: BeaconState, supported_validator_stake: uint64, validator_indices: Sequence[ValidatorIndex]) -> Sequence[ValidatorIndex]:


### PR DESCRIPTION
The way the validator custody is currently formulated is problematic and complex because:

1. its dynamic dynamic (they can come and go especially with multi beacons and backup setups. especially when new validators come online via new activations or attaching/sharing with friend's validators)
2. state dependent with attached validator indices polluting very basis of a node operation
3.UX is complex and 
4. I forsee error prone implementation as has already been noted by Lion and others who are already implementing it as complex.

My Suggestion
---------------------
we treat the custody as static only and if there are validators attached to a beacon node you will need to spin it up with `--supported_validator_stake XXXX` (in eth) which essentially will statically declare to the beacon node how much stake validators can be attached (figuring out attaching is similar to validator  registering problem (for metrics/builder/proposal), so assuming solvable )

so if the custody changes (goes up) for the window the beacon has to maintain the custody, it syncs those custody from network become becoming SYNCED and ready to attest.

And it registers and keep tracks of indices/stake that is attesting/building/proposing through it, and have rules to warn or reject the validator duties for the validators which are going above that.

that way the UX is taken care of, if the user is below then custody over a period of time, one can log a message that custody can be dropped, but if a user if above he will immediately see it through the errors on the validator and can re-spin the node

So the is_data_available to use the `get_stake_custody_requirement` and not worry about the indices in the beacon node operation as it can still be kept free from attached validator indices pollution 

------
this suggestion still "complies" with the original spec of making sure custody scales with validators but with simpler implementation
