### PR TITLE
Generate spec index pages in mkdocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,5 +20,5 @@ jobs:
         with:
           key: ${{ github.ref }}
           path: .cache
-      - run: pip install mkdocs==1.4.2 mkdocs-material==9.1.5 mdx-truly-sane-lists==1.3 mkdocs-awesome-pages-plugin==2.8.0
+      - run: pip install mkdocs==1.4.2 mkdocs-material==9.1.5 mdx-truly-sane-lists==1.3 mkdocs-awesome-pages-plugin==2.8.0 mkdocs-gen-files==0.5.0
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,24 +1,36 @@
 
 name: Publish docs
+
+defaults:
+  run:
+    shell: zsh -e {0}
+
 on:
   push:
     branches:
       - master
+
 permissions:
   contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install dependencies to venv
+        run: make pyspec
+
       - name: Build docs
         run: make _copy_docs
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: 3.x
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          key: ${{ github.ref }}
-          path: .cache
-      - run: pip install mkdocs==1.4.2 mkdocs-material==9.1.5 mdx-truly-sane-lists==1.3 mkdocs-awesome-pages-plugin==2.8.0 mkdocs-gen-files==0.5.0
-      - run: mkdocs gh-deploy --force
+
+      - name: Deploy
+        run: venv/bin/mkdocs gh-deploy --force

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ PYTHON_VENV = $(VENV)/bin/python3
 PIP_VENV = $(VENV)/bin/pip3
 CODESPELL_VENV = $(VENV)/bin/codespell
 MDFORMAT_VENV = $(VENV)/bin/mdformat
+MKDOCS_VENV = $(VENV)/bin/mkdocs
 
 # Make a virtual environment.
 $(VENV):
@@ -164,9 +165,9 @@ _copy_docs:
 	@cp $(CURDIR)/README.md $(DOCS_DIR)/README.md
 
 # Start a local documentation server.
-serve_docs: _copy_docs
-	@mkdocs build
-	@mkdocs serve
+serve_docs: pyspec _copy_docs
+	@$(MKDOCS_VENV) build
+	@$(MKDOCS_VENV) serve
 
 ###############################################################################
 # Checks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,9 @@ markdown_extensions:
 plugins:
   - search
   - awesome-pages
