### PR TITLE
Make PTC selection balance-weighted

### DIFF
--- a/pysetup/spec_builders/eip7732.py
+++ b/pysetup/spec_builders/eip7732.py
@@ -14,10 +14,18 @@ from eth2spec.electra import {preset_name} as electra
     @classmethod
     def sundry_functions(cls) -> str:
         return """
+def get_power_of_two_floor(x: int) -> int:
+    if x <= 1:
+        return 1
+    if x == 2:
+        return x
+    else:
+        return 2 * get_power_of_two_floor(x // 2)
+
 def concat_generalized_indices(*indices: GeneralizedIndex) -> GeneralizedIndex:
     o = GeneralizedIndex(1)
     for i in indices:
-        o = GeneralizedIndex(o * bit_floor(i) + (i - bit_floor(i)))
+        o = GeneralizedIndex(o * get_power_of_two_floor(i) + (i - get_power_of_two_floor(i)))
     return o"""
 
     @classmethod

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -454,10 +454,10 @@ def compute_balance_weighted_selection(
     shuffle_indices: bool = True,
 ) -> Sequence[ValidatorIndex]:
     """
-    Return `size` indices sampled by effective balance, using `indices`
-    as candidates. If `shuffle_indices` is `True`, candidate indices
-    are themselves sampled from `indices` by shuffling it, otherwise
-    `indices` is traversed in order.
+    Return ``size`` indices sampled by effective balance, using ``indices``
+    as candidates. If ``shuffle_indices`` is ``True``, candidate indices
+    are themselves sampled from ``indices`` by shuffling it, otherwise
+    ``indices`` is traversed in order.
     """
     total = uint64(len(indices))
     assert total > 0
