### PR TITLE
Fix some typo / grammatical errors in Fulu specs

### DIFF
--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -42,7 +42,7 @@ and is under active development.
 for a given epoch.
 
 There MUST NOT exist multiple blob schedule entries with the same epoch value.
-The maximum blobs per block limit for blob schedules entries MUST be less than
+The maximum blobs per block limit for blob schedule entries MUST be less than
 or equal to `MAX_BLOB_COMMITMENTS_PER_BLOCK`. The blob schedule entries SHOULD
 be sorted by epoch in ascending order. The blob schedule MAY be empty.
 

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -42,9 +42,9 @@ and is under active development.
 for a given epoch.
 
 There MUST NOT exist multiple blob schedule entries with the same epoch value.
-The maximum blobs per block limit for blob schedule entries MUST be less than
-or equal to `MAX_BLOB_COMMITMENTS_PER_BLOCK`. The blob schedule entries SHOULD
-be sorted by epoch in ascending order. The blob schedule MAY be empty.
+The maximum blobs per block limit for blob schedule entries MUST be less than or
+equal to `MAX_BLOB_COMMITMENTS_PER_BLOCK`. The blob schedule entries SHOULD be
+sorted by epoch in ascending order. The blob schedule MAY be empty.
 
 *Note*: The blob schedule is to be determined.
 

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -281,7 +281,7 @@ are they sent in aggregate forms.
 
 ### Why don't nodes custody rows?
 
-In the one-dimension construction, a node samples the peers by requesting the
+In the one-dimensional construction, a node samples the peers by requesting the
 whole `DataColumnSidecar`. In reconstruction, a node can reconstruct all the
 blobs by 50% of the columns. Note that nodes can still download the row via
 `blob_sidecar_{subnet_id}` subnets.

--- a/specs/fulu/fork.md
+++ b/specs/fulu/fork.md
@@ -18,7 +18,7 @@
 
 ## Introduction
 
-This document describes the process of Fulu upgrade.
+This document describes the process of the Fulu upgrade.
 
 ## Configuration
 

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -581,7 +581,7 @@ regardless of whether it is a regular or a Blob-Parameters-Only fork. This new
 entry MUST be added once `FULU_FORK_EPOCH` is assigned any value other than
 `FAR_FUTURE_EPOCH`. Adding this entry prior to the Fulu fork will not impact
 peering as nodes will ignore unknown ENR entries and `nfd` mismatches do not
-cause disconnnects.
+cause disconnects.
 
 If no next fork is scheduled, the `nfd` entry contains the default value for the
 type (i.e., the SSZ representation of a zero-filled array).


### PR DESCRIPTION
This PR fixes a few typos and grammatical errors within the Fulu specs folder.