+  - gen-files:
+      scripts:
+        - scripts/gen_spec_indices.py
 extra_css:
   - stylesheets/extra.css
 extra:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ generator = [
 docs = [
   "mdx-truly-sane-lists==1.3",
   "mkdocs-awesome-pages-plugin==2.10.1",
+  "mkdocs-gen-files==0.5.0",
   "mkdocs-material==9.6.17",
   "mkdocs==1.6.1",
 ]

--- a/scripts/gen_spec_indices.py
+++ b/scripts/gen_spec_indices.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Generate index.md files for specification directories to enable directory browsing in MkDocs.
+
+This script is used by the mkdocs-gen-files plugin to create virtual index pages
+that list all files in each specification directory, providing a GitHub-like
+directory browsing experience on the MkDocs documentation site.
+"""
+
+import os
+from pathlib import Path
+import mkdocs_gen_files
+
+
+def format_filename_as_title(filename: str) -> str:
+    """Convert a filename to a human-readable title."""
+    # Remove .md extension
+    name = filename[:-3] if filename.endswith('.md') else filename
+    
+    # Special case handling for common abbreviations
+    replacements = {
+        'p2p': 'P2P',
+        'api': 'API',
+        'ssz': 'SSZ',
+        'bls': 'BLS',
+    }
+    
+    # Replace hyphens and underscores with spaces
+    name = name.replace('-', ' ').replace('_', ' ')
+    
+    # Title case
+    words = name.split()
+    formatted_words = []
+    for word in words:
+        lower_word = word.lower()
+        if lower_word in replacements:
+            formatted_words.append(replacements[lower_word])
+        else:
+            formatted_words.append(word.title())
+    
+    return ' '.join(formatted_words)
+
+
+def generate_spec_index(dir_path: str, fork_name: str) -> str:
+    """Generate index content for a specification directory."""
+    files = []
+    subdirs = []
+    
+    # Check if directory exists
+    if os.path.exists(dir_path):
+        for item in sorted(os.listdir(dir_path)):
+            item_path = os.path.join(dir_path, item)
+            if os.path.isdir(item_path):
+                subdirs.append(item)
+            elif item.endswith('.md') and item != 'index.md':
+                files.append(item)
+    
+    # Generate content
+    content = f"# {fork_name.title()} Specifications\n\n"
+    
+    # Add description based on fork
+    descriptions = {
+        'phase0': "The initial Ethereum proof-of-stake specifications, defining the core beacon chain functionality.",
+        'altair': "The first beacon chain upgrade, introducing sync committees and other improvements.",
+        'bellatrix': "The merge upgrade, connecting the beacon chain with the execution layer.",
+        'capella': "Enables withdrawals of staked ETH from the beacon chain.",
+        'deneb': "Introduces proto-danksharding (EIP-4844) for improved data availability.",
+        'electra': "Latest improvements to the consensus layer.",
+        'fulu': "In-development specifications for future upgrades.",
+        'gloas': "Builder API specifications for proposer-builder separation."
+    }
+    
+    if fork_name.lower() in descriptions:
+        content += f"{descriptions[fork_name.lower()]}\n\n"
+    
+    # List subdirectories first if any
+    if subdirs:
+        content += "## Subdirectories\n\n"
+        for subdir in subdirs:
+            formatted_name = format_filename_as_title(subdir)
+            content += f"- [{formatted_name}](./{subdir}/)\n"
+        content += "\n"
+    
+    # List specification files
+    if files:
+        content += "## Specification Documents\n\n"
+        
+        # Group files by category for better organization
+        core_files = []
+        other_files = []
+        
+        for file in files:
+            if file in ['beacon-chain.md', 'fork.md', 'validator.md']:
+                core_files.append(file)
+            else:
+                other_files.append(file)
+        
+        if core_files:
+            content += "### Core Specifications\n\n"
+            for file in core_files:
+                name = format_filename_as_title(file)
+                desc = get_file_description(file)
+                content += f"- [{name}](./{file})"
+                if desc:
+                    content += f" - {desc}"
+                content += "\n"
+            content += "\n"
+        
+        if other_files:
+            content += "### Additional Specifications\n\n"
+            for file in other_files:
+                name = format_filename_as_title(file)
+                desc = get_file_description(file)
+                content += f"- [{name}](./{file})"
+                if desc:
+                    content += f" - {desc}"
+                content += "\n"
+    
+    if not files and not subdirs:
+        content += "*No specification files found in this directory.*\n"
+    
+    return content
+
+
+def get_file_description(filename: str) -> str:
+    """Return a brief description for common specification files."""
+    descriptions = {
+        'beacon-chain.md': 'Core beacon chain state transition specifications',
+        'fork.md': 'Fork transition logic and upgrade process',
+        'validator.md': 'Validator duties and responsibilities',
+        'p2p-interface.md': 'Peer-to-peer networking protocol',
+        'fork-choice.md': 'Fork choice algorithm for chain selection',
+        'deposit-contract.md': 'Ethereum deposit contract interface',
+        'weak-subjectivity.md': 'Weak subjectivity period calculations',
+        'sync-protocol.md': 'Light client sync protocol',
+        'full-node.md': 'Full node requirements and behavior',
+        'light-client.md': 'Light client specifications',
+        'bls.md': 'BLS signature scheme specifications',
+    }
+    return descriptions.get(filename, '')
+
+
+
+
+# The script executes directly when loaded by mkdocs-gen-files plugin
+print("[gen_spec_indices.py] Generating specification index pages...")
+
+# List of all specification forks
+spec_forks = ['phase0', 'altair', 'bellatrix', 'capella', 'deneb', 'electra', 'fulu', 'gloas']
+
+# Generate index.md for each specs directory
+for fork in spec_forks:
+    spec_path = f'specs/{fork}'
+    if os.path.exists(spec_path):
+        print(f"  - Generating index for {spec_path}")
+        with mkdocs_gen_files.open(f"{spec_path}/index.md", "w") as f:
+            f.write(generate_spec_index(spec_path, fork))
+
+# Also generate for specs/_features directory
+features_path = 'specs/_features'
+if os.path.exists(features_path):
+    # List all feature directories
+    for feature in os.listdir(features_path):
+        feature_path = os.path.join(features_path, feature)
+        if os.path.isdir(feature_path):
+            print(f"  - Generating index for {feature_path}")
+            with mkdocs_gen_files.open(f"{feature_path}/index.md", "w") as f:
+                f.write(generate_spec_index(feature_path, f"Feature: {feature}"))
+
+# Note: Test directories are not included in MkDocs documentation
+# They contain Python test files, not documentation
+# Links to tests in README.md will continue to work on GitHub only
+
+print("[gen_spec_indices.py] Index generation complete!")

--- a/scripts/gen_spec_indices.py
+++ b/scripts/gen_spec_indices.py
@@ -1,34 +1,30 @@
 #!/usr/bin/env python3
 """
-Generate index.md files for specification directories to enable directory browsing in MkDocs.
+Generate index.md files for specification directories to enable directory browsing in mkdocs.
 
 This script is used by the mkdocs-gen-files plugin to create virtual index pages
 that list all files in each specification directory, providing a GitHub-like
-directory browsing experience on the MkDocs documentation site.
+directory browsing experience on the mkdocs documentation site.
 """
 
 import os
-from pathlib import Path
 import mkdocs_gen_files
 
 
 def format_filename_as_title(filename: str) -> str:
     """Convert a filename to a human-readable title."""
-    # Remove .md extension
-    name = filename[:-3] if filename.endswith('.md') else filename
+    name = filename[-3] if filename.endswith(".md") else filename
 
-    # Special case handling for common abbreviations
     replacements = {
-        'p2p': 'P2P',
-        'api': 'API',
-        'ssz': 'SSZ',
-        'bls': 'BLS',
+        "api": "API",
+        "bls": "BLS",
+        "das": "DAS",
+        "p2p": "P2P",
+        "ssz": "SSZ",
     }
 
-    # Replace hyphens and underscores with spaces
-    name = name.replace('-', ' ').replace('_', ' ')
+    name = name.replace("-", " ").replace("_", " ")
 
-    # Title case
     words = name.split()
     formatted_words = []
     for word in words:
@@ -38,137 +34,61 @@ def format_filename_as_title(filename: str) -> str:
         else:
             formatted_words.append(word.title())
 
-    return ' '.join(formatted_words)
+    return " ".join(formatted_words)
 
 
-def generate_spec_index(dir_path: str, fork_name: str) -> str:
+def generate_spec_index(dir_path: str, level: int = 1) -> str:
     """Generate index content for a specification directory."""
     files = []
     subdirs = []
 
-    # Check if directory exists
     if os.path.exists(dir_path):
         for item in sorted(os.listdir(dir_path)):
             item_path = os.path.join(dir_path, item)
             if os.path.isdir(item_path):
                 subdirs.append(item)
-            elif item.endswith('.md') and item != 'index.md':
+            elif item.endswith(".md") and item != "index.md":
                 files.append(item)
 
-    # Generate content
-    content = f"# {fork_name.title()} Specifications\n\n"
+    content = ""
 
-    # Add description based on fork
-    descriptions = {
-        'phase0': "The initial Ethereum proof-of-stake specifications, defining the core beacon chain functionality.",
-        'altair': "The first beacon chain upgrade, introducing sync committees and other improvements.",
-        'bellatrix': "The merge upgrade, connecting the beacon chain with the execution layer.",
-        'capella': "Enables withdrawals of staked ETH from the beacon chain.",
-        'deneb': "Introduces proto-danksharding (EIP-4844) for improved data availability.",
-        'electra': "Latest improvements to the consensus layer.",
-        'fulu': "In-development specifications for future upgrades.",
-        'gloas': "Builder API specifications for proposer-builder separation."
-    }
+    if level == 1:
+        content = "# Index\n\n"
+        if files:
+            content += "## Core\n\n"
 
-    if fork_name.lower() in descriptions:
-        content += f"{descriptions[fork_name.lower()]}\n\n"
+    for file in files:
+        name = format_filename_as_title(file)
+        content += f"- [{name}](./{file})\n"
 
-    # List subdirectories first if any
-    if subdirs:
-        content += "## Subdirectories\n\n"
-        for subdir in subdirs:
-            formatted_name = format_filename_as_title(subdir)
-            content += f"- [{formatted_name}](./{subdir}/)\n"
-        content += "\n"
+    for subdir in subdirs:
+        formatted_name = format_filename_as_title(subdir)
+        heading_level = "#" * (level + 1)
+        content += f"\n{heading_level} {formatted_name}\n\n"
+        subdir_path = os.path.join(dir_path, subdir)
+        subdir_content = generate_spec_index(subdir_path, level + 1)
+        if subdir_content.strip():
+            content += subdir_content
+        else:
+            content += f"*No files in {subdir}/*\n"
 
-    # List specification files
-    if files:
-        content += "## Specification Documents\n\n"
-
-        # Group files by category for better organization
-        core_files = []
-        other_files = []
-
-        for file in files:
-            if file in ['beacon-chain.md', 'fork.md', 'validator.md']:
-                core_files.append(file)
-            else:
-                other_files.append(file)
-
-        if core_files:
-            content += "### Core Specifications\n\n"
-            for file in core_files:
-                name = format_filename_as_title(file)
-                desc = get_file_description(file)
-                content += f"- [{name}](./{file})"
-                if desc:
-                    content += f" - {desc}"
-                content += "\n"
-            content += "\n"
-
-        if other_files:
-            content += "### Additional Specifications\n\n"
-            for file in other_files:
-                name = format_filename_as_title(file)
-                desc = get_file_description(file)
-                content += f"- [{name}](./{file})"
-                if desc:
-                    content += f" - {desc}"
-                content += "\n"
-
-    if not files and not subdirs:
+    if not files and not subdirs and level == 1:
         content += "*No specification files found in this directory.*\n"
 
     return content
 
 
-def get_file_description(filename: str) -> str:
-    """Return a brief description for common specification files."""
-    descriptions = {
-        'beacon-chain.md': 'Core beacon chain state transition specifications',
-        'fork.md': 'Fork transition logic and upgrade process',
-        'validator.md': 'Validator duties and responsibilities',
-        'p2p-interface.md': 'Peer-to-peer networking protocol',
-        'fork-choice.md': 'Fork choice algorithm for chain selection',
-        'deposit-contract.md': 'Ethereum deposit contract interface',
-        'weak-subjectivity.md': 'Weak subjectivity period calculations',
-        'sync-protocol.md': 'Light client sync protocol',
-        'full-node.md': 'Full node requirements and behavior',
-        'light-client.md': 'Light client specifications',
-        'bls.md': 'BLS signature scheme specifications',
-    }
-    return descriptions.get(filename, '')
+print("Generating specification index pages...")
 
+spec_forks = []
+if os.path.exists("specs"):
+    for item in sorted(os.listdir("specs")):
+        item_path = os.path.join("specs", item)
+        if os.path.isdir(item_path) and item not in {"_deprecated", "_features"}:
+            spec_forks.append(item)
 
-
-
-# The script executes directly when loaded by mkdocs-gen-files plugin
-print("[gen_spec_indices.py] Generating specification index pages...")
-
-# List of all specification forks
-spec_forks = ['phase0', 'altair', 'bellatrix', 'capella', 'deneb', 'electra', 'fulu', 'gloas']
-
-# Generate index.md for each specs directory
 for fork in spec_forks:
-    spec_path = f'specs/{fork}'
-    if os.path.exists(spec_path):
-        print(f"  - Generating index for {spec_path}")
-        with mkdocs_gen_files.open(f"{spec_path}/index.md", "w") as f:
-            f.write(generate_spec_index(spec_path, fork))
-
-# Also generate for specs/_features directory
-features_path = 'specs/_features'
-if os.path.exists(features_path):
-    # List all feature directories
-    for feature in os.listdir(features_path):
-        feature_path = os.path.join(features_path, feature)
-        if os.path.isdir(feature_path):
-            print(f"  - Generating index for {feature_path}")
-            with mkdocs_gen_files.open(f"{feature_path}/index.md", "w") as f:
-                f.write(generate_spec_index(feature_path, f"Feature: {feature}"))
-
-# Note: Test directories are not included in MkDocs documentation
-# They contain Python test files, not documentation
-# Links to tests in README.md will continue to work on GitHub only
-
-print("[gen_spec_indices.py] Index generation complete!")
+    spec_path = f"specs/{fork}"
+    print(f"  - Generating index for {spec_path}")
+    with mkdocs_gen_files.open(f"{spec_path}/index.md", "w") as f:
+        f.write(generate_spec_index(spec_path))

--- a/scripts/gen_spec_indices.py
+++ b/scripts/gen_spec_indices.py
@@ -16,7 +16,7 @@ def format_filename_as_title(filename: str) -> str:
     """Convert a filename to a human-readable title."""
     # Remove .md extension
     name = filename[:-3] if filename.endswith('.md') else filename
-    
+
     # Special case handling for common abbreviations
     replacements = {
         'p2p': 'P2P',
@@ -24,10 +24,10 @@ def format_filename_as_title(filename: str) -> str:
         'ssz': 'SSZ',
         'bls': 'BLS',
     }
-    
+
     # Replace hyphens and underscores with spaces
     name = name.replace('-', ' ').replace('_', ' ')
-    
+
     # Title case
     words = name.split()
     formatted_words = []
@@ -37,7 +37,7 @@ def format_filename_as_title(filename: str) -> str:
             formatted_words.append(replacements[lower_word])
         else:
             formatted_words.append(word.title())
-    
+
     return ' '.join(formatted_words)
 
 
@@ -45,7 +45,7 @@ def generate_spec_index(dir_path: str, fork_name: str) -> str:
     """Generate index content for a specification directory."""
     files = []
     subdirs = []
-    
+
     # Check if directory exists
     if os.path.exists(dir_path):
         for item in sorted(os.listdir(dir_path)):
@@ -54,10 +54,10 @@ def generate_spec_index(dir_path: str, fork_name: str) -> str:
                 subdirs.append(item)
             elif item.endswith('.md') and item != 'index.md':
                 files.append(item)
-    
+
     # Generate content
     content = f"# {fork_name.title()} Specifications\n\n"
-    
+
     # Add description based on fork
     descriptions = {
         'phase0': "The initial Ethereum proof-of-stake specifications, defining the core beacon chain functionality.",
@@ -69,10 +69,10 @@ def generate_spec_index(dir_path: str, fork_name: str) -> str:
         'fulu': "In-development specifications for future upgrades.",
         'gloas': "Builder API specifications for proposer-builder separation."
     }
-    
+
     if fork_name.lower() in descriptions:
         content += f"{descriptions[fork_name.lower()]}\n\n"
-    
+
     # List subdirectories first if any
     if subdirs:
         content += "## Subdirectories\n\n"
@@ -80,21 +80,21 @@ def generate_spec_index(dir_path: str, fork_name: str) -> str:
             formatted_name = format_filename_as_title(subdir)
             content += f"- [{formatted_name}](./{subdir}/)\n"
         content += "\n"
-    
+
     # List specification files
     if files:
         content += "## Specification Documents\n\n"
-        
+
         # Group files by category for better organization
         core_files = []
         other_files = []
-        
+
         for file in files:
             if file in ['beacon-chain.md', 'fork.md', 'validator.md']:
                 core_files.append(file)
             else:
                 other_files.append(file)
-        
+
         if core_files:
             content += "### Core Specifications\n\n"
             for file in core_files:
@@ -105,7 +105,7 @@ def generate_spec_index(dir_path: str, fork_name: str) -> str:
                     content += f" - {desc}"
                 content += "\n"
             content += "\n"
-        
+
         if other_files:
             content += "### Additional Specifications\n\n"
             for file in other_files:
@@ -115,10 +115,10 @@ def generate_spec_index(dir_path: str, fork_name: str) -> str:
                 if desc:
                     content += f" - {desc}"
                 content += "\n"
-    
+
     if not files and not subdirs:
         content += "*No specification files found in this directory.*\n"
-    
+
     return content
 
 

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -79,8 +79,8 @@
 This is the beacon chain specification of the enshrined proposer builder
 separation feature.
 
-*Note*: This specification is built upon [Fulu](../../fulu/beacon-chain.md) and
-is under active development.
+*Note*: This specification is built upon [Fulu](../fulu/beacon-chain.md) and is
+under active development.
 
 This feature adds new staked consensus participants called *Builders* and new
 honest validators duties called *payload timeliness attestations*. The slot is


### PR DESCRIPTION
When clicking on the "specs" links in the readme, it would show a 404. The simplest solution to this is to generate a basic index page for each spec. The "tests" link will still 404 but that's alright, no great way to fix that.

Fixes #4472.