### PR TITLE
Store blob schedule as a VariableDefinition in the pyspec

### DIFF
--- a/pysetup/md_to_spec.py
+++ b/pysetup/md_to_spec.py
@@ -312,7 +312,12 @@ class MarkdownToSpec:
             )
 
         # Set the config variable
-        self.spec["config_vars"][list_of_records_name] = list_of_records_config_file
+        self.spec["config_vars"][list_of_records_name] = VariableDefinition(
+            "tuple[dict[str, Any], ...]",
+            json.dumps(list_of_records_config_file, indent=4),
+            None,
+            None,
+        )
 
     @staticmethod
     def _make_list_of_records_type_map(list_of_records: list[dict[str, str]]) -> dict[str, str]:

--- a/tests/infra/test_md_to_spec.py
+++ b/tests/infra/test_md_to_spec.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -109,11 +110,12 @@ def test_run_includes_list_of_records_table(tmp_path, dummy_preset, dummy_config
     # The result should have 'BLOB_SCHEDULE' in config_vars
     assert "BLOB_SCHEDULE" in spec_obj.config_vars
     # The value should be a list of dicts with type constructors applied
-    assert isinstance(spec_obj.config_vars["BLOB_SCHEDULE"], list)
-    assert spec_obj.config_vars["BLOB_SCHEDULE"][0]["EPOCH"] == "Epoch(269568)"
-    assert spec_obj.config_vars["BLOB_SCHEDULE"][0]["MAX_BLOBS_PER_BLOCK"] == "uint64(6)"
-    assert spec_obj.config_vars["BLOB_SCHEDULE"][1]["EPOCH"] == "Epoch(364032)"
-    assert spec_obj.config_vars["BLOB_SCHEDULE"][1]["MAX_BLOBS_PER_BLOCK"] == "uint64(9)"
+    var = json.loads(spec_obj.config_vars["BLOB_SCHEDULE"].value)
+    assert isinstance(var, list)
+    assert var[0]["EPOCH"] == "Epoch(269568)"
+    assert var[0]["MAX_BLOBS_PER_BLOCK"] == "uint64(6)"
+    assert var[1]["EPOCH"] == "Epoch(364032)"
+    assert var[1]["MAX_BLOBS_PER_BLOCK"] == "uint64(9)"
 
 
 def test_run_includes_list_of_records_table_minimal(tmp_path, dummy_preset, dummy_config):
@@ -141,12 +143,13 @@ def test_run_includes_list_of_records_table_minimal(tmp_path, dummy_preset, dumm
     )
     spec_obj = m2s.run()
     assert "BLOB_SCHEDULE" in spec_obj.config_vars
-    assert isinstance(spec_obj.config_vars["BLOB_SCHEDULE"], list)
     # The result should follow the config, not the table
-    assert spec_obj.config_vars["BLOB_SCHEDULE"][0]["EPOCH"] == "Epoch(2)"
-    assert spec_obj.config_vars["BLOB_SCHEDULE"][0]["MAX_BLOBS_PER_BLOCK"] == "uint64(3)"
-    assert spec_obj.config_vars["BLOB_SCHEDULE"][1]["EPOCH"] == "Epoch(4)"
-    assert spec_obj.config_vars["BLOB_SCHEDULE"][1]["MAX_BLOBS_PER_BLOCK"] == "uint64(5)"
+    var = json.loads(spec_obj.config_vars["BLOB_SCHEDULE"].value)
+    assert isinstance(var, list)
+    assert var[0]["EPOCH"] == "Epoch(2)"
+    assert var[0]["MAX_BLOBS_PER_BLOCK"] == "uint64(3)"
+    assert var[1]["EPOCH"] == "Epoch(4)"
+    assert var[1]["MAX_BLOBS_PER_BLOCK"] == "uint64(5)"
 
 
 def test_run_includes_python_function(tmp_path, dummy_preset, dummy_config):


### PR DESCRIPTION
We forgot to store the blob schedule as a `VariableDefinition` here. This didn't really affect anything internally, but it prevented this config variable from being correctly parsed by outside tooling (eg the consensus specifications viewer).