### PR TITLE
Use consistent note style

### DIFF
--- a/specs/_deprecated/custody_game/beacon-chain.md
+++ b/specs/_deprecated/custody_game/beacon-chain.md
@@ -1,6 +1,6 @@
 # Custody Game -- The Beacon Chain
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_deprecated/custody_game/validator.md
+++ b/specs/_deprecated/custody_game/validator.md
@@ -1,6 +1,6 @@
 # Custody Game -- Honest Validator
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_deprecated/das/das-core.md
+++ b/specs/_deprecated/das/das-core.md
@@ -1,6 +1,6 @@
 # Data Availability Sampling -- Core
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_deprecated/das/fork-choice.md
+++ b/specs/_deprecated/das/fork-choice.md
@@ -1,6 +1,6 @@
 # Data Availability Sampling -- Fork Choice
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_deprecated/das/p2p-interface.md
+++ b/specs/_deprecated/das/p2p-interface.md
@@ -1,6 +1,6 @@
 # Data Availability Sampling -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -123,7 +123,7 @@ This backbone is based on a pure function of the *node* identity and time:
   assuming the peerstore already has a large enough variety of peers.
 - Nodes can be held accountable for contributing to the backbone:
   peers that participate in DAS but are not active on the appropriate backbone topics can be scored down.
-  *Note: This is experimental, DAS should be light enough for all participants to run, but scoring needs to undergo testing*
+  *Note*: This is experimental, DAS should be light enough for all participants to run, but scoring needs to undergo testing.
 
 A node should anticipate backbone topics to subscribe to based their own identity.
 These subscriptions rotate slowly, and with different offsets per node identity to avoid sudden network-wide rotations.

--- a/specs/_deprecated/das/sampling.md
+++ b/specs/_deprecated/das/sampling.md
@@ -1,6 +1,6 @@
 # Data Availability Sampling -- Sampling
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_deprecated/sharding/beacon-chain.md
+++ b/specs/_deprecated/sharding/beacon-chain.md
@@ -1,6 +1,6 @@
 # Sharding -- The Beacon Chain
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -98,7 +98,7 @@ With the introduction of builder blocks the number of slots per epoch is doubled
 
 ## Configuration
 
-Note: Some preset variables may become run-time configurable for testnets, but default to a preset while the spec is unstable.
+*Note*: Some preset variables may become run-time configurable for testnets, but default to a preset while the spec is unstable.
 E.g. `ACTIVE_SHARDS` and `SAMPLES_PER_BLOB`.
 
 ### Time parameters

--- a/specs/_deprecated/sharding/p2p-interface.md
+++ b/specs/_deprecated/sharding/p2p-interface.md
@@ -1,6 +1,6 @@
 # Sharding -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_deprecated/sharding/polynomial-commitments.md
+++ b/specs/_deprecated/sharding/polynomial-commitments.md
@@ -1,6 +1,6 @@
 # Sharding -- Polynomial Commitments
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_deprecated/sharding/validator.md
+++ b/specs/_deprecated/sharding/validator.md
@@ -1,6 +1,6 @@
 # Sharding -- Honest Validator
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -1,6 +1,6 @@
 # EIP6800 -- The Beacon Chain
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_features/eip6800/fork.md
+++ b/specs/_features/eip6800/fork.md
@@ -1,6 +1,6 @@
 # EIP-6800 -- Fork Logic
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_features/eip6914/beacon-chain.md
+++ b/specs/_features/eip6914/beacon-chain.md
@@ -1,6 +1,6 @@
 # EIP-6914 -- The Beacon Chain
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -25,7 +25,7 @@
 
 This is the beacon chain specification to assign new deposits to existing validator records. Refers to [EIP-6914](https://github.com/ethereum/EIPs/pull/6914).
 
-*Note:* This specification is built upon [Capella](../../capella/beacon-chain.md) and is under active development.
+*Note*: This specification is built upon [Capella](../../capella/beacon-chain.md) and is under active development.
 
 ## Preset
 

--- a/specs/_features/eip6914/fork-choice.md
+++ b/specs/_features/eip6914/fork-choice.md
@@ -1,6 +1,6 @@
 # EIP-6914 -- Fork Choice
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_features/eip7441/beacon-chain.md
+++ b/specs/_features/eip7441/beacon-chain.md
@@ -1,6 +1,6 @@
 # EIP-7441 -- The Beacon Chain
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -33,7 +33,7 @@
 
 This document details the beacon chain additions and changes of to support the EIP-7441 (Whisk SSLE).
 
-*Note:* This specification is built upon [capella](../../capella/beacon-chain.md) and is under active development.
+*Note*: This specification is built upon [capella](../../capella/beacon-chain.md) and is under active development.
 
 ## Constants
 

--- a/specs/_features/eip7441/fork.md
+++ b/specs/_features/eip7441/fork.md
@@ -1,6 +1,6 @@
 # EIP-7441 -- Fork Logic
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -1,6 +1,6 @@
 # EIP-7732 -- The Beacon Chain
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -67,7 +67,7 @@
 
 This is the beacon chain specification of the enshrined proposer builder separation feature.
 
-*Note:* This specification is built upon [Electra](../../electra/beacon-chain.md) and is under active development.
+*Note*: This specification is built upon [Electra](../../electra/beacon-chain.md) and is under active development.
 
 This feature adds new staked consensus participants called *Builders* and new honest validators duties called *payload timeliness attestations*. The slot is divided in **four** intervals. Honest validators gather *signed bids* (a `SignedExecutionPayloadHeader`) from builders and submit their consensus blocks (a `SignedBeaconBlock`) including these bids at the beginning of the slot. At the start of the second interval, honest validators submit attestations just as they do previous to this feature). At the  start of the third interval, aggregators aggregate these attestations and the builder broadcasts either a full payload or a message indicating that they are withholding the payload (a `SignedExecutionPayloadEnvelope`). At the start of the fourth interval, some validators selected to be members of the new **Payload Timeliness Committee** (PTC) attest to the presence and timeliness of the builder's payload.
 
