### PR TITLE
Add note about aggregate key in SyncCommittee

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -210,6 +210,7 @@ class SyncAggregate(Container):
 ```
 
 #### `SyncCommittee`
+*Note:* The `aggregate_pubkey` field is computed but is not currently used in the specifications. Typically, sync committee signatures are verified by summing up the public keys of the subset of committee members that signed to obtain their aggregate public key. Notably, this key is different from `aggregate_pubkey`, as it only represents a subset of the committee. The `aggregate_pubkey` field can be used in the following optimization: If more than half of the sync committee members have signed, their aggregate public key can be derived more efficiently by subtracting the keys of the missing members from aggregate_pubkey.
 
 ```python
 class SyncCommittee(Container):

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -443,7 +443,9 @@ def validate_light_client_update(store: LightClientStore,
     signing_root = compute_signing_root(update.attested_header.beacon, domain)
     assert bls.FastAggregateVerify(participant_pubkeys, signing_root, sync_aggregate.sync_committee_signature)
 ```
+
 *Note:* `bls.FastAggregateVerify` internally computes an aggregate public key by summing individual keys from `participant_pubkeys`. There are two potential optimizations:
+
 1. If `len(participant_pubkeys) > sync_committee.pubkeys - len(participant_pubkeys)`, computing the aggregate public key can be more efficient by subtracting the non-participating keys from `sync_committee.aggregate_pubkey` instead of summing the participants.
 2. Assuming the same sync committee members participate across sequential slots, one can optimize further by caching the aggregate public key from the previous slot(s) and incrementally updating it (by adding and subtracting individual keys) for the next slot, where we consider two slots with the same sync committee.
 

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -443,6 +443,9 @@ def validate_light_client_update(store: LightClientStore,
     signing_root = compute_signing_root(update.attested_header.beacon, domain)
     assert bls.FastAggregateVerify(participant_pubkeys, signing_root, sync_aggregate.sync_committee_signature)
 ```
+*Note:* `bls.FastAggregateVerify` internally computes an aggregate public key by summing individual keys from `participant_pubkeys`. There are two potential optimizations:
+1. If `len(participant_pubkeys) > sync_committee.pubkeys - len(participant_pubkeys)`, computing the aggregate public key can be more efficient by subtracting the non-participating keys from `sync_committee.aggregate_pubkey` instead of summing the participants.
+2. Assuming the same sync committee members participate across sequential slots, one can optimize further by caching the aggregate public key from the previous slot(s) and incrementally updating it (by adding and subtracting individual keys) for the next slot, where we consider two slots with the same sync committee.
 
 ### `apply_light_client_update`
 


### PR DESCRIPTION
I observed that the `aggregate_pubkey` field of `SyncCommittee` is never used.
It is set [here](https://github.com/ethereum/consensus-specs/blob/ff99bc03d6da29d9ef6e055bdb8500e1b2942f1e/specs/altair/beacon-chain.md?plain=1#L308), but in verification (e.g., [here](https://github.com/ethereum/consensus-specs/blob/ccd5d8fd2d35178adeffea3b8ff6459b8246ea97/specs/altair/beacon-chain.md?plain=1#L541)) an aggregate pubkey representing a *subset* of the sync committee is assembled.

After discussion with @jtraglia and after looking at client implementations, it seems that only one client actually uses `aggregate_pubkey` (see [here](https://github.com/status-im/nimbus-eth2/blob/fad7b9a7133faf63efb552b6caaa3fb1554aba19/beacon_chain/spec/light_client_sync.nim#L173)). To document these findings, I propose adding a note as in this PR, sketching the optimization.