### PR TITLE
Allow skipping verification for blobs from EL

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -209,11 +209,9 @@ The following validations MUST pass before forwarding the `sidecar: DataColumnSi
 
 Honest nodes SHOULD query `engine_getBlobsV2` as soon as they receive a valid `beacon_block` or `data_column_sidecar` from gossip. If ALL blobs matching `kzg_commitments` are retrieved, they should convert the response to data columns, and import the result.
 
-Clients SHOULD assume the execution layer is trusted and skip verification for blobs retrieved from it.
-
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish data columns on time.
 
-When clients use the local execution layer to retrieve blob and compute data columns, they MUST behave as if the imported `data_column_sidecar` had been received via gossip. In particular, clients MUST:
+When clients use the local execution layer to retrieve blobs, they SHOULD skip verification of those blobs. When subsequently importing the blobs as data columns, they MUST behave as if the `data_column_sidecar` had been received via gossip. In particular, clients MUST:
 
 * Publish the corresponding `data_column_sidecar` on the `data_column_sidecar_{subnet_id}` topic **if and only if** they are **subscribed** to it, either due to custody requirements or additional sampling.
 * Update gossip rule related data structures (i.e. update the anti-equivocation cache).

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -209,6 +209,8 @@ The following validations MUST pass before forwarding the `sidecar: DataColumnSi
 
 Honest nodes SHOULD query `engine_getBlobsV2` as soon as they receive a valid `beacon_block` or `data_column_sidecar` from gossip. If ALL blobs matching `kzg_commitments` are retrieved, they should convert the response to data columns, and import the result.
 
+Clients SHOULD assume the execution layer is trusted and skip verification for blobs retrieved from it.
+
 Implementers are encouraged to leverage this method to increase the likelihood of incorporating and attesting to the last block when its proposer is not able to publish data columns on time.
 
 When clients use the local execution layer to retrieve blob and compute data columns, they MUST behave as if the imported `data_column_sidecar` had been received via gossip. In particular, clients MUST:


### PR DESCRIPTION
Discussion in Discord: https://discord.com/channels/595666850260713488/1252403418941624532/1359124989844127929

Nimbus and Lodestar mentioned that they're already skipping verification on blobs retrieved from the execution layer, so interested in thoughts on whether this would be worth adding to the spec.