### PR TITLE
EIP-7917: Refactor return types from List to Vector

### DIFF
--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -156,7 +156,7 @@ class BeaconState(Container):
 ```python
 def compute_proposer_indices(
     state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
-) -> List[ValidatorIndex, SLOTS_PER_EPOCH]:
+) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
     """
     Return the proposer indices for the given ``epoch``.
     """
@@ -185,7 +185,7 @@ def get_beacon_proposer_index(state: BeaconState) -> ValidatorIndex:
 ```python
 def get_beacon_proposer_indices(
     state: BeaconState, epoch: Epoch
-) -> List[ValidatorIndex, SLOTS_PER_EPOCH]:
+) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
     """
     Return the proposer indices for the given ``epoch``.
     """

--- a/specs/fulu/fork.md
+++ b/specs/fulu/fork.md
@@ -60,7 +60,7 @@ def compute_fork_version(epoch: Epoch) -> Version:
 ```python
 def initialize_proposer_lookahead(
     state: electra.BeaconState,
-) -> List[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]:
+) -> Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]:
     """
     Return the proposer indices for the full available lookahead starting from current epoch.
     Used to initialize the ``proposer_lookahead`` field in the beacon state at genesis and after forks.


### PR DESCRIPTION
The `proposer_lookahead` type is now `Vector` so it is more natural to have the helper functions related to it to also return `Vector`.