### PR TITLE
Update nfd section to say the node MAY disconnect

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -539,7 +539,7 @@ set to the epoch of the next fork, whether a regular fork, _or a BPO fork_.
 When discovering and interfacing with peers, nodes MUST evaluate `nfd` alongside
 their existing consideration of the `ENRForkID::next_*` fields under the `eth2`
 key, to form a more accurate view of the peer's intended next fork for the
-purposes of sustained peering. A mismatch indicates that the node MUST
+purposes of sustained peering. A mismatch indicates that the node MAY
 disconnect from such peers at the fork boundary, but not sooner.
 
 Nodes unprepared to follow the Fulu fork will be unaware of `nfd` entries.


### PR DESCRIPTION
As discussed on discord... stating that the node **MUST** disconnect is a bit too strong. MAY is more appropriate.

<img width="546" alt="image" src="https://github.com/user-attachments/assets/5a63df56-f046-41a7-9aab-d9a8fce9f871" />
