### PR TITLE
Fix python version in CI checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
         run: make _copy_docs
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.x
+          python-version: '3.12.10'
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: ${{ github.ref }}

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12.4'
+          python-version: '3.12.x'
           cache: ''
       - name: Generate tests
         run: |

--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12.x'
+          python-version: '3.12.10'
           cache: ''
       - name: Generate tests
         run: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -38,6 +38,6 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: '3.12.x'
       - name: test-${{ matrix.fork }}
         run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -38,6 +38,6 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12.x'
+          python-version: '3.12.10'
       - name: test-${{ matrix.fork }}
         run: make test preset=mainnet fork=${{ matrix.fork }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: '3.12.x'
           cache: 'pip'
       - name: Run linter for pyspec
         run: |
@@ -58,7 +58,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: '3.12.x'
           cache: 'pip'
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
@@ -72,7 +72,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: '3.12.x'
           cache: 'pip'
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12.x'
+          python-version: '3.12.10'
           cache: 'pip'
       - name: Run linter for pyspec
         run: |
@@ -58,7 +58,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12.x'
+          python-version: '3.12.10'
           cache: 'pip'
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test preset=minimal fork=${{ matrix.fork }}
@@ -72,7 +72,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12.x'
+          python-version: '3.12.10'
           cache: 'pip'
       - name: Run generators with --modcheck
         run: make gen_all modcheck=true 2>&1 | tee consensustestgen.log


### PR DESCRIPTION
This PR aims to fix this error we're seeing:

![image](https://github.com/user-attachments/assets/96ff4937-7e5b-466d-af54-7256c887261b)