### PR TITLE
Rebase FOCIL onto ePBS

### DIFF
--- a/pysetup/spec_builders/eip7732.py
+++ b/pysetup/spec_builders/eip7732.py
@@ -14,11 +14,62 @@ from eth2spec.electra import {preset_name} as electra
     @classmethod
     def sundry_functions(cls) -> str:
         return """
+def cached_or_new_inclusion_list_store() -> InclusionListStore:
+    # pylint: disable=unused-argument
+    return InclusionListStore()
+
 def concat_generalized_indices(*indices: GeneralizedIndex) -> GeneralizedIndex:
     o = GeneralizedIndex(1)
     for i in indices:
         o = GeneralizedIndex(o * bit_floor(i) + (i - bit_floor(i)))
     return o"""
+
+    @classmethod
+    def execution_engine_cls(cls) -> str:
+        return """
+class NoopExecutionEngine(ExecutionEngine):
+
+    def notify_new_payload(self: ExecutionEngine,
+                           execution_payload: ExecutionPayload,
+                           parent_beacon_block_root: Root,
+                           execution_requests_list: Sequence[bytes]) -> bool:
+        return True
+
+    def notify_forkchoice_updated(self: ExecutionEngine,
+                                  head_block_hash: Hash32,
+                                  safe_block_hash: Hash32,
+                                  finalized_block_hash: Hash32,
+                                  payload_attributes: Optional[PayloadAttributes]) -> Optional[PayloadId]:
+        pass
+
+    def get_payload(self: ExecutionEngine, payload_id: PayloadId) -> GetPayloadResponse:
+        # pylint: disable=unused-argument
+        raise NotImplementedError("no default block production")
+
+    def is_valid_block_hash(self: ExecutionEngine,
+                            execution_payload: ExecutionPayload,
+                            parent_beacon_block_root: Root,
+                            execution_requests_list: Sequence[bytes]) -> bool:
+        return True
+
+    def is_valid_versioned_hashes(self: ExecutionEngine, new_payload_request: NewPayloadRequest) -> bool:
+        return True
+
+    def verify_and_notify_new_payload(self: ExecutionEngine,
+                                      new_payload_request: NewPayloadRequest) -> bool:
+        return True
+
+    def get_inclusion_list(self: ExecutionEngine) -> GetInclusionListResponse:
+        # pylint: disable=unused-argument
+        raise NotImplementedError("no default inclusion list production")
+
+    def is_inclusion_list_satisfied(self: ExecutionEngine,
+                                    execution_payload: ExecutionPayload,
+                                    inclusion_list_transactions: Sequence[Transaction]) -> bool:
+        return True
+
+
+EXECUTION_ENGINE = NoopExecutionEngine()"""
 
     @classmethod
     def deprecate_constants(cls) -> set[str]:

