### PR TITLE
Change Store.inclusion_list from List to Set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,12 +243,16 @@ gen_all: $(GENERATOR_TARGETS)
 
 # Detect errors in generators.
 detect_errors: $(TEST_VECTOR_DIR)
-	@find $(TEST_VECTOR_DIR) -name "INCOMPLETE"
+	@incomplete_files=$$(find $(TEST_VECTOR_DIR) -name "INCOMPLETE"); \
+	if [ -n "$$incomplete_files" ]; then \
+		echo "[ERROR] incomplete detected"; \
+		exit 1; \
+	fi
 	@if [ -f $(GENERATOR_ERROR_LOG_FILE) ]; then \
 		echo "[ERROR] $(GENERATOR_ERROR_LOG_FILE) file exists"; \
-	else \
-		echo "[PASSED] error log file does not exist"; \
+		exit 1; \
 	fi
+	@echo "[PASSED] no errors detected"
 
 # Generate KZG trusted setups for testing.
 kzg_setups: pyspec

--- a/specs/_features/eip7805/fork-choice.md
+++ b/specs/_features/eip7805/fork-choice.md
@@ -57,7 +57,7 @@ class Store(object):
     latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
     unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
     # [New in EIP-7805]
-    inclusion_lists: Dict[Tuple[Slot, Root], Sequence[InclusionList]] = field(default_factory=dict)
+    inclusion_lists: Dict[Tuple[Slot, Root], Set[InclusionList]] = field(default_factory=dict)
     inclusion_list_equivocators: Dict[Tuple[Slot, Root], Set[ValidatorIndex]] = field(default_factory=dict)
     unsatisfied_inclusion_list_blocks: Set[Root] = field(default_factory=Set)
 ```
@@ -200,5 +200,5 @@ def on_inclusion_list(
                 store.inclusion_list_equivocators[(message.slot, root)].add(validator_index)
         # This inclusion list is not an equivocation. Store it if prior to the view freeze deadline
         elif is_before_freeze_deadline:
-            store.inclusion_lists[(message.slot, root)].append(message)
+            store.inclusion_lists[(message.slot, root)].add(message)
 ```

--- a/specs/_features/eip7805/fork-choice.md
+++ b/specs/_features/eip7805/fork-choice.md
@@ -57,7 +57,7 @@ class Store(object):
     latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
     unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
     # [New in EIP-7805]
-    inclusion_lists: Dict[Tuple[Slot, Root], List[InclusionList]] = field(default_factory=dict)
+    inclusion_lists: Dict[Tuple[Slot, Root], Sequence[InclusionList]] = field(default_factory=dict)
     inclusion_list_equivocators: Dict[Tuple[Slot, Root], Set[ValidatorIndex]] = field(default_factory=dict)
     unsatisfied_inclusion_list_blocks: Set[Root] = field(default_factory=Set)
 ```


### PR DESCRIPTION
The `remerkleable.List` type must have a max length associated with it. Pretty sure this should be a Set instead. I noticed this because some test generators were failing. Our `detect_errors` rule didn't pick up on that, fixed that too.