### PR TITLE
Add execution_requests to fulu.GetPayloadResponse

### DIFF
--- a/specs/fulu/validator.md
+++ b/specs/fulu/validator.md
@@ -81,6 +81,7 @@ class GetPayloadResponse(object):
     execution_payload: ExecutionPayload
     block_value: uint256
     blobs_bundle: BlobsBundle  # [Modified in Fulu:EIP7594]
+    execution_requests: Sequence[bytes]
 ```
 
 ## Protocol


### PR DESCRIPTION
Noticed that this was missing. This field was added in Electra & should exist here in Fulu.