### PR TITLE
Improve `run_get_committee_assignment`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
@@ -36,7 +36,6 @@ def run_get_committee_assignment(spec, state, epoch, validator_index, valid=True
         assert committee == spec.get_beacon_committee(state, slot, committee_index)
         assert committee_index < spec.get_committee_count_per_slot(state, epoch)
         assert validator_index in committee
-        assert valid
     except AssertionError:
         assert not valid
     else:


### PR DESCRIPTION
This PR improve `run_get_committee_assignment` by removing unnecessary assertion. The existing `assert valid` passes when `valid` is True. When `valid` is False, it raises `AssertionError` and gets caught by the except AssertionError clause. It executes `assert not valid`, which also passes.

In other words, when L33-L38 pass, it currently doesn't care whether `valid` is true or false. However, it's more natural to interpret that the committee assignment is valid when L33-L38 pass. Hence, this PR changes it to expect `valid == True` in such cases.

> The use of the else clause is better than adding additional code to the try clause because it avoids accidentally catching an exception that wasn’t raised by the code being protected by the try … except statement. [Source](https://docs.python.org/3.13/tutorial/errors.html)