### PR TITLE
Add reference tests for KZG compute challenge functions

### DIFF
--- a/tests/formats/kzg_4844/README.md
+++ b/tests/formats/kzg_4844/README.md
@@ -14,3 +14,4 @@ The KZG test suite runner has the following handlers:
 - [`compute_blob_kzg_proof`](./compute_blob_kzg_proof.md)
 - [`verify_blob_kzg_proof`](./verify_blob_kzg_proof.md)
 - [`verify_blob_kzg_proof_batch`](./verify_blob_kzg_proof_batch.md)
+- [`compute_challenge`](./compute_challenge.md)

--- a/tests/formats/kzg_4844/compute_challenge.md
+++ b/tests/formats/kzg_4844/compute_challenge.md
@@ -1,0 +1,32 @@
+# Test format: Compute challenge
+
+Compute the Fiat-Shamir challenge value for KZG operations.
+
+## Test case format
+
+The test data is declared in a `data.yaml` file:
+
+```yaml
+input:
+  blob: Blob -- the blob data
+  commitment: Bytes48 -- the KZG commitment
+output: Bytes32 -- the computed challenge value
+```
+
+- `Blob` is a 131072-byte hexadecimal string, prefixed with `0x`.
+- `Bytes48` is a 48-byte hexadecimal string, prefixed with `0x`.
+- `Bytes32` is a 32-byte hexadecimal string, prefixed with `0x`.
+
+All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with
+`0x`.
+
+## Condition
+
+The `compute_challenge` handler should compute a challenge value using the
+Fiat-Shamir heuristic by hashing together the protocol domain separator, the
+polynomial degree, the blob, and the commitment. This is an internal helper
+function, so all inputs are assumed to be valid. The computed challenge should
+match the expected `output`.
+
+Note: This function is not a public method but an internal helper used by other
+KZG functions. It assumes all inputs are already validated.

--- a/tests/formats/kzg_7594/README.md
+++ b/tests/formats/kzg_7594/README.md
@@ -8,6 +8,8 @@ We do not recommend rolling your own crypto or using an untested KZG library.
 
 The KZG test suite runner has the following handlers:
 
+- [`compute_cells`](./compute_cells.md)
 - [`compute_cells_and_kzg_proofs`](./compute_cells_and_kzg_proofs.md)
 - [`recover_cells_and_kzg_proofs`](./recover_cells_and_kzg_proofs.md)
 - [`verify_cell_kzg_proof_batch`](./verify_cell_kzg_proof_batch.md)
+- [`compute_verify_cell_kzg_proof_batch_challenge`](./compute_verify_cell_kzg_proof_batch_challenge.md)

--- a/tests/formats/kzg_7594/compute_verify_cell_kzg_proof_batch_challenge.md
+++ b/tests/formats/kzg_7594/compute_verify_cell_kzg_proof_batch_challenge.md
@@ -1,0 +1,37 @@
+# Test format: Compute verify cell KZG proof batch challenge
+
+Compute the challenge value used for batch verification of cell KZG proofs.
+
+## Test case format
+
+The test data is declared in a `data.yaml` file:
+
+```yaml
+input:
+  commitments: List[Bytes48] -- the unique KZG commitments
+  commitment_indices: List[CommitmentIndex] -- the commitment index for each cell
+  cell_indices: List[CellIndex] -- the cell index for each cell
+  cosets_evals: List[CosetEvals] -- the coset evaluations for each cell
+  proofs: List[Bytes48] -- the KZG proof for each cell
+output: Bytes32 -- the computed challenge value
+```
+
+- `Bytes48` is a 48-byte hexadecimal string, prefixed with `0x`.
+- `Bytes32` is a 32-byte hexadecimal string, prefixed with `0x`.
+- `CommitmentIndex` is an unsigned 64-bit integer.
+- `CellIndex` is an unsigned 64-bit integer.
+- `CosetEvals` is a list of field elements, each encoded as a 32-byte
+  hexadecimal string prefixed with `0x`.
+
+All byte(s) fields are encoded as strings, hexadecimal encoding, prefixed with
+`0x`.
+
+## Condition
+
+The `compute_verify_cell_kzg_proof_batch_challenge` handler should compute a
+challenge value by hashing together all the inputs according to the Fiat-Shamir
+heuristic. This is an internal helper function, so all inputs are assumed to be
+valid. The computed challenge should match the expected `output`.
+
+Note: This function is not a public method but an internal helper used by
+`verify_cell_kzg_proof_batch`. It assumes all inputs are already validated.

