### PR TITLE
eip7732: fix inclusion proof depth

### DIFF
--- a/presets/mainnet/eip7732.yaml
+++ b/presets/mainnet/eip7732.yaml
@@ -6,5 +6,5 @@
 PTC_SIZE: 512
 # 2**2 (= 4)
 MAX_PAYLOAD_ATTESTATIONS: 2
-# floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK) (= 8 + 1 + 12 = 21)
-KZG_COMMITMENT_INCLUSION_PROOF_DEPTH_EIP7732: 21
+# floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK) (= 9 + 1 + 12 = 22)
+KZG_COMMITMENT_INCLUSION_PROOF_DEPTH_EIP7732: 22

--- a/presets/minimal/eip7732.yaml
+++ b/presets/minimal/eip7732.yaml
@@ -6,5 +6,5 @@
 PTC_SIZE: 2
 # 2**2 (= 4)
 MAX_PAYLOAD_ATTESTATIONS: 2
-# floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK) (= 8 + 1 + 5 = 14)
+# floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK) (= 9 + 1 + 5 = 15)
 KZG_COMMITMENT_INCLUSION_PROOF_DEPTH_EIP7732: 15

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -47,7 +47,7 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 | Name                                           | Value        | Description                                                 |
 | ---------------------------------------------- | ------------ | ----------------------------------------------------------- |
-| `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH_EIP7732` | `21` **TBD** | Merkle proof depth for the `blob_kzg_commitments` list item |
+| `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH_EIP7732` | `22` **TBD** | Merkle proof depth for the `blob_kzg_commitments` list item |
 
 ### Configuration
 


### PR DESCRIPTION
Got this error when generating test vectors last night. The mainnet value was wrong.

```
Exception: invalid inputs length: 22, vector length is: 21
```