### PR TITLE
Combine helpers into compute_time_at_slot

### DIFF
--- a/specs/_deprecated/sharding/beacon-chain.md
+++ b/specs/_deprecated/sharding/beacon-chain.md
@@ -412,7 +412,7 @@ def process_execution_payload(
         # Verify random
         assert payload.random == get_randao_mix(state, get_current_epoch(state))
         # Verify timestamp
-        assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+        assert payload.timestamp == compute_time_at_slot(state, state.slot)
 
         # Get sharded data commitments
         sharded_commitments_container = block.body.sharded_commitments_container

--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -174,7 +174,7 @@ def process_execution_payload(
     # Verify prev_randao
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
-    assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+    assert payload.timestamp == compute_time_at_slot(state, state.slot)
 
     # Verify commitments are under limit
     assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -762,7 +762,7 @@ def process_execution_payload(
         # Verify prev_randao
         assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
         # Verify timestamp
-        assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+        assert payload.timestamp == compute_time_at_slot(state, state.slot)
         # Verify commitments are under limit
         assert len(envelope.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
         # Verify the execution payload is valid

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -145,7 +145,7 @@ regards to the `ExecutionPayload` are removed:
   `len(signed_beacon_block.message.body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK`
 - _[REJECT]_ The block's execution payload timestamp is correct with respect to
   the slot -- i.e.
-  `execution_payload.timestamp == compute_timestamp_at_slot(state, block.slot)`.
+  `execution_payload.timestamp == compute_time_at_slot(state, block.slot)`.
 - If `execution_payload` verification of block's parent by an execution node is
   *not* complete:
   - [REJECT] The block's parent (defined by `block.parent_root`) passes all

--- a/specs/_features/eip7805/beacon-chain.md
+++ b/specs/_features/eip7805/beacon-chain.md
@@ -231,7 +231,7 @@ def process_execution_payload(
     # Verify prev_randao
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
-    assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+    assert payload.timestamp == compute_time_at_slot(state, state.slot)
     # Verify commitments are under limit
     assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK_ELECTRA
     # Verify the execution payload is valid

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -21,8 +21,6 @@
     - [`is_merge_transition_complete`](#is_merge_transition_complete)
     - [`is_merge_transition_block`](#is_merge_transition_block)
     - [`is_execution_enabled`](#is_execution_enabled)
-  - [Misc](#misc)
-    - [`compute_timestamp_at_slot`](#compute_timestamp_at_slot)
   - [Beacon state accessors](#beacon-state-accessors)
     - [Modified `get_inactivity_penalty_deltas`](#modified-get_inactivity_penalty_deltas)
   - [Beacon state mutators](#beacon-state-mutators)
@@ -223,18 +221,6 @@ def is_execution_enabled(state: BeaconState, body: BeaconBlockBody) -> bool:
     return is_merge_transition_block(state, body) or is_merge_transition_complete(state)
 ```
 
-### Misc
-
-#### `compute_timestamp_at_slot`
-
-*Note*: This function is unsafe with respect to overflows and underflows.
-
-```python
-def compute_timestamp_at_slot(state: BeaconState, slot: Slot) -> uint64:
-    slots_since_genesis = slot - GENESIS_SLOT
-    return uint64(state.genesis_time + slots_since_genesis * SECONDS_PER_SLOT)
-```
-
 ### Beacon state accessors
 
 #### Modified `get_inactivity_penalty_deltas`
@@ -406,7 +392,7 @@ def process_execution_payload(
     # Verify prev_randao
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
-    assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+    assert payload.timestamp == compute_time_at_slot(state, state.slot)
     # Verify the execution payload is valid
     assert execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(execution_payload=payload)

--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -87,7 +87,7 @@ If the execution is enabled for the block -- i.e.
 
 - _[REJECT]_ The block's execution payload timestamp is correct with respect to
   the slot -- i.e.
-  `execution_payload.timestamp == compute_timestamp_at_slot(state, block.slot)`.
+  `execution_payload.timestamp == compute_time_at_slot(state, block.slot)`.
 - If `execution_payload` verification of block's parent by an execution node is
   *not* complete:
   - _[REJECT]_ The block's parent (defined by `block.parent_root`) passes all

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -172,7 +172,7 @@ def prepare_execution_payload(
 
     # Set the forkchoice head and initiate the payload build process
     payload_attributes = PayloadAttributes(
-        timestamp=compute_timestamp_at_slot(state, state.slot),
+        timestamp=compute_time_at_slot(state, state.slot),
         prev_randao=get_randao_mix(state, get_current_epoch(state)),
         suggested_fee_recipient=suggested_fee_recipient,
     )

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -415,7 +415,7 @@ def process_execution_payload(
     # Verify prev_randao
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
-    assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+    assert payload.timestamp == compute_time_at_slot(state, state.slot)
     # Verify the execution payload is valid
     assert execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(execution_payload=payload)

--- a/specs/capella/validator.md
+++ b/specs/capella/validator.md
@@ -92,7 +92,7 @@ def prepare_execution_payload(
 
     # Set the forkchoice head and initiate the payload build process
     payload_attributes = PayloadAttributes(
-        timestamp=compute_timestamp_at_slot(state, state.slot),
+        timestamp=compute_time_at_slot(state, state.slot),
         prev_randao=get_randao_mix(state, get_current_epoch(state)),
         suggested_fee_recipient=suggested_fee_recipient,
         withdrawals=get_expected_withdrawals(state),  # [New in Capella]

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -437,7 +437,7 @@ def process_execution_payload(
     # Verify prev_randao
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
-    assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+    assert payload.timestamp == compute_time_at_slot(state, state.slot)
 
     # [New in Deneb:EIP4844] Verify commitments are under limit
     assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK

--- a/specs/deneb/validator.md
+++ b/specs/deneb/validator.md
@@ -127,7 +127,7 @@ def prepare_execution_payload(
 
     # Set the forkchoice head and initiate the payload build process
     payload_attributes = PayloadAttributes(
-        timestamp=compute_timestamp_at_slot(state, state.slot),
+        timestamp=compute_time_at_slot(state, state.slot),
         prev_randao=get_randao_mix(state, get_current_epoch(state)),
         suggested_fee_recipient=suggested_fee_recipient,
         withdrawals=get_expected_withdrawals(state),

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1336,7 +1336,7 @@ def process_execution_payload(
     # Verify prev_randao
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
-    assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+    assert payload.timestamp == compute_time_at_slot(state, state.slot)
     # [Modified in Electra:EIP7691] Verify commitments are under limit
     assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK_ELECTRA
     # Verify the execution payload is valid

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -234,7 +234,7 @@ def prepare_execution_payload(
     withdrawals, _ = get_expected_withdrawals(state)  # [Modified in EIP-7251]
 
     payload_attributes = PayloadAttributes(
-        timestamp=compute_timestamp_at_slot(state, state.slot),
+        timestamp=compute_time_at_slot(state, state.slot),
         prev_randao=get_randao_mix(state, get_current_epoch(state)),
         suggested_fee_recipient=suggested_fee_recipient,
         withdrawals=withdrawals,

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -72,7 +72,7 @@ def process_execution_payload(
     # Verify prev_randao
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
-    assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+    assert payload.timestamp == compute_time_at_slot(state, state.slot)
     # [Modified in Fulu:EIP7892] Verify commitments are under limit
     assert (
         len(body.blob_kzg_commitments)

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -73,6 +73,7 @@
     - [`compute_shuffled_index`](#compute_shuffled_index)
     - [`compute_proposer_index`](#compute_proposer_index)
     - [`compute_committee`](#compute_committee)
+    - [`compute_time_at_slot`](#compute_time_at_slot)
     - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
     - [`compute_start_slot_at_epoch`](#compute_start_slot_at_epoch)
     - [`compute_activation_exit_epoch`](#compute_activation_exit_epoch)
@@ -871,6 +872,13 @@ def compute_committee(
         indices[compute_shuffled_index(uint64(i), uint64(len(indices)), seed)]
         for i in range(start, end)
     ]
+```
+
+#### `compute_time_at_slot`
+
+```python
+def compute_time_at_slot(state: BeaconState, slot: Slot) -> uint64:
+    return uint64(state.genesis_time + slot * SECONDS_PER_SLOT)
 ```
 
 #### `compute_epoch_at_slot`

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -449,11 +449,6 @@ An honest block proposer sets
 `block.body.eth1_data = get_eth1_vote(state, eth1_chain)` where:
 
 ```python
-def compute_time_at_slot(state: BeaconState, slot: Slot) -> uint64:
-    return uint64(state.genesis_time + slot * SECONDS_PER_SLOT)
-```
-
-```python
 def voting_period_start_time(state: BeaconState) -> uint64:
     eth1_voting_period_start_slot = Slot(
         state.slot - state.slot % (EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -309,7 +309,7 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
     Assuming a pre-state of the same slot, build a valid ExecutionPayload without any transactions.
     """
     latest = state.latest_execution_payload_header
-    timestamp = spec.compute_timestamp_at_slot(state, state.slot)
+    timestamp = spec.compute_time_at_slot(state, state.slot)
     empty_txs = spec.List[spec.Transaction, spec.MAX_TRANSACTIONS_PER_PAYLOAD]()
 
     if randao_mix is None:


### PR DESCRIPTION
Thanks @rolfyone for pointing this out.

There were two helpers for the same thing:

https://github.com/ethereum/consensus-specs/blob/e2b1a17023ce7f940b603b7a6024112019d8a03f/specs/phase0/validator.md?plain=1#L451-L454

https://github.com/ethereum/consensus-specs/blob/e2b1a17023ce7f940b603b7a6024112019d8a03f/specs/bellatrix/beacon-chain.md?plain=1#L232-L236

This PR moves the phase0:validator func to phase0:beacon-chain & removes the bellatrix func.