### PR TITLE
Add test for lookahead consistency with effective balance change at fork

### DIFF
--- a/tests/core/pyspec/eth2spec/test/fulu/fork/test_fork_lookahead_consistency.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/fork/test_fork_lookahead_consistency.py
@@ -12,7 +12,10 @@ from eth2spec.test.helpers.fulu.fork import (
     run_fork_test,
 )
 from eth2spec.test.utils import with_meta_tags
-from tests.core.pyspec.eth2spec.test.helpers.state import simulate_lookahead
+from tests.core.pyspec.eth2spec.test.helpers.state import next_epoch, simulate_lookahead
+from eth2spec.test.helpers.withdrawals import (
+    set_compounding_withdrawal_credential,
+)
 
 
 @with_phases(phases=[ELECTRA], other_phases=[FULU])
@@ -34,3 +37,42 @@ def test_lookahead_consistency_at_fork(spec, phases, state):
 
     # Check if the pre-fork simulation matches the post-fork `state.proposer_lookahead`
     assert pre_fork_proposers == state.proposer_lookahead
+
+@with_phases(phases=[ELECTRA], other_phases=[FULU])
+@spec_test
+@with_state
+@with_meta_tags(FULU_FORK_TEST_META_TAGS)
+def test_lookahead_consistency_with_effective_balance_change_at_fork(spec, phases, state):
+    next_epoch(spec, state)
+    next_epoch(spec, state)
+    next_epoch(spec, state)
+    next_epoch(spec, state)
+
+    # Move to the penultimate slot of the current epoch
+    spec.process_slots(state, state.slot + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH) - 1)
+    assert state.slot % spec.SLOTS_PER_EPOCH == spec.SLOTS_PER_EPOCH - 1
+
+    # Change the balances so the epoch processing will change the effective balances,
+    # which will affect the proposers selection.
+    current_epoch = spec.get_current_epoch(state)
+    active_validator_indices = spec.get_active_validator_indices(state, current_epoch)
+    for validator_index in active_validator_indices:
+        # Set compounding withdrawal credentials for the validator
+        set_compounding_withdrawal_credential(spec, state, validator_index)
+        state.validators[validator_index].effective_balance = 32000000000
+        # Set balance to close the next hysteresis threshold
+        state.balances[validator_index] = 33250000000 - 1
+
+    # Calculate the lookahead after the effective balance change, and before the Electra epoch processing
+    pre_fork_proposers = simulate_lookahead(spec, state)
+
+    # This will run electra epoch processing
+    spec.process_slots(state, state.slot + 1) 
+    assert state.slot % spec.SLOTS_PER_EPOCH == 0
+    # Upgrade to Fulu
+    spec = phases[FULU]
+    state = yield from run_fork_test(spec, state)
+
+    # Because the electra epoch processing is always run right before the fulu upgrade,
+    # the proposers lookahead will change depending on the effective balance change.
+    assert pre_fork_proposers != state.proposer_lookahead


### PR DESCRIPTION
## Overview
This PR introduces a new test function, `test_lookahead_consistency_with_effective_balance_change_at_fork`, in `test_fork_lookahead_consistency.py`. The test is designed to verify the behavior of the proposer lookahead mechanism during a fork, specifically when validator effective balances change at the fork boundary.

## Test Description
The new test simulates a scenario where all active validators have their effective balances set to the maximum value and their actual balances set just below the next hysteresis threshold. This setup ensures that the effective balance will change during the next epoch transition (Electra epoch processing), which occurs immediately before the Fulu fork upgrade.

The test performs the following steps:
1. Advances the state to the penultimate slot of the current epoch.
2. Modifies all active validators' balances and credentials to trigger an effective balance change at the next epoch transition.
3. Simulates the proposer lookahead before the epoch transition and fork.
4. Processes the next slot, triggering the Electra epoch processing and effective balance update.
5. Upgrades the state to the Fulu fork.
6. Asserts that the proposer lookahead after the fork is different from the pre-fork simulation, confirming that the effective balance change impacts proposer selection as expected.

## Motivation
This test ensures that the fork transition logic correctly accounts for changes in validator effective balances, which can affect proposer selection. It validates that the lookahead mechanism is consistent with the expected protocol behavior when a fork coincides with an epoch transition that changes effective balances.