### PR TITLE
Ensure cell indices are sorted in `recover_cells_and_kzg_proofs`

### DIFF
--- a/specs/fulu/polynomial-commitments-sampling.md
+++ b/specs/fulu/polynomial-commitments-sampling.md
@@ -801,6 +801,8 @@ def recover_cells_and_kzg_proofs(
     assert CELLS_PER_EXT_BLOB // 2 <= len(cell_indices) <= CELLS_PER_EXT_BLOB
     # Check for duplicates
     assert len(cell_indices) == len(set(cell_indices))
+    # Check that indices are in ascending order
+    assert cell_indices == sorted(cell_indices)
     # Check that the cell indices are within bounds
     for cell_index in cell_indices:
         assert cell_index < CELLS_PER_EXT_BLOB
@@ -808,16 +810,11 @@ def recover_cells_and_kzg_proofs(
     for cell in cells:
         assert len(cell) == BYTES_PER_CELL
 
-    # Sort cell indices and cells together to ensure proper order
-    sorted_pairs = sorted(zip(cell_indices, cells), key=lambda x: x[0])
-    sorted_cell_indices = [pair[0] for pair in sorted_pairs]
-    sorted_cells = [pair[1] for pair in sorted_pairs]
-
     # Convert cells to coset evaluations
-    cosets_evals = [cell_to_coset_evals(cell) for cell in sorted_cells]
+    cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
 
     # Given the coset evaluations, recover the polynomial in coefficient form
-    polynomial_coeff = recover_polynomialcoeff(sorted_cell_indices, cosets_evals)
+    polynomial_coeff = recover_polynomialcoeff(cell_indices, cosets_evals)
 
     # Recompute all cells/proofs
     return compute_cells_and_kzg_proofs_polynomialcoeff(polynomial_coeff)

--- a/specs/fulu/polynomial-commitments-sampling.md
+++ b/specs/fulu/polynomial-commitments-sampling.md
@@ -808,11 +808,16 @@ def recover_cells_and_kzg_proofs(
     for cell in cells:
         assert len(cell) == BYTES_PER_CELL
 
+    # Sort cell indices and cells together to ensure proper order
+    sorted_pairs = sorted(zip(cell_indices, cells), key=lambda x: x[0])
+    sorted_cell_indices = [pair[0] for pair in sorted_pairs]
+    sorted_cells = [pair[1] for pair in sorted_pairs]
+
     # Convert cells to coset evaluations
-    cosets_evals = [cell_to_coset_evals(cell) for cell in cells]
+    cosets_evals = [cell_to_coset_evals(cell) for cell in sorted_cells]
 
     # Given the coset evaluations, recover the polynomial in coefficient form
-    polynomial_coeff = recover_polynomialcoeff(cell_indices, cosets_evals)
+    polynomial_coeff = recover_polynomialcoeff(sorted_cell_indices, cosets_evals)
 
     # Recompute all cells/proofs
     return compute_cells_and_kzg_proofs_polynomialcoeff(polynomial_coeff)

--- a/tests/core/pyspec/eth2spec/test/fulu/unittests/das/test_das.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/unittests/das/test_das.py
@@ -62,8 +62,8 @@ def test_recover_matrix(spec):
     # Construct a matrix with some entries missing
     partial_matrix = []
     for blob_entries in chunks(matrix, spec.CELLS_PER_EXT_BLOB):
-        rng.shuffle(blob_entries)
-        partial_matrix.extend(blob_entries[:N_SAMPLES])
+        indices = sorted(rng.sample(range(len(blob_entries)), N_SAMPLES))
+        partial_matrix.extend([blob_entries[i] for i in indices])
 
     # Given the partial matrix, recover the missing entries
     recovered_matrix = spec.recover_matrix(partial_matrix, blob_count)

--- a/tests/core/pyspec/eth2spec/test/fulu/unittests/polynomial_commitments/test_polynomial_commitments.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/unittests/polynomial_commitments/test_polynomial_commitments.py
@@ -237,23 +237,15 @@ def test_verify_cell_kzg_proof_batch_invalid(spec):
 def test_recover_cells_and_kzg_proofs(spec):
     rng = random.Random(5566)
 
-    # Number of samples we will be recovering from
-    N_SAMPLES = spec.CELLS_PER_EXT_BLOB // 2
-
     # Get the data we will be working with
     blob = get_sample_blob(spec)
 
     # Extend data with Reed-Solomon and split the extended data in cells
     cells, proofs = spec.compute_cells_and_kzg_proofs(blob)
 
-    # Compute the cells we will be recovering from
-    cell_indices = []
-    # First figure out just the indices of the cells
-    for i in range(N_SAMPLES):
-        j = rng.randint(0, spec.CELLS_PER_EXT_BLOB - 1)
-        while j in cell_indices:
-            j = rng.randint(0, spec.CELLS_PER_EXT_BLOB - 1)
-        cell_indices.append(j)
+    # Compute the cells we will be recovering from (50% available)
+    cell_indices = sorted(rng.sample(range(spec.CELLS_PER_EXT_BLOB), spec.CELLS_PER_EXT_BLOB // 2))
+
     # Now the cells themselves
     known_cells = [cells[cell_index] for cell_index in cell_indices]
 

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -495,38 +495,6 @@ def case_recover_cells_and_kzg_proofs():
             get_test_runner(get_inputs),
         )
 
-    # Valid: Shuffled indices, no missing cells
-    if True:
-
-        def get_inputs():
-            cells, _ = cached_compute_cells_and_kzg_proofs(VALID_BLOBS[4])
-            cell_indices = list(range(spec.CELLS_PER_EXT_BLOB))
-            random.seed(42)  # Use fixed seed for reproducibility
-            random.shuffle(cell_indices)
-            partial_cells = [cells[cell_index] for cell_index in cell_indices]
-            return cell_indices, partial_cells
-
-        yield (
-            "recover_cells_and_kzg_proofs_case_valid_shuffled_no_missing",
-            get_test_runner(get_inputs),
-        )
-
-    # Valid: Shuffled indices, one missing
-    if True:
-
-        def get_inputs():
-            cells, _ = cached_compute_cells_and_kzg_proofs(VALID_BLOBS[5])
-            cell_indices = list(range(spec.CELLS_PER_EXT_BLOB - 1))
-            random.seed(42)  # Use fixed seed for reproducibility
-            random.shuffle(cell_indices)
-            partial_cells = [cells[cell_index] for cell_index in cell_indices]
-            return cell_indices, partial_cells
-
-        yield (
-            "recover_cells_and_kzg_proofs_case_valid_shuffled_one_missing",
-            get_test_runner(get_inputs),
-        )
-
     # Edge case: All cells are missing
     if True:
 
@@ -642,6 +610,38 @@ def case_recover_cells_and_kzg_proofs():
 
         yield (
             "recover_cells_and_kzg_proofs_case_invalid_duplicate_cell_index",
+            get_test_runner(get_inputs),
+        )
+
+    # Edge case: Shuffled indices, no missing cells
+    if True:
+
+        def get_inputs():
+            cells, _ = cached_compute_cells_and_kzg_proofs(VALID_BLOBS[4])
+            cell_indices = list(range(spec.CELLS_PER_EXT_BLOB))
+            random.seed(42)  # Use fixed seed for reproducibility
+            random.shuffle(cell_indices)
+            all_cells = [cells[cell_index] for cell_index in cell_indices]
+            return cell_indices, all_cells
+
+        yield (
+            "recover_cells_and_kzg_proofs_case_invalid_shuffled_no_missing",
+            get_test_runner(get_inputs),
+        )
+
+    # Edge case: Shuffled indices, one missing
+    if True:
+
+        def get_inputs():
+            cells, _ = cached_compute_cells_and_kzg_proofs(VALID_BLOBS[5])
+            cell_indices = list(range(spec.CELLS_PER_EXT_BLOB - 1))
+            random.seed(42)  # Use fixed seed for reproducibility
+            random.shuffle(cell_indices)
+            partial_cells = [cells[cell_index] for cell_index in cell_indices]
+            return cell_indices, partial_cells
+
+        yield (
+            "recover_cells_and_kzg_proofs_case_invalid_shuffled_one_missing",
             get_test_runner(get_inputs),
         )
 

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -613,7 +613,7 @@ def case_recover_cells_and_kzg_proofs():
             get_test_runner(get_inputs),
         )
 
-    # Edge case: Shuffled indices, no missing cells
+    # Edge case: Shuffled indices, no missing
     if True:
 
         def get_inputs():
@@ -642,6 +642,22 @@ def case_recover_cells_and_kzg_proofs():
 
         yield (
             "recover_cells_and_kzg_proofs_case_invalid_shuffled_one_missing",
+            get_test_runner(get_inputs),
+        )
+
+    # Edge case: Shuffled indices, half missing
+    if True:
+
+        def get_inputs():
+            cells, _ = cached_compute_cells_and_kzg_proofs(VALID_BLOBS[5])
+            cell_indices = list(range(spec.CELLS_PER_EXT_BLOB // 2))
+            random.seed(42)  # Use fixed seed for reproducibility
+            random.shuffle(cell_indices)
+            partial_cells = [cells[cell_index] for cell_index in cell_indices]
+            return cell_indices, partial_cells
+
+        yield (
+            "recover_cells_and_kzg_proofs_case_invalid_shuffled_half_missing",
             get_test_runner(get_inputs),
         )
 

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -2,6 +2,7 @@
 KZG test vectors generator for EIP-7594
 """
 
+import random
 from collections.abc import Iterable
 from functools import cache
 
@@ -491,6 +492,38 @@ def case_recover_cells_and_kzg_proofs():
 
         yield (
             "recover_cells_and_kzg_proofs_case_valid_half_missing_second_half",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Shuffled indices, no missing cells
+    if True:
+
+        def get_inputs():
+            cells, _ = cached_compute_cells_and_kzg_proofs(VALID_BLOBS[4])
+            cell_indices = list(range(spec.CELLS_PER_EXT_BLOB))
+            random.seed(42)  # Use fixed seed for reproducibility
+            random.shuffle(cell_indices)
+            partial_cells = [cells[cell_index] for cell_index in cell_indices]
+            return cell_indices, partial_cells
+
+        yield (
+            "recover_cells_and_kzg_proofs_case_valid_shuffled_no_missing",
+            get_test_runner(get_inputs),
+        )
+
+    # Valid: Shuffled indices, one missing
+    if True:
+
+        def get_inputs():
+            cells, _ = cached_compute_cells_and_kzg_proofs(VALID_BLOBS[5])
+            cell_indices = list(range(spec.CELLS_PER_EXT_BLOB - 1))
+            random.seed(42)  # Use fixed seed for reproducibility
+            random.shuffle(cell_indices)
+            partial_cells = [cells[cell_index] for cell_index in cell_indices]
+            return cell_indices, partial_cells
+
+        yield (
+            "recover_cells_and_kzg_proofs_case_valid_shuffled_one_missing",
             get_test_runner(get_inputs),
         )
 


### PR DESCRIPTION
<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What this PR does (but not how it does it)
* Why this PR is necessary, including context
-->

This PR rejects shuffled inputs (cell indices & cells) that are provided to `recover_cells_and_kzg_proofs`. Previously, we assumed that the inputs were in the correct order; now we enforce it. I've added two reference tests to ensure implementations handle this situation appropriately.

<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->

Thanks to @asanso for pointing this out.
