### PR TITLE
Include pre-releases in release drafter & update labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,6 +36,9 @@ categories:
   # Fallback
   - title: Other
 
+commitish: master
+filter-by-commitish: true
+include-pre-releases: true
 sort-direction: ascending
 change-title-escapes: '\<*_&'
 change-template: '- $TITLE (#$NUMBER)'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,19 +13,19 @@ categories:
   - title: Electra
     label: electra
   - title: Fulu
-    label: fulu
+    labels:
+      - fulu
+      - eip7594
   - title: Gloas
-    label: gloas
+    labels:
+      - gloas
+      - eip7732
 
   # Features
   - title: EIP-6110
     label: eip6110
   - title: EIP-7441
     label: eip7441
-  - title: EIP-7594
-    label: eip7594
-  - title: EIP-7732
-    label: eip7732
   - title: EIP-7805
     label: eip7805
 


### PR DESCRIPTION
<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What this PR does (but not how it does it)
* Why this PR is necessary, including context
-->

This PR sets `include-pre-releases` to true and explicitly specifies that `master` is the branch that tags are created from. For some reason, release drafter is including old PR lines in the release notes which I've had to manually delete. It's confused about what the previous tag is or something. I'm hoping these changes fix it.

This PR also updates the labels so that `eip7594` and `eip7732` PRs are included in the Fulu/Gloas sections, respectively. I don't want there to be a disconnect here now. These should be under the fork section, not the feature section.

<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->