@@ -182,7 +182,7 @@ class SignedExecutionPayloadEnvelope(Container):
 
 #### `BeaconBlockBody`
 
-**Note:** The Beacon Block body is modified to contain a `Signed ExecutionPayloadHeader`. The containers `BeaconBlock` and `SignedBeaconBlock` are modified indirectly. The field `execution_requests` is removed from the beacon block body and moved into the signed execution payload envelope.
+*Note*: The Beacon Block body is modified to contain a `Signed ExecutionPayloadHeader`. The containers `BeaconBlock` and `SignedBeaconBlock` are modified indirectly. The field `execution_requests` is removed from the beacon block body and moved into the signed execution payload envelope.
 
 ```python
 class BeaconBlockBody(Container):
@@ -208,7 +208,7 @@ class BeaconBlockBody(Container):
 
 #### `ExecutionPayloadHeader`
 
-**Note:** The `ExecutionPayloadHeader` is modified to only contain the block hash of the committed `ExecutionPayload` in addition to the builder's payment information, gas limit and KZG commitments root to verify the inclusion proofs.
+*Note*: The `ExecutionPayloadHeader` is modified to only contain the block hash of the committed `ExecutionPayload` in addition to the builder's payment information, gas limit and KZG commitments root to verify the inclusion proofs.
 
 ```python
 class ExecutionPayloadHeader(Container):
@@ -447,7 +447,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 ##### Modified `process_withdrawals`
 
-**Note:** This is modified to take only the `state` as parameter. Withdrawals are deterministic given the beacon state, any execution payload that has the corresponding block as parent beacon block is required to honor these withdrawals in the execution layer. This function must be called before `process_execution_payload_header` as this latter function affects validator balances.
+*Note*: This is modified to take only the `state` as parameter. Withdrawals are deterministic given the beacon state, any execution payload that has the corresponding block as parent beacon block is required to honor these withdrawals in the execution layer. This function must be called before `process_execution_payload_header` as this latter function affects validator balances.
 
 ```python
 def process_withdrawals(state: BeaconState) -> None:
@@ -529,7 +529,7 @@ def process_execution_payload_header(state: BeaconState, block: BeaconBlock) -> 
 
 ##### Modified `process_operations`
 
-**Note:** `process_operations` is modified to process PTC attestations
+*Note*: `process_operations` is modified to process PTC attestations
 
 ```python
 def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:

--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -1,6 +1,6 @@
 # EIP-7732 -- Honest Builder
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_features/eip7732/fork-choice.md
+++ b/specs/_features/eip7732/fork-choice.md
@@ -1,6 +1,6 @@
 # EIP-7732 -- Fork Choice
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -71,7 +71,7 @@ class ChildNode(Container):
 
 ### Modified `LatestMessage`
 
