### PR TITLE
Remove out-of-style comment from BeaconState container in electra

### DIFF
--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -412,8 +412,7 @@ class BeaconState(Container):
     consolidation_balance_to_consume: Gwei  # [New in Electra:EIP7251]
     earliest_consolidation_epoch: Epoch  # [New in Electra:EIP7251]
     pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]  # [New in Electra:EIP7251]
-    # [New in Electra:EIP7251]
-    pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
+    pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT] # [New in Electra:EIP7251]
     pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]  # [New in Electra:EIP7251]
 ```
 


### PR DESCRIPTION
Non-zero confusion has stemmed from this. Multiple engineers, to my despair, glanced at the container and assumed electra only added 2 fields to BeaconState.