### PR TITLE
Update Weak Subjectivity calculations for Electra

### DIFF
--- a/specs/electra/weak-subjectivity.md
+++ b/specs/electra/weak-subjectivity.md
@@ -42,12 +42,8 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
     """
     t = get_total_active_balance(state)
     delta = get_balance_churn_limit(state)
-    D = SAFETY_DECAY
-
-    epochs_for_validator_set_churn = D * t // (4 * delta * 100)
-    ws_period = MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
-
-    return ws_period
+    epochs_for_validator_set_churn = SAFETY_DECAY * t // (4 * delta * 100)
+    return MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
 ```
 
 #### Modified `is_within_weak_subjectivity_period`

--- a/specs/electra/weak-subjectivity.md
+++ b/specs/electra/weak-subjectivity.md
@@ -9,8 +9,8 @@
 - [Introduction](#introduction)
 - [Weak Subjectivity Period](#weak-subjectivity-period)
   - [Calculating the Weak Subjectivity Period](#calculating-the-weak-subjectivity-period)
-    - [`compute_weak_subjectivity_period`](#compute_weak_subjectivity_period)
-    - [`is_within_weak_subjectivity_period`](#is_within_weak_subjectivity_period)
+    - [Modified `compute_weak_subjectivity_period`](#modified-compute_weak_subjectivity_period)
+    - [Modified `is_within_weak_subjectivity_period`](#modified-is_within_weak_subjectivity_period)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -29,7 +29,7 @@ maximum effective balance for validators and allows validators to consolidate.
 
 ### Calculating the Weak Subjectivity Period
 
-#### `compute_weak_subjectivity_period`
+#### Modified `compute_weak_subjectivity_period`
 
 A detailed analysis of the calculation of the Weak Subjectivity Period for Electra is made
 [here](https://notes.ethereum.org/@CarlBeek/electra_weak_subjectivity).
@@ -53,7 +53,7 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
     return ws_period
 ```
 
-#### `is_within_weak_subjectivity_period`
+#### Modified `is_within_weak_subjectivity_period`
 
 ```python
 def is_within_weak_subjectivity_period(store: Store, ws_state: BeaconState, ws_checkpoint: Checkpoint) -> bool:
@@ -61,7 +61,7 @@ def is_within_weak_subjectivity_period(store: Store, ws_state: BeaconState, ws_c
     assert ws_state.latest_block_header.state_root == ws_checkpoint.root
     assert compute_epoch_at_slot(ws_state.slot) == ws_checkpoint.epoch
 
-    ws_period = compute_weak_subjectivity_period(ws_state)
+    ws_period = compute_weak_subjectivity_period(ws_state)  # [Modified in Electra]
     ws_state_epoch = compute_epoch_at_slot(ws_state.slot)
     current_epoch = compute_epoch_at_slot(get_current_slot(store))
     return current_epoch <= ws_state_epoch + ws_period

--- a/specs/electra/weak-subjectivity.md
+++ b/specs/electra/weak-subjectivity.md
@@ -24,7 +24,13 @@
 
 ## Introduction
 
-This document is a guide for implementing Weak Subjectivity protections in Electra. The Weak Subjectivity Period (WSP) calculations have changed in Electra due to changes to how the `churn_limit` changed to account for the increased `MAXIMUM_EFFECTIVE_BALANCE` and the introductions of `ConsolidationRequest`s.
+This document is an extension of the [Phase 0 -- Weak Subjectivity
+Guide](../phase0/weak-subjectivity.md). All behaviors and definitions defined in this document, and
+documents it extends, carry over unless explicitly noted or overridden.
+
+This document is a guide for implementing Weak Subjectivity protections in Electra. The Weak
+Subjectivity Period (WSP) calculations have changed in Electra due to EIP-7251, which increases the
+maximum effective balance for validators and allows validators to consolidate.
 
 ## Custom Types
 

--- a/specs/electra/weak-subjectivity.md
+++ b/specs/electra/weak-subjectivity.md
@@ -88,31 +88,16 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
     """
     Returns the weak subjectivity period for the current ``state``.
     This computation takes into account the effect of:
