### PR TITLE
Add two consolidation request processing edge case tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
@@ -561,7 +561,7 @@ def test_consolidation_requests_when_pending_consolidation_queue_is_full(spec, s
         target_index = spec.get_active_validator_indices(state, current_epoch)[i + 1]
         set_compounding_withdrawal_credential_with_balance(spec, state, target_index)
 
-        # Make the consolidaiton request
+        # Make the consolidation request
         consolidation_requests.append(
             spec.ConsolidationRequest(
                 source_address=source_address,


### PR DESCRIPTION
This PR adds two new tests:

* `test_consolidation_requests_when_pending_consolidation_queue_is_full`
  * Given the current config, this processes two consolidation requests.
  * The pending consolidation queue has space for one more.
  * It accepts the first one; since there's space in the queue.
  * It rejects the second one; as the queue is now full.
  * This test ensures the limit is configured correctly and clients will reject requests when the queue is full.
* `test_switch_to_compounding_requests_when_pending_consolidation_queue_is_full`
  * Given the current config, this processes two "switch to compounding validator" requests.
  * The pending consolidation queue starts as full.
  * It accepts both requests and processes them immediately.
  * This test ensures the client accepts switch requests when the queue is full.
  * And ensures that the client doesn't stop processing after the first request.

There is sort of an existing test for this, but it only tests with a single switch request. These two tests added in this PR could be considered variations/extensions of this. 

https://github.com/ethereum/consensus-specs/blob/d7622015c86ec933fe1770edc06f5ceb82388951/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_consolidation_request.py#L539-L559

The second new test would have caught this bug:

* https://github.com/prysmaticlabs/prysm/pull/15122