### PR TITLE
Replace some instances of "extended" with "modified"

### DIFF
--- a/specs/_deprecated/custody_game/beacon-chain.md
+++ b/specs/_deprecated/custody_game/beacon-chain.md
@@ -18,7 +18,7 @@
   - [Size parameters](#size-parameters)
   - [Reward and penalty quotients](#reward-and-penalty-quotients)
 - [Data structures](#data-structures)
-  - [Extended types](#extended-types)
+  - [Modified types](#modified-types)
     - [`Validator`](#validator)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`BeaconState`](#beaconstate)
@@ -116,7 +116,7 @@ building upon the [Sharding](../sharding/beacon-chain.md) specification.
 
 ## Data structures
 
-### Extended types
+### Modified types
 
 #### `Validator`
 

--- a/specs/_deprecated/sharding/beacon-chain.md
+++ b/specs/_deprecated/sharding/beacon-chain.md
@@ -25,7 +25,7 @@
     - [`BuilderBlockBidWithRecipientAddress`](#builderblockbidwithrecipientaddress)
     - [`ShardedCommitmentsContainer`](#shardedcommitmentscontainer)
     - [`ShardSample`](#shardsample)
-  - [Modified Containers](#modified-containers)
+  - [Modified containers](#modified-containers)
     - [`BeaconState`](#beaconstate)
     - [`BuilderBlockData`](#builderblockdata)
     - [`BeaconBlockBody`](#beaconblockbody)
@@ -175,7 +175,7 @@ class ShardSample(Container):
     signature: BLSSignature
 ```
 
-### Modified Containers
+### Modified containers
 
 #### `BeaconState`
 

--- a/specs/_deprecated/sharding/beacon-chain.md
+++ b/specs/_deprecated/sharding/beacon-chain.md
@@ -25,7 +25,7 @@
     - [`BuilderBlockBidWithRecipientAddress`](#builderblockbidwithrecipientaddress)
     - [`ShardedCommitmentsContainer`](#shardedcommitmentscontainer)
     - [`ShardSample`](#shardsample)
-  - [Extended Containers](#extended-containers)
+  - [Modified Containers](#modified-containers)
     - [`BeaconState`](#beaconstate)
     - [`BuilderBlockData`](#builderblockdata)
     - [`BeaconBlockBody`](#beaconblockbody)
@@ -175,7 +175,7 @@ class ShardSample(Container):
     signature: BLSSignature
 ```
 
-### Extended Containers
+### Modified Containers
 
 #### `BeaconState`
 

--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -13,7 +13,7 @@
 - [Preset](#preset)
   - [Execution](#execution)
 - [Containers](#containers)
-  - [Modified Containers](#modified-containers)
+  - [Modified containers](#modified-containers)
     - [`ExecutionPayload`](#executionpayload)
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
   - [New containers](#new-containers)
@@ -56,7 +56,7 @@ This upgrade adds transaction execution to the beacon chain as part of the eip68
 
 ## Containers
 
-### Modified Containers
+### Modified containers
 
 #### `ExecutionPayload`
 

--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -13,7 +13,7 @@
 - [Preset](#preset)
   - [Execution](#execution)
 - [Containers](#containers)
-  - [Extended containers](#extended-containers)
+  - [Modified Containers](#modified-containers)
     - [`ExecutionPayload`](#executionpayload)
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
   - [New containers](#new-containers)
@@ -56,7 +56,7 @@ This upgrade adds transaction execution to the beacon chain as part of the eip68
 
 ## Containers
 
-### Extended containers
+### Modified Containers
 
 #### `ExecutionPayload`
 

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -14,7 +14,7 @@
 - [Configuration](#configuration)
   - [Transition settings](#transition-settings)
 - [Containers](#containers)
-  - [Modified Containers](#modified-containers)
+  - [Modified containers](#modified-containers)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`BeaconState`](#beaconstate)
   - [New containers](#new-containers)
@@ -99,7 +99,7 @@ Bellatrix updates a few configuration values to move penalty parameters to their
 
 ## Containers
 
-### Modified Containers
+### Modified containers
 
 #### `BeaconBlockBody`
 

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -14,7 +14,7 @@
 - [Configuration](#configuration)
   - [Transition settings](#transition-settings)
 - [Containers](#containers)
-  - [Extended containers](#extended-containers)
+  - [Modified Containers](#modified-containers)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`BeaconState`](#beaconstate)
   - [New containers](#new-containers)
@@ -99,7 +99,7 @@ Bellatrix updates a few configuration values to move penalty parameters to their
 
 ## Containers
 
-### Extended containers
+### Modified Containers
 
 #### `BeaconBlockBody`
 

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -19,7 +19,7 @@
     - [`BLSToExecutionChange`](#blstoexecutionchange)
     - [`SignedBLSToExecutionChange`](#signedblstoexecutionchange)
     - [`HistoricalSummary`](#historicalsummary)
-  - [Modified Containers](#modified-containers)
+  - [Modified containers](#modified-containers)
     - [`ExecutionPayload`](#executionpayload)
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
     - [`BeaconBlockBody`](#beaconblockbody)
@@ -135,7 +135,7 @@ class HistoricalSummary(Container):
     state_summary_root: Root
 ```
 
-### Modified Containers
+### Modified containers
 
 #### `ExecutionPayload`
 

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -19,7 +19,7 @@
     - [`BLSToExecutionChange`](#blstoexecutionchange)
     - [`SignedBLSToExecutionChange`](#signedblstoexecutionchange)
     - [`HistoricalSummary`](#historicalsummary)
-  - [Extended Containers](#extended-containers)
+  - [Modified Containers](#modified-containers)
     - [`ExecutionPayload`](#executionpayload)
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
     - [`BeaconBlockBody`](#beaconblockbody)
@@ -135,7 +135,7 @@ class HistoricalSummary(Container):
     state_summary_root: Root
 ```
 
-### Extended Containers
+### Modified Containers
 
 #### `ExecutionPayload`
 

--- a/specs/capella/fork-choice.md
+++ b/specs/capella/fork-choice.md
@@ -12,7 +12,7 @@
   - [`ExecutionEngine`](#executionengine)
     - [`notify_forkchoice_updated`](#notify_forkchoice_updated)
 - [Helpers](#helpers)
-  - [Extended `PayloadAttributes`](#extended-payloadattributes)
+  - [Modified `PayloadAttributes`](#modified-payloadattributes)
 - [Updated fork-choice handlers](#updated-fork-choice-handlers)
   - [`on_block`](#on_block)
 
@@ -49,7 +49,7 @@ def notify_forkchoice_updated(self: ExecutionEngine,
 
 ## Helpers
 
-### Extended `PayloadAttributes`
+### Modified `PayloadAttributes`
 
 `PayloadAttributes` is extended with the `withdrawals` field.
 

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -16,7 +16,7 @@
   - [Execution](#execution-1)
   - [Validator cycle](#validator-cycle)
 - [Containers](#containers)
-  - [Modified Containers](#modified-containers)
+  - [Modified containers](#modified-containers)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`ExecutionPayload`](#executionpayload)
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
@@ -99,7 +99,7 @@ and are limited by `MAX_BLOB_GAS_PER_BLOCK // GAS_PER_BLOB`. However the CL limi
 
 ## Containers
 
-### Modified Containers
+### Modified containers
 
 #### `BeaconBlockBody`
 

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -16,7 +16,7 @@
   - [Execution](#execution-1)
   - [Validator cycle](#validator-cycle)
 - [Containers](#containers)
-  - [Extended containers](#extended-containers)
+  - [Modified Containers](#modified-containers)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`ExecutionPayload`](#executionpayload)
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
@@ -99,7 +99,7 @@ and are limited by `MAX_BLOB_GAS_PER_BLOCK // GAS_PER_BLOB`. However the CL limi
 
 ## Containers
 
-### Extended containers
+### Modified Containers
 
 #### `BeaconBlockBody`
 

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -9,7 +9,7 @@
 - [Introduction](#introduction)
 - [Containers](#containers)
 - [Helpers](#helpers)
-  - [Extended `PayloadAttributes`](#extended-payloadattributes)
+  - [Modified `PayloadAttributes`](#modified-payloadattributes)
   - [`is_data_available`](#is_data_available)
 - [Updated fork-choice handlers](#updated-fork-choice-handlers)
   - [`on_block`](#on_block)
@@ -25,7 +25,7 @@ This is the modification of the fork choice accompanying the Deneb upgrade.
 
 ## Helpers
 
-### Extended `PayloadAttributes`
+### Modified `PayloadAttributes`
 
 `PayloadAttributes` is extended with the parent beacon block root for EIP-4788.
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -34,10 +34,10 @@
     - [`ConsolidationRequest`](#consolidationrequest)
     - [`ExecutionRequests`](#executionrequests)
     - [`SingleAttestation`](#singleattestation)
-  - [Modified Containers](#modified-containers)
+  - [Modified containers](#modified-containers)
     - [`AttesterSlashing`](#attesterslashing)
     - [`BeaconBlockBody`](#beaconblockbody)
-  - [Modified Containers](#modified-containers-1)
+  - [Modified containers](#modified-containers-1)
     - [`Attestation`](#attestation)
     - [`IndexedAttestation`](#indexedattestation)
     - [`BeaconState`](#beaconstate)
@@ -308,7 +308,7 @@ class SingleAttestation(Container):
     signature: BLSSignature
 ```
 
-### Modified Containers
+### Modified containers
 
 #### `AttesterSlashing`
 
@@ -339,7 +339,7 @@ class BeaconBlockBody(Container):
     execution_requests: ExecutionRequests  # [New in Electra]
 ```
 
-### Modified Containers
+### Modified containers
 
 #### `Attestation`
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -37,7 +37,7 @@
   - [Modified Containers](#modified-containers)
     - [`AttesterSlashing`](#attesterslashing)
     - [`BeaconBlockBody`](#beaconblockbody)
-  - [Extended Containers](#extended-containers)
+  - [Modified Containers](#modified-containers-1)
     - [`Attestation`](#attestation)
     - [`IndexedAttestation`](#indexedattestation)
     - [`BeaconState`](#beaconstate)
@@ -339,7 +339,7 @@ class BeaconBlockBody(Container):
     execution_requests: ExecutionRequests  # [New in Electra]
 ```
 
-### Extended Containers
+### Modified Containers
 
 #### `Attestation`
 

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -13,7 +13,7 @@
 - [Helpers](#helpers)
   - [Modified `GetPayloadResponse`](#modified-getpayloadresponse)
 - [Containers](#containers)
-  - [Modified Containers](#modified-containers)
+  - [Modified containers](#modified-containers)
     - [`AggregateAndProof`](#aggregateandproof)
     - [`SignedAggregateAndProof`](#signedaggregateandproof)
 - [Protocol](#protocol)
@@ -63,7 +63,7 @@ class GetPayloadResponse(object):
 
 ## Containers
 
-### Modified Containers
+### Modified containers
 
 #### `AggregateAndProof`
 


### PR DESCRIPTION
In most situations, we prefer to use "modified" instead of "extended" because it's more generic. A structure is not always extended per se. For consistency, this PR makes some replacements.