### PR TITLE
Use `get_blob_parameters` in gossip block validation

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -178,7 +178,7 @@ Some gossip meshes are upgraded in the Fulu fork to support upgraded types.
 
 - _[REJECT]_ The length of KZG commitments is less than or equal to the
   limitation defined in Consensus Layer -- i.e. validate that
-  `len(signed_beacon_block.message.body.blob_kzg_commitments) <= get_max_blobs_per_block(get_current_epoch(state))`
+  `len(signed_beacon_block.message.body.blob_kzg_commitments) <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block`
 
 ##### Blob subnets
 


### PR DESCRIPTION
We have already removed `get_max_blobs_per_block` in #4354 but forgot to update this place