### PR TITLE
State that effective balance should be used

### DIFF
--- a/specs/fulu/validator.md
+++ b/specs/fulu/validator.md
@@ -48,7 +48,7 @@ document and used throughout.
 | Name | Value | Description |
 | - | - | - |
 | `VALIDATOR_CUSTODY_REQUIREMENT` | `8` | Minimum number of custody groups an honest node with validators attached custodies and serves samples from |
-| `BALANCE_PER_ADDITIONAL_CUSTODY_GROUP` | `Gwei(32 * 10**9)` | Balance increment corresponding to one additional group to custody |
+| `BALANCE_PER_ADDITIONAL_CUSTODY_GROUP` | `Gwei(32 * 10**9)` | Effective balance increment corresponding to one additional group to custody |
 
 ## Helpers
 
@@ -108,15 +108,15 @@ A node with validators attached downloads and custodies a higher minimum of cust
 determined by `get_validators_custody_requirement(state, validator_indices)`. Here, `state` is the
 current `BeaconState` and `validator_indices` is the list of indices corresponding to validators
 attached to the node. Any node with at least one validator attached, and with the sum of the
-balances of all attached validators being `total_node_balance`, downloads and custodies
+effective balances of all attached validators being `total_node_balance`, downloads and custodies
 `total_node_balance // BALANCE_PER_ADDITIONAL_CUSTODY_GROUP` custody groups per slot, with a minimum
 of `VALIDATOR_CUSTODY_REQUIREMENT` and of course a maximum of `NUMBER_OF_CUSTODY_GROUPS`. The node
-SHOULD dynamically adjust its custody groups following any changes to the balances of attached
-validators.
+SHOULD dynamically adjust its custody groups following any changes to the effective balances of
+attached validators.
 
 ```python
 def get_validators_custody_requirement(state: BeaconState, validator_indices: Sequence[ValidatorIndex]) -> uint64:
-    total_node_balance = sum(state.balances[index] for index in validator_indices)
+    total_node_balance = sum(state.validators[index].effective_balance for index in validator_indices)
     count = total_node_balance // BALANCE_PER_ADDITIONAL_CUSTODY_GROUP
     return min(max(count, VALIDATOR_CUSTODY_REQUIREMENT), NUMBER_OF_CUSTODY_GROUPS)
 ```
@@ -125,9 +125,10 @@ This higher custody is advertised in the node's Metadata by setting a higher `cu
 and in the node's ENR by setting a higher `custody_group_count`. As with the regular custody
 requirement, a node with validators MAY still choose to custody, advertise and serve more than
 this minimum. As with the regular custody requirement, a node MUST backfill columns when syncing. In
-addition, when the validator custody requirement increases, due to an increase in the total balance
-of the attached validators, a node MUST backfill columns from the new custody groups. However, a
-node MAY wait to advertise a higher custody in its Metadata and ENR until backfilling is complete.
+addition, when the validator custody requirement increases, due to an increase in the total
+effective balance of the attached validators, a node MUST backfill columns from the new custody
+groups. However, a node MAY wait to advertise a higher custody in its Metadata and ENR until
+backfilling is complete.
 
 *Note:* The node SHOULD manage validator custody (and any changes during its lifetime) without any
 input from the user, for example by using existing signals about validator metadata to compute the


### PR DESCRIPTION
We should use validators' effective balances (rather than their balances) to determine which columns a node custodies.

Fixes #4212.