### PR TITLE
[Issue 4136] Added blank lines before bullet lists which didn't render correctly in mkdocs. 

### DIFF
--- a/specs/_deprecated/das/p2p-interface.md
+++ b/specs/_deprecated/das/p2p-interface.md
@@ -59,12 +59,14 @@ without concentrating too many requests on a single node, or breaking the networ
 ## DAS Subnets
 
 On a high level, the push-model roles are divided into:
+
 - Sources: create blobs of shard block data, and transformed into many tiny samples.
 - Sinks: continuously look for samples
 
 At full operation, the network has one proposer, per shard, per slot.
 
 In the push-model, there are:
+
 - *Vertical subnets*: Sinks can subscribe to indices of samples: there is a sample to subnet mapping.
 - *Horizontal subnets*: Sources need to distribute samples to all vertical networks: they participate in a fan-out layer.
 
@@ -115,6 +117,7 @@ TODO: define `(shard, slot, sample_index) -> subnet_index` hash function.
 To allow for subscriptions to rotate quickly and randomly, a backbone is formed to help onboard peers into other topics.
 
 This backbone is based on a pure function of the *node* identity and time:
+
 - Nodes can be found *without additional discovery overhead*:
   peers on a vertical topic can be found by searching the local peerstore for identities that hash to the desired topic(s),
   assuming the peerstore already has a large enough variety of peers.
