### PR TITLE
Test generator: allow customization of CLI argument parser

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/args.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/args.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 
 
-def parse_arguments():
+def create_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="generator",
         description=f"Generate YAML test suite files.",
@@ -70,4 +70,8 @@ def parse_arguments():
         default=os.cpu_count(),
         help="Generate tests with N threads. Defaults to core count.",
     )
-    return parser.parse_args()
+    return parser
+
+
+def parse_arguments():
+    return create_arg_parser().parse_args()

--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
@@ -73,9 +73,10 @@ def execute_test(test_case: TestCase, dumper: Dumper):
         dumper.dump_meta(test_case, meta)
 
 
-def run_generator(input_test_cases: Iterable[TestCase]):
+def run_generator(input_test_cases: Iterable[TestCase], args=None):
     start_time = time.time()
-    args = parse_arguments()
+    if args is None:
+        args = parse_arguments()
 
     # Bail here if we are checking modules.
     if args.modcheck:


### PR DESCRIPTION
Currently, test generator arguments are parsed inside [run_generator](https://github.com/ethereum/consensus-specs/blob/e006240378602c5dea7d57c74f8cb2105943ce21/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py#L78).
This makes complicated adding generator specific CLI arguments (for example, fork choice compliance test generator #3831 needs additional options).
The PR allows passing pre-parsed arguments to `run_generator`. The `args` parameter is optional, so that existing behavior is preserved, if the `args` are not passed.
Additionally, it makes the default `argparse.ArgumentParser` accessible to test generator commands, so that they can modify it.