### PR TITLE
Add test for proposer lookahead excluding exited validators

### DIFF
--- a/tests/core/pyspec/eth2spec/test/fulu/epoch_processing/test_process_proposer_lookahead.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/epoch_processing/test_process_proposer_lookahead.py
@@ -29,3 +29,45 @@ def test_proposer_lookahead_in_state_matches_computed_lookahead(spec, state):
     # Verify lookahead in state matches the computed lookahead
     computed_lookahead = spec.initialize_proposer_lookahead(state)
     assert state.proposer_lookahead == computed_lookahead
+
+
+@with_fulu_and_later
+@spec_state_test
+def test_proposer_lookahead_does_not_contain_exited_validators(spec, state):
+    """
+    Test proposer lookahead does not contain exited validators.
+    """
+    # Transition few epochs to past the MIN_SEED_LOOKAHEAD
+    for _ in range(spec.MIN_SEED_LOOKAHEAD + 1):
+        next_epoch(spec, state)
+
+    # Exit first half of active validators
+    active_validators = spec.get_active_validator_indices(state, spec.get_current_epoch(state))
+    validators_to_exit = active_validators[: len(active_validators) // 2]
+
+    # Initiate validator exits
+    for validator_index in validators_to_exit:
+        spec.initiate_validator_exit(state, validator_index)
+
+    # Check when these validators are scheduled to exit
+    exit_epochs = [state.validators[i].exit_epoch for i in validators_to_exit]
+    min_exit_epoch = min(exit_epochs)
+
+    # Progress epoch until we reach the epoch with the first validator exit
+    while spec.get_current_epoch(state) < min_exit_epoch - 1:
+        next_epoch(spec, state)
+
+    yield "pre", state
+
+    # Run epoch processing, many validators will exit in this epoch
+    yield from run_epoch_processing_with(spec, state, "process_proposer_lookahead")
+    # run_epoch_processing_with does not increment the slot
+    state.slot += 1
+
+    # Check that the proposer lookahead does not contain exited validators
+    for validator_index in state.proposer_lookahead:
+        assert spec.is_active_validator(
+            state.validators[validator_index], spec.get_current_epoch(state)
+        ), f"Validator {validator_index} in lookahead should be active"
+
+    yield "post", state


### PR DESCRIPTION
Add tests that check that the proposer lookahead excludes exited validators.

I tried doing the same for activation (i.e., proposer lookahead for epoch `N+1` can contain proposers that were activated in `N`), but it turned out a lot more complicated. But think this test should be sufficient to test that the proposer lookahead takes the proper active validator set into consideration.
