### PR TITLE
Remove unnecessary config overrides in test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/fulu/validator/test_compute_fork_digest.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/validator/test_compute_fork_digest.py
@@ -11,8 +11,6 @@ from eth2spec.test.context import (
 @single_phase
 @with_config_overrides(
     {
-        "ELECTRA_FORK_EPOCH": 9,
-        "FULU_FORK_EPOCH": 100,
         "BLOB_SCHEDULE": [
             {"EPOCH": 9, "MAX_BLOBS_PER_BLOCK": 9},
             {"EPOCH": 100, "MAX_BLOBS_PER_BLOCK": 100},


### PR DESCRIPTION
There's no need to define fork epochs as we define epoch & fork version in the test inputs. Defining those here is misleading because `compute_fork_digest` is different prior to Fulu and we are not testing that function.