@@ -481,8 +481,8 @@ def compute_balance_weighted_acceptance(
     state: BeaconState, index: ValidatorIndex, seed: Bytes32, i: uint64
 ) -> bool:
     """
-    Return whether to accept the selection of the validator `index`, with probability
-    proportional to its `effective_balance`, and randomness given by `seed` and `i`.
+    Return whether to accept the selection of the validator ``index``, with probability
+    proportional to its ``effective_balance``, and randomness given by ``seed`` and ``i``.
     """
     MAX_RANDOM_VALUE = 2**16 - 1
     random_bytes = hash(seed + uint_to_bytes(i // 16))

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -494,6 +494,10 @@ def compute_balance_weighted_acceptance(
 
 #### Modified `compute_proposer_indices`
 
+*Note*: `compute_proposer_indices` is refactored to use
+`compute_balance_weighted_selection` as a helper for the balance-weighted
+sampling process.
+
 ```python
 def compute_proposer_indices(
     state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
@@ -509,6 +513,10 @@ def compute_proposer_indices(
 ### Beacon State accessors
 
 #### Modified `get_next_sync_committee_indices`
+
+*Note*: `get_next_sync_committee_indices` is refactored to use
+`compute_balance_weighted_selection` as a helper for the balance-weighted
+sampling process.
 
 ```python
 def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -584,20 +584,12 @@ def get_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
     """
     epoch = compute_epoch_at_slot(slot)
     seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
-    committees_per_slot = get_committee_count_per_slot(state, epoch)
-    epoch_start_slot = compute_start_slot_at_epoch(epoch)
     indices: List[ValidatorIndex] = []
-    # concatenate all committees for this epoch in order,
-    # starting from the committees for `slot`
-    for s in range(SLOTS_PER_EPOCH):
-        slots_into_epoch = (slot + s) % SLOTS_PER_EPOCH
-        for i in range(committees_per_slot):
-            committee = get_beacon_committee(
-                state=state,
-                slot=epoch_start_slot + slots_into_epoch,
-                index=CommitteeIndex(i),
-            )
-            indices.extend(committee)
+    # Concatenate all committees for this slot in order
+    committees_per_slot = get_committee_count_per_slot(state, epoch)
+    for i in range(committees_per_slot):
+        committee = get_beacon_committee(state, slot, CommitteeIndex(i))
+        indices.extend(committee)
     return compute_balance_weighted_selection(
         state, indices, seed, size=PTC_SIZE, shuffle_indices=False
     )

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -451,7 +451,7 @@ def compute_balance_weighted_selection(
     indices: Sequence[ValidatorIndex],
     seed: Bytes32,
     size: uint64,
-    shuffle_indices: bool = True,
+    shuffle_indices: bool,
 ) -> Sequence[ValidatorIndex]:
     """
     Return ``size`` indices sampled by effective balance, using ``indices``
@@ -507,7 +507,10 @@ def compute_proposer_indices(
     """
     start_slot = compute_start_slot_at_epoch(epoch)
     seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
-    return [compute_balance_weighted_selection(state, indices, seed, size=1)[0] for seed in seeds]
+    return [
+        compute_balance_weighted_selection(state, indices, seed, size=1, shuffle_indices=True)[0]
+        for seed in seeds
+    ]
 ```
 
 ### Beacon State accessors
@@ -526,7 +529,9 @@ def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorInd
     epoch = Epoch(get_current_epoch(state) + 1)
     seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
     indices = get_active_validator_indices(state, epoch)
-    return compute_balance_weighted_selection(state, indices, seed, size=SYNC_COMMITTEE_SIZE)
+    return compute_balance_weighted_selection(
+        state, indices, seed, size=SYNC_COMMITTEE_SIZE, shuffle_indices=True
+    )
 ```
 
 #### New `get_attestation_participation_flag_indices`

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -344,8 +344,6 @@ class BeaconState(Container):
     # [New in EIP7732]
     latest_block_hash: Hash32
     # [New in EIP7732]
-    latest_full_slot: Slot
-    # [New in EIP7732]
     latest_withdrawals_root: Root
 ```
 
@@ -1292,7 +1290,6 @@ def process_execution_payload(
     # Cache the execution payload hash
     state.execution_payload_availability[state.slot % SLOTS_PER_HISTORICAL_ROOT] = 0b1
     state.latest_block_hash = payload.block_hash
-    state.latest_full_slot = state.slot
 
     # Verify the state root
     if verify:

--- a/specs/_features/eip7732/beacon-chain.md
+++ b/specs/_features/eip7732/beacon-chain.md
@@ -29,8 +29,6 @@
     - [`ExecutionPayloadHeader`](#executionpayloadheader)
     - [`BeaconState`](#beaconstate)
 - [Helper functions](#helper-functions)
-  - [Misc](#misc-2)
-    - [New `remove_flag`](#new-remove_flag)
   - [Predicates](#predicates)
     - [New `has_builder_withdrawal_credential`](#new-has_builder_withdrawal_credential)
     - [Modified `has_compounding_withdrawal_credential`](#modified-has_compounding_withdrawal_credential)
@@ -38,7 +36,13 @@
     - [New `is_builder_withdrawal_credential`](#new-is_builder_withdrawal_credential)
     - [New `is_valid_indexed_payload_attestation`](#new-is_valid_indexed_payload_attestation)
     - [New `is_parent_block_full`](#new-is_parent_block_full)
+  - [Misc](#misc-2)
+    - [New `remove_flag`](#new-remove_flag)
+    - [New `compute_balance_weighted_selection`](#new-compute_balance_weighted_selection)
+    - [New `compute_balance_weighted_acceptance`](#new-compute_balance_weighted_acceptance)
+    - [Modified `compute_proposer_indices`](#modified-compute_proposer_indices)
   - [Beacon State accessors](#beacon-state-accessors)
+    - [Modified `get_next_sync_committee_indices`](#modified-get_next_sync_committee_indices)
     - [New `get_attestation_participation_flag_indices`](#new-get_attestation_participation_flag_indices)
     - [New `get_ptc`](#new-get_ptc)
     - [New `get_payload_attesting_indices`](#new-get_payload_attesting_indices)
@@ -347,16 +351,6 @@ class BeaconState(Container):
 
 ## Helper functions
 
-### Misc
-
-#### New `remove_flag`
-
-```python
-def remove_flag(flags: ParticipationFlags, flag_index: int) -> ParticipationFlags:
-    flag = ParticipationFlags(2**flag_index)
-    return flags & ~flag
-```
-
 ### Predicates
 
 #### New `has_builder_withdrawal_credential`
@@ -441,7 +435,93 @@ def is_parent_block_full(state: BeaconState) -> bool:
     return state.latest_execution_payload_header.block_hash == state.latest_block_hash
 ```
 
+### Misc
+
+#### New `remove_flag`
+
+```python
+def remove_flag(flags: ParticipationFlags, flag_index: int) -> ParticipationFlags:
+    flag = ParticipationFlags(2**flag_index)
+    return flags & ~flag
+```
+
+#### New `compute_balance_weighted_selection`
+
+```python
+def compute_balance_weighted_selection(
+    state: BeaconState,
+    indices: Sequence[ValidatorIndex],
+    seed: Bytes32,
+    size: uint64,
+    shuffle_indices: bool = True,
+) -> Sequence[ValidatorIndex]:
+    """
+    Return `size` indices sampled by effective balance, using `indices`
+    as candidates. If `shuffle_indices` is `True`, candidate indices
+    are themselves sampled from `indices` by shuffling it, otherwise
+    `indices` is traversed in order.
+    """
+    total = uint64(len(indices))
+    assert total > 0
+    selected: List[ValidatorIndex] = []
+    i = uint64(0)
+    while len(selected) < size:
+        next_index = i % total
+        if shuffle_indices:
+            next_index = compute_shuffled_index(next_index, total, seed)
+        candidate_index = indices[next_index]
+        if compute_balance_weighted_acceptance(state, candidate_index, seed, i):
+            selected.append(candidate_index)
+        i += 1
+    return selected
+```
+
+#### New `compute_balance_weighted_acceptance`
+
+```python
+def compute_balance_weighted_acceptance(
+    state: BeaconState, index: ValidatorIndex, seed: Bytes32, i: uint64
+) -> bool:
+    """
+    Return whether to accept the selection of the validator `index`, with probability
+    proportional to its `effective_balance`, and randomness given by `seed` and `i`.
+    """
+    MAX_RANDOM_VALUE = 2**16 - 1
+    random_bytes = hash(seed + uint_to_bytes(i // 16))
+    offset = i % 16 * 2
+    random_value = bytes_to_uint64(random_bytes[offset : offset + 2])
+    effective_balance = state.validators[index].effective_balance
+    return effective_balance * MAX_RANDOM_VALUE >= MAX_EFFECTIVE_BALANCE_ELECTRA * random_value
+```
+
+#### Modified `compute_proposer_indices`
+
+```python
+def compute_proposer_indices(
+    state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
+) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+    """
+    Return the proposer indices for the given ``epoch``.
+    """
+    start_slot = compute_start_slot_at_epoch(epoch)
+    seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
+    return [compute_balance_weighted_selection(state, indices, seed, size=1)[0] for seed in seeds]
+```
+
 ### Beacon State accessors
+
+#### Modified `get_next_sync_committee_indices`
+
+```python
+def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
+    """
+    Return the sync committee indices, with possible duplicates, for the next sync committee.
+    """
+    epoch = Epoch(get_current_epoch(state) + 1)
+    seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
+    indices = get_active_validator_indices(state, epoch)
+    return compute_balance_weighted_selection(state, indices, seed, size=SYNC_COMMITTEE_SIZE)
+```
 
 #### New `get_attestation_participation_flag_indices`
 
@@ -496,36 +576,25 @@ def get_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
     """
     Get the payload timeliness committee for the given ``slot``
     """
-    MAX_RANDOM_VALUE = 2**16 - 1
     epoch = compute_epoch_at_slot(slot)
     seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
     committees_per_slot = get_committee_count_per_slot(state, epoch)
-    committee_indices = [CommitteeIndex(i) for i in range(committees_per_slot)]
     epoch_start_slot = compute_start_slot_at_epoch(epoch)
-    slot_into_epoch = slot % SLOTS_PER_EPOCH
-    i = uint64(0)
-    ptc: List[ValidatorIndex] = []
-    while len(ptc) < PTC_SIZE:
-        for committee_index in committee_indices:
+    indices: List[ValidatorIndex] = []
+    # concatenate all committees for this epoch in order,
+    # starting from the committees for `slot`
+    for s in range(SLOTS_PER_EPOCH):
+        slots_into_epoch = (slot + s) % SLOTS_PER_EPOCH
+        for i in range(committees_per_slot):
             committee = get_beacon_committee(
                 state=state,
-                slot=epoch_start_slot + slot_into_epoch,
-                index=committee_index,
+                slot=epoch_start_slot + slots_into_epoch,
+                index=CommitteeIndex(i),
             )
-            for candidate_index in committee:
-                random_bytes = hash(seed + uint_to_bytes(i // 16))
-                offset = i % 16 * 2
-                random_value = bytes_to_uint64(random_bytes[offset : offset + 2])
-                effective_balance = state.validators[candidate_index].effective_balance
-                if (
-                    effective_balance * MAX_RANDOM_VALUE
-                    >= MAX_EFFECTIVE_BALANCE_ELECTRA * random_value
-                ):
-                    ptc.append(candidate_index)
-                    if len(ptc) == PTC_SIZE:
-                        return ptc
-                i += 1
-        slot_into_epoch = (slot_into_epoch + 1) % SLOTS_PER_EPOCH
+            indices.extend(committee)
+    return compute_balance_weighted_selection(
+        state, indices, seed, size=PTC_SIZE, shuffle_indices=False
+    )
 ```
 
 #### New `get_payload_attesting_indices`

--- a/specs/_features/eip7732/fork-choice.md
+++ b/specs/_features/eip7732/fork-choice.md
@@ -183,8 +183,8 @@ def notify_ptc_messages(
                     validator_index=idx,
                     data=payload_attestation.data,
                     signature=BLSSignature(),
-                    is_from_block=True,
                 ),
+                is_from_block=True,
             )
 ```
 

--- a/specs/_features/eip7732/fork-choice.md
+++ b/specs/_features/eip7732/fork-choice.md
@@ -191,34 +191,20 @@ def notify_ptc_messages(
 ### New `is_payload_timely`
 
 ```python
-def is_payload_timely(store: Store, beacon_block_root: Root) -> bool:
+def is_payload_timely(store: Store, root: Root) -> bool:
     """
-    Return whether the execution payload for the beacon block with root ``beacon_block_root``
+    Return whether the execution payload for the beacon block with root ``root``
     was voted as present by the PTC, and was locally determined to be available.
     """
     # The beacon block root must be known
-    assert beacon_block_root in store.ptc_vote
+    assert root in store.ptc_vote
+
     # If the payload is not locally available, the payload
     # is not considered available regardless of the PTC vote
-    if beacon_block_root not in store.execution_payload_states:
+    if root not in store.execution_payload_states:
         return False
 
-    checkpoint_state = store.checkpoint_states[store.justified_checkpoint]
-    block_state = store.block_states[beacon_block_root]
-    ptc = get_ptc(block_state, block_state.slot)
-    ptc_score = Gwei(
-        sum(
-            checkpoint_state.validators[i].effective_balance
-            for i, vote in zip(ptc, store.ptc_vote[beacon_block_root])
-            if (
-                vote
-                and not block_state.validators[i].slashed
-                and i not in store.equivocating_indices
-            )
-        )
-    )
-    total_ptc_score = Gwei(sum(checkpoint_state.validators[i].effective_balance for i in ptc))
-    return ptc_score > total_ptc_score // 2
+    return sum(store.ptc_vote[root]) > PAYLOAD_TIMELY_THRESHOLD
 ```
 
 ### New `get_parent_payload_status`

--- a/specs/_features/eip7732/fork.md
+++ b/specs/_features/eip7732/fork.md
@@ -124,8 +124,6 @@ def upgrade_to_eip7732(pre: electra.BeaconState) -> BeaconState:
         # [New in EIP7732]
         latest_block_hash=pre.latest_execution_payload_header.block_hash,
         # [New in EIP7732]
-        latest_full_slot=pre.slot,
-        # [New in EIP7732]
         latest_withdrawals_root=Root(),
     )
 

--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -44,7 +44,6 @@ def run_execution_payload_processing(
         )
         post_state = state.copy()
         post_state.latest_block_hash = execution_payload.block_hash
-        post_state.latest_full_slot = state.slot
         envelope.state_root = post_state.hash_tree_root()
         privkey = privkeys[envelope.builder_index]
         signature = spec.get_execution_payload_envelope_signature(
@@ -96,7 +95,6 @@ def run_execution_payload_processing(
     yield "post", state
 
     if is_post_eip7732(spec):
-        assert state.latest_full_slot == state.slot
         assert state.latest_block_hash == execution_payload.block_hash
     else:
         assert state.latest_execution_payload_header == get_execution_payload_header(

--- a/tests/core/pyspec/eth2spec/test/deneb/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/block_processing/test_process_execution_payload.py
@@ -65,7 +65,6 @@ def run_execution_payload_processing(
 
         post_state.execution_payload_availability[state.slot % spec.SLOTS_PER_HISTORICAL_ROOT] = 0b1
         post_state.latest_block_hash = execution_payload.block_hash
-        post_state.latest_full_slot = state.slot
         envelope.state_root = post_state.hash_tree_root()
         privkey = privkeys[envelope.builder_index]
         signature = spec.get_execution_payload_envelope_signature(
@@ -124,7 +123,6 @@ def run_execution_payload_processing(
             state.execution_payload_availability[state.slot % spec.SLOTS_PER_HISTORICAL_ROOT] == 0b1
         )
         assert state.latest_block_hash == execution_payload.block_hash
-        assert state.latest_full_slot == state.slot
     else:
         assert state.latest_execution_payload_header == get_execution_payload_header(
             spec, state, execution_payload

--- a/tests/core/pyspec/eth2spec/test/helpers/state.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/state.py
@@ -99,7 +99,6 @@ def payload_state_transition_no_store(spec, state, block):
             state.latest_block_header.state_root = previous_state_root
         # also perform the state transition as if the payload was revealed
         state.latest_block_hash = block.body.signed_execution_payload_header.message.block_hash
-        state.latest_full_slot = block.slot
     return state
 
 


### PR DESCRIPTION
1. The first commit changes the sampling logic in `get_ptc` to be balance weighted, for security reasons (see discord discussion starting [here](https://discord.com/channels/595666850260713488/874767108809031740/1400916536197251082)). Unlike for sync-committees and proposers, it doesn't use a new shuffle to select candidate indices to which a balance-weighted acceptance probability is applied. Instead, to minimize computational load, it just reuses the existing committee shuffle, starting from the committees of the PTC's `slot` and moving forward from there (wrapping around if necessary).
2. The second commit refactors all functions that do balance weighted sampling, through helpers `compute_balance_weighted_selection` and `compute_balance_weighted_acceptance`:
     - `compute_balance_weighted_acceptance` takes care of the balance-weighted acceptance (whether a candidate index is accepted or not, with probability proportional to its balance)
     -  `compute_balance_weighted_selection` takes care of the whole selection process, going over the given `indices` and selecting them with balance-weighted probability until the required number has been selected. It has a parameter `shuffle_indices` which indicates whether `indices` should be shuffled or not. This is `False` for the PTC, since we are just reusing the existing shuffle
3. The other commits remove `state.latest_full_slot`, which is unused after the introduction of `state.execution_payload_availability`, and fixes a small mistake in `fork-choice.md`

If people think the refactor is unnecessary, we could just go with the first commit. On the one end, the refactor might make it a bit more annoying to change the selection logic for just some of these in the future. On the other hand, there is currently a lot of code duplication and lack of readability, and `get_ptc` is in particular quite hard to understand because there's a lot going on in it. 

Another option could be a smaller refactor with just `compute_balance_weighted_acceptance`, which should be much less likely to be customized by different selection processes (whereas `compute_balance_weighted_selection` already has some customization with `shuffle_indices`, and there's other possibilities like fixed size or not)


