### PR TITLE
Add workflow to run nightly mainnet tests

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -38,6 +38,6 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
-          python-version: '3.13'
+          python-version: '3.12'
       - name: test-${{ matrix.fork }}
         run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,43 @@
+name: Nightly mainnet tests
+
+defaults:
+  run:
+    shell: zsh {0}
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The branch, tag or SHA to checkout and build from
+        default: dev
+        type: string
+        required: true
+  schedule:
+    # Every day at 00:00 UTC
+    - cron: '0 0 * * *'
+
+jobs:
+  tests:
+    runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
+    strategy:
+      fail-fast: false
+      matrix:
+        fork:
+          - phase0
+          - altair
+          - bellatrix
+          - capella
+          - deneb
+          - electra
+          - fulu
+          - eip7441
+          - eip7732
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: '3.13'
+      - name: test-${{ matrix.fork }}
+        run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,11 +13,9 @@ jobs:
   lint:
     runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     steps:
-      - &checkout-step
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - &setup-python-step
-        name: Setup python
+      - name: Setup python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: '3.13'
@@ -30,7 +28,8 @@ jobs:
   whitespace:
     runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     steps:
-      - *checkout-step
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check for trailing whitespace
         run: |
           if git grep -n '[[:blank:]]$'; then
@@ -41,8 +40,13 @@ jobs:
   modcheck:
     runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     steps:
-      - *checkout-step
-      - *setup-python-step
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: '3.13'
+          cache: 'pip'
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log
       - name: Check for errors
@@ -68,7 +72,12 @@ jobs:
           - eip7441
           - eip7732
     steps:
-      - *checkout-step
-      - *setup-python-step
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: '3.13'
+          cache: 'pip'
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: 'pip'
       - name: Run linter for pyspec
         run: |
@@ -34,25 +34,6 @@ jobs:
         run: |
           if git grep -n '[[:blank:]]$'; then
             echo "Trailing whitespace found. Please fix it."
-            exit 1
-          fi
-
-  modcheck:
-    runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
-        with:
-          python-version: '3.13'
-          cache: 'pip'
-      - name: Run generators with --modcheck
-        run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log
-      - name: Check for errors
-        run: |
-          if grep -q "\[ERROR\]" consensustestgen.log; then
-            echo "There is an error in the log"
             exit 1
           fi
 
@@ -77,7 +58,27 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: 'pip'
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
+
+  modcheck:
+    needs: [lint, whitespace]
+    runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Run generators with --modcheck
+        run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log
+      - name: Check for errors
+        run: |
+          if grep -q "\[ERROR\]" consensustestgen.log; then
+            echo "There is an error in the log"
+            exit 1
+          fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,49 +1,36 @@
-name: Run spec tests and linter
+name: Run tests
 
 defaults:
   run:
     shell: zsh {0}
 
-env:
-  TEST_PRESET_TYPE: "minimal"
-
 on:
   push:
-    branches:
-      - dev
-      - master
+    branches: [dev, master]
   pull_request:
-  workflow_dispatch:
-    inputs:
-      test_preset_type:
-        default: minimal
-        description: Type of test to run, either mainnet or minimal
-        type: string
-        required: true
-  schedule:
-    - cron: '0 0 * * *'
 
 jobs:
   lint:
-    runs-on: [self-hosted-ghr-custom, size-l-x64, profile-consensusSpecs]
+    runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     steps:
-      - name: Checkout repository
+      - &checkout-step
+        name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Python
+      - &setup-python-step
+        name: Setup python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
-          python-version: '3.12.4'
-          cache: ''
+          python-version: '3.13'
+          cache: 'pip'
       - name: Run linter for pyspec
         run: |
           make lint
           git diff --exit-code
 
   whitespace:
-    runs-on: [self-hosted-ghr-custom, size-l-x64, profile-consensusSpecs]
+    runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - *checkout-step
       - name: Check for trailing whitespace
         run: |
           if git grep -n '[[:blank:]]$'; then
@@ -51,56 +38,11 @@ jobs:
             exit 1
           fi
 
-  pyspec-tests:
-    runs-on: [self-hosted-ghr-custom, size-xl-x64, profile-consensusSpecs]
-    needs: [lint]
-    strategy:
-      matrix:
-        version: ["phase0", "altair", "bellatrix", "capella", "deneb", "electra", "fulu", "eip7441", "eip7732"]
+  modcheck:
+    runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Rust for dependencies
-        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
-      - name: Setup Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
-        with:
-          python-version: '3.12.4'
-          cache: ''
-      - name: set preset
-        if: github.event.inputs.test_preset_type != ''
-        run: |
-          echo "spec_test_preset_type=${{ github.event.inputs.test_preset_type || env.TEST_PRESET_TYPE }}" >> $GITHUB_ENV
-      - name: set preset
-        if: ${{ (github.event_name == 'push' && github.ref_name != 'master') || github.event_name == 'pull_request' }}
-        run: |
-          echo "spec_test_preset_type=${{ env.TEST_PRESET_TYPE }}" >> $GITHUB_ENV
-      - name: set preset
-        if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
-        run: |
-          echo "spec_test_preset_type=mainnet" >> $GITHUB_ENV
-      - name: set preset
-        if: github.event.schedule=='0 0 * * *'
-        run: |
-          echo "spec_test_preset_type=mainnet" >> $GITHUB_ENV
-      - name: test-${{ matrix.version }}
-        run: make test fork=${{ matrix.version }} preset=${{ env.spec_test_preset_type }}
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: always()
-        with:
-          name: test-reports-${{ matrix.version }}
-          path: tests/core/pyspec/test-reports
-
-  gen-modcheck:
-   runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
-   steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
-        with:
-          python-version: '3.12.4'
-          cache: ''
+      - *checkout-step
+      - *setup-python-step
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log
       - name: Check for errors
@@ -109,3 +51,24 @@ jobs:
             echo "There is an error in the log"
             exit 1
           fi
+
+  tests:
+    needs: [lint, whitespace]
+    runs-on: [self-hosted-ghr-custom, size-xl-x64, profile-consensusSpecs]
+    strategy:
+      matrix:
+        fork:
+          - phase0
+          - altair
+          - bellatrix
+          - capella
+          - deneb
+          - electra
+          - fulu
+          - eip7441
+          - eip7732
+    steps:
+      - *checkout-step
+      - *setup-python-step
+      - name: Run pyspec tests for ${{ matrix.fork }}
+        run: make test preset=minimal fork=${{ matrix.fork }}


### PR DESCRIPTION
The motivation for this: I noticed that the mainnet tests weren't actually being run each night.

This PR does two things:

1. Adds a workflow file which runs mainnet tests each night.
2. Cleans up the original tests workflow.