### PR TITLE
eip7732: fix builder pending withdrawals processing

### DIFF
--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -821,10 +821,8 @@ def process_withdrawals(state: BeaconState) -> None:
         decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
 
     # Update the pending builder withdrawals
-    state.builder_pending_withdrawals[:processed_builder_withdrawals_count] = [
-        w
-        for w in state.builder_pending_withdrawals[:processed_builder_withdrawals_count]
-        if not is_builder_payment_withdrawable(state, w)
+    state.builder_pending_withdrawals = state.builder_pending_withdrawals[
+        processed_builder_withdrawals_count:
     ]
 
     # Update pending partial withdrawals


### PR DESCRIPTION
I think `process_withdrawals` slice assignment logic is off:
```python
  state.builder_pending_withdrawals[:processed_builder_withdrawals_count] = [
      w
      for w in state.builder_pending_withdrawals[:processed_builder_withdrawals_count]
      if not is_builder_payment_withdrawable(state, w)
  ]
```
The left side creates a slice of exactly N items, but the filtered list comprehension on the right could produce fewer items I think what should have happened is `processed_builder_withdrawals_count` tracks how many withdrawals were processed from the queue (regardless of success), and we should remove exactly that many items from the front of the queue. This is similar to how `processed_partial_withdrawals_count` work