### PR TITLE
Generate reference tests for EIP7732 & EIP7805

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ALL_EXECUTABLE_SPEC_NAMES = \
 	eip6800   \
 	eip7441   \
 	eip7732   \
-  eip7805
+	eip7805
 
 # A list of fake targets.
 .PHONY: \
@@ -36,14 +36,14 @@ NORM = $(shell tput sgr0)
 
 # Print target descriptions.
 help:
-	@echo "make $(BOLD)clean$(NORM)         -- delete all untracked files"
-	@echo "make $(BOLD)coverage$(NORM)      -- run pyspec tests with coverage"
-	@echo "make $(BOLD)kzg_setups$(NORM)    -- generate trusted setups"
-	@echo "make $(BOLD)lint$(NORM)          -- run the linters"
-	@echo "make $(BOLD)pyspec$(NORM)        -- build python specifications"
-	@echo "make $(BOLD)reftests$(NORM)      -- generate reference tests"
-	@echo "make $(BOLD)serve_docs$(NORM)    -- start a local docs web server"
-	@echo "make $(BOLD)test$(NORM)          -- run pyspec tests"
+	@echo "make $(BOLD)clean$(NORM)      -- delete all untracked files"
+	@echo "make $(BOLD)coverage$(NORM)   -- run pyspec tests with coverage"
+	@echo "make $(BOLD)kzg_setups$(NORM) -- generate trusted setups"
+	@echo "make $(BOLD)lint$(NORM)       -- run the linters"
+	@echo "make $(BOLD)pyspec$(NORM)     -- build python specifications"
+	@echo "make $(BOLD)reftests$(NORM)   -- generate reference tests"
+	@echo "make $(BOLD)serve_docs$(NORM) -- start a local docs web server"
+	@echo "make $(BOLD)test$(NORM)       -- run pyspec tests"
 
 ###############################################################################
 # Virtual Environment

--- a/specs/_features/eip7805/fork-choice.md
+++ b/specs/_features/eip7805/fork-choice.md
@@ -8,6 +8,7 @@
 - [Fork choice](#fork-choice)
   - [Helpers](#helpers)
     - [Modified `Store`](#modified-store)
+  - [Modified `get_forkchoice_store`](#modified-get_forkchoice_store)
     - [New `validate_inclusion_lists`](#new-validate_inclusion_lists)
     - [New `get_attester_head`](#new-get_attester_head)
       - [Modified `get_proposer_head`](#modified-get_proposer_head)
@@ -56,6 +57,36 @@ class Store(object):
     inclusion_lists: Dict[Tuple[Slot, Root], Set[InclusionList]] = field(default_factory=dict)
     inclusion_list_equivocators: Dict[Tuple[Slot, Root], Set[ValidatorIndex]] = field(default_factory=dict)
     unsatisfied_inclusion_list_blocks: Set[Root] = field(default_factory=Set)
+```
+
+### Modified `get_forkchoice_store`
+
+```python
+def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
+    assert anchor_block.state_root == hash_tree_root(anchor_state)
+    anchor_root = hash_tree_root(anchor_block)
+    anchor_epoch = get_current_epoch(anchor_state)
+    justified_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
+    finalized_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
+    proposer_boost_root = Root()
+    return Store(
+        time=uint64(anchor_state.genesis_time + SECONDS_PER_SLOT * anchor_state.slot),
+        genesis_time=anchor_state.genesis_time,
+        justified_checkpoint=justified_checkpoint,
+        finalized_checkpoint=finalized_checkpoint,
+        unrealized_justified_checkpoint=justified_checkpoint,
+        unrealized_finalized_checkpoint=finalized_checkpoint,
+        proposer_boost_root=proposer_boost_root,
+        equivocating_indices=set(),
+        blocks={anchor_root: copy(anchor_block)},
+        block_states={anchor_root: copy(anchor_state)},
+        checkpoint_states={justified_checkpoint: copy(anchor_state)},
+        unrealized_justifications={anchor_root: justified_checkpoint},
+        # [New in EIP-7805]
+        inclusion_lists={},
+        inclusion_list_equivocators={},
+        unsatisfied_inclusion_list_blocks=set(),
+    )
 ```
 
 #### New `validate_inclusion_lists`

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -219,7 +219,7 @@ Efficient algorithms for computing this object can be found in [the implementati
 We first define helper functions:
 
 - `size_of(B)`, where `B` is a basic type: the length, in bytes, of the serialized form of the basic type.
-- `chunk_count(type)`: calculate the amount of leafs for merkleization of the type.
+- `chunk_count(type)`: calculate the amount of leaves for merkleization of the type.
   - all basic types: `1`
   - `Bitlist[N]` and `Bitvector[N]`: `(N + 255) // 256` (dividing by chunk size, rounding up)
   - `List[B, N]` and `Vector[B, N]`, where `B` is a basic type: `(N * size_of(B) + 31) // 32` (dividing by chunk size, rounding up)

--- a/tests/core/pyspec/eth2spec/test/helpers/constants.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/constants.py
@@ -35,11 +35,12 @@ ALL_PHASES = (
     FULU,
     # Experimental patches
     EIP7732,
+    EIP7805,
 )
 # The forks that have light client specs
 LIGHT_CLIENT_TESTING_FORKS = [item for item in MAINNET_FORKS if item != PHASE0]
 # The forks that output to the test vectors.
-TESTGEN_FORKS = (*MAINNET_FORKS, FULU)
+TESTGEN_FORKS = (*MAINNET_FORKS, FULU, EIP7732, EIP7805)
 # Forks allowed in the test runner `--fork` flag, to fail fast in case of typos
 ALLOWED_TEST_RUNNER_FORKS = (*ALL_PHASES, EIP7441)
 


### PR DESCRIPTION
This PR adds EIP7732 and EIP7805 to `TESTGEN_FORKS`. So for both of these feature forks, the standard suite of tests (ie `epoch_processing`, `finality`, `fork_choice`, `merkle_proof`, `operations`, `rewards`, `sanity`, `ssz_static`) will be included in the generated reference tests. There are a few small nit fixes here.

Note: in EIP7805, we forgot to add an updated `get_forkchoice_store` spec function.