@@ -166,6 +169,7 @@ Shard blob samples can be verified with just a 48 byte KZG proof (commitment quo
 against the commitment to blob polynomial, specific to that `(shard, slot)` key.
 
 The following validations MUST pass before forwarding the `sample` on the vertical subnet.
+
 - _[IGNORE]_ The commitment for the (`sample.shard`, `sample.slot`, `sample.index`) tuple must be known.
    If not known, the client MAY queue the sample if it passes formatting conditions.
 - _[REJECT]_ `sample.shard`, `sample.slot` and `sample.index` are hashed into a `sbunet_index` (TODO: define hash) which MUST match the topic `{subnet_index}` parameter.
@@ -214,6 +218,7 @@ Response Content:
 ```
 
 When the sample is:
+
 - Available: respond with a `Success` result code, and the encoded sample.
 - Expected to be available, but not: respond with a `ResourceUnavailable` result code.
 - Not available, but never of interest to the node: respond with an `InvalidRequest` result code.

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -70,6 +70,7 @@ This is the beacon chain specification of the enshrined proposer builder separat
 This feature adds new staked consensus participants called *Builders* and new honest validators duties called *payload timeliness attestations*. The slot is divided in **four** intervals. Honest validators gather *signed bids* (a `SignedExecutionPayloadHeader`) from builders and submit their consensus blocks (a `SignedBeaconBlock`) including these bids at the beginning of the slot. At the start of the second interval, honest validators submit attestations just as they do previous to this feature). At the  start of the third interval, aggregators aggregate these attestations and the builder broadcasts either a full payload or a message indicating that they are withholding the payload (a `SignedExecutionPayloadEnvelope`). At the start of the fourth interval, some validators selected to be members of the new **Payload Timeliness Committee** (PTC) attest to the presence and timeliness of the builder's payload.
 
 At any given slot, the status of the blockchain's head may be either
+
 - A block from a previous slot (e.g. the current slot's proposer did not submit its block).
 - An *empty* block from the current slot (e.g. the proposer submitted a timely block, but the builder did not reveal the payload on time).
 - A full block for the current slot (both the proposer and the builder revealed on time).

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -112,8 +112,9 @@ Some gossip meshes are upgraded in the fork of EIP-7732 to support upgraded type
 Topics follow the same specification as in prior upgrades.
 
 The `beacon_block` topic is updated to support the modified type
-| Name | Message Type |
-| --- | --- |
+
+| Name           | Message Type                               |
+|----------------|--------------------------------------------|
 | `beacon_block` | `SignedBeaconBlock` [modified in EIP-7732] |
 
 The new topics along with the type of the `data` field of a gossipsub message are given in this table:
@@ -162,6 +163,7 @@ The following validations MUST pass before forwarding the `signed_execution_payl
 
 Let `block` be the block with `envelope.beacon_block_root`.
 Let `header` alias `block.body.signed_execution_payload_header.message` (notice that this can be obtained from the `state.signed_execution_payload_header`)
+
 - _[REJECT]_ `block` passes validation.
 - _[REJECT]_ `envelope.builder_index == header.builder_index`
 - if `envelope.payload_withheld == False` then

--- a/specs/_features/eip7732/validator.md
+++ b/specs/_features/eip7732/validator.md
@@ -81,6 +81,7 @@ Validators are still expected to propose `SignedBeaconBlock` at the beginning of
 #### Constructing the new `signed_execution_payload_header` field in  `BeaconBlockBody`
 
 To obtain `signed_execution_payload_header`, a block proposer building a block on top of a `state` must take the following actions:
+
 * Listen to the `execution_payload_header` gossip global topic and save an accepted `signed_execution_payload_header` from a builder. Proposer MAY obtain these signed messages by other off-protocol means.
 * The `signed_execution_payload_header` must satisfy the verification conditions found in `process_execution_payload_header`, that is
     - The header signature must be valid
@@ -93,6 +94,7 @@ To obtain `signed_execution_payload_header`, a block proposer building a block o
 #### Constructing the new `payload_attestations` field in  `BeaconBlockBody`
 
 Up to `MAX_PAYLOAD_ATTESTATIONS`, aggregate payload attestations can be included in the block. The validator will have to
+
 * Listen to the `payload_attestation_message` gossip global topic
 * The payload attestations added must satisfy the verification conditions found in payload attestation gossip validation and payload attestation processing. This means
     - The `data.beacon_block_root` corresponds to `block.parent_root`.
@@ -116,6 +118,7 @@ If a validator is in the payload attestation committee for the current slot (as 
 according to the logic in `get_payload_attestation_message` below and broadcast it not after  `SECONDS_PER_SLOT * 3 / INTERVALS_PER_SLOT` seconds since the start of the slot, to the global `payload_attestation_message` pubsub topic.
 
 The validator creates `payload_attestation_message` as follows:
+
 * If the validator has not seen any beacon block for the assigned slot, do not submit a payload attestation. It will be ignored anyway.
 * Set `data.beacon_block_root` be the HTR of the beacon block seen for the assigned slot
 * Set `data.slot` to be the assigned slot.

--- a/specs/altair/light-client/p2p-interface.md
+++ b/specs/altair/light-client/p2p-interface.md
@@ -57,13 +57,16 @@ New global topics are added to provide light clients with the latest updates.
 This topic is used to propagate the latest `LightClientFinalityUpdate` to light clients, allowing them to keep track of the latest `finalized_header`.
 
 The following validations MUST pass before forwarding the `finality_update` on the network.
+
 - _[IGNORE]_ The `finalized_header.beacon.slot` is greater than that of all previously forwarded `finality_update`s, or it matches the highest previously forwarded slot and also has a `sync_aggregate` indicating supermajority (> 2/3) sync committee participation while the previously forwarded `finality_update` for that slot did not indicate supermajority
 - _[IGNORE]_ The `finality_update` is received after the block at `signature_slot` was given enough time to propagate through the network -- i.e. validate that one-third of `finality_update.signature_slot` has transpired (`SECONDS_PER_SLOT / INTERVALS_PER_SLOT` seconds after the start of the slot, with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance)
 
 For full nodes, the following validations MUST additionally pass before forwarding the `finality_update` on the network.
+
 - _[IGNORE]_ The received `finality_update` matches the locally computed one exactly (as defined in [`create_light_client_finality_update`](./full-node.md#create_light_client_finality_update))
 
 For light clients, the following validations MUST additionally pass before forwarding the `finality_update` on the network.
+
 - _[REJECT]_ The `finality_update` is valid -- i.e. validate that `process_light_client_finality_update` does not indicate errors
 - _[IGNORE]_ The `finality_update` advances the `finalized_header` of the local `LightClientStore` -- i.e. validate that processing `finality_update` increases `store.finalized_header.beacon.slot`
 
@@ -85,13 +88,16 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 This topic is used to propagate the latest `LightClientOptimisticUpdate` to light clients, allowing them to keep track of the latest `optimistic_header`.
 
 The following validations MUST pass before forwarding the `optimistic_update` on the network.
+
 - _[IGNORE]_ The `attested_header.beacon.slot` is greater than that of all previously forwarded `optimistic_update`s
 - _[IGNORE]_ The `optimistic_update` is received after the block at `signature_slot` was given enough time to propagate through the network -- i.e. validate that one-third of `optimistic_update.signature_slot` has transpired (`SECONDS_PER_SLOT / INTERVALS_PER_SLOT` seconds after the start of the slot, with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance)
 
 For full nodes, the following validations MUST additionally pass before forwarding the `optimistic_update` on the network.
+
 - _[IGNORE]_ The received `optimistic_update` matches the locally computed one exactly (as defined in [`create_light_client_optimistic_update`](./full-node.md#create_light_client_optimistic_update))
 
 For light clients, the following validations MUST additionally pass before forwarding the `optimistic_update` on the network.
+
 - _[REJECT]_ The `optimistic_update` is valid -- i.e. validate that `process_light_client_optimistic_update` does not indicate errors
 - _[IGNORE]_ The `optimistic_update` either matches corresponding fields of the most recently forwarded `LightClientFinalityUpdate` (if any), or it advances the `optimistic_header` of the local `LightClientStore` -- i.e. validate that processing `optimistic_update` increases `store.optimistic_header.beacon.slot`
 

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -74,6 +74,7 @@ The specification around the creation, validation, and dissemination of messages
 
 The derivation of the `message-id` has changed starting with Altair to incorporate the message `topic` along with the message `data`. These are fields of the `Message` Protobuf, and interpreted as empty byte strings if missing.
 The `message-id` MUST be the following 20 byte value computed from the message:
+
 * If `message.data` has a valid snappy decompression, set `message-id` to the first 20 bytes of the `SHA256` hash of
   the concatenation of the following data: `MESSAGE_DOMAIN_VALID_SNAPPY`, the length of the topic byte string (encoded as little-endian `uint64`),
   the topic byte string, and the snappy decompressed message data:
@@ -192,12 +193,15 @@ Topic-meshes can be grafted quickly as the nodes are already connected and excha
 
 Messages SHOULD NOT be re-broadcast from one fork to the other.
 A node's behavior before the fork and after the fork are as follows:
+
 Pre-fork:
+
 - Peers who propagate messages on the post-fork topics MAY be scored negatively proportionally to time till fork,
   to account for clock discrepancy.
 - Messages can be IGNORED on the post-fork topics, with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` margin.
 
 Post-fork:
+
 - Peers who propagate messages on the pre-fork topics MUST NOT be scored negatively. Lagging IWANT may force them to.
 - Messages on pre and post-fork variants of topics share application-level caches.
   E.g. an attestation on the both the old and new topic is ignored like any duplicate.

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -176,6 +176,7 @@ For this reason, *always* get committee assignments via the fields of the `Beaco
 
 A validator should plan for future sync committee assignments by noting which sync committee periods they are selected for participation.
 Specifically, a validator should:
+
 * Upon (re)syncing the chain and upon sync committee period boundaries, check for assignments in the current and next sync committee periods.
 * If the validator is in the current sync committee period, then they perform the responsibilities below for sync committee rewards.
 * If the validator is in the next sync committee period, they should wait until the next `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` boundary and then perform the responsibilities throughout that period.

--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -78,7 +78,6 @@ Alias `block = signed_beacon_block.message`, `execution_payload = block.body.exe
 
 - If the execution is enabled for the block -- i.e. `is_execution_enabled(state, block.body)`
   then validate the following:
-
     - _[REJECT]_ The block's execution payload timestamp is correct with respect to the slot
        -- i.e. `execution_payload.timestamp == compute_timestamp_at_slot(state, block.slot)`.
     - If `execution_payload` verification of block's parent by an execution node is *not* complete:

--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -89,7 +89,7 @@ Alias `block = signed_beacon_block.message`, `execution_payload = block.body.exe
 
 The following gossip validation from prior specifications MUST NOT be applied if the execution is enabled for the block -- i.e. `is_execution_enabled(state, block.body)`:
   
-  - [REJECT] The block's parent (defined by `block.parent_root`) passes validation.
+- [REJECT] The block's parent (defined by `block.parent_root`) passes validation.
 
 #### Transitioning the gossip
 

--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -75,8 +75,10 @@ validity of the execution payload. This prevents network segregation between
 In addition to the gossip validations for this topic from prior specifications,
 the following validations MUST pass before forwarding the `signed_beacon_block` on the network.
 Alias `block = signed_beacon_block.message`, `execution_payload = block.body.execution_payload`.
+
 - If the execution is enabled for the block -- i.e. `is_execution_enabled(state, block.body)`
   then validate the following:
+
     - _[REJECT]_ The block's execution payload timestamp is correct with respect to the slot
        -- i.e. `execution_payload.timestamp == compute_timestamp_at_slot(state, block.slot)`.
     - If `execution_payload` verification of block's parent by an execution node is *not* complete:
@@ -87,6 +89,7 @@ Alias `block = signed_beacon_block.message`, `execution_payload = block.body.exe
     	  validation (including execution node verification of the `block.body.execution_payload`).
 
 The following gossip validation from prior specifications MUST NOT be applied if the execution is enabled for the block -- i.e. `is_execution_enabled(state, block.body)`:
+  
   - [REJECT] The block's parent (defined by `block.parent_root`) passes validation.
 
 #### Transitioning the gossip

--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -88,8 +88,8 @@ Alias `block = signed_beacon_block.message`, `execution_payload = block.body.exe
     	  validation (including execution node verification of the `block.body.execution_payload`).
 
 The following gossip validation from prior specifications MUST NOT be applied if the execution is enabled for the block -- i.e. `is_execution_enabled(state, block.body)`:
-  
-- [REJECT] The block's parent (defined by `block.parent_root`) passes validation.
+
+  - [REJECT] The block's parent (defined by `block.parent_root`) passes validation.
 
 #### Transitioning the gossip
 

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -46,6 +46,7 @@
 
 Capella is a consensus-layer upgrade containing a number of features related
 to validator withdrawals. Including:
+
 * Automatic withdrawals of `withdrawable` validators.
 * Partial withdrawals sweep for validators with 0x01 withdrawal
   credentials and balances in excess of `MAX_EFFECTIVE_BALANCE`.

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -50,6 +50,7 @@
 ## Introduction
 
 Deneb is a consensus-layer upgrade containing a number of features. Including:
+
 * [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788): Beacon block root in the EVM
 * [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844): Shard Blob Transactions scale data-availability of Ethereum in a simple, forwards-compatible manner
 * [EIP-7044](https://eips.ethereum.org/EIPS/eip-7044): Perpetually Valid Signed Voluntary Exits

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -154,11 +154,13 @@ New validation:
 *[Modified in Deneb:EIP7045]*
 
 The following validation is removed:
+
 * _[IGNORE]_ `aggregate.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate.data.slot`
   (a client MAY queue future aggregates for processing at the appropriate slot).
 
 The following validations are added in its place:
+
 * _[IGNORE]_ `aggregate.data.slot` is equal to or earlier than the `current_slot` (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `aggregate.data.slot <= current_slot`
   (a client MAY queue future aggregates for processing at the appropriate slot).
@@ -208,11 +210,13 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 *[Modified in Deneb:EIP7045]*
 
 The following validation is removed:
+
 * _[IGNORE]_ `attestation.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot`
   (a client MAY queue future attestations for processing at the appropriate slot).
 
 The following validations are added in its place:
+
 * _[IGNORE]_ `attestation.data.slot` is equal to or earlier than the `current_slot` (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `attestation.data.slot <= current_slot`
   (a client MAY queue future attestation for processing at the appropriate slot).
@@ -415,6 +419,7 @@ In addition to `BlobSidecarsByRoot` requests, recent blobs MAY be retrieved by q
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish blobs on time.
 
 When clients use the local execution layer to retrieve blobs, they MUST behave as if the corresponding `blob_sidecar` had been received via gossip. In particular they MUST:
+
 * publish the corresponding `blob_sidecar` on the `blob_sidecar_{subnet_id}` subnet.
 * update gossip rule related data structures (i.e. update the anti-equivocation cache).
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -116,6 +116,7 @@
 ## Introduction
 
 Electra is a consensus-layer upgrade containing a number of features. Including:
+
 * [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): Supply validator deposits on chain
 * [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002): Execution layer triggerable exits
 * [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): Increase the MAX_EFFECTIVE_BALANCE

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -76,9 +76,11 @@ The derivation of the `message-id` remains stable.
 ###### `beacon_aggregate_and_proof`
 
 The following convenience variables are re-defined
+
 - `index = get_committee_indices(aggregate.committee_bits)[0]`
 
 The following validations are added:
+
 * [REJECT] `len(committee_indices) == 1`, where `committee_indices = get_committee_indices(aggregate)`.
 * [REJECT] `aggregate.data.index == 0`
 
@@ -97,14 +99,17 @@ The existing validations all apply as given from previous forks, with the follow
 The topic is updated to propagate `SingleAttestation` objects.
 
 The following convenience variables are re-defined:
+
 - `index = attestation.committee_index`
 
 The following validations are added:
+
 - _[REJECT]_ `attestation.data.index == 0`
 - _[REJECT]_ The attester is a member of the committee -- i.e.
   `attestation.attester_index in get_beacon_committee(state, attestation.data.slot, index)`.
 
 The following validations are removed:
+
 - _[REJECT]_ The attestation is unaggregated --
   that is, it has exactly one participating validator (`len([bit for bit in aggregation_bits if bit]) == 1`, i.e. exactly 1 bit is set).
 - _[REJECT]_ The number of aggregation bits matches the committee size -- i.e.

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -306,6 +306,7 @@ Starting from Gossipsub v1.1, clients MUST enforce this by applying the `StrictN
 [signature policy](https://github.com/libp2p/specs/blob/master/pubsub/README.md#signature-policy-options).
 
 The `message-id` of a gossipsub message MUST be the following 20 byte value computed from the message data:
+
 * If `message.data` has a valid snappy decompression, set `message-id` to the first 20 bytes of the `SHA256` hash of
   the concatenation of `MESSAGE_DOMAIN_VALID_SNAPPY` with the snappy decompressed message data,
   i.e. `SHA256(MESSAGE_DOMAIN_VALID_SNAPPY + snappy_decompress(message.data))[:20]`.
@@ -356,6 +357,7 @@ The `beacon_block` topic is used solely for propagating new signed beacon blocks
 Signed blocks are sent in their entirety.
 
 The following validations MUST pass before forwarding the `signed_beacon_block` on the network.
+
 - _[IGNORE]_ The block is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. validate that `signed_beacon_block.message.slot <= current_slot`
   (a client MAY queue future blocks for processing at the appropriate slot).
@@ -384,12 +386,14 @@ The `beacon_aggregate_and_proof` topic is used to propagate aggregated attestati
 to subscribing nodes (typically validators) to be included in future blocks.
 
 We define the following variables for convenience:
+
 - `aggregate_and_proof = signed_aggregate_and_proof.message`
 - `aggregate = aggregate_and_proof.aggregate`
 - `index = aggregate.data.index`
 - `aggregation_bits = attestation.aggregation_bits`
 
 The following validations MUST pass before forwarding the `signed_aggregate_and_proof` on the network.
+
 - _[REJECT]_ The committee index is within the expected range -- i.e. `index < get_committee_count_per_slot(state, aggregate.data.target.epoch)`.
 - _[IGNORE]_ `aggregate.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate.data.slot`
@@ -429,6 +433,7 @@ The `voluntary_exit` topic is used solely for propagating signed voluntary valid
 Signed voluntary exits are sent in their entirety.
 
 The following validations MUST pass before forwarding the `signed_voluntary_exit` on to the network.
+
 - _[IGNORE]_ The voluntary exit is the first valid voluntary exit received
   for the validator with index `signed_voluntary_exit.message.validator_index`.
 - _[REJECT]_ All of the conditions within `process_voluntary_exit` pass validation.
@@ -439,6 +444,7 @@ The `proposer_slashing` topic is used solely for propagating proposer slashings 
 Proposer slashings are sent in their entirety.
 
 The following validations MUST pass before forwarding the `proposer_slashing` on to the network.
+
 - _[IGNORE]_ The proposer slashing is the first valid proposer slashing received
   for the proposer with index `proposer_slashing.signed_header_1.message.proposer_index`.
 - _[REJECT]_ All of the conditions within `process_proposer_slashing` pass validation.
@@ -449,6 +455,7 @@ The `attester_slashing` topic is used solely for propagating attester slashings 
 Attester slashings are sent in their entirety.
 
 Clients who receive an attester slashing on this topic MUST validate the conditions within `process_attester_slashing` before forwarding it across the network.
+
 - _[IGNORE]_ At least one index in the intersection of the attesting indices of each attestation
   has not yet been seen in any prior `attester_slashing`
   (i.e. `attester_slashed_indices = set(attestation_1.attesting_indices).intersection(attestation_2.attesting_indices)`,
@@ -465,10 +472,12 @@ The `beacon_attestation_{subnet_id}` topics are used to propagate unaggregated a
 to the subnet `subnet_id` (typically beacon and persistent committees) to be aggregated before being gossiped to `beacon_aggregate_and_proof`.
 
 We define the following variables for convenience:
+
 - `index = attestation.data.index`
 - `aggregation_bits = attestation.aggregation_bits`
 
 The following validations MUST pass before forwarding the `attestation` on the subnet.
+
 - _[REJECT]_ The committee index is within the expected range -- i.e. `index < get_committee_count_per_slot(state, attestation.data.target.epoch)`.
 - _[REJECT]_ The attestation is for the correct subnet --
   i.e. `compute_subnet_for_attestation(committees_per_slot, attestation.data.slot, index) == subnet_id`,
@@ -1462,6 +1471,7 @@ libp2p streams are full-duplex, and each party is responsible for closing their 
 We can therefore use stream closure to mark the end of the request and response independently.
 
 Nevertheless, in the case of `ssz_snappy`, messages are still length-prefixed with the length of the underlying data:
+
 * A basic reader can prepare a correctly sized buffer before reading the message
 * A more advanced reader can stream-decode SSZ given the length of the SSZ data.
 * Alignment with protocols like gRPC over HTTP/2 that prefix with length

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -256,6 +256,7 @@ A validator should plan for future assignments by noting their assigned attestat
 slot and joining the committee index attestation subnet related to their committee assignment.
 
 Specifically a validator should:
+
 * Call `_, committee_index, _ = get_committee_assignment(state, next_epoch, validator_index)` when checking for next epoch assignments.
 * Calculate the committees per slot for the next epoch: `committees_per_slot = get_committee_count_per_slot(state, next_epoch)`
 * Calculate the subnet index: `subnet_id = compute_subnet_for_attestation(committees_per_slot, slot, committee_index)`
@@ -512,6 +513,7 @@ def get_attestation_signature(state: BeaconState, attestation_data: AttestationD
 Finally, the validator broadcasts `attestation` to the associated attestation subnet, the `beacon_attestation_{subnet_id}` pubsub topic.
 
 The `subnet_id` for the `attestation` is calculated with:
+
 - Let `committees_per_slot = get_committee_count_per_slot(state, attestation.data.target.epoch)`.
 - Let `subnet_id = compute_subnet_for_attestation(committees_per_slot, attestation.data.slot, attestation.data.index)`.
 


### PR DESCRIPTION
Added blank lines before bullet lists everywhere where it didn't render correctly. Additionally, fixed a table in eip7732 -> p2p-interface.md that didn't render correctly.