### PR TITLE
Fulu validator custody: Use finalized state as inactivity leak protection.

### DIFF
--- a/specs/fulu/validator.md
+++ b/specs/fulu/validator.md
@@ -106,7 +106,7 @@ def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> GetPayloadRespo
 
 A node with validators attached downloads and custodies a higher minimum of custody groups per slot,
 determined by `get_validators_custody_requirement(state, validator_indices)`. Here, `state` is the
-current `BeaconState` and `validator_indices` is the list of indices corresponding to validators
+latest finalized `BeaconState` and `validator_indices` is the list of indices corresponding to validators
 attached to the node. Any node with at least one validator attached, and with the sum of the
 balances of all attached validators being `total_node_balance`, downloads and custodies
 `total_node_balance // BALANCE_PER_ADDITIONAL_CUSTODY_GROUP` custody groups per slot, with a minimum


### PR DESCRIPTION
In `get_validators_custody_requirement`, use the latest finalized state as `BeaconState` instead of the current beacon state.

**Rationale:**
During an inactivity leak, the balances of always-offline validators will continuously decrease.
As a result, the announced ENR/metadata custody group count will also decrease.

The more time passes, the harder it will be for a beacon node to correctly sync with all its required columns.

By using the latest finalized beacon state instead of the current beacon state in the `get_validators_custody_requirement` function, we ensure that in the event of an inactivity leak, the announced custody group count remains consistent with the checkpoint just before the inactivity leak began.

**Note:**
Once the network finalizes again, a drop in the custody group count may still occur for heavily penalized nodes.
However, the goal of this PR is to minimize disruption in what may already be a chaotic situation—the inactivity leak.