-        - validator set churn (bounded by ``get_validator_churn_limit()`` per epoch), and
-        - validator balance top-ups (bounded by ``MAX_DEPOSITS * SLOTS_PER_EPOCH`` per epoch).
+        - validator set churn (bounded by ``get_balance_churn_limit()`` per epoch), and
     A detailed calculation can be found at:
     https://github.com/runtimeverification/beacon-chain-verification/blob/master/weak-subjectivity/weak-subjectivity-analysis.pdf
     """
-    ws_period = MIN_VALIDATOR_WITHDRAWABILITY_DELAY
-    N = len(get_active_validator_indices(state, get_current_epoch(state)))
-    t = get_total_active_balance(state) // N // ETH_TO_GWEI
-    T = MAX_EFFECTIVE_BALANCE // ETH_TO_GWEI
-    delta = get_validator_churn_limit(state)
-    Delta = MAX_DEPOSITS * SLOTS_PER_EPOCH
+    t = get_total_active_balance(state)
+    delta = get_balance_churn_limit(state)
     D = SAFETY_DECAY
 
-    if T * (200 + 3 * D) < t * (200 + 12 * D):
-        epochs_for_validator_set_churn = (
-            N * (t * (200 + 12 * D) - T * (200 + 3 * D)) // (600 * delta * (2 * t + T))
-        )
-        epochs_for_balance_top_ups = (
-            N * (200 + 3 * D) // (600 * Delta)
-        )
-        ws_period += max(epochs_for_validator_set_churn, epochs_for_balance_top_ups)
-    else:
-        ws_period += (
-            3 * N * D * t // (200 * Delta * (T - t))
-        )
+    epochs_for_validator_set_churn = D * t // (2 * delta)
+    ws_period = MIN_VALIDATOR_WITHDRAWABILITY_DELAY + epochs_for_validator_set_churn
 
     return ws_period
 ```

--- a/specs/electra/weak-subjectivity.md
+++ b/specs/electra/weak-subjectivity.md
@@ -31,17 +31,14 @@ maximum effective balance for validators and allows validators to consolidate.
 
 #### Modified `compute_weak_subjectivity_period`
 
-A detailed analysis of the calculation of the Weak Subjectivity Period for Electra is made
-[here](https://notes.ethereum.org/@CarlBeek/electra_weak_subjectivity).
-
 ```python
 def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
     """
     Returns the weak subjectivity period for the current ``state``.
     This computation takes into account the effect of:
-        - validator set churn (bounded by ``get_balance_churn_limit()`` per epoch), and
+        - validator set churn (bounded by ``get_balance_churn_limit()`` per epoch)
     A detailed calculation can be found at:
