### PR TITLE
Switch to pypy3.11 for CI tasks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: pypy3.11
+        env:
+          LC_ALL: C
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: ${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
         run: make _copy_docs
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.x
+          python-version: pypy3.12
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: ${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "LC_ALL=C" >> $GITHUB_ENV
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: pypy3.11
+          python-version: pypy3.10
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: ${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build docs
         run: make _copy_docs
+      - name: Set LC_ALL to C
+        run: echo "LC_ALL=C" >> $GITHUB_ENV
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: pypy3.11
-        env:
-          LC_ALL: C
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: ${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
         run: make _copy_docs
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: pypy3.12
+          python-version: pypy3.11
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: ${{ github.ref }}

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.12'
+          python-version: 'pypy3.11'
       - name: Generate tests
         run: |
           cd consensus-specs

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.11'
+          python-version: 'pypy3.10'
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: Generate tests

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: Generate tests
         run: |
           cd consensus-specs

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'py3.12'
+          python-version: 'pypy3.12'
           cache: ''
       - name: Generate tests
         run: |

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12.4'
+          python-version: 'py3.12'
           cache: ''
       - name: Generate tests
         run: |

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -26,12 +26,12 @@ jobs:
           repository: 'ethereum/consensus-specs'
           path: 'consensus-specs'
           ref: ${{ inputs.ref || 'dev' }}
+      - name: Set LC_ALL to C
+        run: echo "LC_ALL=C" >> $GITHUB_ENV
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
-        env:
-          LC_ALL: C
       - name: Generate tests
         run: |
           cd consensus-specs

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+        env:
+          LC_ALL: C
       - name: Generate tests
         run: |
           cd consensus-specs

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.12'
-          cache: ''
       - name: Generate tests
         run: |
           cd consensus-specs

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -39,5 +39,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+        env:
+          LC_ALL: C
       - name: test-${{ matrix.fork }}
         run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.11'
+          python-version: 'pypy3.10'
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: test-${{ matrix.fork }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -39,5 +39,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: test-${{ matrix.fork }}
         run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -38,6 +38,6 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'py3.12'
+          python-version: 'pypy3.12'
       - name: test-${{ matrix.fork }}
         run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -39,7 +39,5 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
-        env:
-          LC_ALL: C
       - name: test-${{ matrix.fork }}
         run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -38,6 +38,6 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.12'
+          python-version: 'pypy3.11'
       - name: test-${{ matrix.fork }}
         run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -38,6 +38,6 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: 'py3.12'
       - name: test-${{ matrix.fork }}
         run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+        env:
+          LC_ALL: C
       - name: Run linter for pyspec
         run: |
           make lint
@@ -58,6 +60,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+        env:
+          LC_ALL: C
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
 
@@ -71,6 +75,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+        env:
+          LC_ALL: C
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log
       - name: Check for errors

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.11'
+          python-version: 'pypy3.10'
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: Run linter for pyspec
@@ -63,7 +63,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.11'
+          python-version: 'pypy3.10'
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: Run pyspec tests for ${{ matrix.fork }}
@@ -80,7 +80,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.11'
+          python-version: 'pypy3.10'
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: Run generators with --modcheck

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set LC_ALL to C
+        run: echo "LC_ALL=C" >> $GITHUB_ENV
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
-        env:
-          LC_ALL: C
       - name: Run linter for pyspec
         run: |
           make lint
@@ -56,12 +56,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set LC_ALL to C
+        run: echo "LC_ALL=C" >> $GITHUB_ENV
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
-        env:
-          LC_ALL: C
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
 
@@ -71,12 +71,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set LC_ALL to C
+        run: echo "LC_ALL=C" >> $GITHUB_ENV
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
-        env:
-          LC_ALL: C
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log
       - name: Check for errors

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: 'py3.12'
           cache: 'pip'
       - name: Run linter for pyspec
         run: |
@@ -58,7 +58,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: 'py3.12'
           cache: 'pip'
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
@@ -72,7 +72,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: 'py3.12'
           cache: 'pip'
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.12'
-          cache: 'pip'
       - name: Run linter for pyspec
         run: |
           make lint
@@ -59,7 +58,6 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.12'
-          cache: 'pip'
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
 
@@ -73,7 +71,6 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.12'
-          cache: 'pip'
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log
       - name: Check for errors

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: Run linter for pyspec
         run: |
           make lint
@@ -62,6 +64,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
 
@@ -77,6 +81,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 'pypy3.11'
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log
       - name: Check for errors

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'py3.12'
+          python-version: 'pypy3.12'
           cache: 'pip'
       - name: Run linter for pyspec
         run: |
@@ -58,7 +58,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'py3.12'
+          python-version: 'pypy3.12'
           cache: 'pip'
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
@@ -72,7 +72,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'py3.12'
+          python-version: 'pypy3.12'
           cache: 'pip'
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.12'
+          python-version: 'pypy3.11'
       - name: Run linter for pyspec
         run: |
           make lint
@@ -57,7 +57,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.12'
+          python-version: 'pypy3.11'
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
 
@@ -70,7 +70,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 'pypy3.12'
+          python-version: 'pypy3.11'
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log
       - name: Check for errors


### PR DESCRIPTION
Getting this error, there is no `3.12` string in that list, only `3.12.x`. `pypy` should be faster, let's give that a shot and see if we can kill two birds with one stone.

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/8a834aa5-2bba-4ad3-b7aa-af8835d6bf8f" />