### PR TITLE
move IL committee domain to constant

### DIFF
--- a/presets/mainnet/eip7805.yaml
+++ b/presets/mainnet/eip7805.yaml
@@ -4,4 +4,3 @@
 # ---------------------------------------------------------------
 # 2**4 (= 16)
 INCLUSION_LIST_COMMITTEE_SIZE: 16
-DOMAIN_INCLUSION_LIST_COMMITTEE: 0x0C000000

--- a/presets/minimal/eip7805.yaml
+++ b/presets/minimal/eip7805.yaml
@@ -4,4 +4,3 @@
 # ---------------------------------------------------------------
 # 2**4 (= 16)
 INCLUSION_LIST_COMMITTEE_SIZE: 16
-DOMAIN_INCLUSION_LIST_COMMITTEE: 0x0C000000

--- a/specs/_features/eip7805/beacon-chain.md
+++ b/specs/_features/eip7805/beacon-chain.md
@@ -3,8 +3,9 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Preset](#preset)
+- [Constants](#constants)
   - [Domain types](#domain-types)
+- [Preset](#preset)
   - [Inclusion List Committee](#inclusion-list-committee)
 - [Containers](#containers)
   - [New containers](#new-containers)
@@ -34,13 +35,15 @@ This is the beacon chain specification to add EIP-7805 / fork-choice enforced, c
 - [FOCIL CL & EL workflow](https://ethresear.ch/t/focil-cl-el-workflow/20526)
   *Note*: This specification is built upon [Electra](../../electra/beacon_chain.md) and is under active development.
 
-## Preset
+## Constants
 
 ### Domain types
 
 | Name                              | Value                      |
 | --------------------------------- | -------------------------- |
 | `DOMAIN_INCLUSION_LIST_COMMITTEE` | `DomainType('0x0C000000')` |
+
+## Preset
 
 ### Inclusion List Committee
 


### PR DESCRIPTION
Move `DOMAIN_INCLUSION_LIST_COMMITTEE` to constants as discussed [here](https://github.com/ethereum/consensus-specs/pull/4268#pullrequestreview-2775591189)