### PR TITLE
Fix duplicate function call

### DIFF
--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -656,8 +656,6 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     process_withdrawals(state)
     # [Modified in EIP7732]
     # Removed `process_execution_payload`
-    # [Modified in EIP7732]
-    process_withdrawals(state)
     # [New in EIP7732]
     process_execution_payload_header(state, block)
     process_randao(state, block.body)

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -656,8 +656,6 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     process_withdrawals(state)
     # [Modified in EIP7732]
     # Removed `process_execution_payload`
-    # [New in EIP7732]
-    process_execution_payload_header(state, block)
     # [Modified in EIP7732]
     process_withdrawals(state)
     # [New in EIP7732]


### PR DESCRIPTION
This keeps calling process_execution_payload_header() after processing withdrawals.