### PR TITLE
Remove Deneb/Electra from blob schedule and default to Electra limit

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -195,9 +195,3 @@ MAX_BYTES_PER_INCLUSION_LIST: 8192
 # ---------------------------------------------------------------
 
 BLOB_SCHEDULE:
-  # Deneb
-  - EPOCH: 269568
-    MAX_BLOBS_PER_BLOCK: 6
-  # Electra
-  - EPOCH: 364032
-    MAX_BLOBS_PER_BLOCK: 9

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -192,9 +192,3 @@ MAX_BYTES_PER_INCLUSION_LIST: 8192
 # ---------------------------------------------------------------
 
 BLOB_SCHEDULE:
-  # Deneb
-  - EPOCH: 18446744073709551615
-    MAX_BLOBS_PER_BLOCK: 6
-  # Electra
-  - EPOCH: 18446744073709551615
-    MAX_BLOBS_PER_BLOCK: 9

--- a/pysetup/helpers.py
+++ b/pysetup/helpers.py
@@ -384,7 +384,10 @@ def parse_config_vars(conf: Dict[str, str]) -> Dict[str, Union[str, List[Dict[st
     """
     out: Dict[str, Union[str, List[Dict[str, str]]]] = dict()
     for k, v in conf.items():
-        if isinstance(v, list):
+        if v == "":
+            # When a list of records is empty
+            out[k] = []
+        elif isinstance(v, list):
             # A special case for list of records
             out[k] = v
         elif isinstance(v, str) and (

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -75,12 +75,12 @@ specification.
 *[New in EIP7892]* This schedule defines the maximum blobs per block limit for a
 given epoch.
 
+*Note*: The blob schedule is to be determined.
+
 <!-- list-of-records:blob_schedule -->
 
-| Epoch                       | Max Blobs Per Block | Description                      |
-| --------------------------- | ------------------- | -------------------------------- |
-| `Epoch(269568)` **Deneb**   | `uint64(6)`         | The limit is set to `6` blobs    |
-| `Epoch(364032)` **Electra** | `uint64(9)`         | The limit is raised to `9` blobs |
+| Epoch | Max Blobs Per Block | Description |
+| ----- | ------------------- | ----------- |
 
 ### Containers
 
@@ -140,11 +140,10 @@ def get_max_blobs_per_block(epoch: Epoch) -> uint64:
     """
     Return the maximum number of blobs that can be included in a block for a given epoch.
     """
-    assert len(BLOB_SCHEDULE) > 0
     for entry in sorted(BLOB_SCHEDULE, key=lambda e: e["EPOCH"], reverse=True):
         if epoch >= entry["EPOCH"]:
             return entry["MAX_BLOBS_PER_BLOCK"]
-    return min(entry["MAX_BLOBS_PER_BLOCK"] for entry in BLOB_SCHEDULE)
+    return MAX_BLOBS_PER_BLOCK_ELECTRA
 ```
 
 ### `compute_columns_for_custody_group`


### PR DESCRIPTION
Instead of #4313, let's just make the blob schedule a Fulu-only specification change.

* Remove Deneb/Electra limits from the blob schedule.
* Default to `MAX_BLOBS_PER_BLOCK_ELECTRA` in `get_max_blobs_per_block()`.