### PR TITLE
Do not wrap long lines in `config.yaml` files

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/dumper.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/dumper.py
@@ -30,6 +30,7 @@ def get_cfg_yaml():
     # Spec config is using a YAML subset
     cfg_yaml = YAML(pure=True)
     cfg_yaml.default_flow_style = False  # Emit separate line for each key
+    cfg_yaml.width = 1024  # Do not wrap long lines
 
     def cfg_represent_bytes(self, data):
         return self.represent_int(encode_hex(data))


### PR DESCRIPTION
Spec configs follow a YAML subset that does not involve linebreaks, to avoid requiring client implementations to include a full YAML lib.

When Ruamel YAML was updated recently, the default settings changed and certain tests started to emit `config.yaml` with linebreaks. By setting Ruamel config `width` to a larger value, previous behaviour is restored.