### PR TITLE
Modify fork digest to distinguish BPO forks + add entry to ENR

### DIFF
--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -10,13 +10,11 @@
 - [Configuration](#configuration)
   - [Data size](#data-size)
   - [Custody setting](#custody-setting)
-  - [Blob schedule](#blob-schedule)
   - [Containers](#containers)
     - [`DataColumnSidecar`](#datacolumnsidecar)
     - [`MatrixEntry`](#matrixentry)
 - [Helper functions](#helper-functions)
   - [`get_custody_groups`](#get_custody_groups)
-  - [`get_max_blobs_per_block`](#get_max_blobs_per_block)
   - [`compute_columns_for_custody_group`](#compute_columns_for_custody_group)
   - [`compute_matrix`](#compute_matrix)
   - [`recover_matrix`](#recover_matrix)
@@ -70,18 +68,6 @@ specification.
 | `NUMBER_OF_CUSTODY_GROUPS` | `128` | Number of custody groups available for nodes to custody                           |
 | `CUSTODY_REQUIREMENT`      | `4`   | Minimum number of custody groups an honest node custodies and serves samples from |
 
-### Blob schedule
-
-*[New in EIP7892]* This schedule defines the maximum blobs per block limit for a
-given epoch.
-
-*Note*: The blob schedule is to be determined.
-
-<!-- list-of-records:blob_schedule -->
-
-| Epoch | Max Blobs Per Block | Description |
-| ----- | ------------------- | ----------- |
-
 ### Containers
 
 #### `DataColumnSidecar`
@@ -131,19 +117,6 @@ def get_custody_groups(node_id: NodeID, custody_group_count: uint64) -> Sequence
 
     assert len(custody_groups) == len(set(custody_groups))
     return sorted(custody_groups)
-```
-
-### `get_max_blobs_per_block`
-
-```python
-def get_max_blobs_per_block(epoch: Epoch) -> uint64:
-    """
-    Return the maximum number of blobs that can be included in a block for a given epoch.
-    """
-    for entry in sorted(BLOB_SCHEDULE, key=lambda e: e["EPOCH"], reverse=True):
-        if epoch >= entry["EPOCH"]:
-            return entry["MAX_BLOBS_PER_BLOCK"]
-    return MAX_BLOBS_PER_BLOCK_ELECTRA
 ```
 
 ### `compute_columns_for_custody_group`

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -34,6 +34,7 @@
   - [The discovery domain: discv5](#the-discovery-domain-discv5)
     - [ENR structure](#enr-structure)
       - [Custody group count](#custody-group-count)
+      - [Next fork digest](#next-fork-digest)
 
 <!-- mdformat-toc end -->
 
@@ -492,3 +493,18 @@ column discovery.
 | Key   | Value                                                                                                             |
 | ----- | ----------------------------------------------------------------------------------------------------------------- |
 | `cgc` | Custody group count, `uint64` big endian integer with no leading zero bytes (`0` is encoded as empty byte string) |
+
+##### Next fork digest
+
+A new field is added to the ENR under the key `nfd`, short for _next fork
+digest_. This field communicates the digest of the next scheduled fork,
+regardless of whether it is a regular or a Blob-Parameters-Only fork.
+
+| Key   | Value                   |
+| :---- | :---------------------- |
+| `nfd` | SSZ Bytes4 `ForkDigest` |
+
+When discovering and interfacing with peers, nodes MUST evaluate `nfd` alongside
+their existing consideration of the `ENRForkID::next_*` fields under the `eth2`
+key, to form a more accurate view of the peer's intended next fork for the
+purposes of sustained peering.


### PR DESCRIPTION
Applies https://github.com/ethereum/EIPs/pull/9818/ here, by:

- Adding a `BlobScheduleEntry` type.
- Updating `compute_fork_digest`.
- Adds the `nfd` (next fork digest) entry to the ENR.

We also move the blob schedule and `get_max_blobs_per_block` from the `das-core.md` to `beacon-chain.md`, as they affect block validation.