### PR TITLE
Make commitment deduplication in `verify_cell_kzg_proof_batch` deterministic

### DIFF
--- a/specs/fulu/polynomial-commitments-sampling.md
+++ b/specs/fulu/polynomial-commitments-sampling.md
@@ -650,7 +650,9 @@ def verify_cell_kzg_proof_batch(
 
     # Create the list of deduplicated commitments we are dealing with
     deduplicated_commitments = [
-        bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in set(commitments_bytes)
+        bytes_to_kzg_commitment(commitment_bytes)
+        for index, commitment_bytes in enumerate(commitments_bytes)
+        if commitments_bytes.index(commitment_bytes) == index
     ]
     # Create indices list mapping initial commitments (that may contain duplicates) to the deduplicated commitments
     commitment_indices = [

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -194,6 +194,37 @@ def case_verify_cell_kzg_proof_batch():
             get_test_runner(get_inputs),
         )
 
+    # Valid: Not sorted
+    if True:
+
+        def get_inputs():
+            cell_indices = [3, 2, 0, 1]
+
+            commitments = []
+            commitments.append(cached_blob_to_kzg_commitment(VALID_BLOBS[3]))
+            commitments.append(cached_blob_to_kzg_commitment(VALID_BLOBS[4]))
+            commitments.append(cached_blob_to_kzg_commitment(VALID_BLOBS[3]))
+            commitments.append(cached_blob_to_kzg_commitment(VALID_BLOBS[5]))
+
+            cells = []
+            cells.append(cached_compute_cells_and_kzg_proofs(VALID_BLOBS[3])[0][3])
+            cells.append(cached_compute_cells_and_kzg_proofs(VALID_BLOBS[4])[0][2])
+            cells.append(cached_compute_cells_and_kzg_proofs(VALID_BLOBS[3])[0][0])
+            cells.append(cached_compute_cells_and_kzg_proofs(VALID_BLOBS[5])[0][1])
+
+            proofs = []
+            proofs.append(cached_compute_cells_and_kzg_proofs(VALID_BLOBS[3])[1][3])
+            proofs.append(cached_compute_cells_and_kzg_proofs(VALID_BLOBS[4])[1][2])
+            proofs.append(cached_compute_cells_and_kzg_proofs(VALID_BLOBS[3])[1][0])
+            proofs.append(cached_compute_cells_and_kzg_proofs(VALID_BLOBS[5])[1][1])
+
+            return commitments, cell_indices, cells, proofs
+
+        yield (
+            "verify_cell_kzg_proof_batch_case_valid_not_sorted",
+            get_test_runner(get_inputs),
+        )
+
     # Incorrect commitment
     if True:
 


### PR DESCRIPTION
We found a small issue w.r.t. the deduplication of commitments in `verify_cell_kzg_proof_batch`:

```python
    # Create the list of deduplicated commitments we are dealing with
    deduplicated_commitments = [
        bytes_to_kzg_commitment(commitment_bytes) for commitment_bytes in set(commitments_bytes)
    ]
```

In short, using `set` to remove the duplicates is wrong as sets are unordered objects:

```python
>>> a = [1, 3, 2, 1]
>>> list(set(a))
[1, 2, 3]
```

Because of that, between runs, `deduplicated_commitments` will be different and so `commitment_indices`. The issue here is that the Fiat-Shamir challenge is computed by taking this arguments and hashing them together:

```python
def verify_cell_kzg_proof_batch_impl(
    commitments: Sequence[KZGCommitment],
    commitment_indices: Sequence[CommitmentIndex],
    cell_indices: Sequence[CellIndex],
    cosets_evals: Sequence[CosetEvals],
    proofs: Sequence[KZGProof],
) -> bool:

    ...

    # Step 1: Compute a challenge r and its powers r^0, ..., r^{num_cells-1}
    r = compute_verify_cell_kzg_proof_batch_challenge(
        commitments, commitment_indices, cell_indices, cosets_evals, proofs
    )

   ...
```

so, if between runs they change due to the non-deterministic deduplication, so does the challenge. This breaks Fiat-Shamir because if the prover generates a challenge $c_i$ and the verifier generates $c_j$ so that $c_i != c_j$ for the same set of inputs $S$, then proofs won't be able to be verified, even if "correct".

Right now this is not an issue as this is used in PeerDAS as an optimization, not like the usual two-parties setup we find in ZK. However, for correctness, this should be addressed, as the specs are "formally" wrong as of now.