--- a/specs/_features/eip7732/inclusion-list.md
+++ b/specs/_features/eip7732/inclusion-list.md
@@ -1,0 +1,147 @@
+# EIP-7805 -- Inclusion List
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
+
+- [Introduction](#introduction)
+- [Containers](#containers)
+  - [New containers](#new-containers)
+    - [`InclusionListStore`](#inclusionliststore)
+- [Helpers](#helpers)
+  - [New `get_inclusion_list_store`](#new-get_inclusion_list_store)
+  - [New `process_inclusion_list`](#new-process_inclusion_list)
+  - [New `get_inclusion_list_transactions`](#new-get_inclusion_list_transactions)
+  - [New `get_inclusion_list_bits`](#new-get_inclusion_list_bits)
+  - [New `is_inclusion_list_bits_inclusive`](#new-is_inclusion_list_bits_inclusive)
+
+<!-- mdformat-toc end -->
+
+## Introduction
+
+This is the inclusion list specification for the fork-choice enforced inclusion
+list feature.
+
+## Containers
+
+### New containers
+
+#### `InclusionListStore`
+
+```python
+@dataclass
+class InclusionListStore(object):
+    inclusion_lists: DefaultDict[Tuple[Slot, Root], Set[InclusionList]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
+    equivocators: DefaultDict[Tuple[Slot, Root], Set[ValidatorIndex]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
+```
+
+## Helpers
+
+### New `get_inclusion_list_store`
+
+```python
+def get_inclusion_list_store() -> InclusionListStore:
+    # `cached_or_new_inclusion_list_store` is implementation and context dependent.
+    # It returns the cached `InclusionListStore`; if none exists,
+    # it initializes a new instance, caches it and returns it.
+    inclusion_list_store = cached_or_new_inclusion_list_store()
+
+    return inclusion_list_store
+```
+
+### New `process_inclusion_list`
+
+```python
+def process_inclusion_list(
+    store: InclusionListStore, inclusion_list: InclusionList, is_before_view_freeze_deadline: bool
+) -> None:
+    key = (inclusion_list.slot, inclusion_list.inclusion_list_committee_root)
+
+    # Ignore `inclusion_list` from equivocators.
+    if inclusion_list.validator_index in store.equivocators[key]:
+        return
+
+    for stored_inclusion_list in store.inclusion_lists[key]:
+        if stored_inclusion_list.validator_index != inclusion_list.validator_index:
+            continue
+
+        if stored_inclusion_list != inclusion_list:
+            store.equivocators[key].add(inclusion_list.validator_index)
+            store.inclusion_lists[key].remove(stored_inclusion_list)
+
+        # Whether it was an equivocation or not, we have processed this `inclusion_list`.
+        return
+
+    # Only store `inclusion_list` if it arrived before the view freeze deadline.
+    if is_before_view_freeze_deadline:
+        store.inclusion_lists[key].add(inclusion_list)
+```
+
+### New `get_inclusion_list_transactions`
+
+*Note*: `get_inclusion_list_transactions` returns a list of unique transactions
+from all valid and non-equivocating `InclusionList`s that were received in a
+timely manner on the p2p network for the given slot and for which the
+`inclusion_list_committee_root` in the `InclusionList` matches the one
+calculated based on the current state.
+
+```python
+def get_inclusion_list_transactions(
+    store: InclusionListStore, state: BeaconState, slot: Slot
+) -> Sequence[Transaction]:
+    inclusion_list_committee = get_inclusion_list_committee(state, slot)
+    inclusion_list_committee_root = hash_tree_root(inclusion_list_committee)
+    key = (slot, inclusion_list_committee_root)
+
+    inclusion_list_transactions = [
+        transaction
+        for inclusion_list in store.inclusion_lists[key]
+        if inclusion_list.validator_index not in store.equivocators[key]
+        for transaction in inclusion_list.transactions
+    ]
+
+    # Deduplicate inclusion list transactions. Order does not need to be preserved.
+    return list(set(inclusion_list_transactions))
+```
+
+### New `get_inclusion_list_bits`
+
+```python
+def get_inclusion_list_bits(
+    store: InclusionListStore, state: BeaconState, slot: Slot
+) -> Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]:
+    inclusion_list_committee = get_inclusion_list_committee(state, slot)
+    inclusion_list_committee_root = hash_tree_root(inclusion_list_committee)
+    key = (slot, inclusion_list_committee_root)
+
+    validator_indices = [
+        inclusion_list.validator_index for inclusion_list in store.inclusion_lists[key]
+    ]
+
+    return Bitvector[INCLUSION_LIST_COMMITTEE_SIZE](
+        validator_index in validator_indices for validator_index in inclusion_list_committee
+    )
+```
+
+### New `is_inclusion_list_bits_inclusive`
+
+```python
+def is_inclusion_list_bits_inclusive(
+    store: InclusionListStore,
+    state: BeaconState,
+    slot: Slot,
+    inclusion_list_bits: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE],
+) -> bool:
+    inclusion_list_store = get_inclusion_list_store()
+
+    local_inclusion_list_bits = get_inclusion_list_bits(inclusion_list_store, state, Slot(slot - 1))
+
+    return all(
+        inclusion_bit or not local_inclusion_bit
+        for inclusion_bit, local_inclusion_bit in zip(
+            inclusion_list_bits, local_inclusion_list_bits
+        )
+    )
+```


### PR DESCRIPTION
This PR demonstrates how FOCIL can rebase onto ePBS. The main idea behind these changes are based on [this article](https://ethereum-magicians.org/t/epbs-focil-compatibility/24777). Attesters check the IL inclusivity but it's because of simplicity and doesn't mean any preferences.