### PR TITLE
Detect errors in reference test generator action

### DIFF
--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -1,4 +1,4 @@
-name: Run test vector generation
+name: Generate reference tests
 
 defaults:
   run:
@@ -39,15 +39,10 @@ jobs:
       - name: Generate tests
         run: |
           cd consensus-specs
+          set -o pipefail
           make reftests verbose=true 2>&1 | tee ../consensustestgen.log
           cp -r presets/ ../consensus-spec-tests/presets
           cp -r configs/ ../consensus-spec-tests/configs
-      - name: Check for errors
-        run: |
-          if grep -q "\[ERROR\]" consensustestgen.log; then
-            echo "There is an error in the log"
-            exit 1
-          fi
       - name: Archive configurations
         run: |
           cd consensus-spec-tests


### PR DESCRIPTION
I manually ran this action on a branch with a mistake but the action still passed.

![image](https://github.com/user-attachments/assets/359ff1fb-b399-4181-af94-93cd3db4199f)

The reason this happened was because the pipe would mask the error. Setting `pipefail` will fix this.

I've also renamed the action title & removed an old error detection method.

See also: https://github.com/sigp/lighthouse/pull/7538