### PR TITLE
Enforce blob schedule entry's epoch to be post-fulu

### DIFF
--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -42,9 +42,10 @@ and is under active development.
 for a given epoch.
 
 There MUST NOT exist multiple blob schedule entries with the same epoch value.
-The maximum blobs per block limit for blob schedules entries MUST be less than
-or equal to `MAX_BLOB_COMMITMENTS_PER_BLOCK`. The blob schedule entries SHOULD
-be sorted by epoch in ascending order. The blob schedule MAY be empty.
+Epoch value of each entry MUST be greater or equal than `FULU_FORK_EPOCH`. The
+maximum blobs per block limit for blob schedules entries MUST be less than or
+equal to `MAX_BLOB_COMMITMENTS_PER_BLOCK`. The blob schedule entries SHOULD be
+sorted by epoch in ascending order. The blob schedule MAY be empty.
 
 *Note*: The blob schedule is to be determined.
 

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -42,10 +42,10 @@ and is under active development.
 for a given epoch.
 
 There MUST NOT exist multiple blob schedule entries with the same epoch value.
-Epoch value of each entry MUST be greater or equal than `FULU_FORK_EPOCH`. The
-maximum blobs per block limit for blob schedules entries MUST be less than or
-equal to `MAX_BLOB_COMMITMENTS_PER_BLOCK`. The blob schedule entries SHOULD be
-sorted by epoch in ascending order. The blob schedule MAY be empty.
+Epoch value of each entry MUST be greater than or equal to `FULU_FORK_EPOCH`.
+The maximum blobs per block limit for blob schedules entries MUST be less than
+or equal to `MAX_BLOB_COMMITMENTS_PER_BLOCK`. The blob schedule entries SHOULD
+be sorted by epoch in ascending order. The blob schedule MAY be empty.
 
 *Note*: The blob schedule is to be determined.
 


### PR DESCRIPTION
Not sure if this is relevant.

I think so far we have assumed entries in the blob schedule to be post-fulu but I just realize there is no enforcement of it in the spec. 

Adding requirement of blob schedule entry's epoch to be greater than or equal to `FULU_FORK_EPOCH`