### PR TITLE
Add `inclusion-list.md` to EIP-7805 spec

### DIFF
--- a/specs/_features/eip7805/fork-choice.md
+++ b/specs/_features/eip7805/fork-choice.md
@@ -5,9 +5,6 @@
 - [Introduction](#introduction)
 - [Configuration](#configuration)
   - [Time parameters](#time-parameters)
-- [Containers](#containers)
-  - [New containers](#new-containers)
-    - [`InclusionListStore`](#inclusionliststore)
 - [Protocols](#protocols)
   - [`ExecutionEngine`](#executionengine)
     - [New `is_inclusion_list_satisfied`](#new-is_inclusion_list_satisfied)
@@ -16,9 +13,6 @@
   - [Modified `PayloadAttributes`](#modified-payloadattributes)
   - [Modified `Store`](#modified-store)
   - [Modified `get_forkchoice_store`](#modified-get_forkchoice_store)
-  - [New `get_inclusion_list_store`](#new-get_inclusion_list_store)
-  - [New `process_inclusion_list`](#new-process_inclusion_list)
-  - [New `get_inclusion_list_transactions`](#new-get_inclusion_list_transactions)
     - [New `validate_inclusion_lists`](#new-validate_inclusion_lists)
   - [New `get_attester_head`](#new-get_attester_head)
   - [Modified `get_proposer_head`](#modified-get_proposer_head)
@@ -39,23 +33,6 @@ This is the modification of the fork choice accompanying the EIP-7805 upgrade.
 | Name                   | Value                           |  Unit   | Duration  |
 | ---------------------- | ------------------------------- | :-----: | :-------: |
 | `VIEW_FREEZE_DEADLINE` | `SECONDS_PER_SLOT * 2 // 3 + 1` | seconds | 9 seconds |
-
-## Containers
-
-### New containers
-
-#### `InclusionListStore`
-
-```python
-@dataclass
-class InclusionListStore(object):
-    inclusion_lists: DefaultDict[Tuple[Slot, Root], Set[InclusionList]] = field(
-        default_factory=lambda: defaultdict(set)
-    )
-    equivocators: DefaultDict[Tuple[Slot, Root], Set[ValidatorIndex]] = field(
-        default_factory=lambda: defaultdict(set)
-    )
-```
 
 ## Protocols
 
@@ -171,73 +148,6 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
         unrealized_justifications={anchor_root: justified_checkpoint},
         unsatisfied_inclusion_list_blocks=set(),  # [New in EIP7805]
     )
-```
-
-### New `get_inclusion_list_store`
-
-```python
-def get_inclusion_list_store() -> InclusionListStore:
-    # `cached_or_new_inclusion_list_store` is implementation and context dependent.
-    # It returns the cached `InclusionListStore`; if none exists,
-    # it initializes a new instance, caches it and returns it.
-    inclusion_list_store = cached_or_new_inclusion_list_store()
-
-    return inclusion_list_store
-```
-
-### New `process_inclusion_list`
-
-```python
-def process_inclusion_list(
-    store: InclusionListStore, inclusion_list: InclusionList, is_before_view_freeze_deadline: bool
-) -> None:
-    key = (inclusion_list.slot, inclusion_list.inclusion_list_committee_root)
-
-    # Ignore `inclusion_list` from equivocators.
-    if inclusion_list.validator_index in store.equivocators[key]:
-        return
-
-    for stored_inclusion_list in store.inclusion_lists[key]:
-        if stored_inclusion_list.validator_index != inclusion_list.validator_index:
-            continue
-
-        if stored_inclusion_list != inclusion_list:
-            store.equivocators[key].add(inclusion_list.validator_index)
-            store.inclusion_lists[key].remove(stored_inclusion_list)
-
-        # Whether it was an equivocation or not, we have processed this `inclusion_list`.
-        return
-
-    # Only store `inclusion_list` if it arrived before the view freeze deadline.
-    if is_before_view_freeze_deadline:
-        store.inclusion_lists[key].add(inclusion_list)
-```
-
-### New `get_inclusion_list_transactions`
-
-*Note*: `get_inclusion_list_transactions` returns a list of unique transactions
-from all valid and non-equivocating `InclusionList`s that were received in a
-timely manner on the p2p network for the given slot and for which the
-`inclusion_list_committee_root` in the `InclusionList` matches the one
-calculated based on the current state.
-
-```python
-def get_inclusion_list_transactions(
-    store: InclusionListStore, state: BeaconState, slot: Slot
-) -> Sequence[Transaction]:
-    inclusion_list_committee = get_inclusion_list_committee(state, slot)
-    inclusion_list_committee_root = hash_tree_root(inclusion_list_committee)
-    key = (slot, inclusion_list_committee_root)
-
-    inclusion_list_transactions = [
-        transaction
-        for inclusion_list in store.inclusion_lists[key]
-        if inclusion_list.validator_index not in store.equivocators[key]
-        for transaction in inclusion_list.transactions
-    ]
-
-    # Deduplicate inclusion list transactions. Order does not need to be preserved.
-    return list(set(inclusion_list_transactions))
 ```
 
 #### New `validate_inclusion_lists`

--- a/specs/_features/eip7805/inclusion-list.md
+++ b/specs/_features/eip7805/inclusion-list.md
@@ -1,0 +1,105 @@
+# EIP-7805 -- Inclusion List
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
+
+- [Introduction](#introduction)
+- [Containers](#containers)
+  - [New containers](#new-containers)
+    - [`InclusionListStore`](#inclusionliststore)
+- [Helpers](#helpers)
+  - [New `get_inclusion_list_store`](#new-get_inclusion_list_store)
+  - [New `process_inclusion_list`](#new-process_inclusion_list)
+  - [New `get_inclusion_list_transactions`](#new-get_inclusion_list_transactions)
+
+<!-- mdformat-toc end -->
+
+## Introduction
+
+This is the inclusion list specification for the fork-choice enforced inclusion
+list feature.
+
+## Containers
+
+### New containers
+
+#### `InclusionListStore`
+
+```python
+@dataclass
+class InclusionListStore(object):
+    inclusion_lists: DefaultDict[Tuple[Slot, Root], Set[InclusionList]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
+    equivocators: DefaultDict[Tuple[Slot, Root], Set[ValidatorIndex]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
+```
+
+## Helpers
+
+### New `get_inclusion_list_store`
+
+```python
+def get_inclusion_list_store() -> InclusionListStore:
+    # `cached_or_new_inclusion_list_store` is implementation and context dependent.
+    # It returns the cached `InclusionListStore`; if none exists,
+    # it initializes a new instance, caches it and returns it.
+    inclusion_list_store = cached_or_new_inclusion_list_store()
+
+    return inclusion_list_store
+```
+
+### New `process_inclusion_list`
+
+```python
+def process_inclusion_list(
+    store: InclusionListStore, inclusion_list: InclusionList, is_before_view_freeze_deadline: bool
+) -> None:
+    key = (inclusion_list.slot, inclusion_list.inclusion_list_committee_root)
+
+    # Ignore `inclusion_list` from equivocators.
+    if inclusion_list.validator_index in store.equivocators[key]:
+        return
+
+    for stored_inclusion_list in store.inclusion_lists[key]:
+        if stored_inclusion_list.validator_index != inclusion_list.validator_index:
+            continue
+
+        if stored_inclusion_list != inclusion_list:
+            store.equivocators[key].add(inclusion_list.validator_index)
+            store.inclusion_lists[key].remove(stored_inclusion_list)
+
+        # Whether it was an equivocation or not, we have processed this `inclusion_list`.
+        return
+
+    # Only store `inclusion_list` if it arrived before the view freeze deadline.
+    if is_before_view_freeze_deadline:
+        store.inclusion_lists[key].add(inclusion_list)
+```
+
+### New `get_inclusion_list_transactions`
+
+*Note*: `get_inclusion_list_transactions` returns a list of unique transactions
+from all valid and non-equivocating `InclusionList`s that were received in a
+timely manner on the p2p network for the given slot and for which the
+`inclusion_list_committee_root` in the `InclusionList` matches the one
+calculated based on the current state.
+
+```python
+def get_inclusion_list_transactions(
+    store: InclusionListStore, state: BeaconState, slot: Slot
+) -> Sequence[Transaction]:
+    inclusion_list_committee = get_inclusion_list_committee(state, slot)
+    inclusion_list_committee_root = hash_tree_root(inclusion_list_committee)
+    key = (slot, inclusion_list_committee_root)
+
+    inclusion_list_transactions = [
+        transaction
+        for inclusion_list in store.inclusion_lists[key]
+        if inclusion_list.validator_index not in store.equivocators[key]
+        for transaction in inclusion_list.transactions
+    ]
+
+    # Deduplicate inclusion list transactions. Order does not need to be preserved.
+    return list(set(inclusion_list_transactions))
+```


### PR DESCRIPTION
This PR adds `inclusion-list.md` as [suggested](https://github.com/ethereum/consensus-specs/pull/4351#pullrequestreview-3023153485) in the previous PR. `inclusion-list.md` encapsulates `InclusionListStore` and inclusion list handling logic. Fork-choice store interacts with IL store via functions defined in `inclusion-list.md`, leveraging this abstraction.

On top of this, I'd like to discuss further encapsulating `InclusionListStore`, making it a module similar to `ExecutionEngine`. Currently, IL store is abstracted from the perspective of fork-choice store but the interaction is done via stateless functions. Alternatively, we could modularize it as follows:

AS-IS
```
def process_inclusion_list(store: InclusionListStore, inclusion_list: InclusionList, is_before_view_freeze_deadline: bool) -> None:
    pass


process_inclusion_list(inclusion_list_store, inclusion_list, is_before_view_freeze_deadline)
```
TO-BE
```
def process_inclusion_list(self: InclusionListStore, inclusion_list: InclusionList, is_before_view_freeze_deadline: bool) -> None:
    pass


inclusion_list_store.process_inclusion_list(inclusion_list, is_before_view_freeze_deadline)
```

Lastly, if you found anything to comment from the previous PR, please feel free to share it here :)

Tagging relevant people for visibility @jtraglia @mkalinin 