### PR TITLE
Add fork version to compute fork digest test cases

### DIFF
--- a/tests/core/pyspec/eth2spec/test/fulu/validator/test_compute_fork_digest.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/validator/test_compute_fork_digest.py
@@ -29,108 +29,167 @@ def test_compute_fork_digest(spec):
         # Different epochs and blob limits:
         {
             "epoch": 9,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x39f8e7c3",
+            "expected_fork_digest": "0xab3ae6c8",
         },
         {
             "epoch": 10,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x39f8e7c3",
+            "expected_fork_digest": "0xab3ae6c8",
         },
         {
             "epoch": 11,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x39f8e7c3",
+            "expected_fork_digest": "0xab3ae6c8",
         },
         {
             "epoch": 99,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x39f8e7c3",
+            "expected_fork_digest": "0xab3ae6c8",
         },
         {
             "epoch": 100,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x44a571e8",
+            "expected_fork_digest": "0xdf67557b",
         },
         {
             "epoch": 101,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x44a571e8",
+            "expected_fork_digest": "0xdf67557b",
         },
         {
             "epoch": 150,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x1171afca",
+            "expected_fork_digest": "0x8ab38b59",
         },
         {
             "epoch": 199,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x1171afca",
+            "expected_fork_digest": "0x8ab38b59",
         },
         {
             "epoch": 200,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x427a30ab",
+            "expected_fork_digest": "0xd9b81438",
         },
         {
             "epoch": 201,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x427a30ab",
+            "expected_fork_digest": "0xd9b81438",
         },
         {
             "epoch": 250,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0xd5310ef1",
+            "expected_fork_digest": "0x4ef32a62",
         },
         {
             "epoch": 299,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0xd5310ef1",
+            "expected_fork_digest": "0x4ef32a62",
         },
         {
             "epoch": 300,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x51d229f7",
+            "expected_fork_digest": "0xca100d64",
         },
         {
             "epoch": 301,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x00" * 32,
-            "expected_fork_digest": "0x51d229f7",
+            "expected_fork_digest": "0xca100d64",
         },
         # Different genesis validators roots:
         {
             "epoch": 9,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x01" * 32,
-            "expected_fork_digest": "0xe41615ba",
+            "expected_fork_digest": "0x89671111",
         },
         {
             "epoch": 9,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x02" * 32,
-            "expected_fork_digest": "0x46790ef9",
+            "expected_fork_digest": "0xf49b0e24",
         },
         {
             "epoch": 9,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x03" * 32,
-            "expected_fork_digest": "0xa072c2f5",
+            "expected_fork_digest": "0x86544e4f",
         },
         {
             "epoch": 100,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x01" * 32,
-            "expected_fork_digest": "0xbfe98545",
+            "expected_fork_digest": "0xfd3aa2a2",
         },
         {
             "epoch": 100,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x02" * 32,
-            "expected_fork_digest": "0x9b7e4788",
+            "expected_fork_digest": "0x80c6bd97",
         },
         {
             "epoch": 100,
+            "fork_version": "0x06000000",
             "genesis_validators_root": b"\x03" * 32,
-            "expected_fork_digest": "0x8b5ce4af",
+            "expected_fork_digest": "0xf209fdfc",
+        },
+        # Different fork versions
+        {
+            "epoch": 9,
+            "fork_version": "0x06000001",
+            "genesis_validators_root": b"\x00" * 32,
+            "expected_fork_digest": "0x30f8c25b",
+        },
+        {
+            "epoch": 9,
+            "fork_version": "0x07000000",
+            "genesis_validators_root": b"\x00" * 32,
+            "expected_fork_digest": "0x0432f5a9",
+        },
+        {
+            "epoch": 9,
+            "fork_version": "0x07000001",
+            "genesis_validators_root": b"\x00" * 32,
+            "expected_fork_digest": "0x6e69a671",
+        },
+        {
+            "epoch": 100,
+            "fork_version": "0x06000001",
+            "genesis_validators_root": b"\x00" * 32,
+            "expected_fork_digest": "0x44a571e8",
+        },
+        {
+            "epoch": 100,
+            "fork_version": "0x07000000",
+            "genesis_validators_root": b"\x00" * 32,
+            "expected_fork_digest": "0x706f461a",
+        },
+        {
+            "epoch": 100,
+            "fork_version": "0x07000001",
+            "genesis_validators_root": b"\x00" * 32,
+            "expected_fork_digest": "0x1a3415c2",
         },
     ]
 
     for case in test_cases:
+        # Override function to return fork version in test case
+        spec.compute_fork_version = lambda _: case["fork_version"]
         # Compute the fork digest given the inputs from the test case
         fork_digest = spec.compute_fork_digest(case["genesis_validators_root"], case["epoch"])
         # Check that the computed fork digest matches our expected value


### PR DESCRIPTION
Currently, this test case fails if you run it under the mainnet preset. When updating it after some review feedback, I removed the fork version field from the test case input because we used `compute_fork_version` instead of passing it into `compute_fork_digest`. I sort of forgot this wouldn't work on mainnet.