### PR TITLE
Clean up electra presets

### DIFF
--- a/presets/mainnet/electra.yaml
+++ b/presets/mainnet/electra.yaml
@@ -7,44 +7,44 @@ MIN_ACTIVATION_BALANCE: 32000000000
 # 2**11 * 10**9 (= 2,048,000,000,000) Gwei
 MAX_EFFECTIVE_BALANCE_ELECTRA: 2048000000000
 
-# State list lengths
+# Rewards and penalties
 # ---------------------------------------------------------------
-# `uint64(2**27)` (= 134,217,728)
-PENDING_DEPOSITS_LIMIT: 134217728
-# `uint64(2**27)` (= 134,217,728)
-PENDING_PARTIAL_WITHDRAWALS_LIMIT: 134217728
-# `uint64(2**18)` (= 262,144)
-PENDING_CONSOLIDATIONS_LIMIT: 262144
-
-# Reward and penalty quotients
-# ---------------------------------------------------------------
-# `uint64(2**12)` (= 4,096)
+# 2**12 (= 4,096)
 MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA: 4096
-# `uint64(2**12)` (= 4,096)
+# 2**12 (= 4,096)
 WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA: 4096
 
-# # Max operations per block
+# State list lengths
 # ---------------------------------------------------------------
-# `uint64(2**0)` (= 1)
+# 2**27 (= 134,217,728) pending deposits
+PENDING_DEPOSITS_LIMIT: 134217728
+# 2**27 (= 134,217,728) pending partial withdrawals
+PENDING_PARTIAL_WITHDRAWALS_LIMIT: 134217728
+# 2**18 (= 262,144) pending consolidations
+PENDING_CONSOLIDATIONS_LIMIT: 262144
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**0 (= 1) attester slashings
 MAX_ATTESTER_SLASHINGS_ELECTRA: 1
-# `uint64(2**3)` (= 8)
+# 2**3 (= 8) attestations
 MAX_ATTESTATIONS_ELECTRA: 8
-# `uint64(2**1)` (= 2)
-MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 
 # Execution
 # ---------------------------------------------------------------
-# 2**13 (= 8192) deposit requests
+# 2**13 (= 8,192) deposit requests
 MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: 8192
 # 2**4 (= 16) withdrawal requests
 MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 16
+# 2**1 (= 2) consolidation requests
+MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 
 # Withdrawals processing
 # ---------------------------------------------------------------
-# 2**3 ( = 8) pending withdrawals
+# 2**3 (= 8) pending withdrawals
 MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 8
 
 # Pending deposits processing
 # ---------------------------------------------------------------
-# 2**4 ( = 4) pending deposits
+# 2**4 (= 16) pending deposits
 MAX_PENDING_DEPOSITS_PER_EPOCH: 16

--- a/presets/minimal/electra.yaml
+++ b/presets/minimal/electra.yaml
@@ -7,44 +7,44 @@ MIN_ACTIVATION_BALANCE: 32000000000
 # 2**11 * 10**9 (= 2,048,000,000,000) Gwei
 MAX_EFFECTIVE_BALANCE_ELECTRA: 2048000000000
 
-# State list lengths
+# Rewards and penalties
 # ---------------------------------------------------------------
-# `uint64(2**27)` (= 134,217,728)
-PENDING_DEPOSITS_LIMIT: 134217728
-# [customized] `uint64(2**6)` (= 64)
-PENDING_PARTIAL_WITHDRAWALS_LIMIT: 64
-# [customized] `uint64(2**6)` (= 64)
-PENDING_CONSOLIDATIONS_LIMIT: 64
-
-# Reward and penalty quotients
-# ---------------------------------------------------------------
-# `uint64(2**12)` (= 4,096)
+# 2**12 (= 4,096)
 MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA: 4096
-# `uint64(2**12)` (= 4,096)
+# 2**12 (= 4,096)
 WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA: 4096
 
-# # Max operations per block
+# State list lengths
 # ---------------------------------------------------------------
-# `uint64(2**0)` (= 1)
+# 2**27 (= 134,217,728) pending deposits
+PENDING_DEPOSITS_LIMIT: 134217728
+# [customized] 2**6 (= 64) pending partial withdrawals
+PENDING_PARTIAL_WITHDRAWALS_LIMIT: 64
+# [customized] 2**6 (= 64) pending consolidations
+PENDING_CONSOLIDATIONS_LIMIT: 64
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**0 (= 1) attester slashings
 MAX_ATTESTER_SLASHINGS_ELECTRA: 1
-# `uint64(2**3)` (= 8)
+# 2**3 (= 8) attestations
 MAX_ATTESTATIONS_ELECTRA: 8
-# `uint64(2**1)` (= 2)
-MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 
 # Execution
 # ---------------------------------------------------------------
-# [customized]
+# [customized] 2**2 (= 4) deposit requests
 MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: 4
 # [customized] 2**1 (= 2) withdrawal requests
 MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 2
+# 2**1 (= 2) consolidation requests
+MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 
 # Withdrawals processing
 # ---------------------------------------------------------------
-# 2**1 ( = 2) pending withdrawals
+# 2**1 (= 2) pending withdrawals
 MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 2
 
 # Pending deposits processing
 # ---------------------------------------------------------------
-# 2**4 ( = 4) pending deposits
+# 2**4 (= 16) pending deposits
 MAX_PENDING_DEPOSITS_PER_EPOCH: 16


### PR DESCRIPTION
I was reviewing this and had several nits:

* The sections (naming, order) should match the [spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#preset) but didn't.
* In preset files, we don't do the `uint64` type casting.
* The comment for `MAX_PENDING_DEPOSITS_PER_EPOCH` was wrong.
* Several other small things...