### PR TITLE
📝 `electra`: update `fork.md` to add the switch epoch 

### DIFF
--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -22,7 +22,7 @@ This document describes the process of the Electra upgrade.
 Warning: this configuration is not definitive.
 
 | Name                   | Value                                         |
-| ---------------------- |-----------------------------------------------|
+| ---------------------- | --------------------------------------------- |
 | `ELECTRA_FORK_VERSION` | `Version('0x05000000')`                       |
 | `ELECTRA_FORK_EPOCH`   | `Epoch(364032)` (May 7, 2025, 10:05:11am UTC) |
 

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -21,10 +21,10 @@ This document describes the process of the Electra upgrade.
 
 Warning: this configuration is not definitive.
 
-| Name                   | Value                                 |
-| ---------------------- | ------------------------------------- |
-| `ELECTRA_FORK_VERSION` | `Version('0x05000000')`               |
-| `ELECTRA_FORK_EPOCH`   | `Epoch(18446744073709551615)` **TBD** |
+| Name                   | Value                                         |
+| ---------------------- |-----------------------------------------------|
+| `ELECTRA_FORK_VERSION` | `Version('0x05000000')`                       |
+| `ELECTRA_FORK_EPOCH`   | `Epoch(364032)` (May 7, 2025, 10:05:11am UTC) |
 
 ## Helper functions
 


### PR DESCRIPTION
Hi team,

I don't know if it's expected or not but `electra/fork.md` is missing the epoch field in the configuration table. If I remember well for deneb, the update of this file was done a few weeks before the Deneb fork; so I assume it should have been done for electra too.