### PR TITLE
Clarify payload envelope construction in EIP-7732

### DIFF
--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -86,7 +86,7 @@ This feature adds new staked consensus participants called *Builders* and new
 honest validators duties called *payload timeliness attestations*. The slot is
 divided in **four** intervals. Honest validators gather *signed bids* (a
 `SignedExecutionPayloadHeader`) from builders and submit their consensus blocks
-(a `SignedBeaconBlock`) including an accepted bid at the beginning of the slot. At
+(a `SignedBeaconBlock`) including accepted bids at the beginning of the slot. At
 the start of the second interval, honest validators submit attestations just as
 they do previous to this feature). At the start of the third interval,
 aggregators aggregate these attestations and the builder broadcasts either a

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -86,7 +86,7 @@ This feature adds new staked consensus participants called *Builders* and new
 honest validators duties called *payload timeliness attestations*. The slot is
 divided in **four** intervals. Honest validators gather *signed bids* (a
 `SignedExecutionPayloadHeader`) from builders and submit their consensus blocks
-(a `SignedBeaconBlock`) including these bids at the beginning of the slot. At
+(a `SignedBeaconBlock`) including an accepted bid at the beginning of the slot. At
 the start of the second interval, honest validators submit attestations just as
 they do previous to this feature). At the start of the third interval,
 aggregators aggregate these attestations and the builder broadcasts either a

--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -149,15 +149,15 @@ corresponding `SignedExecutionPayloadEnvelope` that fulfills this commitment.
 See below for a special case of an *honestly withheld payload*.
 
 To construct the `execution_payload_envelope` the builder must perform the
-following steps. We alias `block` to be the corresponding beacon block and
-alias `header` to be the committed `ExecutionPayloadHeader` in
+following steps. We alias `block` to be the corresponding beacon block and alias
+`header` to be the committed `ExecutionPayloadHeader` in
 `block.body.signed_execution_payload_header.message`.
 
 1. Set the `payload` field to be the `ExecutionPayload` constructed when
    creating the corresponding bid. This payload **MUST** have the same block
    hash as `header.block_hash`.
-2. Set the `execution_requests` field to be the `ExecutionRequests`
-   associated with `payload`.
+2. Set the `execution_requests` field to be the `ExecutionRequests` associated
+   with `payload`.
 3. Set the `builder_index` field to be the validator index of the builder
    performing these steps. This field **MUST** be `header.builder_index`.
 4. Set `beacon_block_root` to be `hash_tree_root(block)`.

--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -149,8 +149,8 @@ corresponding `SignedExecutionPayloadEnvelope` that fulfills this commitment.
 See below for a special case of an *honestly withheld payload*.
 
 To construct the `execution_payload_envelope` the builder must perform the
-following steps. We alias `block` to be the corresponding beacon block and 
-alias `header` to be the committed `ExecutionPayloadHeader` in 
+following steps. We alias `block` to be the corresponding beacon block and
+alias `header` to be the committed `ExecutionPayloadHeader` in
 `block.body.signed_execution_payload_header.message`.
 
 1. Set the `payload` field to be the `ExecutionPayload` constructed when

--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -149,20 +149,22 @@ corresponding `SignedExecutionPayloadEnvelope` that fulfills this commitment.
 See below for a special case of an *honestly withheld payload*.
 
 To construct the `execution_payload_envelope` the builder must perform the
-following steps, we alias `header` to be the committed `ExecutionPayloadHeader`
-in the beacon block.
+following steps. We alias `block` to be the corresponding beacon block and 
+alias `header` to be the committed `ExecutionPayloadHeader` in 
+`block.body.signed_execution_payload_header.message`.
 
 1. Set the `payload` field to be the `ExecutionPayload` constructed when
    creating the corresponding bid. This payload **MUST** have the same block
    hash as `header.block_hash`.
-2. Set the `builder_index` field to be the validator index of the builder
+2. Set the `execution_requests` field to be the `ExecutionRequests`
+   associated with `payload`.
+3. Set the `builder_index` field to be the validator index of the builder
    performing these steps. This field **MUST** be `header.builder_index`.
-3. Set `beacon_block_root` to be the `hash_tree_root` of the corresponding
-   beacon block.
-4. Set `blob_kzg_commitments` to be the `commitments` field of the blobs bundle
+4. Set `beacon_block_root` to be the `hash_tree_root(block)`.
+5. Set `slot` to be the `block.slot`.
+6. Set `blob_kzg_commitments` to be the `commitments` field of the blobs bundle
    constructed when constructing the bid. This field **MUST** have a
    `hash_tree_root` equal to `header.blob_kzg_commitments_root`.
-5. Set `payload_withheld` to `False`.
 
 After setting these parameters, the builder should run
 `process_execution_payload(state, signed_envelope, verify=False)` and this

--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -160,8 +160,8 @@ alias `header` to be the committed `ExecutionPayloadHeader` in
    associated with `payload`.
 3. Set the `builder_index` field to be the validator index of the builder
    performing these steps. This field **MUST** be `header.builder_index`.
-4. Set `beacon_block_root` to be the `hash_tree_root(block)`.
-5. Set `slot` to be the `block.slot`.
+4. Set `beacon_block_root` to be `hash_tree_root(block)`.
+5. Set `slot` to be `block.slot`.
 6. Set `blob_kzg_commitments` to be the `commitments` field of the blobs bundle
    constructed when constructing the bid. This field **MUST** have a
    `hash_tree_root` equal to `header.blob_kzg_commitments_root`.

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -208,8 +208,7 @@ obtained from the `state.signed_execution_payload_header`)
 - _[REJECT]_ `block` passes validation.
 - _[REJECT]_ `block.slot` equals `envelope.slot`.
 - _[REJECT]_ `envelope.builder_index == header.builder_index`
-- if `envelope.payload_withheld == False` then
-  - _[REJECT]_ `payload.block_hash == header.block_hash`
+- _[REJECT]_ `payload.block_hash == header.block_hash`
 - _[REJECT]_ The builder signature,
   `signed_execution_payload_envelope.signature`, is valid with respect to the
   builder's public key.


### PR DESCRIPTION
- Add specification on constructing `slot` and `execution_requests` in execution payload envelope
- Remove spec related to `payload_withheld`