### PR TITLE
CI: Add formatting to python blocks in markdown files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ lint: pyspec _check_toc
 	@$(PYTHON_VENV) -m flake8 --config $(FLAKE8_CONFIG) $(TEST_GENERATORS_DIR)
 	@$(PYTHON_VENV) -m pylint --rcfile $(PYLINT_CONFIG) $(PYLINT_SCOPE)
 	@$(PYTHON_VENV) -m mypy --config-file $(MYPY_CONFIG) $(MYPY_SCOPE)
+	@$(PYTHON_VENV) -m blacken_docs --line-length=120 $(MARKDOWN_FILES)
 
 ###############################################################################
 # Generators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ test = [
   "pytest==8.3.4",
 ]
 lint = [
+  "blacken-docs==1.19.1 ",
   "codespell==2.4.0",
   "flake8==5.0.4",
   "mypy==0.981",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ test = [
   "pytest==8.3.4",
 ]
 lint = [
-  "blacken-docs==1.19.1 ",
+  "blacken-docs==1.19.1",
   "codespell==2.4.0",
   "flake8==5.0.4",
   "mypy==0.981",

--- a/specs/_deprecated/custody_game/validator.md
+++ b/specs/_deprecated/custody_game/validator.md
@@ -67,10 +67,9 @@ Proposer and Attester slashings described in Phase 0 remain in place with the ad
 To avoid custody slashings, the attester must never sign any shard transition for which the custody bit is one. The custody bit is computed using the custody secret:
 
 ```python
-def get_custody_secret(state: BeaconState,
-                       validator_index: ValidatorIndex,
-                       privkey: int,
-                       epoch: Epoch=None) -> BLSSignature:
+def get_custody_secret(
+    state: BeaconState, validator_index: ValidatorIndex, privkey: int, epoch: Epoch = None
+) -> BLSSignature:
     if epoch is None:
         epoch = get_current_epoch(state)
     period = get_custody_period_for_validator(validator_index, epoch)

--- a/specs/_deprecated/das/das-core.md
+++ b/specs/_deprecated/das/das-core.md
@@ -65,7 +65,7 @@ def reverse_bit_order(n: int, order: int):
     Reverse the bit order of an integer n
     """
     assert is_power_of_two(order)
-    return int(('{:0' + str(order.bit_length() - 1) + 'b}').format(n)[::-1], 2)
+    return int(("{:0" + str(order.bit_length() - 1) + "b}").format(n)[::-1], 2)
 ```
 
 #### `reverse_bit_order_list`
@@ -90,7 +90,7 @@ def das_fft_extension(data: Sequence[Point]) -> Sequence[Point]:
     such that the second output half of the IFFT is all zeroes.
     """
     poly = inverse_fft(data)
-    return fft(poly + [0]*len(poly))[1::2]
+    return fft(poly + [0] * len(poly))[1::2]
 ```
 
 ### Data recovery
@@ -121,7 +121,7 @@ def extend_data(data: Sequence[Point]) -> Sequence[Point]:
 
 ```python
 def unextend_data(extended_data: Sequence[Point]) -> Sequence[Point]:
-    return extended_data[:len(extended_data)//2]
+    return extended_data[: len(extended_data) // 2]
 ```
 
 ```python
@@ -139,12 +139,12 @@ def construct_proofs(extended_data_as_poly: Sequence[Point]) -> Sequence[BLSComm
     Constructs proofs for samples of extended data (in polynomial form, 2nd half being zeroes).
     Use the FK20 multi-proof approach to construct proofs for a chunk length of POINTS_PER_SAMPLE.
     """
-    ... # Omitted for now, refer to KZG implementation resources.
+    ...  # Omitted for now, refer to KZG implementation resources.
 ```
 
 ```python
 def commit_to_data(data_as_poly: Sequence[Point]) -> BLSCommitment:
-    """Commit to a polynomial by """
+    """Commit to a polynomial by"""
 ```
 
 ```python
@@ -153,7 +153,7 @@ def sample_data(slot: Slot, shard: Shard, extended_data: Sequence[Point]) -> Seq
     assert sample_count <= MAX_SAMPLES_PER_BLOCK
     # get polynomial form of full extended data, second half will be all zeroes.
     poly = ifft(reverse_bit_order_list(extended_data))
-    assert all(v == 0 for v in poly[len(poly)//2:])
+    assert all(v == 0 for v in poly[len(poly) // 2 :])
     proofs = construct_proofs(poly)
     return [
         DASSample(
@@ -165,8 +165,9 @@ def sample_data(slot: Slot, shard: Shard, extended_data: Sequence[Point]) -> Seq
             proof=proofs[reverse_bit_order(i, sample_count)],
             # note: we leave the sample data as-is so it matches the original nicely.
             # The proof applies to `ys = reverse_bit_order_list(sample.data)`
-            data=extended_data[i*POINTS_PER_SAMPLE:(i+1)*POINTS_PER_SAMPLE]
-        ) for i in range(sample_count)
+            data=extended_data[i * POINTS_PER_SAMPLE : (i + 1) * POINTS_PER_SAMPLE],
+        )
+        for i in range(sample_count)
     ]
 ```
 

--- a/specs/_deprecated/das/fork-choice.md
+++ b/specs/_deprecated/das/fork-choice.md
@@ -26,9 +26,11 @@ The "root" of a shard block for data dependency purposes is considered to be a `
 def get_new_dependencies(state: BeaconState) -> Set[DataCommitment]:
     return set(
         # Already confirmed during this epoch
-        [c.commitment for c in state.current_epoch_pending_headers if c.confirmed] +
+        [c.commitment for c in state.current_epoch_pending_headers if c.confirmed]
+        +
         # Already confirmed during previous epoch
-        [c.commitment for c in state.previous_epoch_pending_headers if c.confirmed] +
+        [c.commitment for c in state.previous_epoch_pending_headers if c.confirmed]
+        +
         # Confirmed in the epoch before the previous
         [c for c in shard for shard in state.grandparent_epoch_confirmed_commitments if c != DataCommitment()]
     )

--- a/specs/_deprecated/sharding/polynomial-commitments.md
+++ b/specs/_deprecated/sharding/polynomial-commitments.md
@@ -94,7 +94,7 @@ def reverse_bit_order(n: int, order: int) -> int:
     """
     assert is_power_of_two(order)
     # Convert n to binary with the same number of bits as "order" - 1, then reverse its bit order
-    return int(('{:0' + str(order.bit_length() - 1) + 'b}').format(n)[::-1], 2)
+    return int(("{:0" + str(order.bit_length() - 1) + "b}").format(n)[::-1], 2)
 ```
 
 #### `list_to_reverse_bit_order`
@@ -183,7 +183,7 @@ def low_degree_check(commitments: List[KZGCommitment]):
     # For an efficient implementation, B and Bprime should be precomputed
     def B(z):
         r = 1
-        for w in roots[:d + 1]:
+        for w in roots[: d + 1]:
             r = r * (z - w) % BLS_MODULUS
         return r
 
@@ -191,14 +191,14 @@ def low_degree_check(commitments: List[KZGCommitment]):
         r = 0
         for i in range(d + 1):
             m = 1
-            for w in roots[:i] + roots[i + 1:d + 1]:
+            for w in roots[:i] + roots[i + 1 : d + 1]:
                 m = m * (z - w) % BLS_MODULUS
             r = (r + m) % BLS_MODULUS
         return r
 
     coefs = []
     for i in range(K):
-        coefs.append( - (r_to_K - 1) * bls_modular_inverse(K * roots[i * (K - 1) % K] * (r - roots[i])) % BLS_MODULUS)
+        coefs.append(-(r_to_K - 1) * bls_modular_inverse(K * roots[i * (K - 1) % K] * (r - roots[i])) % BLS_MODULUS)
     for i in range(d + 1):
         coefs[i] = (coefs[i] + B(r) * bls_modular_inverse(Bprime(r) * (r - roots[i]))) % BLS_MODULUS
 
@@ -212,7 +212,7 @@ def vector_lincomb(vectors: List[List[BLSFieldElement]], scalars: List[BLSFieldE
     """
     Compute a linear combination of field element vectors.
     """
-    r = [0]*len(vectors[0])
+    r = [0] * len(vectors[0])
     for v, a in zip(vectors, scalars):
         for i, x in enumerate(v):
             r[i] = (r[i] + a * x) % BLS_MODULUS
@@ -226,7 +226,7 @@ def bytes_to_field_elements(block: bytes) -> List[BLSFieldElement]:
     """
     Slices a block into 31-byte chunks that can fit into field elements.
     """
-    sliced_block = [block[i:i + 31] for i in range(0, len(bytes), 31)]
+    sliced_block = [block[i : i + 31] for i in range(0, len(bytes), 31)]
     return [BLSFieldElement(int.from_bytes(x, "little")) for x in sliced_block]
 ```
 
@@ -337,9 +337,8 @@ def hash_to_bls_field(x: Container, challenge_number: uint64) -> BLSFieldElement
     This function is used to generate Fiat-Shamir challenges. The output is not uniform over the BLS field.
     """
     return (
-        (int.from_bytes(hash(hash_tree_root(x) + int.to_bytes(challenge_number, 32, "little")), "little"))
-        % BLS_MODULUS
-    )
+        int.from_bytes(hash(hash_tree_root(x) + int.to_bytes(challenge_number, 32, "little")), "little")
+    ) % BLS_MODULUS
 ```
 
 ### KZG operations
@@ -354,29 +353,22 @@ def verify_kzg_proof(commitment: KZGCommitment, x: BLSFieldElement, y: BLSFieldE
     """
     zero_poly = G2_SETUP[1].add(G2_SETUP[0].mult(x).neg())
 
-    assert (
-        bls.Pairing(proof, zero_poly)
-        == bls.Pairing(commitment.add(G1_SETUP[0].mult(y).neg), G2_SETUP[0])
-    )
+    assert bls.Pairing(proof, zero_poly) == bls.Pairing(commitment.add(G1_SETUP[0].mult(y).neg), G2_SETUP[0])
 ```
 
 #### `verify_kzg_multiproof`
 
 ```python
-def verify_kzg_multiproof(commitment: KZGCommitment,
-                          xs: List[BLSFieldElement],
-                          ys: List[BLSFieldElement],
-                          proof: KZGCommitment) -> None:
+def verify_kzg_multiproof(
+    commitment: KZGCommitment, xs: List[BLSFieldElement], ys: List[BLSFieldElement], proof: KZGCommitment
+) -> None:
     """
     Verify a KZG multiproof.
     """
-    zero_poly = elliptic_curve_lincomb(G2_SETUP[:len(xs)], interpolate_polynomial(xs, [0] * len(ys)))
-    interpolated_poly = elliptic_curve_lincomb(G2_SETUP[:len(xs)], interpolate_polynomial(xs, ys))
+    zero_poly = elliptic_curve_lincomb(G2_SETUP[: len(xs)], interpolate_polynomial(xs, [0] * len(ys)))
+    interpolated_poly = elliptic_curve_lincomb(G2_SETUP[: len(xs)], interpolate_polynomial(xs, ys))
 
-    assert (
-        bls.Pairing(proof, zero_poly)
-        == bls.Pairing(commitment.add(interpolated_poly.neg()), G2_SETUP[0])
-    )
+    assert bls.Pairing(proof, zero_poly) == bls.Pairing(commitment.add(interpolated_poly.neg()), G2_SETUP[0])
 ```
 
 #### `verify_degree_proof`
@@ -387,8 +379,5 @@ def verify_degree_proof(commitment: KZGCommitment, degree_bound: uint64, proof: 
     Verifies that the commitment is of polynomial degree < degree_bound.
     """
 
-    assert (
-        bls.Pairing(proof, G2_SETUP[0])
-        == bls.Pairing(commitment, G2_SETUP[-degree_bound])
-    )
+    assert bls.Pairing(proof, G2_SETUP[0]) == bls.Pairing(commitment, G2_SETUP[-degree_bound])
 ```

--- a/specs/_deprecated/sharding/validator.md
+++ b/specs/_deprecated/sharding/validator.md
@@ -96,7 +96,7 @@ def verify_sample(state: BeaconState, block: BeaconBlock, sample: SignedShardSam
 
     # Verify KZG proof
     verify_kzg_multiproof(block.body.payload_data.value.sharded_commitments_container.sharded_commitments[sample.row],
-                          roots_in_rbo[sample.column * FIELD_ELEMENTS_PER_SAMPLE:(sample.column + 1) * FIELD_ELEMENTS_PER_SAMPLE]
+                          roots_in_rbo[sample.column * FIELD_ELEMENTS_PER_SAMPLE:(sample.column + 1) * FIELD_ELEMENTS_PER_SAMPLE],
                           sample.data,
                           sample.proof)
 ```

--- a/specs/_deprecated/sharding/validator.md
+++ b/specs/_deprecated/sharding/validator.md
@@ -73,7 +73,6 @@ def reconstruct_polynomial(samples: List[SignedShardSample]) -> List[SignedShard
     """
     Reconstructs one full row/column from at least 1/2 of the samples
     """
-
 ```
 
 ## Sample verification
@@ -95,10 +94,12 @@ def verify_sample(state: BeaconState, block: BeaconBlock, sample: SignedShardSam
     roots_in_rbo = list_to_reverse_bit_order(roots_of_unity(SAMPLES_PER_BLOB * FIELD_ELEMENTS_PER_SAMPLE))
 
     # Verify KZG proof
-    verify_kzg_multiproof(block.body.payload_data.value.sharded_commitments_container.sharded_commitments[sample.row],
-                          roots_in_rbo[sample.column * FIELD_ELEMENTS_PER_SAMPLE:(sample.column + 1) * FIELD_ELEMENTS_PER_SAMPLE],
-                          sample.data,
-                          sample.proof)
+    verify_kzg_multiproof(
+        block.body.payload_data.value.sharded_commitments_container.sharded_commitments[sample.row],
+        roots_in_rbo[sample.column * FIELD_ELEMENTS_PER_SAMPLE : (sample.column + 1) * FIELD_ELEMENTS_PER_SAMPLE],
+        sample.data,
+        sample.proof,
+    )
 ```
 
 # Beacon chain responsibilities

--- a/specs/_features/eip6800/fork.md
+++ b/specs/_features/eip6800/fork.md
@@ -94,7 +94,7 @@ def upgrade_to_eip6800(pre: deneb.BeaconState) -> BeaconState:
         block_hash=pre.latest_execution_payload_header.block_hash,
         transactions_root=pre.latest_execution_payload_header.transactions_root,
         withdrawals_root=pre.latest_execution_payload_header.withdrawals_root,
-        execution_witness_root=hash_tree_root(ExecutionWitness([], []))  # New in eip6800
+        execution_witness_root=hash_tree_root(ExecutionWitness([], [])),  # New in eip6800
     )
     post = BeaconState(
         # Versioning

--- a/specs/_features/eip6914/beacon-chain.md
+++ b/specs/_features/eip6914/beacon-chain.md
@@ -46,10 +46,7 @@ def is_reusable_validator(validator: Validator, balance: Gwei, epoch: Epoch) -> 
     """
     Check if ``validator`` index can be re-assigned to a new deposit.
     """
-    return (
-        epoch > validator.withdrawable_epoch + SAFE_EPOCHS_TO_REUSE_INDEX
-        and balance == 0
-    )
+    return epoch > validator.withdrawable_epoch + SAFE_EPOCHS_TO_REUSE_INDEX and balance == 0
 ```
 
 ## Beacon chain state transition function

--- a/specs/_features/eip7441/beacon-chain.md
+++ b/specs/_features/eip7441/beacon-chain.md
@@ -102,9 +102,11 @@ def bytes_to_bls_field(b: Bytes32) -> BLSFieldElement:
 Note that Curdleproofs (Whisk Shuffle Proofs), the tracker opening proofs and all related data structures and verifier code (along with tests) is specified in [curdleproofs.pie](https://github.com/nalinbhardwaj/curdleproofs.pie/tree/dev) repository.
 
 ```python
-def IsValidWhiskShuffleProof(pre_shuffle_trackers: Sequence[WhiskTracker],
-                             post_shuffle_trackers: Sequence[WhiskTracker],
-                             shuffle_proof: WhiskShuffleProof) -> bool:
+def IsValidWhiskShuffleProof(
+    pre_shuffle_trackers: Sequence[WhiskTracker],
+    post_shuffle_trackers: Sequence[WhiskTracker],
+    shuffle_proof: WhiskShuffleProof,
+) -> bool:
     """
     Verify `post_shuffle_trackers` is a permutation of `pre_shuffle_trackers`.
     Defined in https://github.com/nalinbhardwaj/curdleproofs.pie/blob/dev/curdleproofs/curdleproofs/whisk_interface.py.
@@ -118,9 +120,7 @@ def IsValidWhiskShuffleProof(pre_shuffle_trackers: Sequence[WhiskTracker],
 ```
 
 ```python
-def IsValidWhiskOpeningProof(tracker: WhiskTracker,
-                             k_commitment: BLSG1Point,
-                             tracker_proof: WhiskTrackerProof) -> bool:
+def IsValidWhiskOpeningProof(tracker: WhiskTracker, k_commitment: BLSG1Point, tracker_proof: WhiskTrackerProof) -> bool:
     """
     Verify knowledge of `k` such that `tracker.k_r_G == k * tracker.r_G` and `k_commitment == k * BLS_G1_GENERATOR`.
     Defined in https://github.com/nalinbhardwaj/curdleproofs.pie/blob/dev/curdleproofs/curdleproofs/whisk_interface.py.
@@ -193,11 +193,7 @@ class BeaconState(Container):
 ```python
 def select_whisk_proposer_trackers(state: BeaconState, epoch: Epoch) -> None:
     # Select proposer trackers from candidate trackers
-    proposer_seed = get_seed(
-        state,
-        Epoch(saturating_sub(epoch, PROPOSER_SELECTION_GAP)),
-        DOMAIN_PROPOSER_SELECTION
-    )
+    proposer_seed = get_seed(state, Epoch(saturating_sub(epoch, PROPOSER_SELECTION_GAP)), DOMAIN_PROPOSER_SELECTION)
     for i in range(PROPOSER_TRACKERS_COUNT):
         index = compute_shuffled_index(uint64(i), uint64(len(state.whisk_candidate_trackers)), proposer_seed)
         state.whisk_proposer_trackers[i] = state.whisk_candidate_trackers[index]
@@ -275,7 +271,7 @@ def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
     # Verify proposer is not slashed
     proposer = state.validators[block.proposer_index]
     assert not proposer.slashed
-    process_whisk_opening_proof(state, block)   # [New in EIP7441]
+    process_whisk_opening_proof(state, block)  # [New in EIP7441]
 ```
 
 ### Whisk
@@ -408,10 +404,9 @@ def get_initial_tracker(k: BLSFieldElement) -> WhiskTracker:
 ```
 
 ```python
-def add_validator_to_registry(state: BeaconState,
-                              pubkey: BLSPubkey,
-                              withdrawal_credentials: Bytes32,
-                              amount: uint64) -> None:
+def add_validator_to_registry(
+    state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+) -> None:
     index = get_index_for_new_validator(state)
     validator = get_validator_from_deposit(pubkey, withdrawal_credentials, amount)
     set_or_append_list(state.validators, index, validator)

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -199,7 +199,7 @@ class BeaconBlockBody(Container):
     # Removed blob_kzg_commitments [Removed in EIP-7732]
     # Removed execution_requests [Removed in EIP-7732]
     # PBS
-    signed_execution_payload_header: SignedExecutionPayloadHeader   # [New in EIP-7732]
+    signed_execution_payload_header: SignedExecutionPayloadHeader  # [New in EIP-7732]
     payload_attestations: List[PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS]  # [New in EIP-7732]
 ```
 
@@ -313,8 +313,8 @@ def remove_flag(flags: ParticipationFlags, flag_index: int) -> ParticipationFlag
 
 ```python
 def is_valid_indexed_payload_attestation(
-        state: BeaconState,
-        indexed_payload_attestation: IndexedPayloadAttestation) -> bool:
+    state: BeaconState, indexed_payload_attestation: IndexedPayloadAttestation
+) -> bool:
     """
     Check if ``indexed_payload_attestation`` is not empty, has sorted and unique indices and has
     a valid aggregate signature.
@@ -379,7 +379,8 @@ def get_attesting_indices(state: BeaconState, attestation: Attestation) -> Set[V
     for index in committee_indices:
         committee = get_beacon_committee(state, attestation.data.slot, index)
         committee_attesters = set(
-            index for i, index in enumerate(committee) if attestation.aggregation_bits[committee_offset + i])
+            index for i, index in enumerate(committee) if attestation.aggregation_bits[committee_offset + i]
+        )
         output = output.union(committee_attesters)
         committee_offset += len(committee)
 
@@ -392,8 +393,9 @@ def get_attesting_indices(state: BeaconState, attestation: Attestation) -> Set[V
 #### `get_payload_attesting_indices`
 
 ```python
-def get_payload_attesting_indices(state: BeaconState, slot: Slot,
-                                  payload_attestation: PayloadAttestation) -> Set[ValidatorIndex]:
+def get_payload_attesting_indices(
+    state: BeaconState, slot: Slot, payload_attestation: PayloadAttestation
+) -> Set[ValidatorIndex]:
     """
     Return the set of attesting indices corresponding to ``payload_attestation``.
     """
@@ -404,8 +406,9 @@ def get_payload_attesting_indices(state: BeaconState, slot: Slot,
 #### `get_indexed_payload_attestation`
 
 ```python
-def get_indexed_payload_attestation(state: BeaconState, slot: Slot,
-                                    payload_attestation: PayloadAttestation) -> IndexedPayloadAttestation:
+def get_indexed_payload_attestation(
+    state: BeaconState, slot: Slot, payload_attestation: PayloadAttestation
+) -> IndexedPayloadAttestation:
     """
     Return the indexed payload attestation corresponding to ``payload_attestation``.
     """
@@ -483,8 +486,7 @@ def process_withdrawals(state: BeaconState) -> None:
 ##### New `verify_execution_payload_header_signature`
 
 ```python
-def verify_execution_payload_header_signature(state: BeaconState,
-                                              signed_header: SignedExecutionPayloadHeader) -> bool:
+def verify_execution_payload_header_signature(state: BeaconState, signed_header: SignedExecutionPayloadHeader) -> bool:
     # Check the signature
     builder = state.validators[signed_header.message.builder_index]
     signing_root = compute_signing_root(signed_header.message, get_domain(state, DOMAIN_BEACON_BUILDER))
@@ -649,7 +651,8 @@ def validate_merge_block(block: BeaconBlock) -> None:
 
 ```python
 def verify_execution_payload_envelope_signature(
-        state: BeaconState, signed_envelope: SignedExecutionPayloadEnvelope) -> bool:
+    state: BeaconState, signed_envelope: SignedExecutionPayloadEnvelope
+) -> bool:
     builder = state.validators[signed_envelope.message.builder_index]
     signing_root = compute_signing_root(signed_envelope.message, get_domain(state, DOMAIN_BEACON_BUILDER))
     return bls.Verify(builder.pubkey, signing_root, signed_envelope.signature)
@@ -660,9 +663,12 @@ def verify_execution_payload_envelope_signature(
 *Note*: `process_execution_payload` is now an independent check in state transition. It is called when importing a signed execution payload proposed by the builder of the current slot.
 
 ```python
-def process_execution_payload(state: BeaconState,
-                              signed_envelope: SignedExecutionPayloadEnvelope,
-                              execution_engine: ExecutionEngine, verify: bool = True) -> None:
+def process_execution_payload(
+    state: BeaconState,
+    signed_envelope: SignedExecutionPayloadEnvelope,
+    execution_engine: ExecutionEngine,
+    verify: bool = True,
+) -> None:
     # Verify signature
     if verify:
         assert verify_execution_payload_envelope_signature(state, signed_envelope)
@@ -698,8 +704,9 @@ def process_execution_payload(state: BeaconState,
         # Verify commitments are under limit
         assert len(envelope.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
         # Verify the execution payload is valid
-        versioned_hashes = [kzg_commitment_to_versioned_hash(commitment)
-                            for commitment in envelope.blob_kzg_commitments]
+        versioned_hashes = [
+            kzg_commitment_to_versioned_hash(commitment) for commitment in envelope.blob_kzg_commitments
+        ]
         requests = envelope.execution_requests
         assert execution_engine.verify_and_notify_new_payload(
             NewPayloadRequest(

--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -48,7 +48,8 @@ After building the `header`, the builder obtains a `signature` of the header by 
 
 ```python
 def get_execution_payload_header_signature(
-        state: BeaconState, header: ExecutionPayloadHeader, privkey: int) -> BLSSignature:
+    state: BeaconState, header: ExecutionPayloadHeader, privkey: int
+) -> BLSSignature:
     domain = get_domain(state, DOMAIN_BEACON_BUILDER, compute_epoch_at_slot(header.slot))
     signing_root = compute_signing_root(header, domain)
     return bls.Sign(privkey, signing_root)
@@ -63,10 +64,12 @@ The builder assembles then `signed_execution_payload_header = SignedExecutionPay
 The `BlobSidecar` container is modified indirectly because the constant `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH` is modified. The function `get_blob_sidecars` is modified because the KZG commitments are no longer included in the beacon block but rather in the `ExecutionPayloadEnvelope`, the builder has to send the commitments as parameters to this function.
 
 ```python
-def get_blob_sidecars(signed_block: SignedBeaconBlock,
-                      blobs: Sequence[Blob],
-                      blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
-                      blob_kzg_proofs: Sequence[KZGProof]) -> Sequence[BlobSidecar]:
+def get_blob_sidecars(
+    signed_block: SignedBeaconBlock,
+    blobs: Sequence[Blob],
+    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+    blob_kzg_proofs: Sequence[KZGProof],
+) -> Sequence[BlobSidecar]:
     block = signed_block.message
     block_header = BeaconBlockHeader(
         slot=block.slot,
@@ -98,7 +101,7 @@ def get_blob_sidecars(signed_block: SignedBeaconBlock,
                 kzg_commitment=blob_kzg_commitments[index],
                 kzg_proof=blob_kzg_proofs[index],
                 signed_block_header=signed_block_header,
-                kzg_commitment_inclusion_proof=proof
+                kzg_commitment_inclusion_proof=proof,
             )
         )
     return sidecars
@@ -124,7 +127,8 @@ After preparing the `envelope` the builder should sign the envelope using:
 
 ```python
 def get_execution_payload_envelope_signature(
-        state: BeaconState, envelope: ExecutionPayloadEnvelope, privkey: int) -> BLSSignature:
+    state: BeaconState, envelope: ExecutionPayloadEnvelope, privkey: int
+) -> BLSSignature:
     domain = get_domain(state, DOMAIN_BEACON_BUILDER, compute_epoch_at_slot(state.slot))
     signing_root = compute_signing_root(envelope, domain)
     return bls.Sign(privkey, signing_root)

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -82,10 +82,7 @@ class BlobSidecar(Container):
 
 ```python
 def verify_blob_sidecar_inclusion_proof(blob_sidecar: BlobSidecar) -> bool:
-    inner_gindex = get_generalized_index(
-        List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
-        blob_sidecar.index
-    )
+    inner_gindex = get_generalized_index(List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK], blob_sidecar.index)
     outer_gindex = get_generalized_index(
         BeaconBlockBody,
         "signed_execution_payload_header",

--- a/specs/_features/eip7732/validator.md
+++ b/specs/_features/eip7732/validator.md
@@ -35,10 +35,7 @@ A validator may be a member of the new Payload Timeliness Committee (PTC) for a 
 PTC committee selection is only stable within the context of the current and next epoch.
 
 ```python
-def get_ptc_assignment(
-        state: BeaconState,
-        epoch: Epoch,
-        validator_index: ValidatorIndex) -> Optional[Slot]:
+def get_ptc_assignment(state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex) -> Optional[Slot]:
     """
     Returns the slot during the requested epoch in which the validator with index `validator_index`
     is a member of the PTC. Returns None if no assignment is found.
@@ -130,7 +127,8 @@ Notice that the attester only signs the `PayloadAttestationData` and not the `va
 
 ```python
 def get_payload_attestation_message_signature(
-        state: BeaconState, attestation: PayloadAttestationMessage, privkey: int) -> BLSSignature:
+    state: BeaconState, attestation: PayloadAttestationMessage, privkey: int
+) -> BLSSignature:
     domain = get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(attestation.data.slot))
     signing_root = compute_signing_root(attestation.data, domain)
     return bls.Sign(privkey, signing_root)

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -351,9 +351,9 @@ def get_unslashed_participating_indices(state: BeaconState, flag_index: int, epo
 #### `get_attestation_participation_flag_indices`
 
 ```python
-def get_attestation_participation_flag_indices(state: BeaconState,
-                                               data: AttestationData,
-                                               inclusion_delay: uint64) -> Sequence[int]:
+def get_attestation_participation_flag_indices(
+    state: BeaconState, data: AttestationData, inclusion_delay: uint64
+) -> Sequence[int]:
     """
     Return the flag indices that are satisfied by an attestation.
     """
@@ -432,9 +432,9 @@ def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], S
 and use `PROPOSER_WEIGHT` when calculating the proposer reward.
 
 ```python
-def slash_validator(state: BeaconState,
-                    slashed_index: ValidatorIndex,
-                    whistleblower_index: ValidatorIndex=None) -> None:
+def slash_validator(
+    state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+) -> None:
     """
     Slash the validator with index ``slashed_index``.
     """
@@ -512,10 +512,9 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
 *Note*: The function `add_validator_to_registry` is modified to initialize `inactivity_scores`, `previous_epoch_participation`, and `current_epoch_participation`.
 
 ```python
-def add_validator_to_registry(state: BeaconState,
-                              pubkey: BLSPubkey,
-                              withdrawal_credentials: Bytes32,
-                              amount: uint64) -> None:
+def add_validator_to_registry(
+    state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+) -> None:
     index = get_index_for_new_validator(state)
     validator = get_validator_from_deposit(pubkey, withdrawal_credentials, amount)
     set_or_append_list(state.validators, index, validator)
@@ -627,7 +626,7 @@ def process_rewards_and_penalties(state: BeaconState) -> None:
 
     flag_deltas = [get_flag_index_deltas(state, flag_index) for flag_index in range(len(PARTICIPATION_FLAG_WEIGHTS))]
     deltas = flag_deltas + [get_inactivity_penalty_deltas(state)]
-    for (rewards, penalties) in deltas:
+    for rewards, penalties in deltas:
         for index in range(len(state.validators)):
             increase_balance(state, ValidatorIndex(index), rewards[index])
             decrease_balance(state, ValidatorIndex(index), penalties[index])

--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -30,9 +30,7 @@ This document provides helper functions to enable full nodes to serve light clie
 This function return the Merkle proof of the given SSZ object `object` at generalized index `index`.
 
 ```python
-def compute_merkle_proof(object: SSZObject,
-                         index: GeneralizedIndex) -> Sequence[Bytes32]:
-    ...
+def compute_merkle_proof(object: SSZObject, index: GeneralizedIndex) -> Sequence[Bytes32]: ...
 ```
 
 ### `block_to_light_client_header`
@@ -61,8 +59,7 @@ To form a `LightClientBootstrap`, the following objects are needed:
 - `block`: the corresponding block
 
 ```python
-def create_light_client_bootstrap(state: BeaconState,
-                                  block: SignedBeaconBlock) -> LightClientBootstrap:
+def create_light_client_bootstrap(state: BeaconState, block: SignedBeaconBlock) -> LightClientBootstrap:
     assert compute_epoch_at_slot(state.slot) >= ALTAIR_FORK_EPOCH
 
     assert state.slot == state.latest_block_header.slot
@@ -74,7 +71,8 @@ def create_light_client_bootstrap(state: BeaconState,
         header=block_to_light_client_header(block),
         current_sync_committee=state.current_sync_committee,
         current_sync_committee_branch=CurrentSyncCommitteeBranch(
-            compute_merkle_proof(state, current_sync_committee_gindex_at_slot(state.slot))),
+            compute_merkle_proof(state, current_sync_committee_gindex_at_slot(state.slot))
+        ),
     )
 ```
 
@@ -94,11 +92,13 @@ To form a `LightClientUpdate`, the following historical states and blocks are ne
 - `finalized_block`: the block referred to by `attested_state.finalized_checkpoint.root`, if locally available (may be unavailable, e.g., when using checkpoint sync, or if it was pruned locally)
 
 ```python
-def create_light_client_update(state: BeaconState,
-                               block: SignedBeaconBlock,
-                               attested_state: BeaconState,
-                               attested_block: SignedBeaconBlock,
-                               finalized_block: Optional[SignedBeaconBlock]) -> LightClientUpdate:
+def create_light_client_update(
+    state: BeaconState,
+    block: SignedBeaconBlock,
+    attested_state: BeaconState,
+    attested_block: SignedBeaconBlock,
+    finalized_block: Optional[SignedBeaconBlock],
+) -> LightClientUpdate:
     assert compute_epoch_at_slot(attested_state.slot) >= ALTAIR_FORK_EPOCH
     assert sum(block.message.body.sync_aggregate.sync_committee_bits) >= MIN_SYNC_COMMITTEE_PARTICIPANTS
 
@@ -122,7 +122,8 @@ def create_light_client_update(state: BeaconState,
     if update_attested_period == update_signature_period:
         update.next_sync_committee = attested_state.next_sync_committee
         update.next_sync_committee_branch = NextSyncCommitteeBranch(
-            compute_merkle_proof(attested_state, next_sync_committee_gindex_at_slot(attested_state.slot)))
+            compute_merkle_proof(attested_state, next_sync_committee_gindex_at_slot(attested_state.slot))
+        )
 
     # Indicate finality whenever possible
     if finalized_block is not None:
@@ -132,7 +133,8 @@ def create_light_client_update(state: BeaconState,
         else:
             assert attested_state.finalized_checkpoint.root == Bytes32()
         update.finality_branch = FinalityBranch(
-            compute_merkle_proof(attested_state, finalized_root_gindex_at_slot(attested_state.slot)))
+            compute_merkle_proof(attested_state, finalized_root_gindex_at_slot(attested_state.slot))
+        )
 
     update.sync_aggregate = block.message.body.sync_aggregate
     update.signature_slot = block.message.slot

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -132,7 +132,7 @@ def get_sync_subcommittee_pubkeys(state: BeaconState, subcommittee_index: uint64
     # Return pubkeys for the subcommittee index
     sync_subcommittee_size = SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT
     i = subcommittee_index * sync_subcommittee_size
-    return sync_committee.pubkeys[i:i + sync_subcommittee_size]
+    return sync_committee.pubkeys[i : i + sync_subcommittee_size]
 ```
 
 - _[IGNORE]_ The contribution's slot is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e. `contribution.slot == current_slot`.

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -149,9 +149,7 @@ def compute_sync_committee_period(epoch: Epoch) -> uint64:
 ```
 
 ```python
-def is_assigned_to_sync_committee(state: BeaconState,
-                                  epoch: Epoch,
-                                  validator_index: ValidatorIndex) -> bool:
+def is_assigned_to_sync_committee(state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex) -> bool:
     sync_committee_period = compute_sync_committee_period(epoch)
     current_epoch = get_current_epoch(state)
     current_sync_committee_period = compute_sync_committee_period(current_epoch)
@@ -219,8 +217,7 @@ Given a collection of the best seen `contributions` (with no repeating `subcommi
 the proposer processes them as follows:
 
 ```python
-def process_sync_committee_contributions(block: BeaconBlock,
-                                         contributions: Set[SyncCommitteeContribution]) -> None:
+def process_sync_committee_contributions(block: BeaconBlock, contributions: Set[SyncCommitteeContribution]) -> None:
     sync_aggregate = SyncAggregate()
     signatures = []
     sync_subcommittee_size = SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT
@@ -268,10 +265,9 @@ Meaning, a sync committee member should produce and broadcast a `SyncCommitteeMe
 `get_sync_committee_message(state, block_root, validator_index, privkey)` assumes the parameter `state` is the head state corresponding to processing the block up to the current slot as determined by the fork choice (including any empty slots up to the current slot processed with `process_slots` on top of the latest block), `block_root` is the root of the head block, `validator_index` is the index of the validator in the registry `state.validators` controlled by `privkey`, and `privkey` is the BLS private key for the validator.
 
 ```python
-def get_sync_committee_message(state: BeaconState,
-                               block_root: Root,
-                               validator_index: ValidatorIndex,
-                               privkey: int) -> SyncCommitteeMessage:
+def get_sync_committee_message(
+    state: BeaconState, block_root: Root, validator_index: ValidatorIndex, privkey: int
+) -> SyncCommitteeMessage:
     epoch = get_current_epoch(state)
     domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, epoch)
     signing_root = compute_signing_root(block_root, domain)
@@ -304,10 +300,9 @@ def compute_subnets_for_sync_committee(state: BeaconState, validator_index: Vali
 
     target_pubkey = state.validators[validator_index].pubkey
     sync_committee_indices = [index for index, pubkey in enumerate(sync_committee.pubkeys) if pubkey == target_pubkey]
-    return set([
-        SubnetID(index // (SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT))
-        for index in sync_committee_indices
-    ])
+    return set(
+        [SubnetID(index // (SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT)) for index in sync_committee_indices]
+    )
 ```
 
 *Note*: Subnet assignment does not change during the duration of a validator's assignment to a given sync committee.
@@ -324,10 +319,9 @@ A validator is selected to aggregate based on the value returned by `is_sync_com
 The signature function takes a `BeaconState` with the relevant sync committees for the queried `slot` (i.e. `state.slot` is within the span covered by the current or next sync committee period), the `subcommittee_index` equal to the `subnet_id`, and the `privkey` is the BLS private key associated with the validator.
 
 ```python
-def get_sync_committee_selection_proof(state: BeaconState,
-                                       slot: Slot,
-                                       subcommittee_index: uint64,
-                                       privkey: int) -> BLSSignature:
+def get_sync_committee_selection_proof(
+    state: BeaconState, slot: Slot, subcommittee_index: uint64, privkey: int
+) -> BLSSignature:
     domain = get_domain(state, DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF, compute_epoch_at_slot(slot))
     signing_data = SyncAggregatorSelectionData(
         slot=slot,
@@ -389,10 +383,9 @@ Selection proofs are provided in `ContributionAndProof` to prove to the gossip c
 First, `contribution_and_proof = get_contribution_and_proof(state, validator_index, contribution, privkey)` is constructed.
 
 ```python
-def get_contribution_and_proof(state: BeaconState,
-                               aggregator_index: ValidatorIndex,
-                               contribution: SyncCommitteeContribution,
-                               privkey: int) -> ContributionAndProof:
+def get_contribution_and_proof(
+    state: BeaconState, aggregator_index: ValidatorIndex, contribution: SyncCommitteeContribution, privkey: int
+) -> ContributionAndProof:
     selection_proof = get_sync_committee_selection_proof(
         state,
         contribution.slot,
@@ -409,9 +402,9 @@ def get_contribution_and_proof(state: BeaconState,
 Then `signed_contribution_and_proof = SignedContributionAndProof(message=contribution_and_proof, signature=signature)` is constructed and broadcast. Where `signature` is obtained from:
 
 ```python
-def get_contribution_and_proof_signature(state: BeaconState,
-                                         contribution_and_proof: ContributionAndProof,
-                                         privkey: int) -> BLSSignature:
+def get_contribution_and_proof_signature(
+    state: BeaconState, contribution_and_proof: ContributionAndProof, privkey: int
+) -> BLSSignature:
     contribution = contribution_and_proof.contribution
     domain = get_domain(state, DOMAIN_CONTRIBUTION_AND_PROOF, compute_epoch_at_slot(contribution.slot))
     signing_root = compute_signing_root(contribution_and_proof, domain)

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -275,9 +275,9 @@ def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], S
 *Note*: The function `slash_validator` is modified to use `MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX`.
 
 ```python
-def slash_validator(state: BeaconState,
-                    slashed_index: ValidatorIndex,
-                    whistleblower_index: ValidatorIndex=None) -> None:
+def slash_validator(
+    state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+) -> None:
     """
     Slash the validator with index ``slashed_index``.
     """
@@ -349,14 +349,13 @@ def is_valid_block_hash(self: ExecutionEngine, execution_payload: ExecutionPaylo
 #### `verify_and_notify_new_payload`
 
 ```python
-def verify_and_notify_new_payload(self: ExecutionEngine,
-                                  new_payload_request: NewPayloadRequest) -> bool:
+def verify_and_notify_new_payload(self: ExecutionEngine, new_payload_request: NewPayloadRequest) -> bool:
     """
     Return ``True`` if and only if ``new_payload_request`` is valid with respect to ``self.execution_state``.
     """
     execution_payload = new_payload_request.execution_payload
 
-    if b'' in execution_payload.transactions:
+    if b"" in execution_payload.transactions:
         return False
 
     if not self.is_valid_block_hash(execution_payload):
@@ -430,8 +429,7 @@ def process_slashings(state: BeaconState) -> None:
     epoch = get_current_epoch(state)
     total_balance = get_total_active_balance(state)
     adjusted_total_slashing_balance = min(
-        sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX,  # [Modified in Bellatrix]
-        total_balance
+        sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX, total_balance  # [Modified in Bellatrix]
     )
     for index, validator in enumerate(state.validators):
         if validator.slashed and epoch + EPOCHS_PER_SLASHINGS_VECTOR // 2 == validator.withdrawable_epoch:

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -58,12 +58,13 @@ Additionally, if `payload_attributes` is provided, this function sets in motion 
 `head_block_hash` and returns an identifier of initiated process.
 
 ```python
-def notify_forkchoice_updated(self: ExecutionEngine,
-                              head_block_hash: Hash32,
-                              safe_block_hash: Hash32,
-                              finalized_block_hash: Hash32,
-                              payload_attributes: Optional[PayloadAttributes]) -> Optional[PayloadId]:
-    ...
+def notify_forkchoice_updated(
+    self: ExecutionEngine,
+    head_block_hash: Hash32,
+    safe_block_hash: Hash32,
+    finalized_block_hash: Hash32,
+    payload_attributes: Optional[PayloadAttributes],
+) -> Optional[PayloadId]: ...
 ```
 
 *Note*: The `(head_block_hash, finalized_block_hash)` values of the `notify_forkchoice_updated` function call maps on the `POS_FORKCHOICE_UPDATED` event defined in the [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions).
@@ -125,8 +126,7 @@ def should_override_forkchoice_update(store: Store, head_root: Root) -> bool:
     proposing_on_time = is_proposing_on_time(store)
 
     # Note that this condition is different from `get_proposer_head`
-    current_time_ok = (head_block.slot == current_slot
-                       or (proposal_slot == current_slot and proposing_on_time))
+    current_time_ok = head_block.slot == current_slot or (proposal_slot == current_slot and proposing_on_time)
     single_slot_reorg = parent_slot_ok and current_time_ok
 
     # Check the head weight only if the attestations from the head slot have already been applied.
@@ -139,9 +139,18 @@ def should_override_forkchoice_update(store: Store, head_root: Root) -> bool:
         head_weak = True
         parent_strong = True
 
-    return all([head_late, shuffling_stable, ffg_competitive, finalization_ok,
-                proposing_reorg_slot, single_slot_reorg,
-                head_weak, parent_strong])
+    return all(
+        [
+            head_late,
+            shuffling_stable,
+            ffg_competitive,
+            finalization_ok,
+            proposing_reorg_slot,
+            single_slot_reorg,
+            head_weak,
+            parent_strong,
+        ]
+    )
 ```
 
 *Note*: The ordering of conditions is a suggestion only. Implementations are free to

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -125,12 +125,14 @@ To obtain an execution payload, a block proposer building a block on top of a `s
     * `suggested_fee_recipient` is the value suggested to be used for the `fee_recipient` field of the execution payload
 
 ```python
-def prepare_execution_payload(state: BeaconState,
-                              safe_block_hash: Hash32,
-                              finalized_block_hash: Hash32,
-                              suggested_fee_recipient: ExecutionAddress,
-                              execution_engine: ExecutionEngine,
-                              pow_chain: Optional[Dict[Hash32, PowBlock]]=None) -> Optional[PayloadId]:
+def prepare_execution_payload(
+    state: BeaconState,
+    safe_block_hash: Hash32,
+    finalized_block_hash: Hash32,
+    suggested_fee_recipient: ExecutionAddress,
+    execution_engine: ExecutionEngine,
+    pow_chain: Optional[Dict[Hash32, PowBlock]] = None,
+) -> Optional[PayloadId]:
     if not is_merge_transition_complete(state):
         assert pow_chain is not None
         is_terminal_block_hash_set = TERMINAL_BLOCK_HASH != Hash32()

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -130,6 +130,7 @@ class HistoricalSummary(Container):
     `HistoricalSummary` matches the components of the phase0 `HistoricalBatch`
     making the two hash_tree_root-compatible.
     """
+
     block_summary_root: Root
     state_summary_root: Root
 ```
@@ -270,11 +271,7 @@ def is_fully_withdrawable_validator(validator: Validator, balance: Gwei, epoch: 
     """
     Check if ``validator`` is fully withdrawable.
     """
-    return (
-        has_eth1_withdrawal_credential(validator)
-        and validator.withdrawable_epoch <= epoch
-        and balance > 0
-    )
+    return has_eth1_withdrawal_credential(validator) and validator.withdrawable_epoch <= epoch and balance > 0
 ```
 
 #### `is_partially_withdrawable_validator`
@@ -352,20 +349,24 @@ def get_expected_withdrawals(state: BeaconState) -> Sequence[Withdrawal]:
         validator = state.validators[validator_index]
         balance = state.balances[validator_index]
         if is_fully_withdrawable_validator(validator, balance, epoch):
-            withdrawals.append(Withdrawal(
-                index=withdrawal_index,
-                validator_index=validator_index,
-                address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                amount=balance,
-            ))
+            withdrawals.append(
+                Withdrawal(
+                    index=withdrawal_index,
+                    validator_index=validator_index,
+                    address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                    amount=balance,
+                )
+            )
             withdrawal_index += WithdrawalIndex(1)
         elif is_partially_withdrawable_validator(validator, balance):
-            withdrawals.append(Withdrawal(
-                index=withdrawal_index,
-                validator_index=validator_index,
-                address=ExecutionAddress(validator.withdrawal_credentials[12:]),
-                amount=balance - MAX_EFFECTIVE_BALANCE,
-            ))
+            withdrawals.append(
+                Withdrawal(
+                    index=withdrawal_index,
+                    validator_index=validator_index,
+                    address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                    amount=balance - MAX_EFFECTIVE_BALANCE,
+                )
+            )
             withdrawal_index += WithdrawalIndex(1)
         if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
             break
@@ -461,8 +462,7 @@ def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
 #### New `process_bls_to_execution_change`
 
 ```python
-def process_bls_to_execution_change(state: BeaconState,
-                                    signed_address_change: SignedBLSToExecutionChange) -> None:
+def process_bls_to_execution_change(state: BeaconState, signed_address_change: SignedBLSToExecutionChange) -> None:
     address_change = signed_address_change.message
 
     assert address_change.validator_index < len(state.validators)
@@ -478,8 +478,6 @@ def process_bls_to_execution_change(state: BeaconState,
     assert bls.Verify(address_change.from_bls_pubkey, signing_root, signed_address_change.signature)
 
     validator.withdrawal_credentials = (
-        ETH1_ADDRESS_WITHDRAWAL_PREFIX
-        + b'\x00' * 11
-        + address_change.to_execution_address
+        ETH1_ADDRESS_WITHDRAWAL_PREFIX + b"\x00" * 11 + address_change.to_execution_address
     )
 ```

--- a/specs/capella/fork-choice.md
+++ b/specs/capella/fork-choice.md
@@ -39,12 +39,13 @@ The only change made is to the `PayloadAttributes` container through the additio
 Otherwise, `notify_forkchoice_updated` inherits all prior functionality.
 
 ```python
-def notify_forkchoice_updated(self: ExecutionEngine,
-                              head_block_hash: Hash32,
-                              safe_block_hash: Hash32,
-                              finalized_block_hash: Hash32,
-                              payload_attributes: Optional[PayloadAttributes]) -> Optional[PayloadId]:
-    ...
+def notify_forkchoice_updated(
+    self: ExecutionEngine,
+    head_block_hash: Hash32,
+    safe_block_hash: Hash32,
+    finalized_block_hash: Hash32,
+    payload_attributes: Optional[PayloadAttributes],
+) -> Optional[PayloadId]: ...
 ```
 
 ## Helpers

--- a/specs/capella/light-client/full-node.md
+++ b/specs/capella/light-client/full-node.md
@@ -44,8 +44,7 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
             transactions_root=hash_tree_root(payload.transactions),
             withdrawals_root=hash_tree_root(payload.withdrawals),
         )
-        execution_branch = ExecutionBranch(
-            compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX))
+        execution_branch = ExecutionBranch(compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX))
     else:
         # Note that during fork transitions, `finalized_header` may still point to earlier forks.
         # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_root`),

--- a/specs/capella/light-client/sync-protocol.md
+++ b/specs/capella/light-client/sync-protocol.md
@@ -72,10 +72,7 @@ def is_valid_light_client_header(header: LightClientHeader) -> bool:
     epoch = compute_epoch_at_slot(header.beacon.slot)
 
     if epoch < CAPELLA_FORK_EPOCH:
-        return (
-            header.execution == ExecutionPayloadHeader()
-            and header.execution_branch == ExecutionBranch()
-        )
+        return header.execution == ExecutionPayloadHeader() and header.execution_branch == ExecutionBranch()
 
     return is_valid_merkle_branch(
         leaf=get_lc_execution_root(header),

--- a/specs/capella/validator.md
+++ b/specs/capella/validator.md
@@ -76,11 +76,13 @@ That is, `state` is the `previous_state` processed through any empty slots up to
 `get_expected_withdrawals()` to set the new `withdrawals` field of `PayloadAttributes`.
 
 ```python
-def prepare_execution_payload(state: BeaconState,
-                              safe_block_hash: Hash32,
-                              finalized_block_hash: Hash32,
-                              suggested_fee_recipient: ExecutionAddress,
-                              execution_engine: ExecutionEngine) -> Optional[PayloadId]:
+def prepare_execution_payload(
+    state: BeaconState,
+    safe_block_hash: Hash32,
+    finalized_block_hash: Hash32,
+    suggested_fee_recipient: ExecutionAddress,
+    execution_engine: ExecutionEngine,
+) -> Optional[PayloadId]:
     # [Modified in Capella] Removed `is_merge_transition_complete` check in Capella
     parent_hash = state.latest_execution_payload_header.block_hash
 

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -237,9 +237,9 @@ def kzg_commitment_to_versioned_hash(kzg_commitment: KZGCommitment) -> Versioned
 *Note:* The function `get_attestation_participation_flag_indices` is modified to set the `TIMELY_TARGET_FLAG` for any correct target attestation, regardless of `inclusion_delay` as a baseline reward for any speed of inclusion of an attestation that contributes to justification of the contained chain for EIP-7045.
 
 ```python
-def get_attestation_participation_flag_indices(state: BeaconState,
-                                               data: AttestationData,
-                                               inclusion_delay: uint64) -> Sequence[int]:
+def get_attestation_participation_flag_indices(
+    state: BeaconState, data: AttestationData, inclusion_delay: uint64
+) -> Sequence[int]:
     """
     Return the flag indices that are satisfied by an attestation.
     """
@@ -298,9 +298,9 @@ class NewPayloadRequest(object):
 *Note*: The function `is_valid_block_hash` is modified to include the additional `parent_beacon_block_root` parameter for EIP-4788.
 
 ```python
-def is_valid_block_hash(self: ExecutionEngine,
-                        execution_payload: ExecutionPayload,
-                        parent_beacon_block_root: Root) -> bool:
+def is_valid_block_hash(
+    self: ExecutionEngine, execution_payload: ExecutionPayload, parent_beacon_block_root: Root
+) -> bool:
     """
     Return ``True`` if and only if ``execution_payload.block_hash`` is computed correctly.
     """
@@ -323,9 +323,9 @@ def is_valid_versioned_hashes(self: ExecutionEngine, new_payload_request: NewPay
 *Note*: The function `notify_new_payload` is modified to include the additional `parent_beacon_block_root` parameter for EIP-4788.
 
 ```python
-def notify_new_payload(self: ExecutionEngine,
-                       execution_payload: ExecutionPayload,
-                       parent_beacon_block_root: Root) -> bool:
+def notify_new_payload(
+    self: ExecutionEngine, execution_payload: ExecutionPayload, parent_beacon_block_root: Root
+) -> bool:
     """
     Return ``True`` if and only if ``execution_payload`` is valid with respect to ``self.execution_state``.
     """
@@ -335,15 +335,14 @@ def notify_new_payload(self: ExecutionEngine,
 ##### Modified `verify_and_notify_new_payload`
 
 ```python
-def verify_and_notify_new_payload(self: ExecutionEngine,
-                                  new_payload_request: NewPayloadRequest) -> bool:
+def verify_and_notify_new_payload(self: ExecutionEngine, new_payload_request: NewPayloadRequest) -> bool:
     """
     Return ``True`` if and only if ``new_payload_request`` is valid with respect to ``self.execution_state``.
     """
     execution_payload = new_payload_request.execution_payload
     parent_beacon_block_root = new_payload_request.parent_beacon_block_root  # [New in Deneb:EIP4788]
 
-    if b'' in execution_payload.transactions:
+    if b"" in execution_payload.transactions:
         return False
 
     # [Modified in Deneb:EIP4788]
@@ -495,21 +494,22 @@ def process_registry_updates(state: BeaconState) -> None:
         if is_eligible_for_activation_queue(validator):
             validator.activation_eligibility_epoch = get_current_epoch(state) + 1
 
-        if (
-            is_active_validator(validator, get_current_epoch(state))
-            and validator.effective_balance <= EJECTION_BALANCE
-        ):
+        if is_active_validator(validator, get_current_epoch(state)) and validator.effective_balance <= EJECTION_BALANCE:
             initiate_validator_exit(state, ValidatorIndex(index))
 
     # Queue validators eligible for activation and not yet dequeued for activation
-    activation_queue = sorted([
-        index for index, validator in enumerate(state.validators)
-        if is_eligible_for_activation(state, validator)
-        # Order by the sequence of activation_eligibility_epoch setting and then index
-    ], key=lambda index: (state.validators[index].activation_eligibility_epoch, index))
+    activation_queue = sorted(
+        [
+            index
+            for index, validator in enumerate(state.validators)
+            if is_eligible_for_activation(state, validator)
+            # Order by the sequence of activation_eligibility_epoch setting and then index
+        ],
+        key=lambda index: (state.validators[index].activation_eligibility_epoch, index),
+    )
     # Dequeued validators for activation up to activation churn limit
     # [Modified in Deneb:EIP7514]
-    for index in activation_queue[:get_validator_activation_churn_limit(state)]:
+    for index in activation_queue[: get_validator_activation_churn_limit(state)]:
         validator = state.validators[index]
         validator.activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
 ```

--- a/specs/deneb/light-client/full-node.md
+++ b/specs/deneb/light-client/full-node.md
@@ -50,8 +50,7 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
             execution_header.blob_gas_used = payload.blob_gas_used
             execution_header.excess_blob_gas = payload.excess_blob_gas
 
-        execution_branch = ExecutionBranch(
-            compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX))
+        execution_branch = ExecutionBranch(compute_merkle_proof(block.message.body, EXECUTION_PAYLOAD_GINDEX))
     else:
         # Note that during fork transitions, `finalized_header` may still point to earlier forks.
         # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_root`),

--- a/specs/deneb/light-client/sync-protocol.md
+++ b/specs/deneb/light-client/sync-protocol.md
@@ -70,10 +70,7 @@ def is_valid_light_client_header(header: LightClientHeader) -> bool:
             return False
 
     if epoch < CAPELLA_FORK_EPOCH:
-        return (
-            header.execution == ExecutionPayloadHeader()
-            and header.execution_branch == ExecutionBranch()
-        )
+        return header.execution == ExecutionPayloadHeader() and header.execution_branch == ExecutionBranch()
 
     return is_valid_merkle_branch(
         leaf=get_lc_execution_root(header),

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -102,7 +102,7 @@ class BlobIdentifier(Container):
 
 ```python
 def verify_blob_sidecar_inclusion_proof(blob_sidecar: BlobSidecar) -> bool:
-    gindex = get_subtree_index(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments', blob_sidecar.index))
+    gindex = get_subtree_index(get_generalized_index(BeaconBlockBody, "blob_kzg_commitments", blob_sidecar.index))
     return is_valid_merkle_branch(
         leaf=blob_sidecar.kzg_commitment.hash_tree_root(),
         branch=blob_sidecar.kzg_commitment_inclusion_proof,

--- a/specs/deneb/validator.md
+++ b/specs/deneb/validator.md
@@ -111,11 +111,13 @@ That is, `state` is the `previous_state` processed through any empty slots up to
 parameter to the `PayloadAttributes`.
 
 ```python
-def prepare_execution_payload(state: BeaconState,
-                              safe_block_hash: Hash32,
-                              finalized_block_hash: Hash32,
-                              suggested_fee_recipient: ExecutionAddress,
-                              execution_engine: ExecutionEngine) -> Optional[PayloadId]:
+def prepare_execution_payload(
+    state: BeaconState,
+    safe_block_hash: Hash32,
+    finalized_block_hash: Hash32,
+    suggested_fee_recipient: ExecutionAddress,
+    execution_engine: ExecutionEngine,
+) -> Optional[PayloadId]:
     # Verify consistency of the parent hash with respect to the previous execution payload header
     parent_hash = state.latest_execution_payload_header.block_hash
 
@@ -155,9 +157,9 @@ Blobs associated with a block are packaged into sidecar objects for distribution
 Each `sidecar` is obtained from:
 
 ```python
-def get_blob_sidecars(signed_block: SignedBeaconBlock,
-                      blobs: Sequence[Blob],
-                      blob_kzg_proofs: Sequence[KZGProof]) -> Sequence[BlobSidecar]:
+def get_blob_sidecars(
+    signed_block: SignedBeaconBlock, blobs: Sequence[Blob], blob_kzg_proofs: Sequence[KZGProof]
+) -> Sequence[BlobSidecar]:
     block = signed_block.message
     signed_block_header = compute_signed_block_header(signed_block)
     return [
@@ -169,7 +171,7 @@ def get_blob_sidecars(signed_block: SignedBeaconBlock,
             signed_block_header=signed_block_header,
             kzg_commitment_inclusion_proof=compute_merkle_proof(
                 block.body,
-                get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments', index),
+                get_generalized_index(BeaconBlockBody, "blob_kzg_commitments", index),
             ),
         )
         for index, blob in enumerate(blobs)

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -146,13 +146,10 @@ def upgrade_to_electra(pre: deneb.BeaconState) -> BeaconState:
 
     # [New in Electra:EIP7251]
     # add validators that are not yet active to pending balance deposits
-    pre_activation = sorted([
-        index for index, validator in enumerate(post.validators)
-        if validator.activation_epoch == FAR_FUTURE_EPOCH
-    ], key=lambda index: (
-        post.validators[index].activation_eligibility_epoch,
-        index
-    ))
+    pre_activation = sorted(
+        [index for index, validator in enumerate(post.validators) if validator.activation_epoch == FAR_FUTURE_EPOCH],
+        key=lambda index: (post.validators[index].activation_eligibility_epoch, index),
+    )
 
     for index in pre_activation:
         balance = post.balances[index]
@@ -162,13 +159,15 @@ def upgrade_to_electra(pre: deneb.BeaconState) -> BeaconState:
         validator.activation_eligibility_epoch = FAR_FUTURE_EPOCH
         # Use bls.G2_POINT_AT_INFINITY as a signature field placeholder
         # and GENESIS_SLOT to distinguish from a pending deposit request
-        post.pending_deposits.append(PendingDeposit(
-            pubkey=validator.pubkey,
-            withdrawal_credentials=validator.withdrawal_credentials,
-            amount=balance,
-            signature=bls.G2_POINT_AT_INFINITY,
-            slot=GENESIS_SLOT,
-        ))
+        post.pending_deposits.append(
+            PendingDeposit(
+                pubkey=validator.pubkey,
+                withdrawal_credentials=validator.withdrawal_credentials,
+                amount=balance,
+                signature=bls.G2_POINT_AT_INFINITY,
+                slot=GENESIS_SLOT,
+            )
+        )
 
     # Ensure early adopters of compounding credentials go through the activation churn
     for index, validator in enumerate(post.validators):

--- a/specs/electra/light-client/fork.md
+++ b/specs/electra/light-client/fork.md
@@ -26,8 +26,7 @@ This document describes how to upgrade existing light client objects based on th
 ### `normalize_merkle_branch`
 
 ```python
-def normalize_merkle_branch(branch: Sequence[Bytes32],
-                            gindex: GeneralizedIndex) -> Sequence[Bytes32]:
+def normalize_merkle_branch(branch: Sequence[Bytes32], gindex: GeneralizedIndex) -> Sequence[Bytes32]:
     depth = floorlog2(gindex)
     num_extra = depth - len(branch)
     return [Bytes32()] * num_extra + [*branch]
@@ -52,7 +51,8 @@ def upgrade_lc_bootstrap_to_electra(pre: deneb.LightClientBootstrap) -> LightCli
         header=upgrade_lc_header_to_electra(pre.header),
         current_sync_committee=pre.current_sync_committee,
         current_sync_committee_branch=normalize_merkle_branch(
-            pre.current_sync_committee_branch, CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA),
+            pre.current_sync_committee_branch, CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA
+        ),
     )
 ```
 
@@ -62,10 +62,10 @@ def upgrade_lc_update_to_electra(pre: deneb.LightClientUpdate) -> LightClientUpd
         attested_header=upgrade_lc_header_to_electra(pre.attested_header),
         next_sync_committee=pre.next_sync_committee,
         next_sync_committee_branch=normalize_merkle_branch(
-            pre.next_sync_committee_branch, NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA),
+            pre.next_sync_committee_branch, NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA
+        ),
         finalized_header=upgrade_lc_header_to_electra(pre.finalized_header),
-        finality_branch=normalize_merkle_branch(
-            pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
+        finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
         sync_aggregate=pre.sync_aggregate,
         signature_slot=pre.signature_slot,
     )
@@ -76,8 +76,7 @@ def upgrade_lc_finality_update_to_electra(pre: deneb.LightClientFinalityUpdate) 
     return LightClientFinalityUpdate(
         attested_header=upgrade_lc_header_to_electra(pre.attested_header),
         finalized_header=upgrade_lc_header_to_electra(pre.finalized_header),
-        finality_branch=normalize_merkle_branch(
-            pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
+        finality_branch=normalize_merkle_branch(pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
         sync_aggregate=pre.sync_aggregate,
         signature_slot=pre.signature_slot,
     )

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -78,7 +78,7 @@ class AggregateAndProof(Container):
 
 ```python
 class SignedAggregateAndProof(Container):
-    message: AggregateAndProof   # [Modified in Electra:EIP7549]
+    message: AggregateAndProof  # [Modified in Electra:EIP7549]
     signature: BLSSignature
 ```
 
@@ -164,7 +164,8 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
     period_start = voting_period_start_time(state)
     # `eth1_chain` abstractly represents all blocks in the eth1 chain sorted by ascending block height
     votes_to_consider = [
-        get_eth1_data(block) for block in eth1_chain
+        get_eth1_data(block)
+        for block in eth1_chain
         if (
             is_candidate_block(block, period_start)
             # Ensure cannot move back to earlier deposit contract states
@@ -183,7 +184,7 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
     return max(
         valid_votes,
         key=lambda v: (valid_votes.count(v), -valid_votes.index(v)),  # Tiebreak by smallest distance
-        default=default_vote
+        default=default_vote,
     )
 ```
 
@@ -197,11 +198,13 @@ That is, `state` is the `previous_state` processed through any empty slots up to
 *Note*: The only change to `prepare_execution_payload` is the new definition of `get_expected_withdrawals`.
 
 ```python
-def prepare_execution_payload(state: BeaconState,
-                              safe_block_hash: Hash32,
-                              finalized_block_hash: Hash32,
-                              suggested_fee_recipient: ExecutionAddress,
-                              execution_engine: ExecutionEngine) -> Optional[PayloadId]:
+def prepare_execution_payload(
+    state: BeaconState,
+    safe_block_hash: Hash32,
+    finalized_block_hash: Hash32,
+    suggested_fee_recipient: ExecutionAddress,
+    execution_engine: ExecutionEngine,
+) -> Optional[PayloadId]:
     # Verify consistency of the parent hash with respect to the previous execution payload header
     parent_hash = state.latest_execution_payload_header.block_hash
 
@@ -256,19 +259,12 @@ def get_execution_requests(execution_requests_list: Sequence[bytes]) -> Executio
         prev_request_type = request_type
 
         if request_type == DEPOSIT_REQUEST_TYPE:
-            deposits = ssz_deserialize(
-                List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD],
-                request_data
-            )
+            deposits = ssz_deserialize(List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD], request_data)
         elif request_type == WITHDRAWAL_REQUEST_TYPE:
-            withdrawals = ssz_deserialize(
-                List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD],
-                request_data
-            )
+            withdrawals = ssz_deserialize(List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD], request_data)
         elif request_type == CONSOLIDATION_REQUEST_TYPE:
             consolidations = ssz_deserialize(
-                List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD],
-                request_data
+                List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD], request_data
             )
 
     return ExecutionRequests(

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -111,10 +111,7 @@ def get_custody_groups(node_id: NodeID, custody_group_count: uint64) -> Sequence
     current_id = uint256(node_id)
     custody_groups: List[CustodyIndex] = []
     while len(custody_groups) < custody_group_count:
-        custody_group = CustodyIndex(
-            bytes_to_uint64(hash(uint_to_bytes(current_id))[0:8])
-            % NUMBER_OF_CUSTODY_GROUPS
-        )
+        custody_group = CustodyIndex(bytes_to_uint64(hash(uint_to_bytes(current_id))[0:8]) % NUMBER_OF_CUSTODY_GROUPS)
         if custody_group not in custody_groups:
             custody_groups.append(custody_group)
         if current_id == UINT256_MAX:
@@ -133,10 +130,7 @@ def get_custody_groups(node_id: NodeID, custody_group_count: uint64) -> Sequence
 def compute_columns_for_custody_group(custody_group: CustodyIndex) -> Sequence[ColumnIndex]:
     assert custody_group < NUMBER_OF_CUSTODY_GROUPS
     columns_per_group = NUMBER_OF_COLUMNS // NUMBER_OF_CUSTODY_GROUPS
-    return sorted([
-        ColumnIndex(NUMBER_OF_CUSTODY_GROUPS * i + custody_group)
-        for i in range(columns_per_group)
-    ])
+    return sorted([ColumnIndex(NUMBER_OF_CUSTODY_GROUPS * i + custody_group) for i in range(columns_per_group)])
 ```
 
 ### `compute_matrix`
@@ -153,12 +147,14 @@ def compute_matrix(blobs: Sequence[Blob]) -> Sequence[MatrixEntry]:
     for blob_index, blob in enumerate(blobs):
         cells, proofs = compute_cells_and_kzg_proofs(blob)
         for cell_index, (cell, proof) in enumerate(zip(cells, proofs)):
-            matrix.append(MatrixEntry(
-                cell=cell,
-                kzg_proof=proof,
-                row_index=blob_index,
-                column_index=cell_index,
-            ))
+            matrix.append(
+                MatrixEntry(
+                    cell=cell,
+                    kzg_proof=proof,
+                    row_index=blob_index,
+                    column_index=cell_index,
+                )
+            )
     return matrix
 ```
 
@@ -178,22 +174,24 @@ def recover_matrix(partial_matrix: Sequence[MatrixEntry], blob_count: uint64) ->
         cells = [e.cell for e in partial_matrix if e.row_index == blob_index]
         recovered_cells, recovered_proofs = recover_cells_and_kzg_proofs(cell_indices, cells)
         for cell_index, (cell, proof) in enumerate(zip(recovered_cells, recovered_proofs)):
-            matrix.append(MatrixEntry(
-                cell=cell,
-                kzg_proof=proof,
-                row_index=blob_index,
-                column_index=cell_index,
-            ))
+            matrix.append(
+                MatrixEntry(
+                    cell=cell,
+                    kzg_proof=proof,
+                    row_index=blob_index,
+                    column_index=cell_index,
+                )
+            )
     return matrix
 ```
 
 ### `get_data_column_sidecars`
 
 ```python
-def get_data_column_sidecars(signed_block: SignedBeaconBlock,
-                             cells_and_kzg_proofs: Sequence[Tuple[
-        Vector[Cell, CELLS_PER_EXT_BLOB],
-        Vector[KZGProof, CELLS_PER_EXT_BLOB]]]) -> Sequence[DataColumnSidecar]:
+def get_data_column_sidecars(
+    signed_block: SignedBeaconBlock,
+    cells_and_kzg_proofs: Sequence[Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]],
+) -> Sequence[DataColumnSidecar]:
     """
     Given a signed block and the cells/proofs associated with each blob in the
     block, assemble the sidecars which can be distributed to peers.
@@ -203,7 +201,7 @@ def get_data_column_sidecars(signed_block: SignedBeaconBlock,
     signed_block_header = compute_signed_block_header(signed_block)
     kzg_commitments_inclusion_proof = compute_merkle_proof(
         signed_block.message.body,
-        get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments'),
+        get_generalized_index(BeaconBlockBody, "blob_kzg_commitments"),
     )
 
     sidecars = []
@@ -212,14 +210,16 @@ def get_data_column_sidecars(signed_block: SignedBeaconBlock,
         for cells, proofs in cells_and_kzg_proofs:
             column_cells.append(cells[column_index])
             column_proofs.append(proofs[column_index])
-        sidecars.append(DataColumnSidecar(
-            index=column_index,
-            column=column_cells,
-            kzg_commitments=blob_kzg_commitments,
-            kzg_proofs=column_proofs,
-            signed_block_header=signed_block_header,
-            kzg_commitments_inclusion_proof=kzg_commitments_inclusion_proof,
-        ))
+        sidecars.append(
+            DataColumnSidecar(
+                index=column_index,
+                column=column_cells,
+                kzg_commitments=blob_kzg_commitments,
+                kzg_proofs=column_proofs,
+                signed_block_header=signed_block_header,
+                kzg_commitments_inclusion_proof=kzg_commitments_inclusion_proof,
+            )
+        )
     return sidecars
 ```
 

--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -34,8 +34,7 @@ def is_data_available(beacon_block_root: Root) -> bool:
     # `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs.
     column_sidecars = retrieve_column_sidecars(beacon_block_root)
     return all(
-        verify_data_column_sidecar(column_sidecar)
-        and verify_data_column_sidecar_kzg_proofs(column_sidecar)
+        verify_data_column_sidecar(column_sidecar) and verify_data_column_sidecar_kzg_proofs(column_sidecar)
         for column_sidecar in column_sidecars
     )
 ```

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -123,7 +123,7 @@ def verify_data_column_sidecar_inclusion_proof(sidecar: DataColumnSidecar) -> bo
     """
     Verify if the given KZG commitments included in the given beacon block.
     """
-    gindex = get_subtree_index(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments'))
+    gindex = get_subtree_index(get_generalized_index(BeaconBlockBody, "blob_kzg_commitments"))
     return is_valid_merkle_branch(
         leaf=hash_tree_root(sidecar.kzg_commitments),
         branch=sidecar.kzg_commitments_inclusion_proof,

--- a/specs/fulu/peer-sampling.md
+++ b/specs/fulu/peer-sampling.md
@@ -56,15 +56,15 @@ def get_extended_sample_count(allowed_failures: uint64) -> uint64:
         M = int(M)
         n = int(n)
         N = int(N)
-        return sum([math_comb(n, i) * math_comb(M - n, N - i) / math_comb(M, N)
-                    for i in range(k + 1)])
+        return sum([math_comb(n, i) * math_comb(M - n, N - i) / math_comb(M, N) for i in range(k + 1)])
 
     worst_case_missing = NUMBER_OF_COLUMNS // 2 + 1
-    false_positive_threshold = hypergeom_cdf(0, NUMBER_OF_COLUMNS,
-                                             worst_case_missing, SAMPLES_PER_SLOT)
+    false_positive_threshold = hypergeom_cdf(0, NUMBER_OF_COLUMNS, worst_case_missing, SAMPLES_PER_SLOT)
     for sample_count in range(SAMPLES_PER_SLOT, NUMBER_OF_COLUMNS + 1):
-        if hypergeom_cdf(allowed_failures, NUMBER_OF_COLUMNS,
-                         worst_case_missing, sample_count) <= false_positive_threshold:
+        if (
+            hypergeom_cdf(allowed_failures, NUMBER_OF_COLUMNS, worst_case_missing, sample_count)
+            <= false_positive_threshold
+        ):
             break
     return sample_count
 ```

--- a/specs/fulu/polynomial-commitments-sampling.md
+++ b/specs/fulu/polynomial-commitments-sampling.md
@@ -151,9 +151,9 @@ def _fft_field(vals: Sequence[BLSFieldElement], roots_of_unity: Sequence[BLSFiel
 #### `fft_field`
 
 ```python
-def fft_field(vals: Sequence[BLSFieldElement],
-              roots_of_unity: Sequence[BLSFieldElement],
-              inv: bool=False) -> Sequence[BLSFieldElement]:
+def fft_field(
+    vals: Sequence[BLSFieldElement], roots_of_unity: Sequence[BLSFieldElement], inv: bool = False
+) -> Sequence[BLSFieldElement]:
     if inv:
         # Inverse FFT
         invlen = BLSFieldElement(len(vals)).pow(BLSFieldElement(BLS_MODULUS - 2))
@@ -166,9 +166,9 @@ def fft_field(vals: Sequence[BLSFieldElement],
 #### `coset_fft_field`
 
 ```python
-def coset_fft_field(vals: Sequence[BLSFieldElement],
-                    roots_of_unity: Sequence[BLSFieldElement],
-                    inv: bool=False) -> Sequence[BLSFieldElement]:
+def coset_fft_field(
+    vals: Sequence[BLSFieldElement], roots_of_unity: Sequence[BLSFieldElement], inv: bool = False
+) -> Sequence[BLSFieldElement]:
     """
     Computes an FFT/IFFT over a coset of the roots of unity.
     This is useful for when one wants to divide by a polynomial which
@@ -202,11 +202,13 @@ def coset_fft_field(vals: Sequence[BLSFieldElement],
 #### `compute_verify_cell_kzg_proof_batch_challenge`
 
 ```python
-def compute_verify_cell_kzg_proof_batch_challenge(commitments: Sequence[KZGCommitment],
-                                                  commitment_indices: Sequence[CommitmentIndex],
-                                                  cell_indices: Sequence[CellIndex],
-                                                  cosets_evals: Sequence[CosetEvals],
-                                                  proofs: Sequence[KZGProof]) -> BLSFieldElement:
+def compute_verify_cell_kzg_proof_batch_challenge(
+    commitments: Sequence[KZGCommitment],
+    commitment_indices: Sequence[CommitmentIndex],
+    cell_indices: Sequence[CellIndex],
+    cosets_evals: Sequence[CosetEvals],
+    proofs: Sequence[KZGProof],
+) -> BLSFieldElement:
     """
     Compute a random challenge ``r`` used in the universal verification equation. To compute the
     challenge, ``RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN`` and all data that can influence the
@@ -348,9 +350,7 @@ Extended KZG functions for multiproofs
 #### `compute_kzg_proof_multi_impl`
 
 ```python
-def compute_kzg_proof_multi_impl(
-        polynomial_coeff: PolynomialCoeff,
-        zs: Coset) -> Tuple[KZGProof, CosetEvals]:
+def compute_kzg_proof_multi_impl(polynomial_coeff: PolynomialCoeff, zs: Coset) -> Tuple[KZGProof, CosetEvals]:
     """
     Compute a KZG multi-evaluation proof for a set of `k` points.
 
@@ -373,17 +373,19 @@ def compute_kzg_proof_multi_impl(
     # Compute the quotient polynomial directly in monomial form
     quotient_polynomial = divide_polynomialcoeff(polynomial_coeff, denominator_poly)
 
-    return KZGProof(g1_lincomb(KZG_SETUP_G1_MONOMIAL[:len(quotient_polynomial)], quotient_polynomial)), ys
+    return KZGProof(g1_lincomb(KZG_SETUP_G1_MONOMIAL[: len(quotient_polynomial)], quotient_polynomial)), ys
 ```
 
 #### `verify_cell_kzg_proof_batch_impl`
 
 ```python
-def verify_cell_kzg_proof_batch_impl(commitments: Sequence[KZGCommitment],
-                                     commitment_indices: Sequence[CommitmentIndex],
-                                     cell_indices: Sequence[CellIndex],
-                                     cosets_evals: Sequence[CosetEvals],
-                                     proofs: Sequence[KZGProof]) -> bool:
+def verify_cell_kzg_proof_batch_impl(
+    commitments: Sequence[KZGCommitment],
+    commitment_indices: Sequence[CommitmentIndex],
+    cell_indices: Sequence[CellIndex],
+    cosets_evals: Sequence[CosetEvals],
+    proofs: Sequence[KZGProof],
+) -> bool:
     """
     Helper: Verify that a set of cells belong to their corresponding commitment.
 
@@ -425,11 +427,7 @@ def verify_cell_kzg_proof_batch_impl(commitments: Sequence[KZGCommitment],
 
     # Step 1: Compute a challenge r and its powers r^0, ..., r^{num_cells-1}
     r = compute_verify_cell_kzg_proof_batch_challenge(
-        commitments,
-        commitment_indices,
-        cell_indices,
-        cosets_evals,
-        proofs
+        commitments, commitment_indices, cell_indices, cosets_evals, proofs
     )
     r_powers = compute_powers(r, num_cells)
 
@@ -473,10 +471,12 @@ def verify_cell_kzg_proof_batch_impl(commitments: Sequence[KZGCommitment],
     rl = bls.add(rl, rlp)
 
     # Step 5: Check pairing (LL, LR) = pairing (RL, [1])
-    return (bls.pairing_check([
-        [ll, lr],
-        [rl, bls.neg(bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[0]))],
-    ]))
+    return bls.pairing_check(
+        [
+            [ll, lr],
+            [rl, bls.neg(bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[0]))],
+        ]
+    )
 ```
 
 ### Cell cosets
@@ -493,9 +493,7 @@ def coset_shift_for_cell(cell_index: CellIndex) -> BLSFieldElement:
     This function returns h.
     """
     assert cell_index < CELLS_PER_EXT_BLOB
-    roots_of_unity_brp = bit_reversal_permutation(
-        compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB)
-    )
+    roots_of_unity_brp = bit_reversal_permutation(compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB))
     return roots_of_unity_brp[FIELD_ELEMENTS_PER_CELL * cell_index]
 ```
 
@@ -511,10 +509,8 @@ def coset_for_cell(cell_index: CellIndex) -> Coset:
     This function, returns the coset.
     """
     assert cell_index < CELLS_PER_EXT_BLOB
-    roots_of_unity_brp = bit_reversal_permutation(
-        compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB)
-    )
-    return Coset(roots_of_unity_brp[FIELD_ELEMENTS_PER_CELL * cell_index:FIELD_ELEMENTS_PER_CELL * (cell_index + 1)])
+    roots_of_unity_brp = bit_reversal_permutation(compute_roots_of_unity(FIELD_ELEMENTS_PER_EXT_BLOB))
+    return Coset(roots_of_unity_brp[FIELD_ELEMENTS_PER_CELL * cell_index : FIELD_ELEMENTS_PER_CELL * (cell_index + 1)])
 ```
 
 ## Cells
@@ -546,9 +542,9 @@ def compute_cells(blob: Blob) -> Vector[Cell, CELLS_PER_EXT_BLOB]:
 #### `compute_cells_and_kzg_proofs_polynomialcoeff`
 
 ```python
-def compute_cells_and_kzg_proofs_polynomialcoeff(polynomial_coeff: PolynomialCoeff) -> Tuple[
-        Vector[Cell, CELLS_PER_EXT_BLOB],
-        Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
+def compute_cells_and_kzg_proofs_polynomialcoeff(
+    polynomial_coeff: PolynomialCoeff,
+) -> Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
     """
     Helper function which computes cells/proofs for a polynomial in coefficient form.
     """
@@ -564,9 +560,9 @@ def compute_cells_and_kzg_proofs_polynomialcoeff(polynomial_coeff: PolynomialCoe
 #### `compute_cells_and_kzg_proofs`
 
 ```python
-def compute_cells_and_kzg_proofs(blob: Blob) -> Tuple[
-        Vector[Cell, CELLS_PER_EXT_BLOB],
-        Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
+def compute_cells_and_kzg_proofs(
+    blob: Blob,
+) -> Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
     """
     Compute all the cell proofs for an extended blob. This is an inefficient O(n^2) algorithm,
     for performant implementation the FK20 algorithm that runs in O(n log n) should be
@@ -586,10 +582,12 @@ def compute_cells_and_kzg_proofs(blob: Blob) -> Tuple[
 #### `verify_cell_kzg_proof_batch`
 
 ```python
-def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
-                                cell_indices: Sequence[CellIndex],
-                                cells: Sequence[Cell],
-                                proofs_bytes: Sequence[Bytes48]) -> bool:
+def verify_cell_kzg_proof_batch(
+    commitments_bytes: Sequence[Bytes48],
+    cell_indices: Sequence[CellIndex],
+    cells: Sequence[Cell],
+    proofs_bytes: Sequence[Bytes48],
+) -> bool:
     """
     Verify that a set of cells belong to their corresponding commitments.
 
@@ -614,22 +612,21 @@ def verify_cell_kzg_proof_batch(commitments_bytes: Sequence[Bytes48],
         assert len(proof_bytes) == BYTES_PER_PROOF
 
     # Create the list of deduplicated commitments we are dealing with
-    deduplicated_commitments = [bytes_to_kzg_commitment(commitment_bytes)
-                                for commitment_bytes in set(commitments_bytes)]
+    deduplicated_commitments = [
+        bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in set(commitments_bytes)
+    ]
     # Create indices list mapping initial commitments (that may contain duplicates) to the deduplicated commitments
-    commitment_indices = [CommitmentIndex(deduplicated_commitments.index(commitment_bytes))
-                          for commitment_bytes in commitments_bytes]
+    commitment_indices = [
+        CommitmentIndex(deduplicated_commitments.index(commitment_bytes)) for commitment_bytes in commitments_bytes
+    ]
 
     cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
     proofs = [bytes_to_kzg_proof(proof_bytes) for proof_bytes in proofs_bytes]
 
     # Do the actual verification
     return verify_cell_kzg_proof_batch_impl(
-        deduplicated_commitments,
-        commitment_indices,
-        cell_indices,
-        cosets_evals,
-        proofs)
+        deduplicated_commitments, commitment_indices, cell_indices, cosets_evals, proofs
+    )
 ```
 
 ## Reconstruction
@@ -652,10 +649,12 @@ def construct_vanishing_polynomial(missing_cell_indices: Sequence[CellIndex]) ->
     roots_of_unity_reduced = compute_roots_of_unity(CELLS_PER_EXT_BLOB)
 
     # Compute polynomial that vanishes at all the missing cells (over the small domain)
-    short_zero_poly = vanishing_polynomialcoeff([
-        roots_of_unity_reduced[reverse_bits(missing_cell_index, CELLS_PER_EXT_BLOB)]
-        for missing_cell_index in missing_cell_indices
-    ])
+    short_zero_poly = vanishing_polynomialcoeff(
+        [
+            roots_of_unity_reduced[reverse_bits(missing_cell_index, CELLS_PER_EXT_BLOB)]
+            for missing_cell_index in missing_cell_indices
+        ]
+    )
 
     # Extend vanishing polynomial to full domain using the closed form of the vanishing polynomial over a coset
     zero_poly_coeff = [BLSFieldElement(0)] * FIELD_ELEMENTS_PER_EXT_BLOB
@@ -668,8 +667,7 @@ def construct_vanishing_polynomial(missing_cell_indices: Sequence[CellIndex]) ->
 ### `recover_polynomialcoeff`
 
 ```python
-def recover_polynomialcoeff(cell_indices: Sequence[CellIndex],
-                            cosets_evals: Sequence[CosetEvals]) -> PolynomialCoeff:
+def recover_polynomialcoeff(cell_indices: Sequence[CellIndex], cosets_evals: Sequence[CosetEvals]) -> PolynomialCoeff:
     """
     Recover the polynomial in coefficient form that when evaluated at the roots of unity will give the extended blob.
     """
@@ -689,8 +687,9 @@ def recover_polynomialcoeff(cell_indices: Sequence[CellIndex],
 
     # Compute the vanishing polynomial Z(x) in coefficient form.
     # Z(x) is the polynomial which vanishes on all of the evaluations which are missing.
-    missing_cell_indices = [CellIndex(cell_index) for cell_index in range(CELLS_PER_EXT_BLOB)
-                            if cell_index not in cell_indices]
+    missing_cell_indices = [
+        CellIndex(cell_index) for cell_index in range(CELLS_PER_EXT_BLOB) if cell_index not in cell_indices
+    ]
     zero_poly_coeff = construct_vanishing_polynomial(missing_cell_indices)
 
     # Convert Z(x) to evaluation form over the FFT domain
@@ -728,10 +727,9 @@ def recover_polynomialcoeff(cell_indices: Sequence[CellIndex],
 ### `recover_cells_and_kzg_proofs`
 
 ```python
-def recover_cells_and_kzg_proofs(cell_indices: Sequence[CellIndex],
-                                 cells: Sequence[Cell]) -> Tuple[
-        Vector[Cell, CELLS_PER_EXT_BLOB],
-        Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
+def recover_cells_and_kzg_proofs(
+    cell_indices: Sequence[CellIndex], cells: Sequence[Cell]
+) -> Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]:
     """
     Given at least 50% of cells for a blob, recover all the cells/proofs.
     This algorithm uses FFTs to recover cells faster than using Lagrange

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1566,9 +1566,8 @@ the epoch range that a new node syncing from a checkpoint must backfill.
 [0]: # (eth2spec: skip)
 
 ```python
-MIN_EPOCHS_FOR_BLOCK_REQUESTS = (
-    MIN_VALIDATOR_WITHDRAWABILITY_DELAY
-    + MAX_SAFETY_DECAY * CHURN_LIMIT_QUOTIENT // (2 * 100)
+MIN_EPOCHS_FOR_BLOCK_REQUESTS = MIN_VALIDATOR_WITHDRAWABILITY_DELAY + MAX_SAFETY_DECAY * CHURN_LIMIT_QUOTIENT // (
+    2 * 100
 )
 ```
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -208,10 +208,9 @@ Once a validator is activated, the validator is assigned [responsibilities](#bea
 A validator can get committee assignments for a given epoch using the following helper via `get_committee_assignment(state, epoch, validator_index)` where `epoch <= next_epoch`.
 
 ```python
-def get_committee_assignment(state: BeaconState,
-                             epoch: Epoch,
-                             validator_index: ValidatorIndex
-                             ) -> Optional[Tuple[Sequence[ValidatorIndex], CommitteeIndex, Slot]]:
+def get_committee_assignment(
+    state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex
+) -> Optional[Tuple[Sequence[ValidatorIndex], CommitteeIndex, Slot]]:
     """
     Return the committee assignment in the ``epoch`` for ``validator_index``.
     ``assignment`` returned is a tuple of the following form:
@@ -370,7 +369,8 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
     period_start = voting_period_start_time(state)
     # `eth1_chain` abstractly represents all blocks in the eth1 chain sorted by ascending block height
     votes_to_consider = [
-        get_eth1_data(block) for block in eth1_chain
+        get_eth1_data(block)
+        for block in eth1_chain
         if (
             is_candidate_block(block, period_start)
             # Ensure cannot move back to earlier deposit contract states
@@ -389,7 +389,7 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
     return max(
         valid_votes,
         key=lambda v: (valid_votes.count(v), -valid_votes.index(v)),  # Tiebreak by smallest distance
-        default=default_vote
+        default=default_vote,
     )
 ```
 
@@ -516,9 +516,9 @@ The `subnet_id` for the `attestation` is calculated with:
 - Let `subnet_id = compute_subnet_for_attestation(committees_per_slot, attestation.data.slot, attestation.data.index)`.
 
 ```python
-def compute_subnet_for_attestation(committees_per_slot: uint64,
-                                   slot: Slot,
-                                   committee_index: CommitteeIndex) -> SubnetID:
+def compute_subnet_for_attestation(
+    committees_per_slot: uint64, slot: Slot, committee_index: CommitteeIndex
+) -> SubnetID:
     """
     Compute the correct subnet for an attestation for Phase 0.
     Note, this mimics expected future behavior where attestations will be mapped to their shard subnet.
@@ -586,10 +586,9 @@ Selection proofs are provided in `AggregateAndProof` to prove to the gossip chan
 First, `aggregate_and_proof = get_aggregate_and_proof(state, validator_index, aggregate_attestation, privkey)` is constructed.
 
 ```python
-def get_aggregate_and_proof(state: BeaconState,
-                            aggregator_index: ValidatorIndex,
-                            aggregate: Attestation,
-                            privkey: int) -> AggregateAndProof:
+def get_aggregate_and_proof(
+    state: BeaconState, aggregator_index: ValidatorIndex, aggregate: Attestation, privkey: int
+) -> AggregateAndProof:
     return AggregateAndProof(
         aggregator_index=aggregator_index,
         aggregate=aggregate,
@@ -600,9 +599,9 @@ def get_aggregate_and_proof(state: BeaconState,
 Then `signed_aggregate_and_proof = SignedAggregateAndProof(message=aggregate_and_proof, signature=signature)` is constructed and broadcast. Where `signature` is obtained from:
 
 ```python
-def get_aggregate_and_proof_signature(state: BeaconState,
-                                      aggregate_and_proof: AggregateAndProof,
-                                      privkey: int) -> BLSSignature:
+def get_aggregate_and_proof_signature(
+    state: BeaconState, aggregate_and_proof: AggregateAndProof, privkey: int
+) -> BLSSignature:
     aggregate = aggregate_and_proof.aggregate
     domain = get_domain(state, DOMAIN_AGGREGATE_AND_PROOF, compute_epoch_at_slot(aggregate.data.slot))
     signing_root = compute_signing_root(aggregate_and_proof, domain)

--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -102,17 +102,11 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
     D = SAFETY_DECAY
 
     if T * (200 + 3 * D) < t * (200 + 12 * D):
-        epochs_for_validator_set_churn = (
-            N * (t * (200 + 12 * D) - T * (200 + 3 * D)) // (600 * delta * (2 * t + T))
-        )
-        epochs_for_balance_top_ups = (
-            N * (200 + 3 * D) // (600 * Delta)
-        )
+        epochs_for_validator_set_churn = N * (t * (200 + 12 * D) - T * (200 + 3 * D)) // (600 * delta * (2 * t + T))
+        epochs_for_balance_top_ups = N * (200 + 3 * D) // (600 * Delta)
         ws_period += max(epochs_for_validator_set_churn, epochs_for_balance_top_ups)
     else:
-        ws_period += (
-            3 * N * D * t // (200 * Delta * (T - t))
-        )
+        ws_period += 3 * N * D * t // (200 * Delta * (T - t))
 
     return ws_period
 ```

--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -114,8 +114,9 @@ def item_length(typ: SSZType) -> int:
 ```
 
 ```python
-def get_elem_type(typ: Union[BaseBytes, BaseList, Container],
-                  index_or_variable_name: Union[int, SSZVariableName]) -> SSZType:
+def get_elem_type(
+    typ: Union[BaseBytes, BaseList, Container], index_or_variable_name: Union[int, SSZVariableName]
+) -> SSZType:
     """
     Return the type of the element of an object of the given type with the given index
     or member variable name (eg. `7` for `x[7]`, `"foo"` for `x.foo`)
@@ -174,13 +175,13 @@ def get_generalized_index(typ: SSZType, *path: PyUnion[int, SSZVariableName]) ->
     root = GeneralizedIndex(1)
     for p in path:
         assert not issubclass(typ, BasicValue)  # If we descend to a basic type, the path cannot continue further
-        if p == '__len__':
+        if p == "__len__":
             assert issubclass(typ, (List, ByteList))
             typ = uint64
             root = GeneralizedIndex(root * 2 + 1)
         else:
             pos, _, _ = get_item_position(typ, p)
-            base_index = (GeneralizedIndex(2) if issubclass(typ, (List, ByteList)) else GeneralizedIndex(1))
+            base_index = GeneralizedIndex(2) if issubclass(typ, (List, ByteList)) else GeneralizedIndex(1)
             root = GeneralizedIndex(root * base_index * get_power_of_two_ceil(chunk_count(typ)) + pos)
             typ = get_elem_type(typ, p)
     return root
@@ -321,15 +322,15 @@ def verify_merkle_proof(leaf: Bytes32, proof: Sequence[Bytes32], index: Generali
 Now for multi-item proofs:
 
 ```python
-def calculate_multi_merkle_root(leaves: Sequence[Bytes32],
-                                proof: Sequence[Bytes32],
-                                indices: Sequence[GeneralizedIndex]) -> Root:
+def calculate_multi_merkle_root(
+    leaves: Sequence[Bytes32], proof: Sequence[Bytes32], indices: Sequence[GeneralizedIndex]
+) -> Root:
     assert len(leaves) == len(indices)
     helper_indices = get_helper_indices(indices)
     assert len(proof) == len(helper_indices)
     objects = {
         **{index: node for index, node in zip(indices, leaves)},
-        **{index: node for index, node in zip(helper_indices, proof)}
+        **{index: node for index, node in zip(helper_indices, proof)},
     }
     keys = sorted(objects.keys(), reverse=True)
     pos = 0
@@ -337,8 +338,7 @@ def calculate_multi_merkle_root(leaves: Sequence[Bytes32],
         k = keys[pos]
         if k in objects and k ^ 1 in objects and k // 2 not in objects:
             objects[GeneralizedIndex(k // 2)] = hash(
-                objects[GeneralizedIndex((k | 1) ^ 1)] +
-                objects[GeneralizedIndex(k | 1)]
+                objects[GeneralizedIndex((k | 1) ^ 1)] + objects[GeneralizedIndex(k | 1)]
             )
             keys.append(GeneralizedIndex(k // 2))
         pos += 1
@@ -346,10 +346,9 @@ def calculate_multi_merkle_root(leaves: Sequence[Bytes32],
 ```
 
 ```python
-def verify_merkle_multiproof(leaves: Sequence[Bytes32],
-                             proof: Sequence[Bytes32],
-                             indices: Sequence[GeneralizedIndex],
-                             root: Root) -> bool:
+def verify_merkle_multiproof(
+    leaves: Sequence[Bytes32], proof: Sequence[Bytes32], indices: Sequence[GeneralizedIndex], root: Root
+) -> bool:
     return calculate_multi_merkle_root(leaves, proof, indices) == root
 ```
 

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -162,7 +162,7 @@ variable_parts = [serialize(element) if is_variable_size(element) else b"" for e
 # Compute and check lengths
 fixed_lengths = [len(part) if part != None else BYTES_PER_LENGTH_OFFSET for part in fixed_parts]
 variable_lengths = [len(part) for part in variable_parts]
-assert sum(fixed_lengths + variable_lengths) < 2**(BYTES_PER_LENGTH_OFFSET * BITS_PER_BYTE)
+assert sum(fixed_lengths + variable_lengths) < 2 ** (BYTES_PER_LENGTH_OFFSET * BITS_PER_BYTE)
 
 # Interleave offsets of variable-size parts with fixed-size parts
 variable_offsets = [serialize(uint32(sum(fixed_lengths + variable_lengths[:i]))) for i in range(len(value))]


### PR DESCRIPTION
Hi there!

This pull request adds formatting to python blocks in markdown files, as suggested by https://github.com/ethereum/consensus-specs/issues/3281

I ended up using [`blacken-docs`](https://pypi.org/project/blacken-docs/) (which uses [`black`](https://pypi.org/project/black/) as the formatter) after trialing a few options. It was both fastest and had the simplest usage. `black` has the advantage (over `ruff` and `pycodestyle`) since it has a Python API, allowing wrappers like `blacken-docs` to be much smoother instead of needing `subprocess`es.

This is a deviation from the formatting tools already used in this project. The existing formatter, `pycodestyle`, was a pain to get working in markdown files. I could not find a wrapper specifically for it, so tried a generic one ([doccmd](https://pypi.org/project/doccmd/)), but their interaction made it so inconvenient to use that it was simply not feasible (ie. it would exit after one issue found). Trying `ruff` (with a simple wrapper of [md-snakeoil](https://pypi.org/project/md-snakeoil/)) was much smoother, but it was much slower (30s vs. 3s) because of the `subprocess`es, and the wrapper was not as mature. (If `ruff` was desired, they are eventually making that possible firsthand, which would then be a better option; [reference](https://github.com/astral-sh/ruff/issues/3792)). So it was tough to not go with `blacken-docs` when it _just worked_.

Suggestions appreciated.