### PR TITLE
Improve DataColumnSidecarsByRoot request

### DIFF
--- a/pysetup/helpers.py
+++ b/pysetup/helpers.py
@@ -82,10 +82,12 @@ def objects_to_spec(preset_name: str,
 
     functions = reduce(lambda fns, builder: builder.implement_optimizations(fns), builders, spec_object.functions)
     functions_spec = '\n\n\n'.join(functions.values())
+    ordered_class_objects_spec = '\n\n\n'.join(ordered_class_objects.values())
 
     # Access global dict of config vars for runtime configurables
     for name in spec_object.config_vars.keys():
         functions_spec = re.sub(r"\b%s\b" % name, 'config.' + name, functions_spec)
+        ordered_class_objects_spec = re.sub(r"\b%s\b" % name, 'config.' + name, ordered_class_objects_spec)
 
     def format_config_var(name: str, vardef: VariableDefinition) -> str:
         if vardef.type_name is None:
@@ -140,7 +142,6 @@ def objects_to_spec(preset_name: str,
     constant_vars_spec = '# Constant vars\n' + '\n'.join(format_constant(k, v) for k, v in spec_object.constant_vars.items())
     preset_dep_constant_vars_spec = '# Preset computed constants\n' + '\n'.join(format_constant(k, v) for k, v in spec_object.preset_dep_constant_vars.items())
     preset_vars_spec = '# Preset vars\n' + '\n'.join(format_constant(k, v) for k, v in spec_object.preset_vars.items())
-    ordered_class_objects_spec = '\n\n\n'.join(ordered_class_objects.values())
     ssz_dep_constants = '\n'.join(map(lambda x: '%s = %s' % (x, hardcoded_ssz_dep_constants[x]), hardcoded_ssz_dep_constants))
     ssz_dep_constants_verification = '\n'.join(map(lambda x: 'assert %s == %s' % (x, spec_object.ssz_dep_constants[x]), filtered_ssz_dep_constants))
     func_dep_presets_verification = '\n'.join(map(lambda x: 'assert %s == %s  # noqa: E501' % (x, spec_object.func_dep_presets[x]), filtered_hardcoded_func_dep_presets))

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -9,7 +9,7 @@
   - [Preset](#preset)
   - [Configuration](#configuration)
   - [Containers](#containers)
-    - [`DataColumnIdentifier`](#datacolumnidentifier)
+    - [`DataColumnsByRootIdentifier`](#datacolumnsbyrootidentifier)
   - [Helpers](#helpers)
     - [`verify_data_column_sidecar`](#verify_data_column_sidecar)
     - [`verify_data_column_sidecar_kzg_proofs`](#verify_data_column_sidecar_kzg_proofs)
@@ -61,12 +61,12 @@ The specification of these changes continues in the same format as the network s
 
 ### Containers
 
-#### `DataColumnIdentifier`
+#### `DataColumnsByRootIdentifier`
 
 ```python
-class DataColumnIdentifier(Container):
+class DataColumnsByRootIdentifier(Container):
     block_root: Root
-    index: ColumnIndex
+    columns: List[ColumnIndex, NUMBER_OF_COLUMNS]
 ```
 
 ### Helpers
@@ -314,7 +314,7 @@ Request Content:
 
 ```
 (
-  List[DataColumnIdentifier, MAX_REQUEST_DATA_COLUMN_SIDECARS]
+  List[DataColumnsByRootIdentifier, MAX_REQUEST_BLOCKS_DENEB]
 )
 ```
 
@@ -326,8 +326,8 @@ Response Content:
 )
 ```
 
-Requests sidecars by block root and index.
-The response is a list of `DataColumnIdentifier` whose length is less than or equal to the number of requests.
+Requests data column sidecars by block root and column index.
+The response is a list of `DataColumnSidecar` whose length is less than or equal to `requested_columns_count`, where `requested_columns_count = sum(len(r.columns) for r in request)`.
 It may be less in the case that the responding peer is missing blocks or sidecars.
 
 Before consuming the next response chunk, the response reader SHOULD verify the data column sidecar is well-formatted through `verify_data_column_sidecar`, has valid inclusion proof through `verify_data_column_sidecar_inclusion_proof`, and is correct w.r.t. the expected KZG commitments through `verify_data_column_sidecar_kzg_proofs`.


### PR DESCRIPTION
A suggestion from @terencechain. As discussed on discord [here](https://discord.com/channels/595666850260713488/1252403418941624532/1364252316588314756): it's a bit clunky that each entry in the request specifies a block root. This change also results in a smaller request message. Worst case 640 KiB before, now 132 KiB.

* Updated `pysetup/helpers.py` so I could use a config variable in a class.
* Renamed `DataColumnIdentifier` to `DataColumnsByRootIdentifier`.
* Changed `index: ColumnIndex` to `columns: List[ColumnIndex, NUMBER_OF_COLUMNS]`.
  * Now each request item includes the block root and a list of column indices.
* Updated the response structure appropriately.
* Fixed up the paragraph explanation below. 