### PR TITLE
Convert DAS providers section to supernodes section

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -613,12 +613,12 @@ a peer.
 A supernode is a node which subscribes to all data column sidecar subnets,
 custodies all data column sidecars, and performs
 [reconstruction and cross-seeding](./das-core.md#reconstruction-and-cross-seeding).
-In order to reconstruct missing data, there must be at least one supernode on
-the network. There are expected to be many (hundreds) of supernodes on mainnet
-and it is likely for a node to be connected to several of these by chance. Being
-a supernode requires considerably higher bandwidth, storage, and computation
-resources. Due to
+Being a supernode requires considerably higher bandwidth, storage, and
+computation resources. In order to reconstruct missing data, there must be at
+least one supernode on the network. Due to
 [validator custody requirements](./validator.md#validator-custody), a node which
 is connected to validator(s) with a combined balance greater than or equal to
-4096 ETH must be a supernode. Though, any node with the necessary resources may
-altruisticly be a supernode.
+4096 ETH must be a supernode. Moreover, any node with the necessary resources
+may altruistically be a supernode. Therefore, there are expected to be many
+(hundreds) of supernodes on mainnet and it is likely (though not necessary) for
+a node to be connected to several of these by chance.

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -613,15 +613,12 @@ a peer.
 A supernode is a node which subscribes to all data column sidecar subnets,
 custodies all data column sidecars, and performs
 [reconstruction and cross-seeding](./das-core.md#reconstruction-and-cross-seeding).
-Supernodes are not required for the network to function but they do improve
-network stability, reduce latency, and reduce attackability. Being a supernode
-requires considerably higher bandwidth, storage, and computation resources. Due
-to [validator custody requirements](./validator.md#validator-custody), a node
-which is connected to validator(s) with a combined balance greater than or equal
-to 4096 ETH must be a supernode. Though, any node with the necessary resources
-may altruisticly be a supernode.
-
-Like regular nodes, supernodes can be discovered via discv5. They can also be
-found out-of-band and configured into a node to connect to directly and
-prioritize. Nodes can add some set of these to their local configuration for
-persistent connection to bolster their DAS quality of service.
+In order to reconstruct missing data, there must be at least one supernode on
+the network. There are expected to be many (hundreds) of supernodes on mainnet
+and it is likely for a node to be connected to several of these by chance. Being
+a supernode requires considerably higher bandwidth, storage, and computation
+resources. Due to
+[validator custody requirements](./validator.md#validator-custody), a node which
+is connected to validator(s) with a combined balance greater than or equal to
+4096 ETH must be a supernode. Though, any node with the necessary resources may
+altruisticly be a supernode.

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -38,7 +38,7 @@
       - [Custody group count](#custody-group-count)
       - [Next fork digest](#next-fork-digest)
 - [Peer Scoring](#peer-scoring)
-- [DAS providers](#das-providers)
+- [Supernodes](#supernodes)
 
 <!-- mdformat-toc end -->
 
@@ -608,18 +608,20 @@ should be able to respond to. In the event that a peer does not respond to
 samples of their custodied rows/columns, a node may downscore or disconnect from
 a peer.
 
-## DAS providers
+## Supernodes
 
-A DAS provider is a consistently-available-for-DAS-queries, super-full (or high
-capacity) node. To the p2p, these look just like other nodes but with high
-advertised capacity, and they should generally be able to be latently found via
-normal discovery.
+A supernode is a node which subscribes to all data column sidecar subnets,
+custodies all data column sidecars, and performs
+[reconstruction and cross-seeding](./das-core.md#reconstruction-and-cross-seeding).
+Supernodes are not required for the network to function but they do improve
+network stability, reduce latency, and reduce attackability. Being a supernode
+requires considerably higher bandwidth, storage, and computation resources. Due
+to [validator custody requirements](./validator.md#validator-custody), a node
+which is connected to validator(s) with a combined balance greater than or equal
+to 4096 ETH must be a supernode. Though, any node with the necessary resources
+may altruisticly be a supernode.
 
-DAS providers can also be found out-of-band and configured into a node to
-connect to directly and prioritize. Nodes can add some set of these to their
-local configuration for persistent connection to bolster their DAS quality of
-service.
-
-Such direct peering utilizes a feature supported out of the box today on all
-nodes and can complement (and reduce attackability and increase
-quality-of-service) alternative peer discovery mechanisms.
+Like regular nodes, supernodes can be discovered via discv5. They can also be
+found out-of-band and configured into a node to connect to directly and
+prioritize. Nodes can add some set of these to their local configuration for
+persistent connection to bolster their DAS quality of service.


### PR DESCRIPTION
Please see the comment that @jimmygchen made here:

* https://github.com/ethereum/consensus-specs/pull/4393#discussion_r2168281200

This section introduced a new term, DAS providers, which is not the commonly used term. In this PR, I've updated the section to be about supernodes instead. This refactor should clearly describe what they are and why it matters.