### PR TITLE
Update `isort` to `order_by_type = false`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ profile = "black"
 line_length = 100
 combine_as_imports = true
 known_first_party = ["eth2spec"]
+order_by_type = false
 skip_glob = [
   "tests/core/pyspec/eth2spec/*/mainnet.py",
   "tests/core/pyspec/eth2spec/*/minimal.py",

--- a/tests/core/pyspec/eth2spec/debug/decode.py
+++ b/tests/core/pyspec/eth2spec/debug/decode.py
@@ -2,15 +2,15 @@ from typing import Any
 
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root
 from eth2spec.utils.ssz.ssz_typing import (
+    boolean,
     ByteList,
     ByteVector,
     Container,
     List,
+    uint,
     Union,
     Vector,
     View,
-    boolean,
-    uint,
 )
 
 

--- a/tests/core/pyspec/eth2spec/debug/encode.py
+++ b/tests/core/pyspec/eth2spec/debug/encode.py
@@ -2,12 +2,12 @@ from eth2spec.utils.ssz.ssz_impl import hash_tree_root, serialize
 from eth2spec.utils.ssz.ssz_typing import (
     Bitlist,
     Bitvector,
+    boolean,
     Container,
     List,
+    uint,
     Union,
     Vector,
-    boolean,
-    uint,
 )
 
 

--- a/tests/core/pyspec/eth2spec/debug/random_value.py
+++ b/tests/core/pyspec/eth2spec/debug/random_value.py
@@ -6,15 +6,15 @@ from eth2spec.utils.ssz.ssz_typing import (
     BasicView,
     Bitlist,
     Bitvector,
+    boolean,
     ByteList,
     ByteVector,
     Container,
     List,
+    uint,
     Union,
     Vector,
     View,
-    boolean,
-    uint,
 )
 
 # in bytes

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_data_collection.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_data_collection.py
@@ -7,8 +7,8 @@ from eth2spec.test.helpers.constants import (
     MINIMAL,
 )
 from eth2spec.test.helpers.light_client_data_collection import (
-    BlockID,
     add_new_block,
+    BlockID,
     finish_lc_data_collection_test,
     get_lc_bootstrap_block_id,
     get_lc_update_attested_block_id,

--- a/tests/core/pyspec/eth2spec/test/altair/transition/test_operations.py
+++ b/tests/core/pyspec/eth2spec/test/altair/transition/test_operations.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
-    ForkMeta,
     always_bls,
+    ForkMeta,
     with_fork_metas,
     with_presets,
 )

--- a/tests/core/pyspec/eth2spec/test/bellatrix/sync/test_optimistic.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/sync/test_optimistic.py
@@ -20,11 +20,11 @@ from eth2spec.test.helpers.fork_choice import (
     on_tick_and_append_step,
 )
 from eth2spec.test.helpers.optimistic_sync import (
+    add_optimistic_block,
+    get_optimistic_store,
     MegaStore,
     PayloadStatusV1,
     PayloadStatusV1Status,
-    add_optimistic_block,
-    get_optimistic_store,
 )
 from eth2spec.test.helpers.state import (
     next_epoch,

--- a/tests/core/pyspec/eth2spec/test/deneb/merkle_proof/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/merkle_proof/test_single_merkle_proof.py
@@ -1,8 +1,8 @@
 import random
 
 from eth2spec.debug.random_value import (
-    RandomizationMode,
     get_random_ssz_object,
+    RandomizationMode,
 )
 from eth2spec.test.context import (
     spec_state_test,

--- a/tests/core/pyspec/eth2spec/test/deneb/transition/test_operations.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/transition/test_operations.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
-    ForkMeta,
     always_bls,
+    ForkMeta,
     with_fork_metas,
 )
 from eth2spec.test.helpers.attestations import (
@@ -14,8 +14,8 @@ from eth2spec.test.helpers.constants import (
     DENEB,
 )
 from eth2spec.test.helpers.fork_transition import (
-    OperationType,
     do_fork,
+    OperationType,
     run_transition_with_operation,
     transition_until_fork,
 )

--- a/tests/core/pyspec/eth2spec/test/electra/transition/test_operations.py
+++ b/tests/core/pyspec/eth2spec/test/electra/transition/test_operations.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
-    ForkMeta,
     always_bls,
+    ForkMeta,
     with_fork_metas,
     with_presets,
 )

--- a/tests/core/pyspec/eth2spec/test/fulu/merkle_proof/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/merkle_proof/test_single_merkle_proof.py
@@ -1,8 +1,8 @@
 import random
 
 from eth2spec.debug.random_value import (
-    RandomizationMode,
     get_random_ssz_object,
+    RandomizationMode,
 )
 from eth2spec.test.context import (
     spec_state_test,

--- a/tests/core/pyspec/eth2spec/test/fulu/unittests/test_networking.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/unittests/test_networking.py
@@ -1,8 +1,8 @@
 import random
 
 from eth2spec.debug.random_value import (
-    RandomizationMode,
     get_random_ssz_object,
+    RandomizationMode,
 )
 from eth2spec.test.context import (
     single_phase,

--- a/tests/core/pyspec/eth2spec/test/helpers/blob.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/blob.py
@@ -1,7 +1,7 @@
 import random
 
-from rlp import Serializable, encode
-from rlp.sedes import Binary, CountableList, List as RLPList, big_endian_int, binary
+from rlp import encode, Serializable
+from rlp.sedes import big_endian_int, Binary, binary, CountableList, List as RLPList
 
 from eth2spec.test.helpers.forks import (
     is_post_electra,

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -2,7 +2,7 @@ from hashlib import sha256
 
 from eth_hash.auto import keccak
 from rlp import encode
-from rlp.sedes import Binary, List, big_endian_int
+from rlp.sedes import big_endian_int, Binary, List
 from trie import HexaryTrie
 
 from eth2spec.debug.random_value import get_random_bytes_list

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_transition.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_transition.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import auto, Enum
 
 from eth2spec.test.helpers.attestations import (
     next_slots_with_attestations,

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
@@ -1,9 +1,9 @@
 from random import Random
 
 from eth2spec.test.context import (
-    PHASE0,
     low_single_balance,
     misc_balances,
+    PHASE0,
     single_phase,
     spec_state_test,
     spec_test,

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -1,33 +1,33 @@
 import milagro_bls_binding as milagro_bls  # noqa: F401 for BLS switching option
 import py_arkworks_bls12381 as arkworks_bls  # noqa: F401 for BLS switching option
 from py_arkworks_bls12381 import (
-    GT as arkworks_GT,
     G1Point as arkworks_G1,
     G2Point as arkworks_G2,
+    GT as arkworks_GT,
     Scalar as arkworks_Scalar,
 )
 from py_ecc.bls import G2ProofOfPossession as py_ecc_bls
 from py_ecc.bls.g2_primitives import (  # noqa: F401
+    curve_order as BLS_MODULUS,
     G1_to_pubkey as py_ecc_G1_to_bytes48,
     G2_to_signature as py_ecc_G2_to_bytes96,
-    curve_order as BLS_MODULUS,
     pubkey_to_G1 as py_ecc_bytes48_to_G1,
     signature_to_G2 as _signature_to_G2,
     signature_to_G2 as py_ecc_bytes96_to_G2,
 )
 from py_ecc.optimized_bls12_381 import (  # noqa: F401
+    add as py_ecc_add,
+    final_exponentiate as py_ecc_final_exponentiate,
     FQ,
     FQ2,
     FQ12 as py_ecc_GT,
     G1 as py_ecc_G1,
     G2 as py_ecc_G2,
-    Z1 as py_ecc_Z1,
-    Z2 as py_ecc_Z2,
-    add as py_ecc_add,
-    final_exponentiate as py_ecc_final_exponentiate,
     multiply as py_ecc_mul,
     neg as py_ecc_neg,
     pairing as py_ecc_pairing,
+    Z1 as py_ecc_Z1,
+    Z2 as py_ecc_Z2,
 )
 from py_ecc.utils import prime_field_inv as py_ecc_prime_field_inv
 

--- a/tests/generators/runners/kzg_4844.py
+++ b/tests/generators/runners/kzg_4844.py
@@ -14,14 +14,14 @@ from eth2spec.test.utils.kzg_tests import (
     BLOB_ALL_TWOS,
     BLOB_ALL_ZEROS,
     BLOB_RANDOM_VALID1,
+    bls_add_one,
+    encode_hex_list,
     G1,
     INVALID_BLOBS,
     INVALID_FIELD_ELEMENTS,
     INVALID_G1_POINTS,
     VALID_BLOBS,
     VALID_FIELD_ELEMENTS,
-    bls_add_one,
-    encode_hex_list,
 )
 
 ###############################################################################

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -11,14 +11,14 @@ from eth2spec.fulu import spec
 from eth2spec.gen_helpers.gen_base.gen_typing import TestCase
 from eth2spec.test.helpers.constants import FULU
 from eth2spec.test.utils.kzg_tests import (
+    bls_add_one,
     CELL_RANDOM_VALID1,
     CELL_RANDOM_VALID2,
+    encode_hex_list,
     INVALID_BLOBS,
     INVALID_G1_POINTS,
     INVALID_INDIVIDUAL_CELL_BYTES,
     VALID_BLOBS,
-    bls_add_one,
-    encode_hex_list,
 )
 
 ###############################################################################

--- a/tests/generators/runners/ssz_generic_cases/ssz_basic_vector.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_basic_vector.py
@@ -1,11 +1,10 @@
 from random import Random
 from typing import Dict, Type
 
-from eth2spec.debug.random_value import RandomizationMode, get_random_ssz_object
+from eth2spec.debug.random_value import get_random_ssz_object, RandomizationMode
 from eth2spec.utils.ssz.ssz_impl import serialize
 from eth2spec.utils.ssz.ssz_typing import (
     BasicView,
-    Vector,
     boolean,
     uint8,
     uint16,
@@ -13,6 +12,7 @@ from eth2spec.utils.ssz.ssz_typing import (
     uint64,
     uint128,
     uint256,
+    Vector,
 )
 
 from .ssz_test_case import invalid_test_case, valid_test_case

--- a/tests/generators/runners/ssz_generic_cases/ssz_bitlist.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_bitlist.py
@@ -1,6 +1,6 @@
 from random import Random
 
-from eth2spec.debug.random_value import RandomizationMode, get_random_ssz_object
+from eth2spec.debug.random_value import get_random_ssz_object, RandomizationMode
 from eth2spec.utils.ssz.ssz_impl import serialize
 from eth2spec.utils.ssz.ssz_typing import Bitlist
 

--- a/tests/generators/runners/ssz_generic_cases/ssz_bitvector.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_bitvector.py
@@ -1,6 +1,6 @@
 from random import Random
 
-from eth2spec.debug.random_value import RandomizationMode, get_random_ssz_object
+from eth2spec.debug.random_value import get_random_ssz_object, RandomizationMode
 from eth2spec.utils.ssz.ssz_impl import serialize
 from eth2spec.utils.ssz.ssz_typing import Bitvector
 

--- a/tests/generators/runners/ssz_generic_cases/ssz_container.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_container.py
@@ -1,21 +1,21 @@
 from random import Random
 from typing import Callable, Dict, Sequence, Tuple, Type
 
-from eth2spec.debug.random_value import RandomizationMode, get_random_ssz_object
+from eth2spec.debug.random_value import get_random_ssz_object, RandomizationMode
 from eth2spec.utils.ssz.ssz_impl import serialize
 from eth2spec.utils.ssz.ssz_typing import (
     Bitlist,
     Bitvector,
+    byte,
     ByteList,
     Container,
     List,
-    Vector,
-    View,
-    byte,
     uint8,
     uint16,
     uint32,
     uint64,
+    Vector,
+    View,
 )
 
 from .ssz_test_case import invalid_test_case, valid_test_case

--- a/tests/generators/runners/ssz_generic_cases/ssz_uints.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_uints.py
@@ -1,7 +1,7 @@
 from random import Random
 from typing import Type
 
-from eth2spec.debug.random_value import RandomizationMode, get_random_ssz_object
+from eth2spec.debug.random_value import get_random_ssz_object, RandomizationMode
 from eth2spec.utils.ssz.ssz_typing import BasicView, uint8, uint16, uint32, uint64, uint128, uint256
 
 from .ssz_test_case import invalid_test_case, valid_test_case


### PR DESCRIPTION
> NOTE: type here refers to the implied type from the import name capitalization. isort does not do type introspection for the imports. These "types" are simply: CONSTANT_VARIABLE, CamelCaseClass, variable_or_function. If your project follows PEP8 or a related coding standard and has many imports this is a good default, otherwise you likely will want to turn it off. From the CLI the --dont-order-by-type option will turn this off.

https://pycqa.github.io/isort/docs/configuration/options.html#blocked-extensions