### PR TITLE
Replace black with ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ lint: pyspec
 	@$(MDFORMAT_VENV) --number --wrap=80 $(MARKDOWN_FILES)
 	@$(CODESPELL_VENV) . --skip "./.git,$(VENV),$(PYSPEC_DIR)/.mypy_cache" -I .codespell-whitelist
 	@$(PYTHON_VENV) -m isort --quiet $(CURDIR)/tests $(CURDIR)/pysetup $(CURDIR)/setup.py
+	@$(PYTHON_VENV) -m ruff check --fix --quiet $(CURDIR)/tests $(CURDIR)/pysetup $(CURDIR)/setup.py
 	@$(PYTHON_VENV) -m ruff format --quiet $(CURDIR)/tests $(CURDIR)/pysetup $(CURDIR)/setup.py
 	@$(PYTHON_VENV) -m pylint --rcfile $(PYLINT_CONFIG) $(PYLINT_SCOPE)
 	@$(PYTHON_VENV) -m mypy --config-file $(MYPY_CONFIG) $(MYPY_SCOPE)

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ lint: pyspec
 	@$(MDFORMAT_VENV) --number --wrap=80 $(MARKDOWN_FILES)
 	@$(CODESPELL_VENV) . --skip "./.git,$(VENV),$(PYSPEC_DIR)/.mypy_cache" -I .codespell-whitelist
 	@$(PYTHON_VENV) -m isort --quiet $(CURDIR)/tests $(CURDIR)/pysetup $(CURDIR)/setup.py
