### PR TITLE
Update default shell to bail on error

### DIFF
--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -2,7 +2,7 @@ name: Run test vector generation
 
 defaults:
   run:
-    shell: zsh {0}
+    shell: zsh -e {0}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly mainnet tests
 
 defaults:
   run:
-    shell: zsh {0}
+    shell: zsh -e {0}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: Run tests
 
 defaults:
   run:
-    shell: zsh {0}
+    shell: zsh -e {0}
 
 on:
   push:


### PR DESCRIPTION
I noticed that `make lint` in the CI fails locally but passes on the CI, which is wrong. It appears that it's because of our custom default shell. Adding `-e` should fix this. I'll need to fix the problems next.