### PR TITLE
eip7805: remove unnecessary equivocation filter

### DIFF
--- a/specs/_features/eip7805/inclusion-list.md
+++ b/specs/_features/eip7805/inclusion-list.md
@@ -96,7 +96,6 @@ def get_inclusion_list_transactions(
     inclusion_list_transactions = [
         transaction
         for inclusion_list in store.inclusion_lists[key]
-        if inclusion_list.validator_index not in store.equivocators[key]
         for transaction in inclusion_list.transactions
     ]
 


### PR DESCRIPTION
This PR removes unnecessary equivocation filter. The idea was to make sure we don't include any ILs from equivocators but `process_inclusion_list` already handles this requirement. (See L17 of `process_inclusion_list`.)