### PR TITLE
Add EIP-7916 ProgressiveList specs and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "py_arkworks_bls12381==0.3.8",
   "py_ecc==8.0.0",
   "pycryptodome==3.23.0",
-  "remerkleable==0.1.28",
+  "remerkleable @ git+https://github.com/ethereum/remerkleable@643e8e3d1d80a34f61d4b1e32a46e38ad7e57a18",
   "ruamel.yaml==0.18.14",
   "setuptools==80.9.0",
   "trie==3.1.0",

--- a/tests/core/pyspec/eth2spec/debug/decode.py
+++ b/tests/core/pyspec/eth2spec/debug/decode.py
@@ -7,6 +7,7 @@ from eth2spec.utils.ssz.ssz_typing import (
     ByteVector,
     Container,
     List,
+    ProgressiveList,
     uint,
     Union,
     Vector,
@@ -17,7 +18,7 @@ from eth2spec.utils.ssz.ssz_typing import (
 def decode(data: Any, typ):
     if issubclass(typ, uint | boolean):
         return typ(data)
-    elif issubclass(typ, List | Vector):
+    elif issubclass(typ, List | ProgressiveList | Vector):
         return typ(decode(element, typ.element_cls()) for element in data)
     elif issubclass(typ, ByteVector):
         return typ(bytes.fromhex(data[2:]))

--- a/tests/core/pyspec/eth2spec/debug/encode.py
+++ b/tests/core/pyspec/eth2spec/debug/encode.py
@@ -5,6 +5,7 @@ from eth2spec.utils.ssz.ssz_typing import (
     boolean,
     Container,
     List,
+    ProgressiveList,
     uint,
     Union,
     Vector,
@@ -23,7 +24,7 @@ def encode(value, include_hash_tree_roots=False):
         return "0x" + serialize(value).hex()
     elif isinstance(value, list):  # normal python lists
         return [encode(element, include_hash_tree_roots) for element in value]
-    elif isinstance(value, List | Vector):
+    elif isinstance(value, List | ProgressiveList | Vector):
         return [encode(element, include_hash_tree_roots) for element in value]
     elif isinstance(value, bytes):  # bytes, ByteList, ByteVector
         return "0x" + value.hex()

--- a/tests/core/pyspec/eth2spec/debug/random_value.py
+++ b/tests/core/pyspec/eth2spec/debug/random_value.py
@@ -10,6 +10,7 @@ from eth2spec.utils.ssz.ssz_typing import (
     ByteVector,
     Container,
     List,
+    ProgressiveList,
     uint,
     Union,
     Vector,
@@ -102,19 +103,23 @@ def get_random_ssz_object(
             get_random_ssz_object(rng, elem_type, max_bytes_length, max_list_length, mode, chaos)
             for _ in range(typ.vector_length())
         )
-    elif issubclass(typ, List) or issubclass(typ, Bitlist):
-        length = rng.randint(0, min(typ.limit(), max_list_length))
+    elif issubclass(typ, List) or issubclass(typ, ProgressiveList) or issubclass(typ, Bitlist):
+        limit = max_list_length
+        if (
+            not issubclass(typ, ProgressiveList) and typ.limit() < limit
+        ):  # SSZ imposes a hard limit on lists, we can't put in more than that
+            limit = typ.limit()
+
+        length = rng.randint(0, limit)
         if mode == RandomizationMode.mode_one_count:
             length = 1
         elif mode == RandomizationMode.mode_max_count:
-            length = max_list_length
+            length = limit
         elif mode == RandomizationMode.mode_nil_count:
             length = 0
 
-        # SSZ imposes a hard limit on lists, we can't put in more than that
-        length = min(length, typ.limit())
-
-        elem_type = typ.element_cls() if issubclass(typ, List) else boolean
+        elem_type = boolean if issubclass(typ, Bitlist) else typ.element_cls()
+        max_list_length = 1 << (max_list_length.bit_length() >> 1)
         return typ(
             get_random_ssz_object(rng, elem_type, max_bytes_length, max_list_length, mode, chaos)
             for _ in range(length)

--- a/tests/core/pyspec/eth2spec/utils/ssz/ssz_typing.py
+++ b/tests/core/pyspec/eth2spec/utils/ssz/ssz_typing.py
@@ -25,6 +25,7 @@ from remerkleable.byte_arrays import (
 )
 from remerkleable.complex import Container, List, Vector
 from remerkleable.core import BasicView, Path, View
+from remerkleable.progressive import ProgressiveList
 from remerkleable.union import Union
 
 Bytes20 = ByteVector[20]  # type: ignore

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -16,6 +16,9 @@ into a SSZ type:
 - List
   - `basic_list` *not supported yet*
   - `complex_list` *not supported yet*
+- ProgressiveList
+  - `basic_progressivelist`
+  - `complex_progressivelist` *not supported yet*
 - Bitfields
   - `bitvector`
   - `bitlist`
@@ -105,6 +108,18 @@ Data:
 {length}: an unsigned integer
 ```
 
+### `basic_progressivelist`
+
+```
+Template:
+
+proglist_{element type}
+
+Data:
+
+{element type}: bool, uint8, uint16, uint32, uint64, uint128, uint256
+```
+
 ### `bitlist`
 
 ```
@@ -191,6 +206,13 @@ class ComplexTestStruct(Container):
     E: VarTestStruct
     F: Vector[FixedTestStruct, 4]
     G: Vector[VarTestStruct, 2]
+
+
+class ProgressiveTestStruct(Container):
+    A: ProgressiveList[byte]
+    B: ProgressiveList[uint64]
+    C: ProgressiveList[SmallTestStruct]
+    D: ProgressiveList[ProgressiveList[VarTestStruct]]
 
 
 class BitsStruct(Container):

--- a/tests/generators/runners/ssz_generic.py
+++ b/tests/generators/runners/ssz_generic.py
@@ -4,6 +4,7 @@ from eth2spec.gen_helpers.gen_base.gen_typing import TestCase
 from eth2spec.test.helpers.constants import PHASE0
 
 from .ssz_generic_cases import (
+    ssz_basic_progressivelist,
     ssz_basic_vector,
     ssz_bitlist,
     ssz_bitvector,
@@ -15,6 +16,8 @@ from .ssz_generic_cases import (
 
 def get_test_cases() -> Iterable[TestCase]:
     test_case_fns = [
+        ("basic_progressivelist", "valid", ssz_basic_progressivelist.valid_cases),
+        ("basic_progressivelist", "invalid", ssz_basic_progressivelist.invalid_cases),
         ("basic_vector", "valid", ssz_basic_vector.valid_cases),
         ("basic_vector", "invalid", ssz_basic_vector.invalid_cases),
         ("bitlist", "valid", ssz_bitlist.valid_cases),

--- a/tests/generators/runners/ssz_generic_cases/ssz_basic_progressivelist.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_basic_progressivelist.py
@@ -1,0 +1,87 @@
+from random import Random
+
+from eth2spec.debug.random_value import get_random_ssz_object, RandomizationMode
+from eth2spec.utils.ssz.ssz_impl import serialize
+from eth2spec.utils.ssz.ssz_typing import (
+    BasicView,
+    boolean,
+    ProgressiveList,
+    uint8,
+    uint16,
+    uint32,
+    uint64,
+    uint128,
+    uint256,
+)
+
+from .ssz_test_case import invalid_test_case, valid_test_case
+
+
+def progressive_list_case_fn(
+    rng: Random, mode: RandomizationMode, elem_type: type[BasicView], length: int
+):
+    return get_random_ssz_object(
+        rng,
+        ProgressiveList[elem_type],
+        max_bytes_length=length * 8,
+        max_list_length=length,
+        mode=mode,
+        chaos=False,
+    )
+
+
+BASIC_TYPES: dict[str, type[BasicView]] = {
+    "bool": boolean,
+    "uint8": uint8,
+    "uint16": uint16,
+    "uint32": uint32,
+    "uint64": uint64,
+    "uint128": uint128,
+    "uint256": uint256,
+}
+
+
+def valid_cases():
+    rng = Random(1234)
+    for name, typ in BASIC_TYPES.items():
+        random_modes = [RandomizationMode.mode_zero, RandomizationMode.mode_max]
+        if name != "bool":
+            random_modes.append(RandomizationMode.mode_random)
+        for length in [0, 1, 2, 3, 4, 5, 8, 20, 21, 22, 85, 86, 341, 342, 1365, 1366]:
+            for mode in random_modes:
+                yield (
+                    f"proglist_{name}_{mode.to_name()}_{length}",
+                    valid_test_case(
+                        lambda rng=rng, mode=mode, typ=typ, length=length: progressive_list_case_fn(
+                            rng, mode, typ, length
+                        )
+                    ),
+                )
+
+
+def invalid_cases():
+    rng = Random(1234)
+    for name, typ in BASIC_TYPES.items():
+        random_modes = [RandomizationMode.mode_zero, RandomizationMode.mode_max]
+        if name != "bool":
+            random_modes.append(RandomizationMode.mode_random)
+        for length in [0, 1, 2, 3, 4, 5, 8, 20, 21, 22, 85, 86, 341, 342, 1365, 1366]:
+            for mode in random_modes:
+                if typ.type_byte_length() > 1:
+                    yield (
+                        f"proglist_{name}_{length}_{mode.to_name()}_one_byte_less",
+                        invalid_test_case(
+                            lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
+                                progressive_list_case_fn(rng, mode, typ, length)
+                            )[:-1]
+                        ),
+                    )
+                    yield (
+                        f"proglist_{name}_{length}_{mode.to_name()}_one_byte_more",
+                        invalid_test_case(
+                            lambda rng=rng, mode=mode, typ=typ, length=length: serialize(
+                                progressive_list_case_fn(rng, mode, typ, length)
+                            )
+                            + serialize(progressive_list_case_fn(rng, mode, uint8, 1))
+                        ),
+                    )

--- a/tests/generators/runners/ssz_generic_cases/ssz_container.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_container.py
@@ -10,6 +10,7 @@ from eth2spec.utils.ssz.ssz_typing import (
     ByteList,
     Container,
     List,
+    ProgressiveList,
     uint8,
     uint16,
     uint32,
@@ -52,6 +53,13 @@ class ComplexTestStruct(Container):
     G: Vector[VarTestStruct, 2]
 
 
+class ProgressiveTestStruct(Container):
+    A: ProgressiveList[byte]
+    B: ProgressiveList[uint64]
+    C: ProgressiveList[SmallTestStruct]
+    D: ProgressiveList[ProgressiveList[VarTestStruct]]
+
+
 class BitsStruct(Container):
     A: Bitlist[5]
     B: Bitvector[2]
@@ -72,6 +80,7 @@ PRESET_CONTAINERS: dict[str, tuple[type[View], Sequence[int]]] = {
     "FixedTestStruct": (FixedTestStruct, []),
     "VarTestStruct": (VarTestStruct, [2]),
     "ComplexTestStruct": (ComplexTestStruct, [2, 2 + 4 + 1, 2 + 4 + 1 + 4]),
+    "ProgressiveTestStruct": (ProgressiveTestStruct, [0, 4, 8, 12]),
     "BitsStruct": (BitsStruct, [0, 4 + 1 + 1, 4 + 1 + 1 + 4]),
 }
 
@@ -197,7 +206,7 @@ def invalid_cases():
                         )
                     if mode == RandomizationMode.mode_max_count:
                         serialized = serialize(container_case_fn(rng, mode, typ))
-                        serialized = serialized + serialized[:2]
+                        serialized = serialized + serialized[:3]
                         yield (
                             f"{name}_{mode.to_name()}_last_offset_{offset_index}_overflow",
                             invalid_test_case(lambda serialized=serialized: serialized),


### PR DESCRIPTION
EIP-7916 defines a new SSZ type for lists of unknown length.

Historically, we used List[type, N] with very large N values for this:

- This wastes hashes, as log(N) hashes are still required even if only a single item is present. This is especially bad when nesting lists.

- Generalized indicse break, as is what happened when the Attestation count got reduced in Electra, introducing maintenance burden to apps that possibly involves security countil for upgrading smart contracts.

This PR adds specs and tests for EIP-7916 which fixes these issues, making the new list type available to EIP implementations in _features.

- https://eips.ethereum.org/EIPS/eip-7916