-	@$(PYTHON_VENV) -m black --quiet $(CURDIR)/tests $(CURDIR)/pysetup $(CURDIR)/setup.py
+	@$(PYTHON_VENV) -m ruff format --quiet $(CURDIR)/tests $(CURDIR)/pysetup $(CURDIR)/setup.py
 	@$(PYTHON_VENV) -m pylint --rcfile $(PYLINT_CONFIG) $(PYLINT_SCOPE)
 	@$(PYTHON_VENV) -m mypy --config-file $(MYPY_CONFIG) $(MYPY_SCOPE)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ test = [
   "pytest==8.3.5",
 ]
 lint = [
-  "black==25.1.0",
   "codespell==2.4.1",
   "isort==6.0.1",
   "mdformat-gfm-alerts==1.0.2",
@@ -46,6 +45,7 @@ lint = [
   "mdformat==0.7.22",
   "mypy==1.15.0",
   "pylint==3.3.7",
+  "ruff==0.11.12",
 ]
 generator = [
   "filelock==3.18.0",
@@ -61,7 +61,7 @@ docs = [
   "mkdocs==1.6.1",
 ]
 
-[tool.black]
+[tool.ruff]
 line-length = 100
 
 [tool.isort]

--- a/pysetup/md_doc_paths.py
+++ b/pysetup/md_doc_paths.py
@@ -50,7 +50,7 @@ def is_post_fork(a, b) -> bool:
     prev_fork = PREVIOUS_FORK_OF[a]
     if prev_fork == b:
         return True
-    elif prev_fork == None:
+    elif prev_fork is None:
         return False
     else:
         return is_post_fork(prev_fork, b)

--- a/pysetup/md_to_spec.py
+++ b/pysetup/md_to_spec.py
@@ -294,9 +294,9 @@ class MarkdownToSpec:
         # For mainnet, check that the spec config & file config are the same
         # For minimal, we expect this to be different; just use the file config
         if self.preset_name == "mainnet":
-            assert (
-                list_of_records_spec == list_of_records_config_file
-            ), f"list of records mismatch: {list_of_records_spec} vs {list_of_records_config_file}"
+            assert list_of_records_spec == list_of_records_config_file, (
+                f"list of records mismatch: {list_of_records_spec} vs {list_of_records_config_file}"
+            )
 
         # Set the config variable
         self.spec["config_vars"][list_of_records_name] = list_of_records_config_file
@@ -613,9 +613,9 @@ def check_yaml_matches_spec(
             else:
                 raise ValueError(f"Variable {var} should be a string in the yaml file.")
     try:
-        assert yaml[var_name] == repr(
-            eval(updated_value)
-        ), f"mismatch for {var_name}: {yaml[var_name]} vs {eval(updated_value)}"
+        assert yaml[var_name] == repr(eval(updated_value)), (
+            f"mismatch for {var_name}: {yaml[var_name]} vs {eval(updated_value)}"
+        )
     except NameError:
         # Okay it's probably something more serious, let's ignore
         pass

--- a/pysetup/spec_builders/base.py
+++ b/pysetup/spec_builders/base.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import Dict, Sequence, Set
+from typing import Dict, Set
 
 
 class BaseSpecBuilder(ABC):

--- a/pysetup/spec_builders/deneb.py
+++ b/pysetup/spec_builders/deneb.py
@@ -15,7 +15,7 @@ from eth2spec.capella import {preset_name} as capella
 
     @classmethod
     def classes(cls):
-        return f"""
+        return """
 class BLSFieldElement(bls.Scalar):
     pass
 

--- a/pysetup/spec_builders/eip6800.py
+++ b/pysetup/spec_builders/eip6800.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from ..constants import EIP6800
 from .base import BaseSpecBuilder
 

--- a/pysetup/spec_builders/eip7732.py
+++ b/pysetup/spec_builders/eip7732.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set
+from typing import Set
 
 from ..constants import EIP7732
 from .base import BaseSpecBuilder

--- a/pysetup/spec_builders/fulu.py
+++ b/pysetup/spec_builders/fulu.py
@@ -16,7 +16,7 @@ from eth2spec.electra import {preset_name} as electra
 
     @classmethod
     def classes(cls):
-        return f"""
+        return """
 class PolynomialCoeff(list):
     def __init__(self, coeffs: Sequence[BLSFieldElement]):
         if len(coeffs) > FIELD_ELEMENTS_PER_EXT_BLOB:

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,6 @@ from setuptools.command.build_py import build_py
 
 from pysetup.md_to_spec import MarkdownToSpec
 
-pysetup_path = os.path.abspath(os.path.dirname(__file__))
-sys.path.insert(0, pysetup_path)
-
 from pysetup.constants import (
     PHASE0,
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import os
 import string
-import sys
 import warnings
 from collections import OrderedDict
 from distutils import dir_util
@@ -15,8 +14,6 @@ from ruamel.yaml import YAML
 from setuptools import Command, find_packages, setup
 from setuptools.command.build_py import build_py
 
-from pysetup.md_to_spec import MarkdownToSpec
-
 from pysetup.constants import (
     PHASE0,
 )
@@ -27,6 +24,7 @@ from pysetup.helpers import (
     parse_config_vars,
 )
 from pysetup.md_doc_paths import get_md_doc_paths
+from pysetup.md_to_spec import MarkdownToSpec
 from pysetup.spec_builders import spec_builders
 from pysetup.typing import (
     BuildTarget,

--- a/specs/_features/eip7441/beacon-chain.md
+++ b/specs/_features/eip7441/beacon-chain.md
@@ -89,11 +89,11 @@ def bytes_to_bls_field(b: Bytes32) -> BLSFieldElement:
     return BLSFieldElement(field_element % BLS_MODULUS)
 ```
 
-| Name               | Value                                                                                                                            |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `BLS_G1_GENERATOR` | `BLSG1Point('0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb')  # noqa: E501` |
-| `BLS_MODULUS`      | `52435875175126190479447740508185965837690552500527637822603658699938581184513`                                                  |
-| `CURDLEPROOFS_CRS` | TBD                                                                                                                              |
+| Name               | Value                                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `BLS_G1_GENERATOR` | `BLSG1Point('0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb')` |
+| `BLS_MODULUS`      | `52435875175126190479447740508185965837690552500527637822603658699938581184513`                                    |
+| `CURDLEPROOFS_CRS` | TBD                                                                                                                |
 
 ### Curdleproofs and opening proofs
 

--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/args.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/args.py
@@ -6,7 +6,7 @@ import pathlib
 def create_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="generator",
-        description=f"Generate YAML test suite files.",
+        description="Generate YAML test suite files.",
     )
     parser.add_argument(
         "-o",

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_single_merkle_proof.py
@@ -17,11 +17,14 @@ def test_current_sync_committee_merkle_proof(spec, state):
     yield "object", state
     gindex = latest_current_sync_committee_gindex(spec)
     branch = spec.compute_merkle_proof(state, gindex)
-    yield "proof", {
-        "leaf": "0x" + state.current_sync_committee.hash_tree_root().hex(),
-        "leaf_index": gindex,
-        "branch": ["0x" + root.hex() for root in branch],
-    }
+    yield (
+        "proof",
+        {
+            "leaf": "0x" + state.current_sync_committee.hash_tree_root().hex(),
+            "leaf_index": gindex,
+            "branch": ["0x" + root.hex() for root in branch],
+        },
+    )
     assert spec.is_valid_merkle_branch(
         leaf=state.current_sync_committee.hash_tree_root(),
         branch=branch,
@@ -38,11 +41,14 @@ def test_next_sync_committee_merkle_proof(spec, state):
     yield "object", state
     gindex = latest_next_sync_committee_gindex(spec)
     branch = spec.compute_merkle_proof(state, gindex)
-    yield "proof", {
-        "leaf": "0x" + state.next_sync_committee.hash_tree_root().hex(),
-        "leaf_index": gindex,
-        "branch": ["0x" + root.hex() for root in branch],
-    }
+    yield (
+        "proof",
+        {
+            "leaf": "0x" + state.next_sync_committee.hash_tree_root().hex(),
+            "leaf_index": gindex,
+            "branch": ["0x" + root.hex() for root in branch],
+        },
+    )
     assert spec.is_valid_merkle_branch(
         leaf=state.next_sync_committee.hash_tree_root(),
         branch=branch,
@@ -59,11 +65,14 @@ def test_finality_root_merkle_proof(spec, state):
     yield "object", state
     gindex = latest_finalized_root_gindex(spec)
     branch = spec.compute_merkle_proof(state, gindex)
-    yield "proof", {
-        "leaf": "0x" + state.finalized_checkpoint.root.hex(),
-        "leaf_index": gindex,
-        "branch": ["0x" + root.hex() for root in branch],
-    }
+    yield (
+        "proof",
+        {
+            "leaf": "0x" + state.finalized_checkpoint.root.hex(),
+            "leaf_index": gindex,
+            "branch": ["0x" + root.hex() for root in branch],
+        },
+    )
 
     assert spec.is_valid_merkle_branch(
         leaf=state.finalized_checkpoint.root,

--- a/tests/core/pyspec/eth2spec/test/bellatrix/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/sanity/test_blocks.py
@@ -1,7 +1,6 @@
 from random import Random
 
 from eth2spec.test.context import (
-    BELLATRIX,
     spec_state_test,
     with_all_phases_from_except,
     with_phases,

--- a/tests/core/pyspec/eth2spec/test/capella/light_client/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/capella/light_client/test_single_merkle_proof.py
@@ -21,11 +21,14 @@ def test_execution_merkle_proof(spec, state):
     yield "object", block.message.body
     gindex = spec.EXECUTION_PAYLOAD_GINDEX
     branch = spec.compute_merkle_proof(block.message.body, gindex)
-    yield "proof", {
-        "leaf": "0x" + block.message.body.execution_payload.hash_tree_root().hex(),
-        "leaf_index": gindex,
-        "branch": ["0x" + root.hex() for root in branch],
-    }
+    yield (
+        "proof",
+        {
+            "leaf": "0x" + block.message.body.execution_payload.hash_tree_root().hex(),
+            "leaf_index": gindex,
+            "branch": ["0x" + root.hex() for root in branch],
+        },
+    )
     assert spec.is_valid_merkle_branch(
         leaf=block.message.body.execution_payload.hash_tree_root(),
         branch=branch,

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -18,7 +18,6 @@ from .helpers.constants import (
     CAPELLA,
     DENEB,
     EIP7441,
-    EIP7732,
     ELECTRA,
     FULU,
     LIGHT_CLIENT_TESTING_FORKS,

--- a/tests/core/pyspec/eth2spec/test/deneb/merkle_proof/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/merkle_proof/test_single_merkle_proof.py
@@ -75,11 +75,14 @@ def _run_blob_kzg_commitment_merkle_proof_test(spec, state, rng=None):
             spec.BeaconBlockBody, "blob_kzg_commitments", blob_index
         )
 
-    yield "proof", {
-        "leaf": "0x" + blob_sidecar.kzg_commitment.hash_tree_root().hex(),
-        "leaf_index": gindex,
-        "branch": ["0x" + root.hex() for root in kzg_commitment_inclusion_proof],
-    }
+    yield (
+        "proof",
+        {
+            "leaf": "0x" + blob_sidecar.kzg_commitment.hash_tree_root().hex(),
+            "leaf_index": gindex,
+            "branch": ["0x" + root.hex() for root in kzg_commitment_inclusion_proof],
+        },
+    )
 
     assert spec.is_valid_merkle_branch(
         leaf=blob_sidecar.kzg_commitment.hash_tree_root(),

--- a/tests/core/pyspec/eth2spec/test/fulu/merkle_proof/test_single_merkle_proof.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/merkle_proof/test_single_merkle_proof.py
@@ -47,11 +47,14 @@ def _run_blob_kzg_commitments_merkle_proof_test(spec, state, rng=None, blob_coun
     yield "object", block.body
     kzg_commitments_inclusion_proof = column_sidcar.kzg_commitments_inclusion_proof
     gindex = spec.get_generalized_index(spec.BeaconBlockBody, "blob_kzg_commitments")
-    yield "proof", {
-        "leaf": "0x" + column_sidcar.kzg_commitments.hash_tree_root().hex(),
-        "leaf_index": gindex,
-        "branch": ["0x" + root.hex() for root in kzg_commitments_inclusion_proof],
-    }
+    yield (
+        "proof",
+        {
+            "leaf": "0x" + column_sidcar.kzg_commitments.hash_tree_root().hex(),
+            "leaf_index": gindex,
+            "branch": ["0x" + root.hex() for root in kzg_commitments_inclusion_proof],
+        },
+    )
     assert spec.is_valid_merkle_branch(
         leaf=column_sidcar.kzg_commitments.hash_tree_root(),
         branch=column_sidcar.kzg_commitments_inclusion_proof,

--- a/tests/core/pyspec/eth2spec/test/fulu/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -16,7 +16,6 @@ from eth2spec.utils.bls import BLS_MODULUS
 @spec_test
 @single_phase
 def test_fft(spec):
-
     # in this test we sample a random polynomial in coefficient form
     # then we apply an FFT to get evaluations over the roots of unity
     # we then apply an inverse FFT to the evaluations to get coefficients
@@ -53,7 +52,6 @@ def test_fft(spec):
 @spec_test
 @single_phase
 def test_coset_fft(spec):
-
     # in this test we sample a random polynomial in coefficient form
     # then we apply a Coset FFT to get evaluations over the coset of the roots of unity
     # we then apply an inverse Coset FFT to the evaluations to get coefficients
@@ -132,7 +130,6 @@ def test_verify_cell_kzg_proof_batch_zero_cells(spec):
 @spec_test
 @single_phase
 def test_verify_cell_kzg_proof_batch(spec):
-
     # test with a single blob / commitment
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
@@ -184,7 +181,6 @@ def test_verify_cell_kzg_proof_batch(spec):
 @spec_test
 @single_phase
 def test_verify_cell_kzg_proof_batch_invalid(spec):
-
     # test with a single blob / commitment
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)

--- a/tests/core/pyspec/eth2spec/test/fulu/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/unittests/test_config_invariants.py
@@ -1,7 +1,5 @@
 from eth2spec.test.context import (
-    expect_assertion_error,
     single_phase,
-    spec_state_test,
     spec_test,
     with_fulu_and_later,
     with_presets,

--- a/tests/core/pyspec/eth2spec/test/helpers/optimistic_sync.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/optimistic_sync.py
@@ -132,9 +132,9 @@ def add_optimistic_block(
         while el_block_hash != payload_status.latest_valid_hash and el_block_hash != spec.Bytes32():
             current_block_root = current_block.hash_tree_root()
             assert current_block_root in mega_store.block_payload_statuses
-            mega_store.block_payload_statuses[current_block_root].status = (
-                PayloadStatusV1Status.INVALID
-            )
+            mega_store.block_payload_statuses[
+                current_block_root
+            ].status = PayloadStatusV1Status.INVALID
             # Get parent
             current_block = mega_store.fc_store.blocks[current_block.parent_root]
             el_block_hash = current_block.body.execution_payload.block_hash

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -182,8 +182,9 @@ def run_get_inclusion_delay_deltas(spec, state):
     """
     if is_post_altair(spec):
         # No inclusion_delay_deltas
-        yield "inclusion_delay_deltas", Deltas(
-            rewards=[0] * len(state.validators), penalties=[0] * len(state.validators)
+        yield (
+            "inclusion_delay_deltas",
+            Deltas(rewards=[0] * len(state.validators), penalties=[0] * len(state.validators)),
         )
         return
 

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_registry_updates.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_registry_updates.py
@@ -292,9 +292,9 @@ def run_test_activation_queue_activation_and_ejection(spec, state, num_per_statu
     )
     for validator_index in activation_indices:
         mock_deposit(spec, state, validator_index)
-        state.validators[validator_index].activation_eligibility_epoch = (
-            state.finalized_checkpoint.epoch
-        )
+        state.validators[
+            validator_index
+        ].activation_eligibility_epoch = state.finalized_checkpoint.epoch
 
     # ready for ejection
     ejection_start_index = num_per_status * 2

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
@@ -66,7 +66,11 @@ def test_genesis(spec, state):
     yield "steps", test_steps
 
     if is_post_altair(spec):
-        yield "description", "meta", f"Although it's not phase 0, we may use {spec.fork} spec to start testnets."
+        yield (
+            "description",
+            "meta",
+            f"Although it's not phase 0, we may use {spec.fork} spec to start testnets.",
+        )
 
 
 @with_altair_and_later

--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
@@ -21,10 +21,13 @@ def get_post_altair_description(spec):
 
 
 def eth1_init_data(eth1_block_hash, eth1_timestamp):
-    yield "eth1", {
-        "eth1_block_hash": "0x" + eth1_block_hash.hex(),
-        "eth1_timestamp": int(eth1_timestamp),
-    }
+    yield (
+        "eth1",
+        {
+            "eth1_block_hash": "0x" + eth1_block_hash.hex(),
+            "eth1_timestamp": int(eth1_timestamp),
+        },
+    )
 
 
 @with_phases([PHASE0])

--- a/tests/core/pyspec/eth2spec/test/utils/utils.py
+++ b/tests/core/pyspec/eth2spec/test/utils/utils.py
@@ -23,7 +23,6 @@ def vector_test(description: str = None):
         #   - "ssz": raw SSZ bytes
         #   - "data": a python structure to be encoded by the user.
         def entry(*args, **kw):
-
             def generator_mode():
                 if description is not None:
                     # description can be explicit

--- a/tests/core/pyspec/eth2spec/utils/ssz/ssz_typing.py
+++ b/tests/core/pyspec/eth2spec/utils/ssz/ssz_typing.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F401
+
 from remerkleable.basic import (
     bit,
     boolean,

--- a/tests/generators/runners/bls.py
+++ b/tests/generators/runners/bls.py
@@ -78,7 +78,7 @@ def case_eth_aggregate_pubkeys():
             try:
                 aggregate_pubkey = None
                 aggregate_pubkey = spec.eth_aggregate_pubkeys(pubkeys)
-            except:
+            except Exception:
                 expect_exception(milagro_bls._AggregatePKs, pubkeys)
             if aggregate_pubkey is not None:
                 assert aggregate_pubkey == milagro_bls._AggregatePKs(pubkeys)
@@ -158,7 +158,7 @@ def case_eth_fast_aggregate_verify():
             try:
                 ok = None
                 ok = spec.eth_fast_aggregate_verify(pubkeys, message, aggregate_signature)
-            except:
+            except Exception:
                 pass
             return [
                 (

--- a/tests/generators/runners/bls.py
+++ b/tests/generators/runners/bls.py
@@ -222,8 +222,9 @@ def case_eth_fast_aggregate_verify():
         def get_inputs():
             return [], MESSAGES[-1], G2_POINT_AT_INFINITY
 
-        yield "eth_fast_aggregate_verify_na_pubkeys_and_infinity_signature", get_test_runner(
-            get_inputs
+        yield (
+            "eth_fast_aggregate_verify_na_pubkeys_and_infinity_signature",
+            get_test_runner(get_inputs),
         )
 
     # Invalid pubkeys and signature -- len(pubkeys) == 0 and signature == 0x00...

--- a/tests/generators/runners/kzg_4844.py
+++ b/tests/generators/runners/kzg_4844.py
@@ -184,8 +184,9 @@ def case_verify_kzg_proof():
             proof = spec.G1_POINT_AT_INFINITY
             return commitment, z, y, proof
 
-        yield f"verify_kzg_proof_case_incorrect_proof_point_at_infinity_{index}", get_test_runner(
-            get_inputs
+        yield (
+            f"verify_kzg_proof_case_incorrect_proof_point_at_infinity_{index}",
+            get_test_runner(get_inputs),
         )
 
     # Correct `G1_POINT_AT_INFINITY` proof for zero poly
@@ -198,8 +199,9 @@ def case_verify_kzg_proof():
             proof = spec.G1_POINT_AT_INFINITY
             return commitment, z, y, proof
 
-        yield f"verify_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly_{index}", get_test_runner(
-            get_inputs
+        yield (
+            f"verify_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly_{index}",
+            get_test_runner(get_inputs),
         )
 
     # Correct `G1_POINT_AT_INFINITY` proof for poly of all twos
@@ -212,8 +214,9 @@ def case_verify_kzg_proof():
             proof = spec.G1_POINT_AT_INFINITY
             return commitment, z, y, proof
 
-        yield f"verify_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly_{index}", get_test_runner(
-            get_inputs
+        yield (
+            f"verify_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly_{index}",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Invalid commitment
@@ -378,8 +381,9 @@ def case_verify_blob_kzg_proof():
             proof = spec.G1_POINT_AT_INFINITY
             return blob, commitment, proof
 
-        yield "verify_blob_kzg_proof_case_incorrect_proof_point_at_infinity", get_test_runner(
-            get_inputs
+        yield (
+            "verify_blob_kzg_proof_case_incorrect_proof_point_at_infinity",
+            get_test_runner(get_inputs),
         )
 
     # Correct `G1_POINT_AT_INFINITY` proof and commitment for zero poly
@@ -391,8 +395,9 @@ def case_verify_blob_kzg_proof():
             proof = spec.G1_POINT_AT_INFINITY
             return blob, commitment, proof
 
-        yield "verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly", get_test_runner(
-            get_inputs
+        yield (
+            "verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly",
+            get_test_runner(get_inputs),
         )
 
     # Correct `G1_POINT_AT_INFINITY` proof for all twos poly
@@ -404,8 +409,9 @@ def case_verify_blob_kzg_proof():
             proof = spec.G1_POINT_AT_INFINITY
             return blob, commitment, proof
 
-        yield "verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly", get_test_runner(
-            get_inputs
+        yield (
+            "verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Invalid blob
@@ -496,8 +502,9 @@ def case_verify_blob_kzg_proof_batch():
             proofs = [bls_add_one(proofs[0])] + proofs[1:]
             return blobs, commitments, proofs
 
-        yield "verify_blob_kzg_proof_batch_case_incorrect_proof_add_one", get_test_runner(
-            get_inputs
+        yield (
+            "verify_blob_kzg_proof_batch_case_incorrect_proof_add_one",
+            get_test_runner(get_inputs),
         )
 
     # Incorrect `G1_POINT_AT_INFINITY` proof
@@ -510,8 +517,9 @@ def case_verify_blob_kzg_proof_batch():
             proofs = [spec.G1_POINT_AT_INFINITY]
             return blobs, commitments, proofs
 
-        yield "verify_blob_kzg_proof_batch_case_incorrect_proof_point_at_infinity", get_test_runner(
-            get_inputs
+        yield (
+            "verify_blob_kzg_proof_batch_case_incorrect_proof_point_at_infinity",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Invalid blobs
@@ -542,8 +550,9 @@ def case_verify_blob_kzg_proof_batch():
             commitments = [commitment] + commitments[1:]
             return blobs, commitments, proofs
 
-        yield f"verify_blob_kzg_proof_batch_case_invalid_commitment_{index}", get_test_runner(
-            get_inputs
+        yield (
+            f"verify_blob_kzg_proof_batch_case_invalid_commitment_{index}",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Invalid proof
@@ -589,8 +598,9 @@ def case_verify_blob_kzg_proof_batch():
             commitments = commitments[:-1]
             return blobs, commitments, proofs
 
-        yield "verify_blob_kzg_proof_batch_case_commitment_length_different", get_test_runner(
-            get_inputs
+        yield (
+            "verify_blob_kzg_proof_batch_case_commitment_length_different",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Proof length different

--- a/tests/generators/runners/kzg_4844.py
+++ b/tests/generators/runners/kzg_4844.py
@@ -50,7 +50,7 @@ def case_blob_to_kzg_commitment():
             try:
                 commitment = None
                 commitment = cached_blob_to_kzg_commitment(blob)
-            except:
+            except Exception:
                 pass
             return [
                 (
@@ -85,7 +85,7 @@ def case_compute_kzg_proof():
             try:
                 proof, y = None, None
                 proof, y = spec.compute_kzg_proof(blob, z)
-            except:
+            except Exception:
                 pass
             return [
                 (
@@ -131,7 +131,7 @@ def case_verify_kzg_proof():
             try:
                 ok = None
                 ok = spec.verify_kzg_proof(commitment, z, y, proof)
-            except:
+            except Exception:
                 pass
             return [
                 (
@@ -275,7 +275,7 @@ def case_compute_blob_kzg_proof():
             try:
                 proof = None
                 proof = cached_compute_blob_kzg_proof(blob, commitment)
-            except:
+            except Exception:
                 pass
             return [
                 (
@@ -333,7 +333,7 @@ def case_verify_blob_kzg_proof():
             try:
                 ok = None
                 ok = spec.verify_blob_kzg_proof(blob, commitment, proof)
-            except:
+            except Exception:
                 pass
             return [
                 (
@@ -457,7 +457,7 @@ def case_verify_blob_kzg_proof_batch():
             try:
                 ok = None
                 ok = spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
-            except:
+            except Exception:
                 pass
             return [
                 (

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -419,7 +419,7 @@ def case_recover_cells_and_kzg_proofs():
             cell_indices = list(range(spec.CELLS_PER_EXT_BLOB))
             return cell_indices, cells
 
-        yield f"recover_cells_and_kzg_proofs_case_valid_no_missing", get_test_runner(get_inputs)
+        yield "recover_cells_and_kzg_proofs_case_valid_no_missing", get_test_runner(get_inputs)
 
     # Valid: Half missing cells (every other cell)
     if True:
@@ -431,7 +431,7 @@ def case_recover_cells_and_kzg_proofs():
             return cell_indices, partial_cells
 
         yield (
-            f"recover_cells_and_kzg_proofs_case_valid_half_missing_every_other_cell",
+            "recover_cells_and_kzg_proofs_case_valid_half_missing_every_other_cell",
             get_test_runner(get_inputs),
         )
 
@@ -445,7 +445,7 @@ def case_recover_cells_and_kzg_proofs():
             return cell_indices, partial_cells
 
         yield (
-            f"recover_cells_and_kzg_proofs_case_valid_half_missing_first_half",
+            "recover_cells_and_kzg_proofs_case_valid_half_missing_first_half",
             get_test_runner(get_inputs),
         )
 
@@ -459,7 +459,7 @@ def case_recover_cells_and_kzg_proofs():
             return cell_indices, partial_cells
 
         yield (
-            f"recover_cells_and_kzg_proofs_case_valid_half_missing_second_half",
+            "recover_cells_and_kzg_proofs_case_valid_half_missing_second_half",
             get_test_runner(get_inputs),
         )
 
@@ -470,7 +470,7 @@ def case_recover_cells_and_kzg_proofs():
             return [], []
 
         yield (
-            f"recover_cells_and_kzg_proofs_case_invalid_all_cells_are_missing",
+            "recover_cells_and_kzg_proofs_case_invalid_all_cells_are_missing",
             get_test_runner(get_inputs),
         )
 
@@ -484,7 +484,7 @@ def case_recover_cells_and_kzg_proofs():
             return cell_indices, partial_cells
 
         yield (
-            f"recover_cells_and_kzg_proofs_case_invalid_more_than_half_missing",
+            "recover_cells_and_kzg_proofs_case_invalid_more_than_half_missing",
             get_test_runner(get_inputs),
         )
 
@@ -498,7 +498,7 @@ def case_recover_cells_and_kzg_proofs():
             return cell_indices, partial_cells
 
         yield (
-            f"recover_cells_and_kzg_proofs_case_invalid_more_cells_than_cells_per_ext_blob",
+            "recover_cells_and_kzg_proofs_case_invalid_more_cells_than_cells_per_ext_blob",
             get_test_runner(get_inputs),
         )
 
@@ -513,7 +513,7 @@ def case_recover_cells_and_kzg_proofs():
             cell_indices[0] = int(spec.CELLS_PER_EXT_BLOB)
             return cell_indices, partial_cells
 
-        yield f"recover_cells_and_kzg_proofs_case_invalid_cell_index", get_test_runner(get_inputs)
+        yield "recover_cells_and_kzg_proofs_case_invalid_cell_index", get_test_runner(get_inputs)
 
     # Edge case: Invalid cell
     for index, cell in enumerate(INVALID_INDIVIDUAL_CELL_BYTES):
@@ -540,7 +540,7 @@ def case_recover_cells_and_kzg_proofs():
             return cell_indices, partial_cells
 
         yield (
-            f"recover_cells_and_kzg_proofs_case_invalid_more_cell_indices_than_cells",
+            "recover_cells_and_kzg_proofs_case_invalid_more_cell_indices_than_cells",
             get_test_runner(get_inputs),
         )
 
@@ -556,7 +556,7 @@ def case_recover_cells_and_kzg_proofs():
             return cell_indices, partial_cells
 
         yield (
-            f"recover_cells_and_kzg_proofs_case_invalid_more_cells_than_cell_indices",
+            "recover_cells_and_kzg_proofs_case_invalid_more_cells_than_cell_indices",
             get_test_runner(get_inputs),
         )
 
@@ -577,7 +577,7 @@ def case_recover_cells_and_kzg_proofs():
             return cell_indices, partial_cells
 
         yield (
-            f"recover_cells_and_kzg_proofs_case_invalid_duplicate_cell_index",
+            "recover_cells_and_kzg_proofs_case_invalid_duplicate_cell_index",
             get_test_runner(get_inputs),
         )
 

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -47,7 +47,7 @@ def case_compute_cells():
             try:
                 cells = None
                 cells = spec.compute_cells(blob)
-            except:
+            except Exception:
                 pass
             return [
                 (
@@ -82,7 +82,7 @@ def case_compute_cells_and_kzg_proofs():
             try:
                 cells, proofs = None, None
                 cells, proofs = cached_compute_cells_and_kzg_proofs(blob)
-            except:
+            except Exception:
                 pass
             return [
                 (
@@ -122,7 +122,7 @@ def case_verify_cell_kzg_proof_batch():
             try:
                 ok = None
                 ok = spec.verify_cell_kzg_proof_batch(commitments, cell_indices, cells, proofs)
-            except:
+            except Exception:
                 pass
             return [
                 (
@@ -389,7 +389,7 @@ def case_recover_cells_and_kzg_proofs():
                 recovered_cells, recovered_proofs = spec.recover_cells_and_kzg_proofs(
                     cell_indices, cells
                 )
-            except:
+            except Exception:
                 pass
             return [
                 (

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -189,8 +189,9 @@ def case_verify_cell_kzg_proof_batch():
             proofs = [cached_compute_cells_and_kzg_proofs(VALID_BLOBS[3])[1][0]] * num_duplicates
             return commitments, cell_indices, cells, proofs
 
-        yield "verify_cell_kzg_proof_batch_case_valid_same_cell_multiple_times", get_test_runner(
-            get_inputs
+        yield (
+            "verify_cell_kzg_proof_batch_case_valid_same_cell_multiple_times",
+            get_test_runner(get_inputs),
         )
 
     # Incorrect commitment
@@ -247,8 +248,9 @@ def case_verify_cell_kzg_proof_batch():
             cell_indices = list(range(len(cells)))
             return commitments, cell_indices, cells, proofs
 
-        yield f"verify_cell_kzg_proof_batch_case_invalid_commitment_{index}", get_test_runner(
-            get_inputs
+        yield (
+            f"verify_cell_kzg_proof_batch_case_invalid_commitment_{index}",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Invalid cell_index
@@ -314,8 +316,9 @@ def case_verify_cell_kzg_proof_batch():
             cell_indices = list(range(len(cells)))
             return commitments, cell_indices, cells, proofs
 
-        yield "verify_cell_kzg_proof_batch_case_invalid_missing_commitment", get_test_runner(
-            get_inputs
+        yield (
+            "verify_cell_kzg_proof_batch_case_invalid_missing_commitment",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Missing a cell index
@@ -332,8 +335,9 @@ def case_verify_cell_kzg_proof_batch():
             cell_indices = list(range(len(cells) - 1))
             return commitments, cell_indices, cells, proofs
 
-        yield "verify_cell_kzg_proof_batch_case_invalid_missing_cell_index", get_test_runner(
-            get_inputs
+        yield (
+            "verify_cell_kzg_proof_batch_case_invalid_missing_cell_index",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Missing a cell
@@ -426,8 +430,9 @@ def case_recover_cells_and_kzg_proofs():
             partial_cells = [cells[cell_index] for cell_index in cell_indices]
             return cell_indices, partial_cells
 
-        yield f"recover_cells_and_kzg_proofs_case_valid_half_missing_every_other_cell", get_test_runner(
-            get_inputs
+        yield (
+            f"recover_cells_and_kzg_proofs_case_valid_half_missing_every_other_cell",
+            get_test_runner(get_inputs),
         )
 
     # Valid: Half missing cells (first half)
@@ -439,8 +444,9 @@ def case_recover_cells_and_kzg_proofs():
             partial_cells = [cells[cell_index] for cell_index in cell_indices]
             return cell_indices, partial_cells
 
-        yield f"recover_cells_and_kzg_proofs_case_valid_half_missing_first_half", get_test_runner(
-            get_inputs
+        yield (
+            f"recover_cells_and_kzg_proofs_case_valid_half_missing_first_half",
+            get_test_runner(get_inputs),
         )
 
     # Valid: Half missing cells (second half)
@@ -452,8 +458,9 @@ def case_recover_cells_and_kzg_proofs():
             partial_cells = [cells[cell_index] for cell_index in cell_indices]
             return cell_indices, partial_cells
 
-        yield f"recover_cells_and_kzg_proofs_case_valid_half_missing_second_half", get_test_runner(
-            get_inputs
+        yield (
+            f"recover_cells_and_kzg_proofs_case_valid_half_missing_second_half",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: All cells are missing
@@ -462,8 +469,9 @@ def case_recover_cells_and_kzg_proofs():
         def get_inputs():
             return [], []
 
-        yield f"recover_cells_and_kzg_proofs_case_invalid_all_cells_are_missing", get_test_runner(
-            get_inputs
+        yield (
+            f"recover_cells_and_kzg_proofs_case_invalid_all_cells_are_missing",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: More than half missing
@@ -475,8 +483,9 @@ def case_recover_cells_and_kzg_proofs():
             partial_cells = [cells[cell_index] for cell_index in cell_indices]
             return cell_indices, partial_cells
 
-        yield f"recover_cells_and_kzg_proofs_case_invalid_more_than_half_missing", get_test_runner(
-            get_inputs
+        yield (
+            f"recover_cells_and_kzg_proofs_case_invalid_more_than_half_missing",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: More cells provided than CELLS_PER_EXT_BLOB
@@ -488,8 +497,9 @@ def case_recover_cells_and_kzg_proofs():
             partial_cells = [cells[cell_index] for cell_index in cell_indices]
             return cell_indices, partial_cells
 
-        yield f"recover_cells_and_kzg_proofs_case_invalid_more_cells_than_cells_per_ext_blob", get_test_runner(
-            get_inputs
+        yield (
+            f"recover_cells_and_kzg_proofs_case_invalid_more_cells_than_cells_per_ext_blob",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Invalid cell_index
@@ -529,8 +539,9 @@ def case_recover_cells_and_kzg_proofs():
             cell_indices.append(int(spec.CELLS_PER_EXT_BLOB - 1))
             return cell_indices, partial_cells
 
-        yield f"recover_cells_and_kzg_proofs_case_invalid_more_cell_indices_than_cells", get_test_runner(
-            get_inputs
+        yield (
+            f"recover_cells_and_kzg_proofs_case_invalid_more_cell_indices_than_cells",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: More cells than cell_indices
@@ -544,8 +555,9 @@ def case_recover_cells_and_kzg_proofs():
             partial_cells.append(CELL_RANDOM_VALID1)
             return cell_indices, partial_cells
 
-        yield f"recover_cells_and_kzg_proofs_case_invalid_more_cells_than_cell_indices", get_test_runner(
-            get_inputs
+        yield (
+            f"recover_cells_and_kzg_proofs_case_invalid_more_cells_than_cell_indices",
+            get_test_runner(get_inputs),
         )
 
     # Edge case: Duplicate cell_index
@@ -564,8 +576,9 @@ def case_recover_cells_and_kzg_proofs():
             cell_indices[0] = cell_indices[1]
             return cell_indices, partial_cells
 
-        yield f"recover_cells_and_kzg_proofs_case_invalid_duplicate_cell_index", get_test_runner(
-            get_inputs
+        yield (
+            f"recover_cells_and_kzg_proofs_case_invalid_duplicate_cell_index",
+            get_test_runner(get_inputs),
         )
 
 

--- a/tests/generators/runners/shuffling.py
+++ b/tests/generators/runners/shuffling.py
@@ -12,11 +12,15 @@ def generate_random_bytes(rng=random.Random(5566)):
 
 
 def shuffling_case_fn(spec, seed, count):
-    yield "mapping", "data", {
-        "seed": "0x" + seed.hex(),
-        "count": count,
-        "mapping": [int(spec.compute_shuffled_index(i, count, seed)) for i in range(count)],
-    }
+    yield (
+        "mapping",
+        "data",
+        {
+            "seed": "0x" + seed.hex(),
+            "count": count,
+            "mapping": [int(spec.compute_shuffled_index(i, count, seed)) for i in range(count)],
+        },
+    )
 
 
 def shuffling_case(spec, seed, count):

--- a/tests/generators/runners/ssz_generic_cases/ssz_basic_vector.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_basic_vector.py
@@ -50,10 +50,13 @@ def valid_cases():
             random_modes.append(RandomizationMode.mode_random)
         for length in [1, 2, 3, 4, 5, 8, 16, 31, 512, 513]:
             for mode in random_modes:
-                yield f"vec_{name}_{length}_{mode.to_name()}", valid_test_case(
-                    lambda rng=rng, mode=mode, typ=typ, length=length: basic_vector_case_fn(
-                        rng, mode, typ, length
-                    )
+                yield (
+                    f"vec_{name}_{length}_{mode.to_name()}",
+                    valid_test_case(
+                        lambda rng=rng, mode=mode, typ=typ, length=length: basic_vector_case_fn(
+                            rng, mode, typ, length
+                        )
+                    ),
                 )
 
 
@@ -72,28 +75,41 @@ def invalid_cases():
             for mode in random_modes:
                 if length == 1:
                     # empty bytes, no elements. It may seem valid, but empty fixed-size elements are not valid SSZ.
-                    yield f"vec_{name}_{length}_{mode.to_name()}_one_less", invalid_test_case(
-                        lambda: b""
+                    yield (
+                        f"vec_{name}_{length}_{mode.to_name()}_one_less",
+                        invalid_test_case(lambda: b""),
                     )
                 else:
-                    yield f"vec_{name}_{length}_{mode.to_name()}_one_less", invalid_test_case(
+                    yield (
+                        f"vec_{name}_{length}_{mode.to_name()}_one_less",
+                        invalid_test_case(
+                            lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
+                                basic_vector_case_fn(rng, mode, typ, length - 1)
+                            )
+                        ),
+                    )
+                yield (
+                    f"vec_{name}_{length}_{mode.to_name()}_one_more",
+                    invalid_test_case(
                         lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
-                            basic_vector_case_fn(rng, mode, typ, length - 1)
+                            basic_vector_case_fn(rng, mode, typ, length + 1)
                         )
-                    )
-                yield f"vec_{name}_{length}_{mode.to_name()}_one_more", invalid_test_case(
-                    lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
-                        basic_vector_case_fn(rng, mode, typ, length + 1)
-                    )
+                    ),
                 )
-                yield f"vec_{name}_{length}_{mode.to_name()}_one_byte_less", invalid_test_case(
-                    lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
-                        basic_vector_case_fn(rng, mode, typ, length)
-                    )[:-1]
+                yield (
+                    f"vec_{name}_{length}_{mode.to_name()}_one_byte_less",
+                    invalid_test_case(
+                        lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
+                            basic_vector_case_fn(rng, mode, typ, length)
+                        )[:-1]
+                    ),
                 )
-                yield f"vec_{name}_{length}_{mode.to_name()}_one_byte_more", invalid_test_case(
-                    lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
-                        basic_vector_case_fn(rng, mode, typ, length)
-                    )
-                    + serialize(basic_vector_case_fn(rng, mode, uint8, 1))
+                yield (
+                    f"vec_{name}_{length}_{mode.to_name()}_one_byte_more",
+                    invalid_test_case(
+                        lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
+                            basic_vector_case_fn(rng, mode, typ, length)
+                        )
+                        + serialize(basic_vector_case_fn(rng, mode, uint8, 1))
+                    ),
                 )

--- a/tests/generators/runners/ssz_generic_cases/ssz_bitlist.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_bitlist.py
@@ -29,8 +29,11 @@ def valid_cases():
                 RandomizationMode.mode_zero,
                 RandomizationMode.mode_max,
             ]:
-                yield f"bitlist_{size}_{mode.to_name()}_{variation}", valid_test_case(
-                    lambda rng=rng, mode=mode, size=size: bitlist_case_fn(rng, mode, size)
+                yield (
+                    f"bitlist_{size}_{mode.to_name()}_{variation}",
+                    valid_test_case(
+                        lambda rng=rng, mode=mode, size=size: bitlist_case_fn(rng, mode, size)
+                    ),
                 )
 
 
@@ -52,8 +55,11 @@ def invalid_cases():
         (32, 33),
         (512, 513),
     ]:
-        yield f"bitlist_{typ_limit}_but_{test_limit}", invalid_test_case(
-            lambda rng=rng, test_limit=test_limit: serialize(
-                bitlist_case_fn(rng, RandomizationMode.mode_max_count, test_limit)
-            )
+        yield (
+            f"bitlist_{typ_limit}_but_{test_limit}",
+            invalid_test_case(
+                lambda rng=rng, test_limit=test_limit: serialize(
+                    bitlist_case_fn(rng, RandomizationMode.mode_max_count, test_limit)
+                )
+            ),
         )

--- a/tests/generators/runners/ssz_generic_cases/ssz_bitvector.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_bitvector.py
@@ -36,8 +36,11 @@ def valid_cases():
             RandomizationMode.mode_zero,
             RandomizationMode.mode_max,
         ]:
-            yield f"bitvec_{size}_{mode.to_name()}", valid_test_case(
-                lambda rng=rng, mode=mode, size=size: bitvector_case_fn(rng, mode, size)
+            yield (
+                f"bitvec_{size}_{mode.to_name()}",
+                valid_test_case(
+                    lambda rng=rng, mode=mode, size=size: bitvector_case_fn(rng, mode, size)
+                ),
             )
 
 
@@ -65,8 +68,11 @@ def invalid_cases():
             RandomizationMode.mode_zero,
             RandomizationMode.mode_max,
         ]:
-            yield f"bitvec_{typ_size}_{mode.to_name()}_{test_size}", invalid_test_case(
-                lambda rng=rng, mode=mode, test_size=test_size, typ_size=typ_size: serialize(
-                    bitvector_case_fn(rng, mode, test_size, invalid_making_pos=typ_size)
-                )
+            yield (
+                f"bitvec_{typ_size}_{mode.to_name()}_{test_size}",
+                invalid_test_case(
+                    lambda rng=rng, mode=mode, test_size=test_size, typ_size=typ_size: serialize(
+                        bitvector_case_fn(rng, mode, test_size, invalid_making_pos=typ_size)
+                    )
+                ),
             )

--- a/tests/generators/runners/ssz_generic_cases/ssz_container.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_container.py
@@ -80,8 +80,11 @@ def valid_cases():
     rng = Random(1234)
     for name, (typ, offsets) in PRESET_CONTAINERS.items():
         for mode in [RandomizationMode.mode_zero, RandomizationMode.mode_max]:
-            yield f"{name}_{mode.to_name()}", valid_test_case(
-                lambda rng=rng, mode=mode, typ=typ: container_case_fn(rng, mode, typ)
+            yield (
+                f"{name}_{mode.to_name()}",
+                valid_test_case(
+                    lambda rng=rng, mode=mode, typ=typ: container_case_fn(rng, mode, typ)
+                ),
             )
 
         if len(offsets) == 0:
@@ -95,10 +98,13 @@ def valid_cases():
 
         for mode in modes:
             for variation in range(3):
-                yield f"{name}_{mode.to_name()}_chaos_{variation}", valid_test_case(
-                    lambda rng=rng, mode=mode, typ=typ: container_case_fn(
-                        rng, mode, typ, chaos=True
-                    )
+                yield (
+                    f"{name}_{mode.to_name()}_chaos_{variation}",
+                    valid_test_case(
+                        lambda rng=rng, mode=mode, typ=typ: container_case_fn(
+                            rng, mode, typ, chaos=True
+                        )
+                    ),
                 )
         # Notes: Below is the second wave of iteration, and only the random mode is selected
         # for container without offset since ``RandomizationMode.mode_zero`` and ``RandomizationMode.mode_max``
@@ -106,8 +112,11 @@ def valid_cases():
         modes = [RandomizationMode.mode_random] if len(offsets) == 0 else list(RandomizationMode)
         for mode in modes:
             for variation in range(10):
-                yield f"{name}_{mode.to_name()}_{variation}", valid_test_case(
-                    lambda rng=rng, mode=mode, typ=typ: container_case_fn(rng, mode, typ)
+                yield (
+                    f"{name}_{mode.to_name()}_{variation}",
+                    valid_test_case(
+                        lambda rng=rng, mode=mode, typ=typ: container_case_fn(rng, mode, typ)
+                    ),
                 )
 
 
@@ -126,11 +135,14 @@ def invalid_cases():
     rng = Random(1234)
     for name, (typ, offsets) in PRESET_CONTAINERS.items():
         # using mode_max_count, so that the extra byte cannot be picked up as normal list content
-        yield f"{name}_extra_byte", invalid_test_case(
-            lambda rng=rng, typ=typ: serialize(
-                container_case_fn(rng, RandomizationMode.mode_max_count, typ)
-            )
-            + b"\xff"
+        yield (
+            f"{name}_extra_byte",
+            invalid_test_case(
+                lambda rng=rng, typ=typ: serialize(
+                    container_case_fn(rng, RandomizationMode.mode_max_count, typ)
+                )
+                + b"\xff"
+            ),
         )
 
         if len(offsets) != 0:
@@ -143,37 +155,57 @@ def invalid_cases():
                 RandomizationMode.mode_max_count,
             ]:
                 for index, offset_index in enumerate(offsets):
-                    yield f"{name}_{mode.to_name()}_offset_{offset_index}_plus_one", invalid_test_case(
-                        lambda rng=rng, mode=mode, typ=typ, offset_index=offset_index: mod_offset(
-                            b=serialize(container_case_fn(rng, mode, typ)),
-                            offset_index=offset_index,
-                            change=lambda x: x + 1,
-                        )
-                    )
-                    yield f"{name}_{mode.to_name()}_offset_{offset_index}_zeroed", invalid_test_case(
-                        lambda rng=rng, mode=mode, typ=typ, offset_index=offset_index: mod_offset(
-                            b=serialize(container_case_fn(rng, mode, typ)),
-                            offset_index=offset_index,
-                            change=lambda x: 0,
-                        )
-                    )
-                    if index == 0:
-                        yield f"{name}_{mode.to_name()}_offset_{offset_index}_minus_one", invalid_test_case(
-                            lambda rng=rng, mode=mode, typ=typ, offset_index=offset_index: mod_offset(
+                    yield (
+                        f"{name}_{mode.to_name()}_offset_{offset_index}_plus_one",
+                        invalid_test_case(
+                            lambda rng=rng,
+                            mode=mode,
+                            typ=typ,
+                            offset_index=offset_index: mod_offset(
                                 b=serialize(container_case_fn(rng, mode, typ)),
                                 offset_index=offset_index,
-                                change=lambda x: x - 1,
+                                change=lambda x: x + 1,
                             )
+                        ),
+                    )
+                    yield (
+                        f"{name}_{mode.to_name()}_offset_{offset_index}_zeroed",
+                        invalid_test_case(
+                            lambda rng=rng,
+                            mode=mode,
+                            typ=typ,
+                            offset_index=offset_index: mod_offset(
+                                b=serialize(container_case_fn(rng, mode, typ)),
+                                offset_index=offset_index,
+                                change=lambda x: 0,
+                            )
+                        ),
+                    )
+                    if index == 0:
+                        yield (
+                            f"{name}_{mode.to_name()}_offset_{offset_index}_minus_one",
+                            invalid_test_case(
+                                lambda rng=rng,
+                                mode=mode,
+                                typ=typ,
+                                offset_index=offset_index: mod_offset(
+                                    b=serialize(container_case_fn(rng, mode, typ)),
+                                    offset_index=offset_index,
+                                    change=lambda x: x - 1,
+                                )
+                            ),
                         )
                     if mode == RandomizationMode.mode_max_count:
                         serialized = serialize(container_case_fn(rng, mode, typ))
                         serialized = serialized + serialized[:2]
-                        yield f"{name}_{mode.to_name()}_last_offset_{offset_index}_overflow", invalid_test_case(
-                            lambda serialized=serialized: serialized
+                        yield (
+                            f"{name}_{mode.to_name()}_last_offset_{offset_index}_overflow",
+                            invalid_test_case(lambda serialized=serialized: serialized),
                         )
                     if mode == RandomizationMode.mode_one_count:
                         serialized = serialize(container_case_fn(rng, mode, typ))
                         serialized = serialized + serialized[:1]
-                        yield f"{name}_{mode.to_name()}_last_offset_{offset_index}_wrong_byte_length", invalid_test_case(
-                            lambda serialized=serialized: serialized
+                        yield (
+                            f"{name}_{mode.to_name()}_last_offset_{offset_index}_wrong_byte_length",
+                            invalid_test_case(lambda serialized=serialized: serialized),
                         )

--- a/tests/generators/runners/ssz_generic_cases/ssz_uints.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_uints.py
@@ -21,36 +21,58 @@ def valid_cases():
     for uint_type in UINT_TYPES:
         mode = RandomizationMode.mode_random
         byte_len = uint_type.type_byte_length()
-        yield f"uint_{byte_len * 8}_last_byte_empty", valid_test_case(
-            lambda uint_type=uint_type, byte_len=byte_len: uint_type(
-                (2 ** ((byte_len - 1) * 8)) - 1
-            )
+        yield (
+            f"uint_{byte_len * 8}_last_byte_empty",
+            valid_test_case(
+                lambda uint_type=uint_type, byte_len=byte_len: uint_type(
+                    (2 ** ((byte_len - 1) * 8)) - 1
+                )
+            ),
         )
         for variation in range(5):
-            yield f"uint_{byte_len * 8}_{mode.to_name()}_{variation}", valid_test_case(
-                lambda rng=rng, mode=mode, uint_type=uint_type: uint_case_fn(rng, mode, uint_type)
+            yield (
+                f"uint_{byte_len * 8}_{mode.to_name()}_{variation}",
+                valid_test_case(
+                    lambda rng=rng, mode=mode, uint_type=uint_type: uint_case_fn(
+                        rng, mode, uint_type
+                    )
+                ),
             )
         for mode in [RandomizationMode.mode_zero, RandomizationMode.mode_max]:
-            yield f"uint_{byte_len * 8}_{mode.to_name()}", valid_test_case(
-                lambda rng=rng, mode=mode, uint_type=uint_type: uint_case_fn(rng, mode, uint_type)
+            yield (
+                f"uint_{byte_len * 8}_{mode.to_name()}",
+                valid_test_case(
+                    lambda rng=rng, mode=mode, uint_type=uint_type: uint_case_fn(
+                        rng, mode, uint_type
+                    )
+                ),
             )
 
 
 def invalid_cases():
     for uint_type in UINT_TYPES:
         byte_len = uint_type.type_byte_length()
-        yield f"uint_{byte_len * 8}_one_too_high", invalid_test_case(
-            lambda byte_len=byte_len: (2 ** (byte_len * 8)).to_bytes(byte_len + 1, "little")
+        yield (
+            f"uint_{byte_len * 8}_one_too_high",
+            invalid_test_case(
+                lambda byte_len=byte_len: (2 ** (byte_len * 8)).to_bytes(byte_len + 1, "little")
+            ),
         )
     for uint_type in [uint8, uint16, uint32, uint64, uint128, uint256]:
         byte_len = uint_type.type_byte_length()
-        yield f"uint_{byte_len * 8}_one_byte_longer", invalid_test_case(
-            lambda byte_len=byte_len: (2 ** (byte_len * 8) - 1).to_bytes(byte_len + 1, "little")
+        yield (
+            f"uint_{byte_len * 8}_one_byte_longer",
+            invalid_test_case(
+                lambda byte_len=byte_len: (2 ** (byte_len * 8) - 1).to_bytes(byte_len + 1, "little")
+            ),
         )
     for uint_type in [uint8, uint16, uint32, uint64, uint128, uint256]:
         byte_len = uint_type.type_byte_length()
-        yield f"uint_{byte_len * 8}_one_byte_shorter", invalid_test_case(
-            lambda byte_len=byte_len: (2 ** ((byte_len - 1) * 8) - 1).to_bytes(
-                byte_len - 1, "little"
-            )
+        yield (
+            f"uint_{byte_len * 8}_one_byte_shorter",
+            invalid_test_case(
+                lambda byte_len=byte_len: (2 ** ((byte_len - 1) * 8) - 1).to_bytes(
+                    byte_len - 1, "little"
+                )
+            ),
         )


### PR DESCRIPTION
I was comparing the features of these two linters and I'm really liking `ruff`. I think it's all-around better. It's noticeably faster, automatically deletes unused imports, and warns for improper things sort of like `cargo clippy`.