### PR TITLE
Add `withdrawal_requests_when_pending_withdrawal_queue_is_full` test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/electra/sanity/blocks/test_blocks.py
@@ -752,7 +752,9 @@ def test_withdrawal_requests_when_pending_withdrawal_queue_is_full(spec, state):
     index = 0
     address = b"\x22" * 20
     balance = spec.MIN_ACTIVATION_BALANCE + spec.EFFECTIVE_BALANCE_INCREMENT
-    set_compounding_withdrawal_credential_with_balance(spec, state, index, balance, balance, address)
+    set_compounding_withdrawal_credential_with_balance(
+        spec, state, index, balance, balance, address
+    )
     assert state.validators[index].exit_epoch == spec.FAR_FUTURE_EPOCH
 
     yield "pre", state


### PR DESCRIPTION
Hi, this covers this comment: https://github.com/ethereum/consensus-specs/pull/4246#issuecomment-2779738726
Reproducing the same edge-case but with partial withdrawals.