### PR TITLE
Increase release action timeout to 24 hours

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    timeout-minutes: 720  # 12 hours
+    timeout-minutes: 1440  # 24 hours
     runs-on: [self-hosted-ghr-custom, size-xl-x64, profile-consensusSpecs]
     permissions:
       contents: write


### PR DESCRIPTION
I underestimated how long the release action would take. It will take longer than 12 hours.