### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!-- Description
+Provide at least one paragraph that clearly and succinctly explains:
+* What this PR does (but not how it does it)
+* Why this PR is necessary, including context
+-->
+
+<!-- Checklist
+Ensure the following tasks have been done prior to submitting the PR:
+* Update documentation (if applicable)
+* Add tests for new functionality (if applicable)
+* Run `make lint` to check formatting
+* Run `make test` to check tests
+-->
+
+<!-- Relations
+Link any related PRs or issues:
+* Use "Fixes #123" to auto-close issues
+* Use "Related to #456" for related work
+-->


### PR DESCRIPTION
I think it would be useful to provide a PR template so that new contributors know what to do prior to making a pull request. Often times, they will forget to run `make lint` which causes the CI checks to immediately fail.