### PR TITLE
Fulu BlobSidecarsByRange/Root Deprecation Support

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -29,6 +29,8 @@
       - [DataColumnSidecarsByRange v1](#datacolumnsidecarsbyrange-v1)
       - [DataColumnSidecarsByRoot v1](#datacolumnsidecarsbyroot-v1)
       - [GetMetaData v3](#getmetadata-v3)
+    - [BlobSidecarsByRange v1](#blobsidecarsbyrange-v1)
+    - [BlobSidecarsByRoot v1](#blobsidecarsbyroot-v1)
   - [The discovery domain: discv5](#the-discovery-domain-discv5)
     - [ENR structure](#enr-structure)
       - [Custody group count](#custody-group-count)
@@ -361,6 +363,26 @@ Response Content:
 ```
 
 Requests the MetaData of a peer, using the new `MetaData` definition given above that is extended from Altair. Other conditions for the `GetMetaData` protocol are unchanged from the Altair p2p networking document.
+
+#### BlobSidecarsByRange v1
+
+`/eth2/beacon_chain/req/blob_sidecars_by_range/1/` is deprecated as of `FULU_FORK_EPOCH + MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`.
+
+During the deprecation transition period:
+
+- Clients MUST respond with a list of blob sidecars from the range `[min(current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, FULU_FORK_EPOCH), FULU_FORK_EPOCH)` if the requested range includes any epochs in this interval.
+- Clients MAY respond with an empty list if the requested range lies entirely at or after `FULU_FORK_EPOCH`.
+- Clients SHOULD NOT penalize peers for requesting blob sidecars from `FULU_FORK_EPOCH`.
+
+#### BlobSidecarsByRoot v1
+
+`/eth2/beacon_chain/req/blob_sidecars_by_root/1/` is deprecated as of `FULU_FORK_EPOCH + MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`.
+
+During the deprecation transition period:
+
+- Clients MUST respond with blob sidecars corresponding to block roots from the range `[min(current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, FULU_FORK_EPOCH), FULU_FORK_EPOCH)` if any of the requested roots correspond to blocks in this interval.
+- Clients MAY respond with an empty list if all requested roots correspond to blocks at or after `FULU_FORK_EPOCH`.
+- Clients SHOULD NOT penalize peers for requesting blob sidecars from `FULU_FORK_EPOCH`.
 
 ### The discovery domain: discv5
 

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -26,11 +26,11 @@
         - [Distributed Blob Publishing using blobs retrieved from local execution layer client](#distributed-blob-publishing-using-blobs-retrieved-from-local-execution-layer-client)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
+      - [BlobSidecarsByRange v1](#blobsidecarsbyrange-v1)
+      - [BlobSidecarsByRoot v1](#blobsidecarsbyroot-v1)
       - [DataColumnSidecarsByRange v1](#datacolumnsidecarsbyrange-v1)
       - [DataColumnSidecarsByRoot v1](#datacolumnsidecarsbyroot-v1)
       - [GetMetaData v3](#getmetadata-v3)
-    - [BlobSidecarsByRange v1](#blobsidecarsbyrange-v1)
-    - [BlobSidecarsByRoot v1](#blobsidecarsbyroot-v1)
   - [The discovery domain: discv5](#the-discovery-domain-discv5)
     - [ENR structure](#enr-structure)
       - [Custody group count](#custody-group-count)
@@ -217,6 +217,30 @@ When clients use the local execution layer to retrieve blobs, they SHOULD skip v
 
 #### Messages
 
+##### BlobSidecarsByRange v1
+
+**Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/1/`
+
+Deprecated as of `FULU_FORK_EPOCH + MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`.
+
+During the deprecation transition period:
+
+- Clients MUST respond with a list of blob sidecars from the range `[min(current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, FULU_FORK_EPOCH), FULU_FORK_EPOCH)` if the requested range includes any epochs in this interval.
+- Clients MAY respond with an empty list if the requested range lies entirely at or after `FULU_FORK_EPOCH`.
+- Clients SHOULD NOT penalize peers for requesting blob sidecars from `FULU_FORK_EPOCH`.
+
+##### BlobSidecarsByRoot v1
+
+**Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_root/1/`
+
+Deprecated as of `FULU_FORK_EPOCH + MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`.
+
+During the deprecation transition period:
+
+- Clients MUST respond with blob sidecars corresponding to block roots from the range `[min(current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, FULU_FORK_EPOCH), FULU_FORK_EPOCH)` if any of the requested roots correspond to blocks in this interval.
+- Clients MAY respond with an empty list if all requested roots correspond to blocks at or after `FULU_FORK_EPOCH`.
+- Clients SHOULD NOT penalize peers for requesting blob sidecars from `FULU_FORK_EPOCH`.
+
 ##### DataColumnSidecarsByRange v1
 
 **Protocol ID:** `/eth2/beacon_chain/req/data_column_sidecars_by_range/1/`
@@ -363,26 +387,6 @@ Response Content:
 ```
 
 Requests the MetaData of a peer, using the new `MetaData` definition given above that is extended from Altair. Other conditions for the `GetMetaData` protocol are unchanged from the Altair p2p networking document.
-
-#### BlobSidecarsByRange v1
-
-`/eth2/beacon_chain/req/blob_sidecars_by_range/1/` is deprecated as of `FULU_FORK_EPOCH + MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`.
-
-During the deprecation transition period:
-
-- Clients MUST respond with a list of blob sidecars from the range `[min(current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, FULU_FORK_EPOCH), FULU_FORK_EPOCH)` if the requested range includes any epochs in this interval.
-- Clients MAY respond with an empty list if the requested range lies entirely at or after `FULU_FORK_EPOCH`.
-- Clients SHOULD NOT penalize peers for requesting blob sidecars from `FULU_FORK_EPOCH`.
-
-#### BlobSidecarsByRoot v1
-
-`/eth2/beacon_chain/req/blob_sidecars_by_root/1/` is deprecated as of `FULU_FORK_EPOCH + MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`.
-
-During the deprecation transition period:
-
-- Clients MUST respond with blob sidecars corresponding to block roots from the range `[min(current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, FULU_FORK_EPOCH), FULU_FORK_EPOCH)` if any of the requested roots correspond to blocks in this interval.
-- Clients MAY respond with an empty list if all requested roots correspond to blocks at or after `FULU_FORK_EPOCH`.
-- Clients SHOULD NOT penalize peers for requesting blob sidecars from `FULU_FORK_EPOCH`.
 
 ### The discovery domain: discv5
 


### PR DESCRIPTION
While implementing Lighthouse to avoid serving Fulu slots with BlobSidecarsByRange RPC, @dapplion and I found a need to clarify the deprecation process in the consensus specs. This PR proposes a clearer deprecation transition: allow blob sidecars for pre-Fulu slots within the availability window to be served until full deprecation (i.e., FULU_FORK_EPOCH + MIN_EPOCHS_FOR_BLOCK_REQUESTS or roughly 18 days after the fork). If the request includes Fulu or post-Fulu slots, clients may return an empty list. To ensure a smooth transition, clients should not penalize peers for requesting blob sidecars from Fulu.

The wording and structure of this deprecation policy are informed by the approach used for BeaconBlocksByRange and BeaconBlocksByRoot deprecations in [phase0/p2p-interface.md](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md), for consistency across RPCs.

Related discussions:
	•	Lighthouse issue: https://github.com/sigp/lighthouse/issues/7122#issuecomment-2811455509
	•	PR discussion: https://github.com/sigp/lighthouse/pull/7328#discussion_r2056231297