### PR TITLE
Make updates to reflect default master branch

### DIFF
--- a/.github/workflows/generate_vectors.yml
+++ b/.github/workflows/generate_vectors.yml
@@ -14,7 +14,7 @@ on:
         required: true
       ref:
         description: The branch, tag or SHA to checkout and build from
-        default: dev
+        default: master
         type: string
         required: true
   schedule:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       ref:
         description: The branch, tag or SHA to checkout and build from
-        default: dev
+        default: master
         type: string
         required: true
   schedule:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,8 +6,11 @@ defaults:
 
 on:
   push:
-    branches: [dev, master]
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 
 jobs:
   lint:

--- a/docs/docs/new-feature.md
+++ b/docs/docs/new-feature.md
@@ -52,27 +52,27 @@ You can refer to the previous fork's `fork.md` file.
 ### 5. Make it executable
 
 - Update Pyspec
-  [`constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/constants.py)
+  [`constants.py`](https://github.com/ethereum/consensus-specs/blob/master/tests/core/pyspec/eth2spec/test/helpers/constants.py)
   with the new feature name.
 - Update helpers for
-  [`setup.py`](https://github.com/ethereum/consensus-specs/blob/dev/setup.py)
+  [`setup.py`](https://github.com/ethereum/consensus-specs/blob/master/setup.py)
   for building the spec:
   - Update
-    [`pysetup/constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/pysetup/constants.py)
+    [`pysetup/constants.py`](https://github.com/ethereum/consensus-specs/blob/master/pysetup/constants.py)
     with the new feature name as Pyspec `constants.py` defined.
   - Update
-    [`pysetup/spec_builders/__init__.py`](https://github.com/ethereum/consensus-specs/blob/dev/pysetup/spec_builders/__init__.py).
+    [`pysetup/spec_builders/__init__.py`](https://github.com/ethereum/consensus-specs/blob/master/pysetup/spec_builders/__init__.py).
     Implement a new `<FEATURE_NAME>SpecBuilder` in
     `pysetup/spec_builders/<FEATURE_NAME>.py` with the new feature name. e.g.,
     `EIP9999SpecBuilder`. Append it to the `spec_builders` list.
   - Update
-    [`pysetup/md_doc_paths.py`](https://github.com/ethereum/consensus-specs/blob/dev/pysetup/md_doc_paths.py):
+    [`pysetup/md_doc_paths.py`](https://github.com/ethereum/consensus-specs/blob/master/pysetup/md_doc_paths.py):
     add the path of the new markdown files in `get_md_doc_paths` function if
     needed.
 - Update `PREVIOUS_FORK_OF` setting in both
-  [`test/helpers/constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/constants.py)
+  [`test/helpers/constants.py`](https://github.com/ethereum/consensus-specs/blob/master/tests/core/pyspec/eth2spec/test/helpers/constants.py)
   and
-  [`pysetup/md_doc_paths.py`](https://github.com/ethereum/consensus-specs/blob/dev/pysetup/md_doc_paths.py).
+  [`pysetup/md_doc_paths.py`](https://github.com/ethereum/consensus-specs/blob/master/pysetup/md_doc_paths.py).
   - NOTE: since these two modules (the pyspec itself and the spec builder tool)
     must be separate, the fork sequence setting has to be defined again.
 
@@ -82,7 +82,7 @@ You can refer to the previous fork's `fork.md` file.
 
 - You can refer to the previous fork's `light-client/*` file.
 - Add the path of the new markdown files in
-  [`pysetup/md_doc_paths.py`](https://github.com/ethereum/consensus-specs/blob/dev/pysetup/md_doc_paths.py)'s
+  [`pysetup/md_doc_paths.py`](https://github.com/ethereum/consensus-specs/blob/master/pysetup/md_doc_paths.py)'s
   `get_md_doc_paths` function.
 
 ### 2. Add the mainnet and minimal presets and update the configs
@@ -91,16 +91,16 @@ You can refer to the previous fork's `fork.md` file.
   `presets/minimal/<new-feature-name>.yaml`
 - Update configs: `configs/mainnet.yaml` and `configs/minimal.yaml`
 
-### 3. Update [`context.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/context.py)
+### 3. Update [`context.py`](https://github.com/ethereum/consensus-specs/blob/master/tests/core/pyspec/eth2spec/test/context.py)
 
 - [Optional] Add `with_<new-feature-name>_and_later` decorator for writing
   pytest cases. e.g., `with_capella_and_later`.
 
-### 4. Update [`constants.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/constants.py)
+### 4. Update [`constants.py`](https://github.com/ethereum/consensus-specs/blob/master/tests/core/pyspec/eth2spec/test/helpers/constants.py)
 
 - Add `<NEW_FEATURE>` to `ALL_PHASES` and `TESTGEN_FORKS`
 
-### 5. Update [`genesis.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/helpers/genesis.py):
+### 5. Update [`genesis.py`](https://github.com/ethereum/consensus-specs/blob/master/tests/core/pyspec/eth2spec/test/helpers/genesis.py):
 
 We use `create_genesis_state` to create the default `state` in tests.
 
@@ -124,7 +124,7 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 ### 6. Update CI configurations
 
 - Update
-  [GitHub Actions config](https://github.com/ethereum/consensus-specs/blob/dev/.github/workflows/run-tests.yml)
+  [GitHub Actions config](https://github.com/ethereum/consensus-specs/blob/master/.github/workflows/run-tests.yml)
   - Update `pyspec-tests.strategy.matrix.version` list by adding new feature to
     it
 

--- a/docs/docs/release.md
+++ b/docs/docs/release.md
@@ -3,9 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Open a Release Pull Request](#open-a-release-pull-request)
 - [Bump the Version](#bump-the-version)
-- [Merge the Release Pull Request](#merge-the-release-pull-request)
 - [Tag the Release](#tag-the-release)
 - [Make an Announcement](#make-an-announcement)
 
@@ -16,32 +14,6 @@
 This document describes the necessary steps to produce a consensus-specs
 release.
 
-## Open a Release Pull Request
-
-> [!NOTE]
-> Try to do this at least a few days prior to the release.
-
-First, create a PR which merges `dev` into `master`.
-
-> [!TIP]
-> Click on the following link to draft a PR:
->
-> - https://github.com/ethereum/consensus-specs/compare/dev...master?expand=1
-
-Title this PR "Release \<version>" (_e.g._, "Release v1.5.0-alpha.10").
-
-In the PR's description, provide a list of items that must be done. At the
-bottom, list unmerged PRs which are to be included in the release; this signals
-to other maintainers and developers that they should review these PRs soon.
-
-```markdown
-- [ ] testgen
-- [ ] version bump
-- [ ] #1234
-- [ ] #2345
-- [ ] #3456
-```
-
 ## Bump the Version
 
 Next, update the `VERSION.txt` file which contains the eth2spec version.
@@ -49,7 +21,7 @@ Next, update the `VERSION.txt` file which contains the eth2spec version.
 > [!TIP]
 > Click on the following link to open the GitHub editor for this file:
 >
-> - https://github.com/ethereum/consensus-specs/edit/dev/tests/core/pyspec/eth2spec/VERSION.txt
+> - https://github.com/ethereum/consensus-specs/edit/master/tests/core/pyspec/eth2spec/VERSION.txt
 
 Next, change the version to the appropriate value and click the "Commit
 changes..." button.
@@ -58,13 +30,6 @@ For the commit message, put "Bump version to \<version>" (_e.g._, "Bump version
 to 1.5.0-alpha.10").
 
 Next, click the "Propose changes" button and proceed to make the PR.
-
-## Merge the Release Pull Request
-
-> [!IMPORTANT]
-> Be sure to merge this using the "Create a merge commit" method.
-
-After all PRs have been merged/addressed, merge the release PR.
 
 ## Tag the Release
 

--- a/setup.py
+++ b/setup.py
@@ -262,14 +262,6 @@ commands = {
 with open("README.md", encoding="utf8") as f:
     readme = f.read()
 
-# How to use "VERSION.txt" file:
-# - dev branch contains "X.Y.Z.dev", where "X.Y.Z" is the target version to release dev into.
-#    -> Changed as part of 'master' backport to 'dev'
-# - master branch contains "X.Y.Z", where "X.Y.Z" is the current version.
-#    -> Changed as part of 'dev' release (or other branch) into 'master'
-#    -> In case of a commit on master without git tag, target the next version
-#        with ".postN" (release candidate, numbered) suffixed.
-# See https://www.python.org/dev/peps/pep-0440/#public-version-identifiers
 with open(os.path.join("tests", "core", "pyspec", "eth2spec", "VERSION.txt")) as f:
     spec_version = f.read().strip()
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ s..                                                                             
 
 One of the `test_empty_block_transition` tests is implemented by a function with
 the same name located in
-[`~/consensus-specs/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py`](https://github.com/ethereum/consensus-specs/blob/dev/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py).
+[`~/consensus-specs/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py`](https://github.com/ethereum/consensus-specs/blob/master/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py).
 To learn how consensus spec tests are written, let's go over the code:
 
 ```
@@ -452,7 +452,7 @@ chain clients. The way these tests get applied by clients is that every few
 weeks
 [new test specifications are released](https://github.com/ethereum/consensus-spec-tests/releases),
 in a format
-[documented here](https://github.com/ethereum/consensus-specs/tree/dev/tests/formats).
+[documented here](https://github.com/ethereum/consensus-specs/tree/master/tests/formats).
 All the consensus layer clients implement test-runners that consume the test
 vectors in this standard format.
 


### PR DESCRIPTION
* Update links to the `dev` branch.
* Set `master` as the default branch in workflows.
* Update release instructions to reflect change.