### PR TITLE
Add support for automated releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,42 @@
+categories:
+  # Forks
+  - title: Phase0
+    label: phase0
+  - title: Altair
+    label: altair
+  - title: Bellatrix
+    label: bellatrix
+  - title: Capella
+    label: capella
+  - title: Deneb
+    label: deneb
+  - title: Electra
+    label: electra
+  - title: Fulu
+    label: fulu
+
+  # Features
+  - title: EIP-6110
+    label: eip6110
+  - title: EIP-7441
+    label: eip7441
+  - title: EIP-7594
+    label: eip7594
+  - title: EIP-7732
+    label: eip7732
+  - title: EIP-7805
+    label: eip7805
+
+  # Testing
+  - title: Testing
+    label: testing
+
+  # Fallback
+  - title: Other
+
+sort-by: number
+sort-direction: ascending
+change-title-escapes: '\<*_&'
+change-template: '- $TITLE (#$NUMBER)'
+template: |
+  $CHANGES

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    timeout-minutes: 720  # 12 hours
+    runs-on: [self-hosted-ghr-custom, size-xl-x64, profile-consensusSpecs]
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: read
+
+    steps:
+      # Clone specs
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: 'consensus-specs'
+
+      # Setup python
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.13'
+
+      # As a sanity check, ensure tests pass
+      - name: Run tests for minimal
+        run: make test preset=minimal
+      - name: Run tests for mainnet
+        run: make test preset=mainnet
+
+      # Add support for large files
+      - name: Install Git LFS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-lfs
+          git lfs install
+
+      # Clone the repo with our PAT and delete old files
+      - name: Clone spec tests repo
+        run: |
+          git clone https://x-access-token:${{ secrets.CONSENSUS_SPEC_TESTS_PAT }}@github.com/ethereum/consensus-spec-tests.git --depth=1
+          cd consensus-spec-tests
+          rm -rf configs presets tests
+
+      # Write presets/configs to the spec tests repo
+      - name: Copy presets/configs
+        run: |
+          cd consensus-specs
+          cp -r presets/ ../consensus-spec-tests/presets
+          cp -r configs/ ../consensus-spec-tests/configs
+
+      # Write reference tests to the spec tests repo
+      - name: Generate reference tests
+        run: |
+          cd consensus-specs
+          make reftests verbose=true
+
+      # Make tarballs
+      - name: Archive configurations
+        run: |
+          cd consensus-spec-tests
+          tar -czvf general.tar.gz tests/general
+          tar -czvf minimal.tar.gz tests/minimal
+          tar -czvf mainnet.tar.gz tests/mainnet
+
+      # Commit the tests to the spec tests repo
+      # Cloned with PAT, so don't need to specify it here
+      - name: Push spec tests
+        run: |
+          cd consensus-spec-tests
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add .
+          if ! git diff --cached --quiet; then
+            git commit -m "release ${{ github.ref_name }} tests"
+            git push
+          else
+            echo "No changes to commit"
+          fi
+
+      # Publish the specs release. We use release-drafter to
+      # organize PRs into the appropriate section based on PR labels
+      - name: Publish specs release
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+        with:
+          name: ${{ github.ref_name }}
+          tag: ${{ github.ref_name }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Finally, publish the spec tests release
+      # Requires a personal access token (PAT) with contents:read-write
+      - name: Publish spec tests release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Spec tests for ${{ github.ref_name }}"
+          body: |
+            Spec tests for `${{ github.ref_name }}`.
+
+            Detailed changelog can be found in [`${{ github.ref_name }}` specs release](https://github.com/ethereum/consensus-specs/releases/tag/${{ github.ref_name }}).
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          draft: false
+          repository: ethereum/consensus-spec-tests
+          files: |
+            consensus-spec-tests/general.tar.gz
+            consensus-spec-tests/minimal.tar.gz
+            consensus-spec-tests/mainnet.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.CONSENSUS_SPEC_TESTS_PAT }}


### PR DESCRIPTION
This PR adds a new release action that is triggered when there's a new tag. The action will:

* Run all tests.
* Generate reference tests.
* Push reference tests commit.
* Publish release for specs.
* Publish release for spec tests.

The release notes use PR labels to organize in the appropriate sections.

After merging the release PR, simply tag that commit and the releases will be created.

Fixes #4377.