### PR TITLE
Update canonical network names for Hoodi

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -6,7 +6,9 @@ PRESET_BASE: 'mainnet'
 # Free-form short name of the network that this configuration applies to - known
 # canonical network names include:
 # * 'mainnet' - there can be only one
-# * 'prater' - testnet
+# * 'sepolia' - testnet
+# * 'holesky' - testnet
+# * 'hoodi' - testnet
 # Must match the regex: [a-z0-9\-]
 CONFIG_NAME: 'mainnet'
 

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -5,8 +5,7 @@ PRESET_BASE: 'minimal'
 
 # Free-form short name of the network that this configuration applies to - known
 # canonical network names include:
-# * 'mainnet' - there can be only one
-# * 'prater' - testnet
+# * 'minimal' - spec-testing
 # Must match the regex: [a-z0-9\-]
 CONFIG_NAME: 'minimal'
 

--- a/presets/README.md
+++ b/presets/README.md
@@ -8,7 +8,7 @@ An implementation may choose to only support 1 preset per build-target and shoul
 the `PRESET_BASE` variable in the config matches the running build.
 
 Standard presets:
-- [`mainnet/`](./mainnet): Used in mainnet, mainnet-like testnets (e.g. Prater), and spec-testing
+- [`mainnet/`](./mainnet): Used in mainnet, mainnet-like testnets (e.g. Hoodi), and spec-testing
 - [`minimal/`](./minimal): Used in low-resource local dev testnets, and spec-testing
 
 Client implementers may opt to support additional presets, e.g. for extra large beacon states for benchmarking.


### PR DESCRIPTION
Bump config documentation to reflect current set of maintained testnets.