### PR TITLE
eip-7732: Fix quorum calc

### DIFF
--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -1027,14 +1027,12 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
                 proposer_reward_numerator += get_base_reward(state, index) * weight
                 # [New in EIP7732]
                 # Update the builder payment weight
-                if flag_index == TIMELY_HEAD_FLAG_INDEX:
+                if flag_index == TIMELY_HEAD_FLAG_INDEX and is_attestation_same_slot(state, data):
                     payment.weight += state.validators[index].effective_balance
-                elif flag_index == TIMELY_TARGET_FLAG_INDEX:
-                    # Also count non-timely head votes towards quorum
+                elif flag_index == TIMELY_TARGET_FLAG_INDEX and is_attestation_same_slot(state, data):
+                    # Also count non-timely head votes towards quorum for same-slot attestations
                     is_correct_block = data.beacon_block_root == get_block_root_at_slot(state, Slot(data.slot))
-                    is_same_slot = is_attestation_same_slot(state, data)
-                    expected_index = 0 if is_same_slot else state.execution_payload_availability[data.slot % SLOTS_PER_HISTORICAL_ROOT]
-                    is_correct_payload = data.index == expected_index
+                    is_correct_payload = data.index == 0  # Same-slot attestations must have index=0
                     
                     if is_correct_block and is_correct_payload:
                         payment.weight += state.validators[index].effective_balance

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -86,7 +86,7 @@ This feature adds new staked consensus participants called *Builders* and new
 honest validators duties called *payload timeliness attestations*. The slot is
 divided in **four** intervals. Honest validators gather *signed bids* (a
 `SignedExecutionPayloadHeader`) from builders and submit their consensus blocks
