### PR TITLE
Fix yields in new proposer lookahead test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/fulu/epoch_processing/test_process_proposer_lookahead.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/epoch_processing/test_process_proposer_lookahead.py
@@ -57,10 +57,9 @@ def test_proposer_lookahead_does_not_contain_exited_validators(spec, state):
     while spec.get_current_epoch(state) < min_exit_epoch - 1:
         next_epoch(spec, state)
 
-    yield "pre", state
-
     # Run epoch processing, many validators will exit in this epoch
     yield from run_epoch_processing_with(spec, state, "process_proposer_lookahead")
+
     # run_epoch_processing_with does not increment the slot
     state.slot += 1
 
@@ -69,5 +68,3 @@ def test_proposer_lookahead_does_not_contain_exited_validators(spec, state):
         assert spec.is_active_validator(
             state.validators[validator_index], spec.get_current_epoch(state)
         ), f"Validator {validator_index} in lookahead should be active"
-
-    yield "post", state


### PR DESCRIPTION
Noticed that Teku was failing this test because the slot in the post state was incremented.

<img width="1324" alt="image" src="https://github.com/user-attachments/assets/645cfec8-7696-436a-b593-9892139ee9f2" />

In the epoch processing tests, we promise not to increment the slot in the post state, because we stop processing immediately after the function being tested is run. The helper function yields these too, so these can be removed.

https://github.com/ethereum/consensus-specs/blob/192f6d2110528c90f0f48c1184edef1ffb9f48c5/tests/core/pyspec/eth2spec/test/helpers/epoch_processing.py#L87-L104

Associated with #4380.

