### PR TITLE
fix: remove duplicate 'presets' package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -286,7 +286,7 @@ setup(
         "sync": "sync",
     },
     packages=find_packages(where="tests/core/pyspec")
-    + ["configs", "presets", "specs", "presets", "sync"],
+    + ["configs", "presets", "specs", "sync"],
     py_modules=["eth2spec"],
     cmdclass=commands,
 )


### PR DESCRIPTION
Remove duplicated 'presets' entry from the packages list in setup.py. This duplicate entry could potentially cause issues during package installation and indicates a copy-paste error