--- a/tests/generators/runners/kzg_4844.py
+++ b/tests/generators/runners/kzg_4844.py
@@ -620,6 +620,56 @@ def case_verify_blob_kzg_proof_batch():
 
 
 ###############################################################################
+# Test cases for compute_challenge
+###############################################################################
+
+
+def case_compute_challenge():
+    def get_test_runner(blob, commitment):
+        def _runner():
+            try:
+                challenge = None
+                challenge = spec.compute_challenge(blob, commitment)
+            except Exception:
+                pass
+            return [
+                (
+                    "data",
+                    "data",
+                    {
+                        "input": {
+                            "blob": encode_hex(blob),
+                            "commitment": encode_hex(commitment),
+                        },
+                        "output": encode_hex(spec.bls_field_to_bytes(challenge))
+                        if challenge is not None
+                        else None,
+                    },
+                )
+            ]
+
+        return _runner
+
+    # Valid cases
+    for index, blob in enumerate(VALID_BLOBS):
+        commitment = cached_blob_to_kzg_commitment(blob)
+        yield f"compute_challenge_case_valid_{index}", get_test_runner(blob, commitment)
+
+    # Valid: Same blob with different commitments (incorrect, but valid format)
+    if True:
+        blob = VALID_BLOBS[3]
+        # Use commitment from a different blob
+        commitment = cached_blob_to_kzg_commitment(VALID_BLOBS[4])
+        yield "compute_challenge_case_mismatched_commitment", get_test_runner(blob, commitment)
+
+    # Valid: G1_POINT_AT_INFINITY as commitment
+    if True:
+        blob = VALID_BLOBS[4]
+        commitment = spec.G1_POINT_AT_INFINITY
+        yield "compute_challenge_case_commitment_at_infinity", get_test_runner(blob, commitment)
+
+
+###############################################################################
 # Main logic
 ###############################################################################
 
@@ -632,6 +682,7 @@ def get_test_cases() -> Iterable[TestCase]:
         ("compute_blob_kzg_proof", case_compute_blob_kzg_proof),
         ("verify_blob_kzg_proof", case_verify_blob_kzg_proof),
         ("verify_blob_kzg_proof_batch", case_verify_blob_kzg_proof_batch),
+        ("compute_challenge", case_compute_challenge),
     ]
 
     test_cases = []

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -614,6 +614,287 @@ def case_recover_cells_and_kzg_proofs():
 
 
 ###############################################################################
