### PR TITLE
fix: correct Bellatrix ExecutionPayload comment

### DIFF
--- a/specs/capella/light-client/full-node.md
+++ b/specs/capella/light-client/full-node.md
@@ -45,7 +45,7 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
         )
     else:
         # Note that during fork transitions, `finalized_header` may still point to earlier forks.
-        # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_root`),
+        # While Bellatrix blocks also contain an `ExecutionPayload` (without withdrawals field),
         # it was not included in the corresponding light client data. To ensure compatibility
         # with legacy data going through `upgrade_lc_header_to_capella`, leave out execution data.
         execution_header = ExecutionPayloadHeader()

--- a/specs/deneb/light-client/full-node.md
+++ b/specs/deneb/light-client/full-node.md
@@ -50,7 +50,7 @@ def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
         )
     else:
         # Note that during fork transitions, `finalized_header` may still point to earlier forks.
-        # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_root`),
+        # While Bellatrix blocks also contain an `ExecutionPayload` (without withdrawals field),
         # it was not included in the corresponding light client data. To ensure compatibility
         # with legacy data going through `upgrade_lc_header_to_capella`, leave out execution data.
         execution_header = ExecutionPayloadHeader()


### PR DESCRIPTION
Fix inaccurate comment about Bellatrix ExecutionPayload structure

Changed "(minus `withdrawals_root`)" to "(without withdrawals field)" in light client specs.

Bellatrix ExecutionPayload never had withdrawals field - it was added in Capella.
