### PR TITLE
Enable payload attestation tests for mainnet

### DIFF
--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_payload_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_payload_attestation.py
@@ -2,9 +2,7 @@ from eth2spec.test.context import (
     always_bls,
     spec_state_test,
     with_gloas_and_later,
-    with_presets,
 )
-from eth2spec.test.helpers.constants import MINIMAL
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.utils.ssz.ssz_typing import Bitvector
 
@@ -109,7 +107,6 @@ def prepare_signed_payload_attestation(
 @with_gloas_and_later
 @spec_state_test
 @always_bls
-@with_presets([MINIMAL], reason="broken on mainnet")
 def test_process_payload_attestation_payload_present(spec, state):
     """
     Test basic valid payload attestation processing
@@ -124,7 +121,6 @@ def test_process_payload_attestation_payload_present(spec, state):
 @with_gloas_and_later
 @spec_state_test
 @always_bls
-@with_presets([MINIMAL], reason="broken on mainnet")
 def test_process_payload_attestation_payload_not_present(spec, state):
     """
     Test valid payload attestation indicating payload was not present
@@ -139,7 +135,6 @@ def test_process_payload_attestation_payload_not_present(spec, state):
 @with_gloas_and_later
 @spec_state_test
 @always_bls
-@with_presets([MINIMAL], reason="broken on mainnet")
 def test_process_payload_attestation_partial_participation(spec, state):
     """
     Test valid payload attestation with only some PTC members participating
@@ -164,7 +159,6 @@ def test_process_payload_attestation_partial_participation(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
-@with_presets([MINIMAL], reason="maybe broken on mainnet")
 def test_process_payload_attestation_invalid_beacon_block_root(spec, state):
     """
     Test payload attestation with wrong beacon block root fails
@@ -186,7 +180,6 @@ def test_process_payload_attestation_invalid_beacon_block_root(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
-@with_presets([MINIMAL], reason="maybe broken on mainnet")
 def test_process_payload_attestation_future_slot(spec, state):
     """
     Test payload attestation for future slot fails
@@ -201,7 +194,6 @@ def test_process_payload_attestation_future_slot(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
-@with_presets([MINIMAL], reason="maybe broken on mainnet")
 def test_process_payload_attestation_too_old_slot(spec, state):
     """
     Test payload attestation for slot too far in the past fails
@@ -217,7 +209,6 @@ def test_process_payload_attestation_too_old_slot(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
-@with_presets([MINIMAL], reason="maybe broken on mainnet")
 def test_process_payload_attestation_invalid_signature(spec, state):
     """
     Test payload attestation with invalid signature fails
@@ -232,7 +223,6 @@ def test_process_payload_attestation_invalid_signature(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
-@with_presets([MINIMAL], reason="maybe broken on mainnet")
 def test_process_payload_attestation_no_attesting_indices(spec, state):
     """
     Test payload attestation with no attesting indices fails


### PR DESCRIPTION
Tests was disabled as part of https://github.com/ethereum/consensus-specs/pull/4495
but they should be fixed by https://github.com/ethereum/consensus-specs/pull/4496
this PR re-enables payload attestation tests for mainnet