### PR TITLE
Fix a small bug in a pending consolidation test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/sanity/test_slots.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/test_slots.py
@@ -111,7 +111,7 @@ def test_pending_consolidation(spec, state):
     # Set withdrawable epoch to current epoch to allow processing
     state.validators[source_index].withdrawable_epoch = current_epoch
     # Set the source withdrawal credential to eth1
-    state.validators[target_index].withdrawal_credentials = (
+    state.validators[source_index].withdrawal_credentials = (
         spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX + b"\x00" * 11 + b"\x11" * 20
     )
     # Set the target withdrawal credential to compounding


### PR DESCRIPTION
Noticed this while reviewing tests. The reason the test passes is because we manually add the pending consolidation to the state. If we had gone through `process_consolidation_request` it wouldn't have worked. So technically an impossible situation, but it doesn't really matter.