-**Note:** The class is modified to keep track of the slot instead of the epoch.
+*Note*: The class is modified to keep track of the slot instead of the epoch.
 
 ```python
 @dataclass(eq=True, frozen=True)
@@ -82,7 +82,7 @@ class LatestMessage(object):
 
 ### Modified `update_latest_messages`
 
-**Note:** the function `update_latest_messages` is updated to use the attestation slot instead of target. Notice that this function is only called on validated attestations and validators cannot attest twice in the same epoch without equivocating. Notice also that target epoch number and slot number are validated on `validate_on_attestation`.
+*Note*: the function `update_latest_messages` is updated to use the attestation slot instead of target. Notice that this function is only called on validated attestations and validators cannot attest twice in the same epoch without equivocating. Notice also that target epoch number and slot number are validated on `validate_on_attestation`.
 
 ```python
 def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIndex], attestation: Attestation) -> None:
@@ -96,7 +96,7 @@ def update_latest_messages(store: Store, attesting_indices: Sequence[ValidatorIn
 
 ### Modified `Store`
 
-**Note:** `Store` is modified to track the intermediate states of "empty" consensus blocks, that is, those consensus blocks for which the corresponding execution payload has not been revealed or has not been included on chain.
+*Note*: `Store` is modified to track the intermediate states of "empty" consensus blocks, that is, those consensus blocks for which the corresponding execution payload has not been revealed or has not been included on chain.
 
 ```python
 @dataclass
@@ -202,7 +202,7 @@ def is_parent_node_full(store: Store, block: BeaconBlock) -> bool:
 
 ### Modified `get_ancestor`
 
-**Note:** `get_ancestor` is modified to return whether the chain is based on an *empty* or *full* block.
+*Note*: `get_ancestor` is modified to return whether the chain is based on an *empty* or *full* block.
 
 ```python
 def get_ancestor(store: Store, root: Root, slot: Slot) -> ChildNode:
@@ -223,7 +223,7 @@ def get_ancestor(store: Store, root: Root, slot: Slot) -> ChildNode:
 
 ### Modified `get_checkpoint_block`
 
-**Note:** `get_checkpoint_block` is modified to use the new `get_ancestor`
+*Note*: `get_checkpoint_block` is modified to use the new `get_ancestor`
 
 ```python
 def get_checkpoint_block(store: Store, root: Root, epoch: Epoch) -> Root:
@@ -315,7 +315,7 @@ def compute_reveal_boost(store: Store, state: BeaconState, node: ChildNode) -> G
 
 ### Modified `get_weight`
 
-**Note:** `get_weight` is modified to only count votes for descending chains that support the status of a triple `Root, Slot, bool`, where the `bool` indicates if the block was full or not. `Slot` is needed for a correct implementation of `(Block, Slot)` voting.
+*Note*: `get_weight` is modified to only count votes for descending chains that support the status of a triple `Root, Slot, bool`, where the `bool` indicates if the block was full or not. `Slot` is needed for a correct implementation of `(Block, Slot)` voting.
 
 ```python
 def get_weight(store: Store, node: ChildNode) -> Gwei:
@@ -341,7 +341,7 @@ def get_weight(store: Store, node: ChildNode) -> Gwei:
 
 ### Modified `get_head`
 
-**Note:** `get_head` is a modified to use the new `get_weight` function. It returns the `ChildNode` object corresponding to the head block.
+*Note*: `get_head` is a modified to use the new `get_weight` function. It returns the `ChildNode` object corresponding to the head block.
 
 ```python
 def get_head(store: Store) -> ChildNode:

--- a/specs/_features/eip7732/fork.md
+++ b/specs/_features/eip7732/fork.md
@@ -1,6 +1,6 @@
 # EIP-7732 -- Fork Logic
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -1,6 +1,6 @@
 # EIP-7732 -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_features/eip7732/validator.md
+++ b/specs/_features/eip7732/validator.md
@@ -1,6 +1,6 @@
 # EIP-7732 -- Honest Validator
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/_features/eip7805/beacon-chain.md
+++ b/specs/_features/eip7805/beacon-chain.md
@@ -37,7 +37,7 @@
 This is the beacon chain specification to add EIP-7805 / fork-choice enforced, committee-based inclusion list (FOCIL) mechanism to allow forced transaction inclusion. Refers to the following posts:
 - [Fork-Choice enforced Inclusion Lists (FOCIL): A simple committee-based inclusion list proposal](https://ethresear.ch/t/fork-choice-enforced-inclusion-lists-focil-a-simple-committee-based-inclusion-list-proposal/19870/1)
 - [FOCIL CL & EL workflow](https://ethresear.ch/t/focil-cl-el-workflow/20526)
-*Note:* This specification is built upon [Electra](../../electra/beacon_chain.md) and is under active development.
+*Note*: This specification is built upon [Electra](../../electra/beacon_chain.md) and is under active development.
 
 ## Preset
 

--- a/specs/_features/eip7805/fork-choice.md
+++ b/specs/_features/eip7805/fork-choice.md
@@ -37,7 +37,7 @@ This is the modification of the fork choice accompanying the EIP-7805 upgrade.
 
 #### Modified `Store`
 
-**Note:** `Store` is modified to track the seen inclusion lists and inclusion list equivocators.
+*Note*: `Store` is modified to track the seen inclusion lists and inclusion list equivocators.
 
 ```python
 @dataclass

--- a/specs/_features/eip7805/fork.md
+++ b/specs/_features/eip7805/fork.md
@@ -1,6 +1,6 @@
 # EIP-7805 -- Fork Logic
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/altair/bls.md
+++ b/specs/altair/bls.md
@@ -40,7 +40,7 @@ def eth_aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
     """
     Return the aggregate public key for the public keys in ``pubkeys``.
 
-    NOTE: the ``+`` operation should be interpreted as elliptic curve point addition, which takes as input
+    Note: the ``+`` operation should be interpreted as elliptic curve point addition, which takes as input
     elliptic curve points that must be decoded from the input ``BLSPubkey``s.
     This implementation is for demonstrative purposes only and ignores encoding/decoding concerns.
     Refer to the BLS signature draft standard for more information.

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -344,7 +344,7 @@ def is_sync_committee_aggregator(signature: BLSSignature) -> bool:
     return bytes_to_uint64(hash(signature)[0:8]) % modulo == 0
 ```
 
-*NOTE*: The set of aggregators generally changes every slot; however, the assignments can be computed ahead of time as soon as the committee is known.
+*Note*: The set of aggregators generally changes every slot; however, the assignments can be computed ahead of time as soon as the committee is known.
 
 ##### Construct sync committee contribution
 

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -103,7 +103,7 @@ and are limited by `MAX_BLOB_GAS_PER_BLOCK // GAS_PER_BLOB`. However the CL limi
 
 #### `BeaconBlockBody`
 
-Note: `BeaconBlock` and `SignedBeaconBlock` types are updated indirectly.
+*Note*: `BeaconBlock` and `SignedBeaconBlock` types are updated indirectly.
 
 ```python
 class BeaconBlockBody(Container):
@@ -235,7 +235,7 @@ def kzg_commitment_to_versioned_hash(kzg_commitment: KZGCommitment) -> Versioned
 
 #### Modified `get_attestation_participation_flag_indices`
 
-*Note:* The function `get_attestation_participation_flag_indices` is modified to set the `TIMELY_TARGET_FLAG` for any correct target attestation, regardless of `inclusion_delay` as a baseline reward for any speed of inclusion of an attestation that contributes to justification of the contained chain for EIP-7045.
+*Note*: The function `get_attestation_participation_flag_indices` is modified to set the `TIMELY_TARGET_FLAG` for any correct target attestation, regardless of `inclusion_delay` as a baseline reward for any speed of inclusion of an attestation that contributes to justification of the contained chain for EIP-7045.
 
 ```python
 def get_attestation_participation_flag_indices(state: BeaconState,

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1,6 +1,6 @@
 # Electra -- The Beacon Chain
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -123,7 +123,7 @@ Electra is a consensus-layer upgrade containing a number of features. Including:
 * [EIP-7549](https://eips.ethereum.org/EIPS/eip-7549): Move committee index outside Attestation
 * [EIP-7691](https://eips.ethereum.org/EIPS/eip-7691): Blob throughput increase
 
-*Note:* This specification is built upon [Deneb](../deneb/beacon-chain.md) and is under active development.
+*Note*: This specification is built upon [Deneb](../deneb/beacon-chain.md) and is under active development.
 
 ## Constants
 

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -1,6 +1,6 @@
 # Electra -- Fork Logic
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/electra/light-client/fork.md
+++ b/specs/electra/light-client/fork.md
@@ -1,6 +1,6 @@
 # Electra Light Client -- Fork Logic
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/electra/light-client/p2p-interface.md
+++ b/specs/electra/light-client/p2p-interface.md
@@ -1,6 +1,6 @@
 # Electra Light Client -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/electra/light-client/sync-protocol.md
+++ b/specs/electra/light-client/sync-protocol.md
@@ -1,6 +1,6 @@
 # Electra Light Client -- Sync Protocol
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -1,6 +1,6 @@
 # Electra -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -1,6 +1,6 @@
 # Electra -- Honest Validator
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -1,6 +1,6 @@
 # Fulu -- The Beacon Chain
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -19,7 +19,7 @@
 
 ## Introduction
 
-*Note:* This specification is built upon [Electra](../electra/beacon-chain.md) and is under active development.
+*Note*: This specification is built upon [Electra](../electra/beacon-chain.md) and is under active development.
 
 ## Configuration
 

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -1,6 +1,6 @@
 # Fulu -- Data Availability Sampling Core
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -1,6 +1,6 @@
 # Fulu -- Fork Choice
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/fulu/fork.md
+++ b/specs/fulu/fork.md
@@ -1,6 +1,6 @@
 # Fulu -- Fork Logic
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -1,6 +1,6 @@
 # Fulu -- Networking
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -202,7 +202,7 @@ The following validations MUST pass before forwarding the `sidecar: DataColumnSi
 - _[REJECT]_ The sidecar is proposed by the expected `proposer_index` for the block's slot in the context of the current shuffling (defined by `block_header.parent_root`/`block_header.slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling, the sidecar MAY be queued for later processing while proposers for the block's branch are calculated -- in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
-*Note:* In the `verify_data_column_sidecar_inclusion_proof(sidecar)` check, for all the sidecars of the same block, it verifies against the same set of `kzg_commitments` of the given beacon block. Client can choose to cache the result of the arguments tuple `(sidecar.kzg_commitments, sidecar.kzg_commitments_inclusion_proof, sidecar.signed_block_header)`.
+*Note*: In the `verify_data_column_sidecar_inclusion_proof(sidecar)` check, for all the sidecars of the same block, it verifies against the same set of `kzg_commitments` of the given beacon block. Client can choose to cache the result of the arguments tuple `(sidecar.kzg_commitments, sidecar.kzg_commitments_inclusion_proof, sidecar.signed_block_header)`.
 
 ### The Req/Resp domain
 

--- a/specs/fulu/peer-sampling.md
+++ b/specs/fulu/peer-sampling.md
@@ -1,6 +1,6 @@
 # Fulu -- Peer Sampling
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 
@@ -50,7 +50,7 @@ def get_extended_sample_count(allowed_failures: uint64) -> uint64:
         return r
 
     def hypergeom_cdf(k: uint64, M: uint64, n: uint64, N: uint64) -> float:
-        # NOTE: It contains float-point computations.
+        # Note: It contains float-point computations.
         # Convert uint64 to Python integers before computations.
         k = int(k)
         M = int(M)

--- a/specs/fulu/polynomial-commitments-sampling.md
+++ b/specs/fulu/polynomial-commitments-sampling.md
@@ -1,6 +1,6 @@
 # Fulu -- Polynomial Commitments Sampling
 
-**Notice**: This document is a work-in-progress for researchers and implementers.
+*Note*: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
 

--- a/specs/fulu/validator.md
+++ b/specs/fulu/validator.md
@@ -129,7 +129,7 @@ addition, when the validator custody requirement increases, due to an increase i
 of the attached validators, a node MUST backfill columns from the new custody groups. However, a
 node MAY wait to advertise a higher custody in its Metadata and ENR until backfilling is complete.
 
-*Note:* The node SHOULD manage validator custody (and any changes during its lifetime) without any
+*Note*: The node SHOULD manage validator custody (and any changes during its lifetime) without any
 input from the user, for example by using existing signals about validator metadata to compute the
 required custody.
 

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -148,9 +148,9 @@ value that Execution Layer client mock returns in responses to the following Eng
 * [`engine_newPayloadV1(payload)`](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_newpayloadv1) if `payload.blockHash == payload_info.block_hash`
 * [`engine_forkchoiceUpdatedV1(forkchoiceState, ...)`](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_forkchoiceupdatedv1) if `forkchoiceState.headBlockHash == payload_info.block_hash`
 
-*Note:* Status of a payload must be *initialized* via `on_payload_info` before the corresponding `on_block` execution step.
+*Note*: Status of a payload must be *initialized* via `on_payload_info` before the corresponding `on_block` execution step.
 
-*Note:* Status of the same payload may be updated for several times throughout the test.
+*Note*: Status of the same payload may be updated for several times throughout the test.
 
 #### Checks step
 


### PR DESCRIPTION
This has been bothering me for a while. I'd like for our note style to be consistent.

All notes will now begin with `*Note*:`.