+# Test cases for compute_verify_cell_kzg_proof_batch_challenge
+###############################################################################
+
+
+def case_compute_verify_cell_kzg_proof_batch_challenge():
+    def get_test_runner(input_getter):
+        def _runner():
+            commitments, commitment_indices, cell_indices, cosets_evals, proofs = input_getter()
+            try:
+                challenge = None
+                challenge = spec.compute_verify_cell_kzg_proof_batch_challenge(
+                    commitments, commitment_indices, cell_indices, cosets_evals, proofs
+                )
+            except Exception:
+                pass
+            return [
+                (
+                    "data",
+                    "data",
+                    {
+                        "input": {
+                            "commitments": encode_hex_list(commitments),
+                            "commitment_indices": commitment_indices,
+                            "cell_indices": cell_indices,
+                            "cosets_evals": [
+                                [encode_hex(spec.bls_field_to_bytes(eval)) for eval in coset_evals]
+                                for coset_evals in cosets_evals
+                            ],
+                            "proofs": encode_hex_list(proofs),
+                        },
+                        "output": encode_hex(spec.bls_field_to_bytes(challenge))
+                        if challenge is not None
+                        else None,
+                    },
+                )
+            ]
+
+        return _runner
+
+    # Valid: Empty inputs
+    if True:
+
+        def get_inputs():
+            return [], [], [], [], []
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_empty",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Single cell
+    if True:
+
+        def get_inputs():
+            blob = VALID_BLOBS[0]
+            cells, proofs = cached_compute_cells_and_kzg_proofs(blob)
+            commitment = cached_blob_to_kzg_commitment(blob)
+
+            commitments = [commitment]
+            commitment_indices = [0]
+            cell_indices = [0]
+            cosets_evals = [spec.cell_to_coset_evals(cells[0])]
+            proofs_selected = [proofs[0]]
+
+            return commitments, commitment_indices, cell_indices, cosets_evals, proofs_selected
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_single_cell",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Multiple cells from single blob
+    if True:
+
+        def get_inputs():
+            blob = VALID_BLOBS[1]
+            cells, proofs = cached_compute_cells_and_kzg_proofs(blob)
+            commitment = cached_blob_to_kzg_commitment(blob)
+
+            num_cells = 4
+            commitments = [commitment]
+            commitment_indices = [0] * num_cells
+            cell_indices = list(range(num_cells))
+            cosets_evals = [spec.cell_to_coset_evals(cells[i]) for i in range(num_cells)]
+            proofs_selected = [proofs[i] for i in range(num_cells)]
+
+            return commitments, commitment_indices, cell_indices, cosets_evals, proofs_selected
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_multiple_cells_single_blob",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Multiple cells from multiple blobs
+    if True:
+
+        def get_inputs():
+            blob0 = VALID_BLOBS[2]
+            blob1 = VALID_BLOBS[3]
+            cells0, proofs0 = cached_compute_cells_and_kzg_proofs(blob0)
+            cells1, proofs1 = cached_compute_cells_and_kzg_proofs(blob1)
+            commitment0 = cached_blob_to_kzg_commitment(blob0)
+            commitment1 = cached_blob_to_kzg_commitment(blob1)
+
+            commitments = [commitment0, commitment1]
+            commitment_indices = [0, 1, 0, 1]
+            cell_indices = [0, 1, 2, 3]
+            cosets_evals = [
+                spec.cell_to_coset_evals(cells0[0]),
+                spec.cell_to_coset_evals(cells1[1]),
+                spec.cell_to_coset_evals(cells0[2]),
+                spec.cell_to_coset_evals(cells1[3]),
+            ]
+            proofs_selected = [proofs0[0], proofs1[1], proofs0[2], proofs1[3]]
+
+            return commitments, commitment_indices, cell_indices, cosets_evals, proofs_selected
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_multiple_cells_multiple_blobs",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Same cell multiple times (duplicate cells)
+    if True:
+
+        def get_inputs():
+            blob = VALID_BLOBS[4]
+            cells, proofs = cached_compute_cells_and_kzg_proofs(blob)
+            commitment = cached_blob_to_kzg_commitment(blob)
+
+            num_duplicates = 3
+            commitments = [commitment]
+            commitment_indices = [0] * num_duplicates
+            cell_indices = [5] * num_duplicates  # Same cell index repeated
+            cosets_evals = [spec.cell_to_coset_evals(cells[5])] * num_duplicates
+            proofs_selected = [proofs[5]] * num_duplicates
+
+            return commitments, commitment_indices, cell_indices, cosets_evals, proofs_selected
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_duplicate_cells",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Many cells (stress test with many cells)
+    if True:
+
+        def get_inputs():
+            blob = VALID_BLOBS[5]
+            cells, proofs = cached_compute_cells_and_kzg_proofs(blob)
+            commitment = cached_blob_to_kzg_commitment(blob)
+
+            # Use half of all cells
+            num_cells = spec.CELLS_PER_EXT_BLOB // 2
+            commitments = [commitment]
+            commitment_indices = [0] * num_cells
+            cell_indices = list(range(num_cells))
+            cosets_evals = [spec.cell_to_coset_evals(cells[i]) for i in range(num_cells)]
+            proofs_selected = [proofs[i] for i in range(num_cells)]
+
+            return commitments, commitment_indices, cell_indices, cosets_evals, proofs_selected
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_many_cells",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Non-sequential cell indices
+    if True:
+
+        def get_inputs():
+            blob = VALID_BLOBS[6]
+            cells, proofs = cached_compute_cells_and_kzg_proofs(blob)
+            commitment = cached_blob_to_kzg_commitment(blob)
+
+            # Use non-sequential indices
+            indices = [10, 5, 20, 15, 0, 30]
+            commitments = [commitment]
+            commitment_indices = [0] * len(indices)
+            cell_indices = indices
+            cosets_evals = [spec.cell_to_coset_evals(cells[i]) for i in indices]
+            proofs_selected = [proofs[i] for i in indices]
+
+            return commitments, commitment_indices, cell_indices, cosets_evals, proofs_selected
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_non_sequential_indices",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Mixed commitment indices order
+    if True:
+
+        def get_inputs():
+            blob0 = VALID_BLOBS[0]
+            blob1 = VALID_BLOBS[1]
+            blob2 = VALID_BLOBS[2]
+            cells0, proofs0 = cached_compute_cells_and_kzg_proofs(blob0)
+            cells1, proofs1 = cached_compute_cells_and_kzg_proofs(blob1)
+            cells2, proofs2 = cached_compute_cells_and_kzg_proofs(blob2)
+            commitment0 = cached_blob_to_kzg_commitment(blob0)
+            commitment1 = cached_blob_to_kzg_commitment(blob1)
+            commitment2 = cached_blob_to_kzg_commitment(blob2)
+
+            # Mix up the order of commitment indices
+            commitments = [commitment0, commitment1, commitment2]
+            commitment_indices = [2, 0, 1, 0, 2, 1]
+            cell_indices = [0, 1, 2, 3, 4, 5]
+            cosets_evals = [
+                spec.cell_to_coset_evals(cells2[0]),
+                spec.cell_to_coset_evals(cells0[1]),
+                spec.cell_to_coset_evals(cells1[2]),
+                spec.cell_to_coset_evals(cells0[3]),
+                spec.cell_to_coset_evals(cells2[4]),
+                spec.cell_to_coset_evals(cells1[5]),
+            ]
+            proofs_selected = [
+                proofs2[0],
+                proofs0[1],
+                proofs1[2],
+                proofs0[3],
+                proofs2[4],
+                proofs1[5],
+            ]
+
+            return commitments, commitment_indices, cell_indices, cosets_evals, proofs_selected
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_mixed_commitment_indices",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Maximum cell index values
+    if True:
+
+        def get_inputs():
+            blob = VALID_BLOBS[3]
+            cells, proofs = cached_compute_cells_and_kzg_proofs(blob)
+            commitment = cached_blob_to_kzg_commitment(blob)
+
+            # Use the highest valid cell indices
+            max_index = spec.CELLS_PER_EXT_BLOB - 1
+            indices = [max_index, max_index - 1, max_index - 2]
+            commitments = [commitment]
+            commitment_indices = [0] * len(indices)
+            cell_indices = indices
+            cosets_evals = [spec.cell_to_coset_evals(cells[i]) for i in indices]
+            proofs_selected = [proofs[i] for i in indices]
+
+            return commitments, commitment_indices, cell_indices, cosets_evals, proofs_selected
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_max_cell_indices",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: All cells from a blob
+    if True:
+
+        def get_inputs():
+            blob = VALID_BLOBS[4]
+            cells, proofs = cached_compute_cells_and_kzg_proofs(blob)
+            commitment = cached_blob_to_kzg_commitment(blob)
+
+            # Use all cells
+            num_cells = spec.CELLS_PER_EXT_BLOB
+            commitments = [commitment]
+            commitment_indices = [0] * num_cells
+            cell_indices = list(range(num_cells))
+            cosets_evals = [spec.cell_to_coset_evals(cells[i]) for i in range(num_cells)]
+            proofs_selected = proofs
+
+            return commitments, commitment_indices, cell_indices, cosets_evals, proofs_selected
+
+        yield (
+            "compute_verify_cell_kzg_proof_batch_challenge_case_all_cells",
+            get_test_runner(get_inputs),
+        )
+
+
+###############################################################################
 # Main logic
 ###############################################################################
 
@@ -624,6 +905,10 @@ def get_test_cases() -> Iterable[TestCase]:
         ("compute_cells_and_kzg_proofs", case_compute_cells_and_kzg_proofs),
         ("verify_cell_kzg_proof_batch", case_verify_cell_kzg_proof_batch),
         ("recover_cells_and_kzg_proofs", case_recover_cells_and_kzg_proofs),
+        (
+            "compute_verify_cell_kzg_proof_batch_challenge",
+            case_compute_verify_cell_kzg_proof_batch_challenge,
+        ),
     ]
 
     test_cases = []


### PR DESCRIPTION
These are internal functions but we think it would be useful to provide tests for them, since it's easy to make a mistake here which might not affect the result. If an input is not included in the hash, it could lead to an underconstraint issue