### PR TITLE
In `get_custody_groups`, skip computation if all groups are custodied

### DIFF
--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -100,6 +100,10 @@ class MatrixEntry(Container):
 def get_custody_groups(node_id: NodeID, custody_group_count: uint64) -> Sequence[CustodyIndex]:
     assert custody_group_count <= NUMBER_OF_CUSTODY_GROUPS
 
+    # Skip computation if all groups are custodied
+    if custody_group_count == NUMBER_OF_CUSTODY_GROUPS:
+        return [CustodyIndex(i) for i in range(NUMBER_OF_CUSTODY_GROUPS)]
+
     current_id = uint256(node_id)
     custody_groups: List[CustodyIndex] = []
     while len(custody_groups) < custody_group_count:


### PR DESCRIPTION
A simple optimization which doesn't change anything, but worth mentioning because not all clients do this. For supernodes which custody everything, we can skip computing the list of custody groups and return the full range of groups. Given that there is quite a bit of hashing involved, this isn't exactly free.

Thanks to @nalepae for suggesting this.