### PR TITLE
Define requirements for the blob schedule

### DIFF
--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -75,6 +75,11 @@ specification.
 *[New in EIP7892]* This schedule defines the maximum blobs per block limit for a
 given epoch.
 
+There MUST NOT exist multiple blob schedule entries with the same epoch value.
+The maximum blobs per block limit for blob schedules entries MUST be less than
+or equal to `MAX_BLOB_COMMITMENTS_PER_BLOCK`. The blob schedule entries SHOULD
+be sorted by epoch in ascending order. The blob schedule MAY be empty.
+
 *Note*: The blob schedule is to be determined.
 
 <!-- list-of-records:blob_schedule -->


### PR DESCRIPTION
This PR defines some simple requirements for the blob schedule, so clients don't have to perform these checks.