### PR TITLE
Further simplify DataColumnSidecarsByRoot request

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -407,7 +407,7 @@ Request Content:
 
 ```
 (
-  blocks: List[Root, MAX_REQUEST_BLOCKS_DENEB],
+  block_roots: List[Root, MAX_REQUEST_BLOCKS_DENEB],
   columns: List[ColumnIndex, NUMBER_OF_COLUMNS]
 )
 ```
@@ -420,10 +420,10 @@ Response Content:
 )
 ```
 
-Requests data column sidecars by column indices for each of the root in blocks. The response is
+Requests data column sidecars by column indices for each block root. The response is
 a flattened list of `DataColumnSidecar` whose length is less than or equal to
 `requested_columns_count`, where
-`requested_columns_count = request.blocks * request.columns`. It may be less
+`requested_columns_count = len(request.block_roots) * len(request.columns)`. It may be less
 in the case that the responding peer is missing blocks or sidecars.
 
 Before consuming the next response chunk, the response reader SHOULD verify the

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -420,12 +420,11 @@ Response Content:
 )
 ```
 
-Requests data column sidecars by column indices for each block root. The response is
-a flattened list of `DataColumnSidecar` whose length is less than or equal to
-`requested_columns_count`, where
-`requested_columns_count = len(request.block_roots) * len(request.columns)`. It may be less
-in the case that the responding peer is missing blocks or sidecars.
-
+Requests data column sidecars by column indices for each block root. The
+response is a flattened list of `DataColumnSidecar` whose length is less than or
+equal to `requested_columns_count`, where
+`requested_columns_count = len(request.block_roots) * len(request.columns)`. It
+may be less in the case that the responding peer is missing blocks or sidecars.
 Before consuming the next response chunk, the response reader SHOULD verify the
 data column sidecar is well-formatted through `verify_data_column_sidecar`, has
 valid inclusion proof through `verify_data_column_sidecar_inclusion_proof`, and

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -8,8 +8,6 @@
 - [Modifications in Fulu](#modifications-in-fulu)
   - [Preset](#preset)
   - [Configuration](#configuration)
-  - [Containers](#containers)
-    - [`DataColumnsByRootIdentifier`](#datacolumnsbyrootidentifier)
   - [Helpers](#helpers)
     - [`verify_data_column_sidecar`](#verify_data_column_sidecar)
     - [`verify_data_column_sidecar_kzg_proofs`](#verify_data_column_sidecar_kzg_proofs)
@@ -61,16 +59,6 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 | `DATA_COLUMN_SIDECAR_SUBNET_COUNT`             | `128`                                          | The number of data column sidecar subnets used in the gossipsub protocol  |
 | `MAX_REQUEST_DATA_COLUMN_SIDECARS`             | `MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS` | Maximum number of data column sidecars in a single request                |
 | `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` | `2**12` (= 4096 epochs, ~18 days)              | The minimum epoch range over which a node must serve data column sidecars |
-
-### Containers
-
-#### `DataColumnsByRootIdentifier`
-
-```python
-class DataColumnsByRootIdentifier(Container):
-    block_root: Root
-    columns: List[ColumnIndex, NUMBER_OF_COLUMNS]
-```
 
 ### Helpers
 
@@ -419,7 +407,8 @@ Request Content:
 
 ```
 (
-  List[DataColumnsByRootIdentifier, MAX_REQUEST_BLOCKS_DENEB]
+  blocks: List[Root, MAX_REQUEST_BLOCKS_DENEB],
+  columns: List[ColumnIndex, NUMBER_OF_COLUMNS]
 )
 ```
 
@@ -431,10 +420,10 @@ Response Content:
 )
 ```
 
-Requests data column sidecars by block root and column indices. The response is
-a list of `DataColumnSidecar` whose length is less than or equal to
+Requests data column sidecars by column indices for each of the root in blocks. The response is
+a flattened list of `DataColumnSidecar` whose length is less than or equal to
 `requested_columns_count`, where
-`requested_columns_count = sum(len(r.columns) for r in request)`. It may be less
+`requested_columns_count = request.blocks * request.columns`. It may be less
 in the case that the responding peer is missing blocks or sidecars.
 
 Before consuming the next response chunk, the response reader SHOULD verify the


### PR DESCRIPTION
PR - https://github.com/ethereum/consensus-specs/pull/4284 simplified DataColumnSidecarsByRoot request. 

this PR further proposes to even pull out columns from the identifiers because a client generally would request same missing columns for a set of roots and hence don't need to keep repeating the same columns again and again for reach block root.

this further shortens the size of request making p2p traffic lighter and should be an easy update to the api usage in the clients.
it may also help the responders to quickly analyze the columns that they need to respond to the request without iterating the entire request which my offer a small space for optimization as well.