### PR TITLE
Increase mainnet tests timeout to 12 hours

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   tests:
+    timeout-minutes: 720  # 12 hours
     runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Last night, the mainnet tests failed due to a timeout after 6 hours. This needs to be increased.

https://github.com/ethereum/consensus-specs/actions/runs/15430735901