### PR TITLE
Use frozendict with list-of-records

### DIFF
--- a/pysetup/md_to_spec.py
+++ b/pysetup/md_to_spec.py
@@ -313,8 +313,8 @@ class MarkdownToSpec:
 
         # Set the config variable
         self.spec["config_vars"][list_of_records_name] = VariableDefinition(
-            "tuple[dict[str, Any], ...]",
-            json.dumps(list_of_records_config_file, indent=4),
+            "tuple[frozendict[str, Any], ...]",
+            self._format_frozen_records(list_of_records_config_file),
             None,
             None,
         )
@@ -358,6 +358,17 @@ class MarkdownToSpec:
         ]
 
         return list_of_records_spec
+
+    @staticmethod
+    def _format_frozen_records(records: list[dict[str, str]]) -> str:
+        lines = ["("]
+        for record in records:
+            lines.append("    frozendict({")
+            for key, value in record.items():
+                lines.append(f'        "{str(key)}": {str(value)},')
+            lines.append("    }),")
+        lines.append(")")
+        return "\n".join(lines)
 
     def _extract_typed_records_config(
         self, list_of_records_name: str, type_map: dict[str, str]

--- a/tests/infra/test_md_to_spec.py
+++ b/tests/infra/test_md_to_spec.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 import pytest
@@ -110,12 +109,19 @@ def test_run_includes_list_of_records_table(tmp_path, dummy_preset, dummy_config
     # The result should have 'BLOB_SCHEDULE' in config_vars
     assert "BLOB_SCHEDULE" in spec_obj.config_vars
     # The value should be a list of dicts with type constructors applied
-    var = json.loads(spec_obj.config_vars["BLOB_SCHEDULE"].value)
-    assert isinstance(var, list)
-    assert var[0]["EPOCH"] == "Epoch(269568)"
-    assert var[0]["MAX_BLOBS_PER_BLOCK"] == "uint64(6)"
-    assert var[1]["EPOCH"] == "Epoch(364032)"
-    assert var[1]["MAX_BLOBS_PER_BLOCK"] == "uint64(9)"
+    assert (
+        spec_obj.config_vars["BLOB_SCHEDULE"].value
+        == """(
+    frozendict({
+        "EPOCH": Epoch(269568),
+        "MAX_BLOBS_PER_BLOCK": uint64(6),
+    }),
+    frozendict({
+        "EPOCH": Epoch(364032),
+        "MAX_BLOBS_PER_BLOCK": uint64(9),
+    }),
+)"""
+    )
 
 
 def test_run_includes_list_of_records_table_minimal(tmp_path, dummy_preset, dummy_config):
@@ -144,26 +150,33 @@ def test_run_includes_list_of_records_table_minimal(tmp_path, dummy_preset, dumm
     spec_obj = m2s.run()
     assert "BLOB_SCHEDULE" in spec_obj.config_vars
     # The result should follow the config, not the table
-    var = json.loads(spec_obj.config_vars["BLOB_SCHEDULE"].value)
-    assert isinstance(var, list)
-    assert var[0]["EPOCH"] == "Epoch(2)"
-    assert var[0]["MAX_BLOBS_PER_BLOCK"] == "uint64(3)"
-    assert var[1]["EPOCH"] == "Epoch(4)"
-    assert var[1]["MAX_BLOBS_PER_BLOCK"] == "uint64(5)"
+    assert (
+        spec_obj.config_vars["BLOB_SCHEDULE"].value
+        == """(
+    frozendict({
+        "EPOCH": Epoch(2),
+        "MAX_BLOBS_PER_BLOCK": uint64(3),
+    }),
+    frozendict({
+        "EPOCH": Epoch(4),
+        "MAX_BLOBS_PER_BLOCK": uint64(5),
+    }),
+)"""
+    )
 
 
 def test_run_includes_python_function(tmp_path, dummy_preset, dummy_config):
-    md_content = """
+    md_content = '''
 #### `compute_epoch_at_slot`
 
 ```python
 def compute_epoch_at_slot(slot: Slot) -> Epoch:
-    \"\"\"
+    """
     Return the epoch number at slot.
-    \"\"\"
+    """
     return Epoch(slot // SLOTS_PER_EPOCH)
 ```
-"""
+'''
     file = tmp_path / "function.md"
     file.write_text(md_content)
     m2s = MarkdownToSpec(


### PR DESCRIPTION
It was like this before but somehow got removed. When there's a non-empty blob schedule, entries must be a frozendict so that it can be hashed.