### PR TITLE
Bind inputs in ssz_generic reftests

### DIFF
--- a/tests/generators/runners/ssz_generic_cases/ssz_basic_vector.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_basic_vector.py
@@ -51,7 +51,9 @@ def valid_cases():
         for length in [1, 2, 3, 4, 5, 8, 16, 31, 512, 513]:
             for mode in random_modes:
                 yield f"vec_{name}_{length}_{mode.to_name()}", valid_test_case(
-                    lambda: basic_vector_case_fn(rng, mode, typ, length)
+                    lambda rng=rng, mode=mode, typ=typ, length=length: basic_vector_case_fn(
+                        rng, mode, typ, length
+                    )
                 )
 
 
@@ -75,15 +77,23 @@ def invalid_cases():
                     )
                 else:
                     yield f"vec_{name}_{length}_{mode.to_name()}_one_less", invalid_test_case(
-                        lambda: serialize(basic_vector_case_fn(rng, mode, typ, length - 1))
+                        lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
+                            basic_vector_case_fn(rng, mode, typ, length - 1)
+                        )
                     )
                 yield f"vec_{name}_{length}_{mode.to_name()}_one_more", invalid_test_case(
-                    lambda: serialize(basic_vector_case_fn(rng, mode, typ, length + 1))
+                    lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
+                        basic_vector_case_fn(rng, mode, typ, length + 1)
+                    )
                 )
                 yield f"vec_{name}_{length}_{mode.to_name()}_one_byte_less", invalid_test_case(
-                    lambda: serialize(basic_vector_case_fn(rng, mode, typ, length))[:-1]
+                    lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
+                        basic_vector_case_fn(rng, mode, typ, length)
+                    )[:-1]
                 )
                 yield f"vec_{name}_{length}_{mode.to_name()}_one_byte_more", invalid_test_case(
-                    lambda: serialize(basic_vector_case_fn(rng, mode, typ, length))
+                    lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
+                        basic_vector_case_fn(rng, mode, typ, length)
+                    )
                     + serialize(basic_vector_case_fn(rng, mode, uint8, 1))
                 )

--- a/tests/generators/runners/ssz_generic_cases/ssz_bitlist.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_bitlist.py
@@ -30,7 +30,7 @@ def valid_cases():
                 RandomizationMode.mode_max,
             ]:
                 yield f"bitlist_{size}_{mode.to_name()}_{variation}", valid_test_case(
-                    lambda: bitlist_case_fn(rng, mode, size)
+                    lambda rng=rng, mode=mode, size=size: bitlist_case_fn(rng, mode, size)
                 )
 
 
@@ -53,5 +53,7 @@ def invalid_cases():
         (512, 513),
     ]:
         yield f"bitlist_{typ_limit}_but_{test_limit}", invalid_test_case(
-            lambda: serialize(bitlist_case_fn(rng, RandomizationMode.mode_max_count, test_limit))
+            lambda rng=rng, test_limit=test_limit: serialize(
+                bitlist_case_fn(rng, RandomizationMode.mode_max_count, test_limit)
+            )
         )

--- a/tests/generators/runners/ssz_generic_cases/ssz_bitvector.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_bitvector.py
@@ -37,7 +37,7 @@ def valid_cases():
             RandomizationMode.mode_max,
         ]:
             yield f"bitvec_{size}_{mode.to_name()}", valid_test_case(
-                lambda: bitvector_case_fn(rng, mode, size)
+                lambda rng=rng, mode=mode, size=size: bitvector_case_fn(rng, mode, size)
             )
 
 
@@ -66,7 +66,7 @@ def invalid_cases():
             RandomizationMode.mode_max,
         ]:
             yield f"bitvec_{typ_size}_{mode.to_name()}_{test_size}", invalid_test_case(
-                lambda: serialize(
+                lambda rng=rng, mode=mode, test_size=test_size, typ_size=typ_size: serialize(
                     bitvector_case_fn(rng, mode, test_size, invalid_making_pos=typ_size)
                 )
             )

--- a/tests/generators/runners/ssz_generic_cases/ssz_uints.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_uints.py
@@ -22,15 +22,17 @@ def valid_cases():
         mode = RandomizationMode.mode_random
         byte_len = uint_type.type_byte_length()
         yield f"uint_{byte_len * 8}_last_byte_empty", valid_test_case(
-            lambda: uint_type((2 ** ((byte_len - 1) * 8)) - 1)
+            lambda uint_type=uint_type, byte_len=byte_len: uint_type(
+                (2 ** ((byte_len - 1) * 8)) - 1
+            )
         )
         for variation in range(5):
             yield f"uint_{byte_len * 8}_{mode.to_name()}_{variation}", valid_test_case(
-                lambda: uint_case_fn(rng, mode, uint_type)
+                lambda rng=rng, mode=mode, uint_type=uint_type: uint_case_fn(rng, mode, uint_type)
             )
         for mode in [RandomizationMode.mode_zero, RandomizationMode.mode_max]:
             yield f"uint_{byte_len * 8}_{mode.to_name()}", valid_test_case(
-                lambda: uint_case_fn(rng, mode, uint_type)
+                lambda rng=rng, mode=mode, uint_type=uint_type: uint_case_fn(rng, mode, uint_type)
             )
 
 
@@ -38,15 +40,17 @@ def invalid_cases():
     for uint_type in UINT_TYPES:
         byte_len = uint_type.type_byte_length()
         yield f"uint_{byte_len * 8}_one_too_high", invalid_test_case(
-            lambda: (2 ** (byte_len * 8)).to_bytes(byte_len + 1, "little")
+            lambda byte_len=byte_len: (2 ** (byte_len * 8)).to_bytes(byte_len + 1, "little")
         )
     for uint_type in [uint8, uint16, uint32, uint64, uint128, uint256]:
         byte_len = uint_type.type_byte_length()
         yield f"uint_{byte_len * 8}_one_byte_longer", invalid_test_case(
-            lambda: (2 ** (byte_len * 8) - 1).to_bytes(byte_len + 1, "little")
+            lambda byte_len=byte_len: (2 ** (byte_len * 8) - 1).to_bytes(byte_len + 1, "little")
         )
     for uint_type in [uint8, uint16, uint32, uint64, uint128, uint256]:
         byte_len = uint_type.type_byte_length()
         yield f"uint_{byte_len * 8}_one_byte_shorter", invalid_test_case(
-            lambda: (2 ** ((byte_len - 1) * 8) - 1).to_bytes(byte_len - 1, "little")
+            lambda byte_len=byte_len: (2 ** ((byte_len - 1) * 8) - 1).to_bytes(
+                byte_len - 1, "little"
+            )
         )


### PR DESCRIPTION
When testing the reference tests against a client, these were failing. After investigating, I saw that the inputs were not being binded properly. When generating these in parallel, they would use the last value in the loop.