### PR TITLE
Add parent block hash verification to Gloas execution payload processing

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -1253,6 +1253,8 @@ def process_execution_payload(
     assert committed_header.gas_limit == payload.gas_limit
     # Verify the block hash
     assert committed_header.block_hash == payload.block_hash
+    # Verify the parent block hash
+    assert committed_header.parent_block_hash == payload.parent_hash
     # Verify consistency of the parent hash with respect to the previous execution payload
     assert payload.parent_hash == state.latest_block_hash
     # Verify prev_randao


### PR DESCRIPTION
This PR adds parent block hash check to `process_execution_payload` such that `committed_header` in state align with `payload`. We also add a spec test case