### PR TITLE
Serve `DataColumnSidecarsByRoot` for finalized epochs

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -475,7 +475,7 @@ The response MUST consist of zero or more `response_chunk`. Each _successful_
 `response_chunk` MUST contain a single `DataColumnSidecar` payload.
 
 Clients MUST support requesting sidecars since `minimum_request_epoch`, where
-`minimum_request_epoch = max(finalized_epoch, current_epoch - MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS, FULU_FORK_EPOCH)`.
+`minimum_request_epoch = max(current_epoch - MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS, FULU_FORK_EPOCH)`.
 If any root in the request content references a block earlier than
 `minimum_request_epoch`, peers MAY respond with error code
 `3: ResourceUnavailable` or not include the data column sidecar in the response.


### PR DESCRIPTION
The current state of the specification prevents nodes to serve data column sidecars by root for finalized epochs.

I think this rule was a copy paste from blobs, which was a copy paste from blocks.
This rule used to make sense for blocks, because some clients do not manage finalized blocks and unfinalized blocks in the same way in the DB. (Accessing unfinalized blocks by root is easy, but accessing finalized blocks by root is not.)

With this PR, I would like to solve the following pattern, with latest finalized epoch = 200
1. A node needs all columns with `indices 1, 2, 4 and 6 from slot 100 to slot 149`.
2. It crafts a by range request with `start: 100`, `count: 50`, `indices:[1, 2, 4, 6]`. (Assuming in this example a single peer is able to serve them all.)
3. After receiving the response, the node has now everything, but: `slot 103 - column 4`, `slot 131 - column 6`, `slot 148 - column 2`. (For some reason, the requested peer was not able to serve them.)

The node has now 2 choices (still assuming a single peer is able to serve them all):
1. Send a new byRange request with the following parameters: `start:103, count: 46, indices: [2, 4, 6]`
2. Send 3 byRange requests with the following parameters: `start:103, count:1, indices:[4]`, `start:131, count:1, indices:[6]`, `start:148, count:1, indices:[2]`.

Pro of solution 1: A single request is needed.
Con of solution 1: A lot of unneeded sidecars will be transmitted over the network.

Pro of solution 2: No unneeded sidecars will be transmitted over the network.
Con of solution 2: 3 requests are needed.

With this PR, we can get the pro of solution 1 and 2: A single request is needed, and no unneeded sidecars will be transmitted over the network.