### PR TITLE
Add EIP-7916 ProgressiveBitlist specs and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "py_arkworks_bls12381==0.3.8",
   "py_ecc==8.0.0",
   "pycryptodome==3.23.0",
-  "remerkleable @ git+https://github.com/ethereum/remerkleable@643e8e3d1d80a34f61d4b1e32a46e38ad7e57a18",
+  "remerkleable @ git+https://github.com/ethereum/remerkleable@7574640617bd87b54cd262b18ee184eba190c11e",
   "ruamel.yaml==0.18.14",
   "setuptools==80.9.0",
   "trie==3.1.0",

--- a/tests/core/pyspec/eth2spec/debug/encode.py
+++ b/tests/core/pyspec/eth2spec/debug/encode.py
@@ -5,6 +5,7 @@ from eth2spec.utils.ssz.ssz_typing import (
     boolean,
     Container,
     List,
+    ProgressiveBitlist,
     ProgressiveList,
     uint,
     Union,
@@ -20,7 +21,7 @@ def encode(value, include_hash_tree_roots=False):
         return int(value)
     elif isinstance(value, boolean):
         return value == 1
-    elif isinstance(value, Bitlist | Bitvector):
+    elif isinstance(value, Bitlist | ProgressiveBitlist | Bitvector):
         return "0x" + serialize(value).hex()
     elif isinstance(value, list):  # normal python lists
         return [encode(element, include_hash_tree_roots) for element in value]

--- a/tests/core/pyspec/eth2spec/debug/random_value.py
+++ b/tests/core/pyspec/eth2spec/debug/random_value.py
@@ -10,6 +10,7 @@ from eth2spec.utils.ssz.ssz_typing import (
     ByteVector,
     Container,
     List,
+    ProgressiveBitlist,
     ProgressiveList,
     uint,
     Union,
@@ -103,10 +104,10 @@ def get_random_ssz_object(
             get_random_ssz_object(rng, elem_type, max_bytes_length, max_list_length, mode, chaos)
             for _ in range(typ.vector_length())
         )
-    elif issubclass(typ, List) or issubclass(typ, ProgressiveList) or issubclass(typ, Bitlist):
+    elif issubclass(typ, List | ProgressiveList | Bitlist | ProgressiveBitlist):
         limit = max_list_length
         # SSZ imposes a hard limit on lists, we can't put in more than that
-        if not issubclass(typ, ProgressiveList) and typ.limit() < limit:
+        if not issubclass(typ, ProgressiveList | ProgressiveBitlist) and typ.limit() < limit:
             limit = typ.limit()
 
         length = rng.randint(0, limit)
@@ -117,7 +118,7 @@ def get_random_ssz_object(
         elif mode == RandomizationMode.mode_nil_count:
             length = 0
 
-        elem_type = boolean if issubclass(typ, Bitlist) else typ.element_cls()
+        elem_type = boolean if issubclass(typ, Bitlist | ProgressiveBitlist) else typ.element_cls()
         max_list_length = 1 << (max_list_length.bit_length() >> 1)
         return typ(
             get_random_ssz_object(rng, elem_type, max_bytes_length, max_list_length, mode, chaos)

--- a/tests/core/pyspec/eth2spec/utils/ssz/ssz_typing.py
+++ b/tests/core/pyspec/eth2spec/utils/ssz/ssz_typing.py
@@ -25,7 +25,7 @@ from remerkleable.byte_arrays import (
 )
 from remerkleable.complex import Container, List, Vector
 from remerkleable.core import BasicView, Path, View
-from remerkleable.progressive import ProgressiveList
+from remerkleable.progressive import ProgressiveBitlist, ProgressiveList
 from remerkleable.union import Union
 
 Bytes20 = ByteVector[20]  # type: ignore

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -22,6 +22,8 @@ into a SSZ type:
 - Bitfields
   - `bitvector`
   - `bitlist`
+- ProgressiveBitlist
+  - `progressive_bitlist`
 - Basic types
   - `boolean`
   - `uints`
@@ -144,6 +146,14 @@ Data:
 {length}: the length, in bits, of the bitvector.
 ```
 
+### `progressive_bitlist`
+
+```
+Template:
+
+progbitlist
+```
+
 ### `boolean`
 
 A boolean has no type variations. Instead, file names just plainly describe the
@@ -221,4 +231,19 @@ class BitsStruct(Container):
     C: Bitvector[1]
     D: Bitlist[6]
     E: Bitvector[8]
+
+
+class ProgressiveBitsStruct(Container):
+    A: Bitvector[256]
+    B: Bitlist[256]
+    C: ProgressiveBitlist
+    D: Bitvector[257]
+    E: Bitlist[257]
+    F: ProgressiveBitlist
+    G: Bitvector[1280]
+    H: Bitlist[1280]
+    I: ProgressiveBitlist
+    J: Bitvector[1281]
+    K: Bitlist[1281]
+    L: ProgressiveBitlist
 ```

--- a/tests/generators/runners/ssz_generic.py
+++ b/tests/generators/runners/ssz_generic.py
@@ -10,6 +10,7 @@ from .ssz_generic_cases import (
     ssz_bitvector,
     ssz_boolean,
     ssz_container,
+    ssz_progressive_bitlist,
     ssz_uints,
 )
 
@@ -26,10 +27,12 @@ def get_test_cases() -> Iterable[TestCase]:
         ("bitvector", "invalid", ssz_bitvector.invalid_cases),
         ("boolean", "valid", ssz_boolean.valid_cases),
         ("boolean", "invalid", ssz_boolean.invalid_cases),
-        ("uints", "valid", ssz_uints.valid_cases),
-        ("uints", "invalid", ssz_uints.invalid_cases),
         ("containers", "valid", ssz_container.valid_cases),
         ("containers", "invalid", ssz_container.invalid_cases),
+        ("progressive_bitlist", "valid", ssz_progressive_bitlist.valid_cases),
+        ("progressive_bitlist", "invalid", ssz_progressive_bitlist.invalid_cases),
+        ("uints", "valid", ssz_uints.valid_cases),
+        ("uints", "invalid", ssz_uints.invalid_cases),
     ]
 
     test_cases = []

--- a/tests/generators/runners/ssz_generic_cases/ssz_bitlist.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_bitlist.py
@@ -6,6 +6,12 @@ from eth2spec.utils.ssz.ssz_typing import Bitlist
 
 from .ssz_test_case import invalid_test_case, valid_test_case
 
+INVALID_BITLIST_CASES = [
+    ("no_delimiter_empty", b""),
+    ("no_delimiter_zero_byte", b"\x00"),
+    ("no_delimiter_zeroes", b"\x00\x00\x00"),
+]
+
 
 def bitlist_case_fn(rng: Random, mode: RandomizationMode, limit: int):
     return get_random_ssz_object(
@@ -38,9 +44,8 @@ def valid_cases():
 
 
 def invalid_cases():
-    yield "bitlist_no_delimiter_empty", invalid_test_case(lambda: b"")
-    yield "bitlist_no_delimiter_zero_byte", invalid_test_case(lambda: b"\x00")
-    yield "bitlist_no_delimiter_zeroes", invalid_test_case(lambda: b"\x00\x00\x00")
+    for description, data in INVALID_BITLIST_CASES:
+        yield f"bitlist_{description}", invalid_test_case(lambda data=data: data)
     rng = Random(1234)
     for typ_limit, test_limit in [
         (1, 2),

--- a/tests/generators/runners/ssz_generic_cases/ssz_progressive_bitlist.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_progressive_bitlist.py
@@ -1,0 +1,74 @@
+from random import Random
+
+from eth2spec.debug.random_value import get_random_ssz_object, RandomizationMode
+from eth2spec.utils.ssz.ssz_typing import ProgressiveBitlist
+
+from .ssz_bitlist import INVALID_BITLIST_CASES
+from .ssz_test_case import invalid_test_case, valid_test_case
+
+
+def progressive_bitlist_case_fn(rng: Random, mode: RandomizationMode, length: int):
+    return get_random_ssz_object(
+        rng,
+        ProgressiveBitlist,
+        max_bytes_length=(length // 8) + 1,
+        max_list_length=length,
+        mode=mode,
+        chaos=False,
+    )
+
+
+def valid_cases():
+    rng = Random(1234)
+    random_modes = [
+        RandomizationMode.mode_nil_count,
+        RandomizationMode.mode_max_count,
+        RandomizationMode.mode_random,
+        RandomizationMode.mode_zero,
+        RandomizationMode.mode_max,
+    ]
+    for length in [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        15,
+        16,
+        17,
+        31,
+        32,
+        33,
+        63,
+        64,
+        65,
+        255,
+        256,
+        257,
+        511,
+        512,
+        513,
+        1023,
+        1024,
+        1025,
+    ]:
+        for variation in range(5):
+            for mode in random_modes:
+                yield (
+                    f"progbitlist_{mode.to_name()}_{length}_{variation}",
+                    valid_test_case(
+                        lambda rng=rng, mode=mode, length=length: progressive_bitlist_case_fn(
+                            rng, mode, length
+                        )
+                    ),
+                )
+
+
+def invalid_cases():
+    for description, data in INVALID_BITLIST_CASES:
+        yield f"progbitlist_{description}", invalid_test_case(lambda data=data: data)


### PR DESCRIPTION
This follows up on #4445 to extend EIP-7916 support for bitlists, making the `ProgressiveBitlist` type available to implementations in _features.

- https://eips.ethereum.org/EIPS/eip-7916