### PR TITLE
Remove early return statement in KZG test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/fulu/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -185,7 +185,7 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
     cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
-    
+
     assert len(cells) == len(proofs)
 
     assert not spec.verify_cell_kzg_proof_batch(

--- a/tests/core/pyspec/eth2spec/test/fulu/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -185,8 +185,7 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
     blob = get_sample_blob(spec)
     commitment = spec.blob_to_kzg_commitment(blob)
     cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
-    return
-
+    
     assert len(cells) == len(proofs)
 
     assert not spec.verify_cell_kzg_proof_batch(


### PR DESCRIPTION
Remove a `return` in the test that might have been introduced by mistake in https://github.com/ethereum/consensus-specs/commit/a9e3aada7fea3a149ada0b1594aa012cb705bae5#diff-125f5485b786e27b6e3eb3c9f70ee70525fd151023d59744b26012ca1fa29d3aR108-R185