### PR TITLE
fix: remove duplicate 'presets' package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -286,7 +286,7 @@ setup(
         "sync": "sync",
     },
     packages=find_packages(where="tests/core/pyspec")
-    + ["configs", "presets", "specs", "presets", "sync"],
+    + ["configs", "presets", "specs", "sync"],
     py_modules=["eth2spec"],
     cmdclass=commands,
 )


### PR DESCRIPTION
## Summary
- Removes redundant 'presets' entry from packages list in setup.py (line 289)
- Fixes the duplicate package definition mentioned in issue #4507

## Description
The `packages` list in `setup.py` contained `"presets"` twice, which is unnecessary and could potentially cause issues. This PR removes the duplicate entry.

## Test plan
- [x] Verified setup.py syntax is valid
- [x] Confirmed the package list now contains unique entries only

Fixes #4507

🤖 Generated with [Claude Code](https://claude.ai/code)