### PR TITLE
test: Implement epoch validation for fork boundary in config override…

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_config_override.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_config_override.py
@@ -27,9 +27,8 @@ def test_config_override(spec, state):
     assert spec.config.GENESIS_FORK_VERSION == spec.Version('0x12345678')
     assert spec.config.ALTAIR_FORK_VERSION == spec.Version('0x11111111')
     assert state.fork.current_version == spec.Version('0x11111111')
-    # TODO: it would be nice if the create_genesis_state actually outputs a state
-    #  for the fork with a slot that matches at least the fork boundary.
-    # assert spec.get_current_epoch(state) >= 4
+    # Verify that the state is at or past the fork boundary
+    assert spec.get_current_epoch(state) >= spec.config.ALTAIR_FORK_EPOCH
 
 
 @with_all_phases


### PR DESCRIPTION
… test

Implements the TODO in test_config_override to verify that the state used in tests 
has an epoch that is at or past the configured fork boundary (ALTAIR_FORK_EPOCH).
This ensures the test state properly represents the post-fork state as expected 
by the test configuration.