-(a `SignedBeaconBlock`) including these bids at the beginning of the slot. At
+(a `SignedBeaconBlock`) including accepted bids at the beginning of the slot. At
 the start of the second interval, honest validators submit attestations just as
 they do previous to this feature). At the start of the third interval,
 aggregators aggregate these attestations and the builder broadcasts either a

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -30,26 +30,26 @@
     - [`BeaconState`](#beaconstate)
 - [Helper functions](#helper-functions)
   - [Math](#math)
-    - [`bit_floor`](#bit_floor)
+    - [New `bit_floor`](#new-bit_floor)
   - [Misc](#misc-2)
-    - [`remove_flag`](#remove_flag)
+    - [New `remove_flag`](#new-remove_flag)
   - [Predicates](#predicates)
     - [New `has_builder_withdrawal_credentials`](#new-has_builder_withdrawal_credentials)
     - [Modified `has_compounding_withdrawal_credential`](#modified-has_compounding_withdrawal_credential)
     - [New `is_attestation_same_slot`](#new-is_attestation_same_slot)
     - [New `is_builder_withdrawal_credential`](#new-is_builder_withdrawal_credential)
-    - [`is_valid_indexed_payload_attestation`](#is_valid_indexed_payload_attestation)
-    - [`is_parent_block_full`](#is_parent_block_full)
+    - [New `is_valid_indexed_payload_attestation`](#new-is_valid_indexed_payload_attestation)
+    - [New `is_parent_block_full`](#new-is_parent_block_full)
   - [Beacon State accessors](#beacon-state-accessors)
-    - [`get_attestation_participation_flag_indices`](#get_attestation_participation_flag_indices)
-    - [`get_ptc`](#get_ptc)
-    - [`get_payload_attesting_indices`](#get_payload_attesting_indices)
-    - [`get_indexed_payload_attestation`](#get_indexed_payload_attestation)
+    - [New `get_attestation_participation_flag_indices`](#new-get_attestation_participation_flag_indices)
+    - [New `get_ptc`](#new-get_ptc)
+    - [New `get_payload_attesting_indices`](#new-get_payload_attesting_indices)
+    - [New `get_indexed_payload_attestation`](#new-get_indexed_payload_attestation)
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
   - [Modified `process_slot`](#modified-process_slot)
   - [Epoch processing](#epoch-processing)
     - [Modified `process_epoch`](#modified-process_epoch)
-    - [New `process_builder_pending_payments(state)`](#new-process_builder_pending_paymentsstate)
+    - [New `process_builder_pending_payments`](#new-process_builder_pending_payments)
   - [Block processing](#block-processing)
     - [Withdrawals](#withdrawals)
       - [New `is_builder_payment_withdrawable`](#new-is_builder_payment_withdrawable)
@@ -63,7 +63,7 @@
       - [Attestations](#attestations)
         - [Modified `process_attestation`](#modified-process_attestation)
       - [Payload Attestations](#payload-attestations)
-        - [`process_payload_attestation`](#process_payload_attestation)
+        - [New `process_payload_attestation`](#new-process_payload_attestation)
     - [Modified `is_merge_transition_complete`](#modified-is_merge_transition_complete)
     - [Modified `validate_merge_block`](#modified-validate_merge_block)
   - [Execution payload processing](#execution-payload-processing)
@@ -352,7 +352,7 @@ class BeaconState(Container):
 
 ### Math
 
-#### `bit_floor`
+#### New `bit_floor`
 
 ```python
 def bit_floor(n: uint64) -> uint64:
@@ -366,7 +366,7 @@ def bit_floor(n: uint64) -> uint64:
 
 ### Misc
 
-#### `remove_flag`
+#### New `remove_flag`
 
 ```python
 def remove_flag(flags: ParticipationFlags, flag_index: int) -> ParticipationFlags:
@@ -424,7 +424,7 @@ def is_builder_withdrawal_credential(withdrawal_credentials: Bytes32) -> bool:
     return withdrawal_credentials[:1] == BUILDER_WITHDRAWAL_PREFIX
 ```
 
-#### `is_valid_indexed_payload_attestation`
+#### New `is_valid_indexed_payload_attestation`
 
 ```python
 def is_valid_indexed_payload_attestation(
@@ -446,7 +446,7 @@ def is_valid_indexed_payload_attestation(
     return bls.FastAggregateVerify(pubkeys, signing_root, indexed_payload_attestation.signature)
 ```
 
-#### `is_parent_block_full`
+#### New `is_parent_block_full`
 
 This function returns true if the last committed payload header was fulfilled
 with a payload, this can only happen when both beacon block and payload were
@@ -460,7 +460,7 @@ def is_parent_block_full(state: BeaconState) -> bool:
 
 ### Beacon State accessors
 
-#### `get_attestation_participation_flag_indices`
+#### New `get_attestation_participation_flag_indices`
 
 ```python
 def get_attestation_participation_flag_indices(
@@ -506,7 +506,7 @@ def get_attestation_participation_flag_indices(
     return participation_flag_indices
 ```
 
-#### `get_ptc`
+#### New `get_ptc`
 
 ```python
 def get_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
@@ -524,7 +524,7 @@ def get_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
     return validator_indices
 ```
 
-#### `get_payload_attesting_indices`
+#### New `get_payload_attesting_indices`
 
 ```python
 def get_payload_attesting_indices(
@@ -537,7 +537,7 @@ def get_payload_attesting_indices(
     return set(index for i, index in enumerate(ptc) if payload_attestation.aggregation_bits[i])
 ```
 
-#### `get_indexed_payload_attestation`
+#### New `get_indexed_payload_attestation`
 
 ```python
 def get_indexed_payload_attestation(
@@ -621,7 +621,7 @@ def process_epoch(state: BeaconState) -> None:
     process_builder_pending_payments(state)
 ```
 
-#### New `process_builder_pending_payments(state)`
+#### New `process_builder_pending_payments`
 
 ```python
 def process_builder_pending_payments(state: BeaconState) -> None:
@@ -1053,7 +1053,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
 
 ##### Payload Attestations
 
-###### `process_payload_attestation`
+###### New `process_payload_attestation`
 
 ```python
 def process_payload_attestation(

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -1019,23 +1019,27 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
 
     proposer_reward_numerator = 0
     for index in get_attesting_indices(state, attestation):
+        # [New in EIP7732]
+        # Calculate weight for same-slot attestations outside the flag loop
+        weight_to_add = 0
+        if is_attestation_same_slot(state, data):
+            is_correct_block = data.beacon_block_root == get_block_root_at_slot(
+                state, Slot(data.slot)
+            )
+            is_correct_payload = data.index == 0  # Same-slot attestations must have index=0
+
+            if is_correct_block and is_correct_payload:
+                weight_to_add = state.validators[index].effective_balance
+
         for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):
             if flag_index in participation_flag_indices and not has_flag(
                 epoch_participation[index], flag_index
             ):
                 epoch_participation[index] = add_flag(epoch_participation[index], flag_index)
                 proposer_reward_numerator += get_base_reward(state, index) * weight
-                # [New in EIP7732]
-                # Update the builder payment weight
-                if flag_index == TIMELY_HEAD_FLAG_INDEX and is_attestation_same_slot(state, data):
-                    payment.weight += state.validators[index].effective_balance
-                elif flag_index == TIMELY_TARGET_FLAG_INDEX and is_attestation_same_slot(state, data):
-                    # Also count non-timely head votes towards quorum for same-slot attestations
-                    is_correct_block = data.beacon_block_root == get_block_root_at_slot(state, Slot(data.slot))
-                    is_correct_payload = data.index == 0  # Same-slot attestations must have index=0
-                    
-                    if is_correct_block and is_correct_payload:
-                        payment.weight += state.validators[index].effective_balance
+
+        # Add the weight once per validator outside the flag loop
+        payment.weight += weight_to_add
 
     # Reward proposer
     proposer_reward_denominator = (

--- a/specs/_features/eip7732/builder.md
+++ b/specs/_features/eip7732/builder.md
@@ -149,20 +149,22 @@ corresponding `SignedExecutionPayloadEnvelope` that fulfills this commitment.
 See below for a special case of an *honestly withheld payload*.
 
 To construct the `execution_payload_envelope` the builder must perform the
-following steps, we alias `header` to be the committed `ExecutionPayloadHeader`
-in the beacon block.
+following steps. We alias `block` to be the corresponding beacon block and alias
+`header` to be the committed `ExecutionPayloadHeader` in
+`block.body.signed_execution_payload_header.message`.
 
 1. Set the `payload` field to be the `ExecutionPayload` constructed when
    creating the corresponding bid. This payload **MUST** have the same block
    hash as `header.block_hash`.
-2. Set the `builder_index` field to be the validator index of the builder
+2. Set the `execution_requests` field to be the `ExecutionRequests` associated
+   with `payload`.
+3. Set the `builder_index` field to be the validator index of the builder
    performing these steps. This field **MUST** be `header.builder_index`.
-3. Set `beacon_block_root` to be the `hash_tree_root` of the corresponding
-   beacon block.
-4. Set `blob_kzg_commitments` to be the `commitments` field of the blobs bundle
+4. Set `beacon_block_root` to be `hash_tree_root(block)`.
+5. Set `slot` to be `block.slot`.
+6. Set `blob_kzg_commitments` to be the `commitments` field of the blobs bundle
    constructed when constructing the bid. This field **MUST** have a
    `hash_tree_root` equal to `header.blob_kzg_commitments_root`.
-5. Set `payload_withheld` to `False`.
 
 After setting these parameters, the builder should run
 `process_execution_payload(state, signed_envelope, verify=False)` and this

--- a/specs/_features/eip7732/fork-choice.md
+++ b/specs/_features/eip7732/fork-choice.md
@@ -13,7 +13,7 @@
   - [Modified `update_latest_messages`](#modified-update_latest_messages)
   - [Modified `Store`](#modified-store)
   - [Modified `get_forkchoice_store`](#modified-get_forkchoice_store)
-  - [`notify_ptc_messages`](#notify_ptc_messages)
+  - [New `notify_ptc_messages`](#new-notify_ptc_messages)
   - [New `is_payload_timely`](#new-is_payload_timely)
   - [New `get_parent_payload_status`](#new-get_parent_payload_status)
   - [New `is_parent_node_full`](#new-is_parent_node_full)
@@ -160,7 +160,7 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
     )
 ```
 
-### `notify_ptc_messages`
+### New `notify_ptc_messages`
 
 ```python
 def notify_ptc_messages(

--- a/specs/_features/eip7732/p2p-interface.md
+++ b/specs/_features/eip7732/p2p-interface.md
@@ -208,8 +208,7 @@ obtained from the `state.signed_execution_payload_header`)
 - _[REJECT]_ `block` passes validation.
 - _[REJECT]_ `block.slot` equals `envelope.slot`.
 - _[REJECT]_ `envelope.builder_index == header.builder_index`
-- if `envelope.payload_withheld == False` then
-  - _[REJECT]_ `payload.block_hash == header.block_hash`
+- _[REJECT]_ `payload.block_hash == header.block_hash`
 - _[REJECT]_ The builder signature,
   `signed_execution_payload_envelope.signature`, is valid with respect to the
   builder's public key.

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -2,7 +2,12 @@ from lru import LRU
 
 from eth2spec.test.context import expect_assertion_error
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
-from eth2spec.test.helpers.forks import is_post_altair, is_post_deneb, is_post_electra
+from eth2spec.test.helpers.forks import (
+    is_post_altair,
+    is_post_deneb,
+    is_post_eip7732,
+    is_post_electra,
+)
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.test.helpers.state import (
     next_epoch,
@@ -79,9 +84,15 @@ def build_attestation_data(spec, state, slot, index, beacon_block_root=None, sha
         source_epoch = state.current_justified_checkpoint.epoch
         source_root = state.current_justified_checkpoint.root
 
+    if is_post_electra(spec):
+        index = 0
+        if is_post_eip7732(spec):
+            if slot >= 1 and beacon_block_root == spec.get_block_root_at_slot(state, slot - 1):
+                index = 1
+
     data = spec.AttestationData(
         slot=slot,
-        index=0 if is_post_electra(spec) else index,
+        index=index,
         beacon_block_root=beacon_block_root,
         source=spec.Checkpoint(epoch=source_epoch, root=source_root),
         target=spec.Checkpoint(epoch=spec.compute_epoch_at_slot(slot), root=epoch_boundary_root),

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -406,15 +406,13 @@ def add_attester_slashing(spec, store, attester_slashing, test_steps, valid=True
 def get_formatted_head_output(spec, store):
     head = spec.get_head(store)
     if is_post_eip7732(spec):
-        return {
-            "slot": int(head.slot),
-            "root": encode_hex(head.root),
-        }
-
-    slot = store.blocks[head].slot
+        head_root = head.root
+    else:
+        head_root = head
+    slot = store.blocks[head_root].slot
     return {
         "slot": int(slot),
-        "root": encode_hex(head),
+        "root": encode_hex(head_root),
     }
 
 

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
@@ -522,9 +522,9 @@ def test_proposer_boost(spec, state):
     payload_state_transition(spec, store, signed_block.message)
     assert store.proposer_boost_root == spec.hash_tree_root(block)
     if is_post_eip7732(spec):
-        node = spec.ChildNode(
+        node = spec.ForkChoiceNode(
             root=spec.hash_tree_root(block),
-            slot=block.slot,
+            payload_status=spec.PAYLOAD_STATUS_PENDING,
         )
         assert spec.get_weight(store, node) > 0
     else:
@@ -539,9 +539,9 @@ def test_proposer_boost(spec, state):
     on_tick_and_append_step(spec, store, time, test_steps)
     assert store.proposer_boost_root == spec.Root()
     if is_post_eip7732(spec):
-        node = spec.ChildNode(
+        node = spec.ForkChoiceNode(
             root=spec.hash_tree_root(block),
-            slot=block.slot,
+            payload_status=spec.PAYLOAD_STATUS_PENDING,
         )
         assert spec.get_weight(store, node) == 0
     else:
@@ -558,9 +558,9 @@ def test_proposer_boost(spec, state):
     payload_state_transition(spec, store, signed_block.message)
     assert store.proposer_boost_root == spec.hash_tree_root(block)
     if is_post_eip7732(spec):
-        node = spec.ChildNode(
+        node = spec.ForkChoiceNode(
             root=spec.hash_tree_root(block),
-            slot=block.slot,
+            payload_status=spec.PAYLOAD_STATUS_PENDING,
         )
         assert spec.get_weight(store, node) > 0
     else:
@@ -575,9 +575,9 @@ def test_proposer_boost(spec, state):
     on_tick_and_append_step(spec, store, time, test_steps)
     assert store.proposer_boost_root == spec.Root()
     if is_post_eip7732(spec):
-        node = spec.ChildNode(
+        node = spec.ForkChoiceNode(
             root=spec.hash_tree_root(block),
-            slot=block.slot,
+            payload_status=spec.PAYLOAD_STATUS_PENDING,
         )
         assert spec.get_weight(store, node) == 0
     else:
@@ -665,9 +665,9 @@ def test_proposer_boost_is_first_block(spec, state):
     # `proposer_boost_root` is now `block_a`
     assert store.proposer_boost_root == spec.hash_tree_root(block_a)
     if is_post_eip7732(spec):
-        node = spec.ChildNode(
+        node = spec.ForkChoiceNode(
             root=spec.hash_tree_root(block_a),
-            slot=block_a.slot,
+            payload_status=spec.PAYLOAD_STATUS_PENDING,
         )
         assert spec.get_weight(store, node) > 0
     else:
@@ -690,9 +690,9 @@ def test_proposer_boost_is_first_block(spec, state):
     # `proposer_boost_root` is still `block_a`
     assert store.proposer_boost_root == spec.hash_tree_root(block_a)
     if is_post_eip7732(spec):
-        node = spec.ChildNode(
+        node = spec.ForkChoiceNode(
             root=spec.hash_tree_root(block_b),
-            slot=block_b.slot,
+            payload_status=spec.PAYLOAD_STATUS_PENDING,
         )
         assert spec.get_weight(store, node) == 0
     else:

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_withholding.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_withholding.py
@@ -23,7 +23,6 @@ from eth2spec.test.helpers.fork_choice import (
     payload_state_transition_no_store,
     tick_and_add_block,
 )
-from eth2spec.test.helpers.forks import is_post_eip7732
 from eth2spec.test.helpers.state import (
     next_epoch,
     state_transition_and_sign_block,
@@ -207,16 +206,11 @@ def test_withholding_attack_unviable_honest_chain(spec, state):
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
 
     # Upon revealing the withheld attack block, it should become the head
-    # Except in EIP7732 in which it's parent becomes head because of the
-    # attestations during the attacker's block's committee.
     yield from tick_and_add_block(spec, store, signed_attack_block, test_steps)
     payload_state_transition(spec, store, signed_attack_block.message)
     # The attack block is pulled up and store.justified_checkpoint is updated
     assert store.justified_checkpoint.epoch == 5
-    if is_post_eip7732(spec):
-        attack_block_root = signed_attack_block.message.parent_root
-    else:
-        attack_block_root = signed_attack_block.message.hash_tree_root()
+    attack_block_root = signed_attack_block.message.hash_tree_root()
     check_head_against_root(spec, store, attack_block_root)
 
     # After going to the next epoch, the honest block should become the head

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
@@ -1,7 +1,6 @@
 from eth2spec.test.context import spec_state_test, with_all_phases
 from eth2spec.test.helpers.attestations import get_valid_attestation, sign_attestation
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
-from eth2spec.test.helpers.constants import ALL_PHASES
 from eth2spec.test.helpers.fork_choice import get_genesis_forkchoice_store
 from eth2spec.test.helpers.forks import is_post_eip7732, is_post_electra
 from eth2spec.test.helpers.state import (
@@ -26,11 +25,13 @@ def run_on_attestation(spec, state, store, attestation, valid=True):
 
     sample_index = indexed_attestation.attesting_indices[0]
     if is_post_eip7732(spec):
+        assert attestation.data.index < 2
         latest_message = spec.LatestMessage(
             slot=attestation.data.slot,
             root=attestation.data.beacon_block_root,
+            payload_present=attestation.data.index == 1,
         )
-    elif spec.fork in ALL_PHASES:
+    else:
         latest_message = spec.LatestMessage(
             epoch=attestation.data.target.epoch,
             root=attestation.data.beacon_block_root,


### PR DESCRIPTION
Continuing from my discord message [here](https://discord.com/channels/595666850260713488/874767108809031740/1397942863534227589):

In line 1030, the payment weight is only incremented when `flag_index == TIMELY_HEAD_FLAG_INDEX`. But `TIMELY_HEAD_FLAG_INDEX` is only set (lines 503–504) when  `inclusion_delay == IN_ATTESTATION_INCLUSION_DELAY`,  which means the attestation must be included in the *next slot*.

If the next slot is missed (no block proposed), attestations from the previous slot cannot be included with `inclusion_delay == 1`, so they won't have `TIMELY_HEAD_FLAG_INDEX` set. This means their weight won't count toward the quorum, potentially preventing the builder from being required to make payment, even if the proposer's block received *substantial* attestations.
