### PR TITLE
Make `*_REQUESTS_PER_PAYLOAD` the same for mainnet/minimal

### DIFF
--- a/presets/minimal/electra.yaml
+++ b/presets/minimal/electra.yaml
@@ -32,10 +32,10 @@ MAX_ATTESTATIONS_ELECTRA: 8
 
 # Execution
 # ---------------------------------------------------------------
-# [customized] 2**2 (= 4) deposit requests
-MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: 4
-# [customized] 2**1 (= 2) withdrawal requests
-MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 2
+# 2**13 (= 8,192) deposit requests
+MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: 8192
+# 2**4 (= 16) withdrawal requests
+MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 16
 # 2**1 (= 2) consolidation requests
 MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 


### PR DESCRIPTION
@barnabasbusa brought to my attention that when running Electra devnets (ie kurtosis) on the minimal preset, things break because the EL will include more requests than the CL is expecting. Controlling this lever on the EL would be complex, so I would suggest we make these presets the same for mainnet and minimal.

Note: the same logic applies to `MAX_BLOB_COMMITMENTS_PER_BLOCK` which is customized on minimal, but this isn't really an issue because we can control the blob count via the blob schedule on the EL. So no need to make these the same.