### PR TITLE
In the release action, add back sudo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
       # Add support for large files
       - name: Install Git LFS
         run: |
-          apt-get update
-          apt-get install -y git-lfs
+          sudo apt-get update
+          sudo apt-get install -y git-lfs
           git lfs install
 
       # Clone the repo with our PAT and delete old files


### PR DESCRIPTION
Nothing is ever easy. Last fix didn't work. Chatted with devops. They added support for `sudo` on our custom runners.

https://github.com/ethereum/devops/issues/1827