### PR TITLE
Add central `get_duration_ms` function with identifiers

### DIFF
--- a/specs/_features/eip7805/p2p-interface.md
+++ b/specs/_features/eip7805/p2p-interface.md
@@ -80,8 +80,7 @@ the network, assuming the alias `message = signed_inclusion_list.message`:
 - _[REJECT]_ The slot `message.slot` is equal to the previous or current slot.
 - _[IGNORE]_ The slot `message.slot` is equal to the current slot, or it is
   equal to the previous slot and the current time is less than
-  `get_slot_component_duration_ms(ATTESTATION_DUE_BPS)` milliseconds into the
-  slot.
+  `get_duration_ms(DURATION_ID_ATTESTATION_DUE)` milliseconds into the slot.
 - _[IGNORE]_ The `inclusion_list_committee` for slot `message.slot` on the
   current branch corresponds to `message.inclusion_list_committee_root`, as
   determined by

--- a/specs/_features/eip7805/validator.md
+++ b/specs/_features/eip7805/validator.md
@@ -148,8 +148,8 @@ processed through any empty slots up to the assigned slot using
 
 *Note*: A proposer should produce an execution payload that satisfies the
 inclusion list constraints with respect to the inclusion lists gathered up to
-`get_slot_component_duration_ms(PROPOSER_INCLUSION_LIST_CUTOFF_BPS)`
-milliseconds into the slot.
+`get_duration_ms(DURATION_ID_PROPOSER_INCLUSION_LIST_CUTOFF)` milliseconds into
+the slot.
 
 ```python
 def prepare_execution_payload(
@@ -197,14 +197,14 @@ of any `slot` for which
 
 If a validator is in the current inclusion list committee, the validator should
 create and broadcast the `signed_inclusion_list` to the global `inclusion_list`
-subnet by `get_slot_component_duration_ms(INCLUSION_LIST_SUBMISSION_DUE_BPS)`
+subnet by `get_duration_ms(DURATION_ID_INCLUSION_LIST_SUBMISSION_DUE)`
 milliseconds into the slot after processing the block for the current slot and
 confirming it as the head. If no block is received by
-`get_slot_component_duration_ms(INCLUSION_LIST_SUBMISSION_DUE_BPS) - 1000`
-milliseconds into the slot, the validator should run `get_head` to determine the
-local head and construct and broadcast the inclusion list based on this local
-head by `get_slot_component_duration_ms(INCLUSION_LIST_SUBMISSION_DUE_BPS)`
-milliseconds into the slot.
+`get_duration_ms(DURATION_ID_INCLUSION_LIST_SUBMISSION_DUE) - 1000` milliseconds
+into the slot, the validator should run `get_head` to determine the local head
+and construct and broadcast the inclusion list based on this local head by
+`get_duration_ms(DURATION_ID_INCLUSION_LIST_SUBMISSION_DUE)` milliseconds into
+the slot.
 
 #### Constructing the `SignedInclusionList`
 

--- a/specs/altair/fork-choice.md
+++ b/specs/altair/fork-choice.md
@@ -1,0 +1,52 @@
+# Altair -- Beacon Chain Fork Choice
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
+
+- [Introduction](#introduction)
+- [Fork choice](#fork-choice)
+  - [Constants](#constants)
+    - [Duration identifiers](#duration-identifiers)
+  - [Helpers](#helpers)
+    - [Modified `get_duration_ms`](#modified-get_duration_ms)
+
+<!-- mdformat-toc end -->
+
+## Introduction
+
+This is the modification of the fork choice according to the Altair upgrade.
+
+Unless stated explicitly, all prior functionality from
+[Phase 0](../phase0/fork-choice.md) is inherited.
+
+## Fork choice
+
+### Constants
+
+#### Duration identifiers
+
+| Name                           | Value           |
+| ------------------------------ | --------------- |
+| `DURATION_ID_SYNC_MESSAGE_DUE` | `DurationId(4)` |
+| `DURATION_ID_CONTRIBUTION_DUE` | `DurationId(5)` |
+
+### Helpers
+
+#### Modified `get_duration_ms`
+
+```python
+def get_duration_ms(duration_id: DurationId) -> uint64:
+    if duration_id == DURATION_ID_SLOT:
+        return SLOT_DURATION_MS
+    elif duration_id == DURATION_ID_PROPOSER_REORG_CUTOFF:
+        return get_slot_component_duration_ms(PROPOSER_REORG_CUTOFF_BPS)
+    elif duration_id == DURATION_ID_ATTESTATION_DUE:
+        return get_slot_component_duration_ms(ATTESTATION_DUE_BPS)
+    elif duration_id == DURATION_ID_AGGREGATE_DUE:
+        return get_slot_component_duration_ms(AGGREGATE_DUE_BPS)
+    # [New in Altair]
+    elif duration_id == DURATION_ID_SYNC_MESSAGE_DUE:
+        return get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS)
+    # [New in Altair]
+    elif duration_id == DURATION_ID_CONTRIBUTION_DUE:
+        return get_slot_component_duration_ms(CONTRIBUTION_DUE_BPS)
+```

--- a/specs/altair/light-client/p2p-interface.md
+++ b/specs/altair/light-client/p2p-interface.md
@@ -64,7 +64,7 @@ the network.
   `finality_update` for that slot did not indicate supermajority
 - _[IGNORE]_ The `finality_update` is received after the block at
   `signature_slot` was given enough time to propagate through the network --
-  i.e. validatate that `get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS)`
+  i.e. validatate that `get_duration_ms(DURATION_ID_SYNC_MESSAGE_DUE)`
   milliseconds (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) has
   transpired since the start of `signature_slot`.
 
@@ -111,7 +111,7 @@ the network.
   previously forwarded `optimistic_update`s
 - _[IGNORE]_ The `optimistic_update` is received after the block at
   `signature_slot` was given enough time to propagate through the network --
-  i.e. validatate that `get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS)`
+  i.e. validatate that `get_duration_ms(DURATION_ID_SYNC_MESSAGE_DUE)`
   milliseconds (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) has
   transpired since the start of `optimistic_update.signature_slot`.
 
@@ -370,8 +370,8 @@ follows:
   no matching message has not yet been forwarded as part of gossip validation.
 
 These messages SHOULD be broadcasted
-`get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS)` milliseconds after the
-start of the slot. To ensure that the corresponding block was given enough time
-to propagate through the network, they SHOULD NOT be sent earlier. Note that
-this is different from how other messages are handled, e.g., attestations, which
-may be sent early.
+`get_duration_ms(DURATION_ID_SYNC_MESSAGE_DUE)` milliseconds after the start of
+the slot. To ensure that the corresponding block was given enough time to
+propagate through the network, they SHOULD NOT be sent earlier. Note that this
+is different from how other messages are handled, e.g., attestations, which may
+be sent early.

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -332,8 +332,8 @@ This logic is triggered upon the same conditions as when producing an
 attestation. Meaning, a sync committee member should produce and broadcast a
 `SyncCommitteeMessage` either when (a) the validator has received a valid block
 from the expected block proposer for the current `slot` or (b)
-`get_slot_component_duration_ms(SYNC_MESSAGE_DUE_BPS)` milliseconds has
-transpired since the start of the slot -- whichever comes first.
+`get_duration_ms(DURATION_ID_SYNC_MESSAGE_DUE)` milliseconds has transpired
+since the start of the slot -- whichever comes first.
 
 `get_sync_committee_message(state, block_root, validator_index, privkey)`
 assumes the parameter `state` is the head state corresponding to processing the
@@ -511,8 +511,7 @@ if one validator maps to multiple indices within the subcommittee.
 If the validator is selected to aggregate (`is_sync_committee_aggregator()`),
 then they broadcast their best aggregate as a `SignedContributionAndProof` to
 the global aggregate channel (`sync_committee_contribution_and_proof` topic)
-`get_slot_component_duration_ms(CONTRIBUTION_DUE_BPS)` milliseconds into the
-slot.
+`get_duration_ms(DURATION_ID_CONTRIBUTION_DUE)` milliseconds into the slot.
 
 Selection proofs are provided in `ContributionAndProof` to prove to the gossip
 channel that the validator has been selected as an aggregator.

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -308,7 +308,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Add block timeliness to the store
     seconds_since_genesis = store.time - store.genesis_time
     time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-    attestation_threshold_ms = get_slot_component_duration_ms(ATTESTATION_DUE_BPS)
+    attestation_threshold_ms = get_duration_ms(DURATION_ID_ATTESTATION_DUE)
     is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
     is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
     store.block_timeliness[hash_tree_root(block)] = is_timely

--- a/specs/capella/fork-choice.md
+++ b/specs/capella/fork-choice.md
@@ -102,7 +102,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Add block timeliness to the store
     seconds_since_genesis = store.time - store.genesis_time
     time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-    attestation_threshold_ms = get_slot_component_duration_ms(ATTESTATION_DUE_BPS)
+    attestation_threshold_ms = get_duration_ms(DURATION_ID_ATTESTATION_DUE)
     is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
     is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
     store.block_timeliness[hash_tree_root(block)] = is_timely

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -111,7 +111,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Add block timeliness to the store
     seconds_since_genesis = store.time - store.genesis_time
     time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-    attestation_threshold_ms = get_slot_component_duration_ms(ATTESTATION_DUE_BPS)
+    attestation_threshold_ms = get_duration_ms(DURATION_ID_ATTESTATION_DUE)
     is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
     is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
     store.block_timeliness[hash_tree_root(block)] = is_timely

--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -83,7 +83,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Add block timeliness to the store
     seconds_since_genesis = store.time - store.genesis_time
     time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-    attestation_threshold_ms = get_slot_component_duration_ms(ATTESTATION_DUE_BPS)
+    attestation_threshold_ms = get_duration_ms(DURATION_ID_ATTESTATION_DUE)
     is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
     is_timely = get_current_slot(store) == block.slot and is_before_attesting_interval
     store.block_timeliness[hash_tree_root(block)] = is_timely

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -83,9 +83,8 @@ All validator responsibilities remain unchanged other than the following:
   becomes a builder's duty.
 - Some validators are selected per slot to become PTC members, these validators
   must broadcast `PayloadAttestationMessage` objects during the assigned slot
-  before the deadline of
-  `get_slot_component_duration_ms(PAYLOAD_ATTESTATION_DUE_BPS)` milliseconds
-  into the slot.
+  before the deadline of `get_duration_ms(PAYLOAD_ATTESTATION_DUE_BPS)`
+  milliseconds into the slot.
 
 ### Attestation
 
@@ -166,8 +165,8 @@ prepared to submit their PTC attestations during the next epoch.
 
 A validator should create and broadcast the `payload_attestation_message` to the
 global execution attestation subnet not after
-`get_slot_component_duration_ms(PAYLOAD_ATTESTATION_DUE_BPS)` milliseconds since
-the start of `slot`.
+`get_duration_ms(PAYLOAD_ATTESTATION_DUE_BPS)` milliseconds since the start of
+`slot`.
 
 #### Constructing a payload attestation
 
@@ -175,8 +174,8 @@ If a validator is in the payload attestation committee for the current slot (as
 obtained from `get_ptc_assignment` above) then the validator should prepare a
 `PayloadAttestationMessage` for the current slot, according to the logic in
 `get_payload_attestation_message` below and broadcast it not after
-`get_slot_component_duration_ms(PAYLOAD_ATTESTATION_DUE_BPS)` milliseconds since
-the start of the slot, to the global `payload_attestation_message` pubsub topic.
+`get_duration_ms(PAYLOAD_ATTESTATION_DUE_BPS)` milliseconds since the start of
+the slot, to the global `payload_attestation_message` pubsub topic.
 
 The validator creates `payload_attestation_message` as follows:
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -611,8 +611,8 @@ validator performs this role during an epoch are defined by
 A validator should create and broadcast the `attestation` to the associated
 attestation subnet when either (a) the validator has received a valid block from
 the expected block proposer for the assigned `slot` or (b)
-`get_slot_component_duration_ms(ATTESTATION_DUE_BPS)` milliseconds has
-transpired since the start of the slot -- whichever comes first.
+`get_duration_ms(DURATION_ID_ATTESTATION_DUE)` milliseconds has transpired since
+the start of the slot -- whichever comes first.
 
 *Note*: Although attestations during `GENESIS_EPOCH` do not count toward FFG
 finality, these initial attestations do give weight to the fork choice, are
@@ -777,7 +777,7 @@ def get_aggregate_signature(attestations: Sequence[Attestation]) -> BLSSignature
 If the validator is selected to aggregate (`is_aggregator`), then they broadcast
 their best aggregate as a `SignedAggregateAndProof` to the global aggregate
 channel (`beacon_aggregate_and_proof`)
-`get_slot_component_duration_ms(AGGREGATE_DUE_BPS)` milliseconds into the slot.
+`get_duration_ms(DURATION_ID_ATTESTATION_DUE)` milliseconds into the slot.
 
 Selection proofs are provided in `AggregateAndProof` to prove to the gossip
 channel that the validator has been selected as an aggregator.

--- a/tests/core/pyspec/eth2spec/test/bellatrix/fork_choice/test_should_override_forkchoice_update.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/fork_choice/test_should_override_forkchoice_update.py
@@ -126,7 +126,7 @@ def test_should_override_forkchoice_update__true(spec, state):
 
     # Make the head block late
     # Round up to nearest second
-    attestation_due_ms = spec.get_slot_component_duration_ms(spec.config.ATTESTATION_DUE_BPS)
+    attestation_due_ms = spec.get_duration_ms(spec.DURATION_ID_ATTESTATION_DUE)
     attesting_cutoff = (attestation_due_ms + 999) // 1000
     current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time + attesting_cutoff
     on_tick_and_append_step(spec, store, current_time, test_steps)

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_proposer_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_proposer_head.py
@@ -121,7 +121,7 @@ def test_basic_is_parent_root(spec, state):
 
     # Make the head block late
     # Round up to nearest second
-    attestation_due_ms = spec.get_slot_component_duration_ms(spec.config.ATTESTATION_DUE_BPS)
+    attestation_due_ms = spec.get_duration_ms(spec.DURATION_ID_ATTESTATION_DUE)
     attesting_cutoff = (attestation_due_ms + 999) // 1000
     current_time = state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time + attesting_cutoff
     on_tick_and_append_step(spec, store, current_time, test_steps)

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
@@ -512,12 +512,7 @@ def test_proposer_boost(spec, state):
 
     # Process block on timely arrival just before end of boost interval
     # Round up to nearest second
-    if is_post_gloas(spec):
-        late_block_cutoff_ms = spec.get_slot_component_duration_ms(
-            spec.config.ATTESTATION_DUE_BPS_GLOAS
-        )
-    else:
-        late_block_cutoff_ms = spec.get_slot_component_duration_ms(spec.config.ATTESTATION_DUE_BPS)
+    late_block_cutoff_ms = spec.get_duration_ms(spec.DURATION_ID_ATTESTATION_DUE)
     late_block_cutoff = (late_block_cutoff_ms + 999) // 1000
     time = store.genesis_time + block.slot * spec.config.SECONDS_PER_SLOT + late_block_cutoff - 1
 
@@ -617,12 +612,7 @@ def test_proposer_boost_root_same_slot_untimely_block(spec, state):
 
     # Process block on untimely arrival in the same slot
     # Round up to nearest second
-    if is_post_gloas(spec):
-        late_block_cutoff_ms = spec.get_slot_component_duration_ms(
-            spec.config.ATTESTATION_DUE_BPS_GLOAS
-        )
-    else:
-        late_block_cutoff_ms = spec.get_slot_component_duration_ms(spec.config.ATTESTATION_DUE_BPS)
+    late_block_cutoff_ms = spec.get_duration_ms(spec.DURATION_ID_ATTESTATION_DUE)
     late_block_cutoff = (late_block_cutoff_ms + 999) // 1000
     time = store.genesis_time + block.slot * spec.config.SECONDS_PER_SLOT + late_block_cutoff
 
@@ -663,12 +653,7 @@ def test_proposer_boost_is_first_block(spec, state):
 
     # Process block on timely arrival just before end of boost interval
     # Round up to nearest second
-    if is_post_gloas(spec):
-        late_block_cutoff_ms = spec.get_slot_component_duration_ms(
-            spec.config.ATTESTATION_DUE_BPS_GLOAS
-        )
-    else:
-        late_block_cutoff_ms = spec.get_slot_component_duration_ms(spec.config.ATTESTATION_DUE_BPS)
+    late_block_cutoff_ms = spec.get_duration_ms(spec.DURATION_ID_ATTESTATION_DUE)
     late_block_cutoff = (late_block_cutoff_ms + 999) // 1000
     time = store.genesis_time + block_a.slot * spec.config.SECONDS_PER_SLOT + late_block_cutoff - 1
 


### PR DESCRIPTION
This PR adds a new `get_duration_ms` function to phase0 which essentially contains a switch block with all possible durations. Along with the new function, there are new `DURATION_ID_*` constants. The idea here is that it will make reducing slot times in the future simpler in both the specifications and client implementations. Initially, I was against this suggestion but I have been convinced of its value. This was a suggestion from @dankrad here:

* https://github.com/ethereum/consensus-specs/pull/4476#discussion_r2250199464
