### PR TITLE
Mark electra as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ sequential upgrades when ready.
 | 2    | **Bellatrix** | `144896`   | [Specs](specs/bellatrix), [Tests](tests/core/pyspec/eth2spec/test/bellatrix) |
 | 3    | **Capella**   | `194048`   | [Specs](specs/capella), [Tests](tests/core/pyspec/eth2spec/test/capella)     |
 | 4    | **Deneb**     | `269568`   | [Specs](specs/deneb), [Tests](tests/core/pyspec/eth2spec/test/deneb)         |
+| 5    | **Electra**   | `364032`   | [Specs](specs/electra), [Tests](tests/core/pyspec/eth2spec/test/electra)     |
 
 ### In-development Specifications
 
-| Seq. | Code Name   | Fork Epoch | Links                                                                    |
-| ---- | ----------- | ---------- | ------------------------------------------------------------------------ |
-| 5    | **Electra** | TBD        | [Specs](specs/electra), [Tests](tests/core/pyspec/eth2spec/test/electra) |
-| 6    | **Fulu**    | TBD        | [Specs](specs/fulu), [Tests](tests/core/pyspec/eth2spec/test/fulu)       |
+| Seq. | Code Name | Fork Epoch | Links                                                              |
+| ---- | --------- | ---------- | ------------------------------------------------------------------ |
+| 6    | **Fulu**  | TBD        | [Specs](specs/fulu), [Tests](tests/core/pyspec/eth2spec/test/fulu) |
 
 ### Accompanying documents
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1441,7 +1441,7 @@ def is_valid_deposit_signature(pubkey: BLSPubkey,
 
 ###### Modified `process_deposit`
 
-*Note*: The function `process_deposit` is modified to to use the modified `apply_deposit`.
+*Note*: The function `process_deposit` is modified to use the modified `apply_deposit`.
 
 ```python
 def process_deposit(state: BeaconState, deposit: Deposit) -> None:

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1,7 +1,5 @@
 # Electra -- The Beacon Chain
 
-*Note*: This document is a work-in-progress for researchers and implementers.
-
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -1,7 +1,5 @@
 # Electra -- Fork Logic
 
-*Note*: This document is a work-in-progress for researchers and implementers.
-
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)

--- a/specs/electra/light-client/fork.md
+++ b/specs/electra/light-client/fork.md
@@ -1,7 +1,5 @@
 # Electra Light Client -- Fork Logic
 
-*Note*: This document is a work-in-progress for researchers and implementers.
-
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)

--- a/specs/electra/light-client/p2p-interface.md
+++ b/specs/electra/light-client/p2p-interface.md
@@ -1,7 +1,5 @@
 # Electra Light Client -- Networking
 
-*Note*: This document is a work-in-progress for researchers and implementers.
-
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Networking](#networking)

--- a/specs/electra/light-client/sync-protocol.md
+++ b/specs/electra/light-client/sync-protocol.md
@@ -1,7 +1,5 @@
 # Electra Light Client -- Sync Protocol
 
-*Note*: This document is a work-in-progress for researchers and implementers.
-
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -1,7 +1,5 @@
 # Electra -- Networking
 
-*Note*: This document is a work-in-progress for researchers and implementers.
-
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -1,7 +1,5 @@
 # Electra -- Honest Validator
 
-*Note*: This document is a work-in-progress for researchers and implementers.
-
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -228,7 +228,7 @@ In the one-dimension construction, a node samples the peers by requesting the wh
 
 The potential benefits of having row custody could include:
 
-1. Allow for more "natural" distribution of data to consumers -- e.g., roll-ups -- but honestly, they won't know a priori which row their blob is going to be included in in the block, so they would either need to listen to all rows or download a particular row after seeing the block. The former looks just like listening to column \[0, N) and the latter is req/resp instead of gossiping.
+1. Allow for more "natural" distribution of data to consumers -- e.g., roll-ups -- but honestly, they won't know a priori which row their blob is going to be included in the block, so they would either need to listen to all rows or download a particular row after seeing the block. The former looks just like listening to column \[0, N) and the latter is req/resp instead of gossiping.
 2. Help with some sort of distributed reconstruction. Those with full rows can compute extensions and seed missing samples to the network. This would either need to be able to send individual points on the gossip or would need some sort of req/resp faculty, potentially similar to an `IHAVEPOINTBITFIELD` and `IWANTSAMPLE`.
 
 However, for simplicity, we don't assign row custody assignments to nodes in the current design.

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -326,7 +326,7 @@ Response Content:
 )
 ```
 
-Requests data column sidecars by block root and column index.
+Requests data column sidecars by block root and column indices.
 The response is a list of `DataColumnSidecar` whose length is less than or equal to `requested_columns_count`, where `requested_columns_count = sum(len(r.columns) for r in request)`.
 It may be less in the case that the responding peer is missing blocks or sidecars.
 


### PR DESCRIPTION
In preparation of the Pectra upgrade and the subsequent v1.5.0 release, mark Electra as stable.