### PR TITLE
Fix some testgen issues related to computed constants

### DIFF
--- a/specs/_features/eip7732/fork-choice.md
+++ b/specs/_features/eip7732/fork-choice.md
@@ -47,7 +47,7 @@ This is the modification of the fork choice accompanying the EIP-7732 upgrade.
 
 | Name                 | Value       |
 | -------------------- | ----------- |
-| `PAYLOAD_TIMELY_THRESHOLD` | `PTC_SIZE / 2` (=`uint64(256)`) |
+| `PAYLOAD_TIMELY_THRESHOLD` | `PTC_SIZE // 2` (= 256) |
 | `INTERVALS_PER_SLOT` | `4` # [modified in EIP-7732] |
 | `PROPOSER_SCORE_BOOST` | `20` # [modified in EIP-7732] |
 | `PAYLOAD_WITHHOLD_BOOST` | `40` |

--- a/tests/generators/kzg_7594/main.py
+++ b/tests/generators/kzg_7594/main.py
@@ -239,7 +239,7 @@ def case_verify_cell_kzg_proof_batch():
     commitments = [VALID_COMMITMENTS[1]]
     cell_indices = list(range(len(cells)))
     # Set first cell index to an invalid value
-    cell_indices[0] = spec.CELLS_PER_EXT_BLOB
+    cell_indices[0] = int(spec.CELLS_PER_EXT_BLOB)
     expect_exception(spec.verify_cell_kzg_proof_batch, commitments, cell_indices, cells, proofs)
     identifier = make_id(commitments, cell_indices, cells, proofs)
     yield f'verify_cell_kzg_proof_batch_case_invalid_cell_index_{identifier}', {
@@ -480,7 +480,7 @@ def case_recover_cells_and_kzg_proofs():
     cell_indices = list(range(spec.CELLS_PER_EXT_BLOB // 2))
     partial_cells = [cells[cell_index] for cell_index in cell_indices]
     # Replace first cell_index with an invalid value
-    cell_indices[0] = spec.CELLS_PER_EXT_BLOB
+    cell_indices[0] = int(spec.CELLS_PER_EXT_BLOB)
     expect_exception(spec.recover_cells_and_kzg_proofs, cell_indices, partial_cells)
     identifier = make_id(cell_indices, partial_cells)
     yield f'recover_cells_and_kzg_proofs_case_invalid_cell_index_{identifier}', {
@@ -513,7 +513,7 @@ def case_recover_cells_and_kzg_proofs():
     cell_indices = list(range(0, spec.CELLS_PER_EXT_BLOB, 2))
     partial_cells = [cells[cell_index] for cell_index in cell_indices]
     # Add another cell_index
-    cell_indices.append(spec.CELLS_PER_EXT_BLOB - 1)
+    cell_indices.append(int(spec.CELLS_PER_EXT_BLOB - 1))
     expect_exception(spec.recover_cells_and_kzg_proofs, cell_indices, partial_cells)
     identifier = make_id(cell_indices, partial_cells)
     yield f'recover_cells_and_kzg_proofs_case_invalid_more_cell_indices_than_cells_{identifier}', {


### PR DESCRIPTION
This PR fixes some small side effects of this change:

* https://github.com/ethereum/consensus-specs/pull/4152

This the error log here:

* https://github.com/ethereum/consensus-specs/actions/runs/13755377250/job/38461868261

Notably:

```
  File "/opt/actions-runner/_work/consensus-specs/consensus-specs/consensus-specs/venv/lib/python3.12/site-packages/eth2spec/eip7732/mainnet.py", line 348, in <module>
    PAYLOAD_TIMELY_THRESHOLD = PTC_SIZE / 2
                               ~~~~~~~~~^~~
  File "/opt/actions-runner/_work/consensus-specs/consensus-specs/consensus-specs/venv/lib/python3.12/site-packages/remerkleable/basic.py", line 120, in __truediv__
    raise OperationNotSupported(f"non-integer division '{self} / {other}' "
remerkleable.basic.OperationNotSupported: non-integer division '512 / 2' is not valid for uint64 left hand type
```

and

```
  File "/opt/actions-runner/_work/consensus-specs/consensus-specs/consensus-specs/venv/lib/python3.12/site-packages/ruamel/yaml/representer.py", line 354, in represent_undefined
    raise RepresenterError(_F('cannot represent an object: {data!s}', data=data))
ruamel.yaml.representer.RepresenterError: cannot represent an object: 127
```