### PR TITLE
Alias effective_balance_increase_changes_lookahead to blocks handler

### DIFF
--- a/tests/generators/runners/sanity.py
+++ b/tests/generators/runners/sanity.py
@@ -8,6 +8,8 @@ def handler_name_fn(mod):
     handler_name = mod.split(".")[-1]
     if handler_name == "test_deposit_transition":
         return "blocks"
+    if handler_name == "test_effective_balance_increase_changes_lookahead":
+        return "blocks"
     return handler_name.replace("test_", "")
 
 


### PR DESCRIPTION
Another little mistake with the alpha.1 tests. We forgot to alias the `effective_balance_increase_changes_lookahead` test handler to `blocks`. Later, I will look into a better way to detect issues like this.