### PR TITLE
Remove source credential type check in `process_consolidation_request`

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1668,12 +1668,8 @@ def process_consolidation_request(
     source_validator = state.validators[source_index]
     target_validator = state.validators[target_index]
 
-    # Verify source withdrawal credentials
-    has_correct_credential = has_execution_withdrawal_credential(source_validator)
-    is_correct_source_address = (
-        source_validator.withdrawal_credentials[12:] == consolidation_request.source_address
-    )
-    if not (has_correct_credential and is_correct_source_address):
+    # Verify withdrawal credential's address matches source address
+    if source_validator.withdrawal_credentials[12:] != consolidation_request.source_address:
         return
 
     # Verify that target has compounding withdrawal credentials


### PR DESCRIPTION
One of the conditions for a consolidation request to be processed is if source validator has credential type of 0x01 or 0x02. 

However one can argue that source validator with 0x00 BLS credential will not pass the source address check ie. the last 20 bytes of the BLS credential cannot match the request's source address.

BLS credential is made up from a hash of validator's public key, whereas request's source address is populated from `msg.sender` ie. the execution address on the contract level. It is impossible for these two to be equal so it is unnecessary to check for credential type here.