-    https://github.com/runtimeverification/beacon-chain-verification/blob/master/weak-subjectivity/weak-subjectivity-analysis.pdf
+    https://notes.ethereum.org/@CarlBeek/electra_weak_subjectivity
     """
     t = get_total_active_balance(state)
     delta = get_balance_churn_limit(state)

--- a/specs/electra/weak-subjectivity.md
+++ b/specs/electra/weak-subjectivity.md
@@ -7,16 +7,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
-- [Custom Types](#custom-types)
-- [Constants](#constants)
-- [Configuration](#configuration)
-- [Weak Subjectivity Checkpoint](#weak-subjectivity-checkpoint)
 - [Weak Subjectivity Period](#weak-subjectivity-period)
   - [Calculating the Weak Subjectivity Period](#calculating-the-weak-subjectivity-period)
     - [`compute_weak_subjectivity_period`](#compute_weak_subjectivity_period)
-- [Weak Subjectivity Sync](#weak-subjectivity-sync)
-  - [Weak Subjectivity Sync Procedure](#weak-subjectivity-sync-procedure)
-  - [Checking for Stale Weak Subjectivity Checkpoint](#checking-for-stale-weak-subjectivity-checkpoint)
     - [`is_within_weak_subjectivity_period`](#is_within_weak_subjectivity_period)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -32,46 +25,14 @@ This document is a guide for implementing Weak Subjectivity protections in Elect
 Subjectivity Period (WSP) calculations have changed in Electra due to EIP-7251, which increases the
 maximum effective balance for validators and allows validators to consolidate.
 
-## Custom Types
-
-| Name | SSZ Equivalent | Description |
-| - | - | - |
-| `Ether` | `uint64` | an amount in Ether |
-
-## Constants
-
-| Name | Value |
-| - | - |
-| `ETH_TO_GWEI` | `uint64(10**9)` |
-
-## Configuration
-
-| Name | Value |
-| - | - |
-| `SAFETY_DECAY` | `uint64(10)` |
-
-## Weak Subjectivity Checkpoint
-
-Any `Checkpoint` object can be used as a Weak Subjectivity Checkpoint.
-These Weak Subjectivity Checkpoints are distributed by providers,
-downloaded by users and/or distributed as a part of clients, and used as input while syncing a client.
-
 ## Weak Subjectivity Period
-
-The Weak Subjectivity Period is the number of recent epochs within which there
-must be a Weak Subjectivity Checkpoint to ensure that an attacker who takes control
-of the validator set at the beginning of the period is slashed at least a minimum threshold
-in the event that a conflicting `Checkpoint` is finalized.
-
-`SAFETY_DECAY` is defined as the maximum percentage tolerable loss in the one-third
-safety margin of FFG finality. Thus, any attack exploiting the Weak Subjectivity Period has
-a safety margin of at least `1/3 - SAFETY_DECAY/100`.
 
 ### Calculating the Weak Subjectivity Period
 
-A detailed analysis of the calculation of the weak subjectivity period is made in [here](https://notes.ethereum.org/@CarlBeek/electra_weak_subjectivity).
-
 #### `compute_weak_subjectivity_period`
+
+A detailed analysis of the calculation of the Weak Subjectivity Period for Electra is made
+[here](https://notes.ethereum.org/@CarlBeek/electra_weak_subjectivity).
 
 ```python
 def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
@@ -91,37 +52,6 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
 
     return ws_period
 ```
-
-## Weak Subjectivity Sync
-
-Clients should allow users to input a Weak Subjectivity Checkpoint at startup,
-and guarantee that any successful sync leads to the given Weak Subjectivity Checkpoint along the canonical chain.
-If such a sync is not possible, the client should treat this as a critical and irrecoverable failure.
-
-### Weak Subjectivity Sync Procedure
-
-1. Input a Weak Subjectivity Checkpoint as a CLI parameter in `block_root:epoch_number` format,
-   where `block_root` (an "0x" prefixed 32-byte hex string) and `epoch_number` (an integer) represent a valid `Checkpoint`.
-   Example of the format:
-
-   ```
-   0x8584188b86a9296932785cc2827b925f9deebacce6d72ad8d53171fa046b43d9:9544
-   ```
-
-2. Check the weak subjectivity requirements:
-    - *IF* `epoch_number > store.finalized_checkpoint.epoch`,
-          then *ASSERT* during block sync that block with root `block_root` is in the sync path at epoch `epoch_number`.
-          Emit descriptive critical error if this assert fails, then exit client process.
-    - *IF* `epoch_number <= store.finalized_checkpoint.epoch`,
-          then *ASSERT* that the block in the canonical chain at epoch `epoch_number` has root `block_root`.
-          Emit descriptive critical error if this assert fails, then exit client process.
-
-### Checking for Stale Weak Subjectivity Checkpoint
-
-Clients may choose to validate that the input Weak Subjectivity Checkpoint is not stale at the time of startup.
-To support this mechanism, the client needs to take the state at the Weak Subjectivity Checkpoint as
-a CLI parameter input (or fetch the state associated with the input Weak Subjectivity Checkpoint from some source).
-The check can be implemented in the following way:
 
 #### `is_within_weak_subjectivity_period`
 


### PR DESCRIPTION
Based off of @mkalinin's PR #4179, with a little more rigor and preserves the original `phase0` file instead overwriting it like we do elsewhere.

See https://notes.ethereum.org/@CarlBeek/electra_weak_subjectivity for details