### PR TITLE
Do not run KZG compute challenge tests in the collection phase

### DIFF
--- a/tests/generators/runners/kzg_4844.py
+++ b/tests/generators/runners/kzg_4844.py
@@ -625,8 +625,9 @@ def case_verify_blob_kzg_proof_batch():
 
 
 def case_compute_challenge():
-    def get_test_runner(blob, commitment):
+    def get_test_runner(input_getter):
         def _runner():
+            blob, commitment = input_getter()
             try:
                 challenge = None
                 challenge = spec.compute_challenge(blob, commitment)
@@ -652,21 +653,31 @@ def case_compute_challenge():
 
     # Valid cases
     for index, blob in enumerate(VALID_BLOBS):
-        commitment = cached_blob_to_kzg_commitment(blob)
-        yield f"compute_challenge_case_valid_{index}", get_test_runner(blob, commitment)
+
+        def get_inputs(blob=blob):
+            commitment = cached_blob_to_kzg_commitment(blob)
+            return blob, commitment
+
+        yield f"compute_challenge_case_valid_{index}", get_test_runner(get_inputs)
 
     # Valid: Same blob with different commitments (incorrect, but valid format)
     if True:
-        blob = VALID_BLOBS[3]
-        # Use commitment from a different blob
-        commitment = cached_blob_to_kzg_commitment(VALID_BLOBS[4])
-        yield "compute_challenge_case_mismatched_commitment", get_test_runner(blob, commitment)
+
+        def get_inputs():
+            # Use commitment from a different blob
+            commitment = cached_blob_to_kzg_commitment(VALID_BLOBS[4])
+            return VALID_BLOBS[3], commitment
+
+        yield "compute_challenge_case_mismatched_commitment", get_test_runner(get_inputs)
 
     # Valid: G1_POINT_AT_INFINITY as commitment
     if True:
-        blob = VALID_BLOBS[4]
-        commitment = spec.G1_POINT_AT_INFINITY
-        yield "compute_challenge_case_commitment_at_infinity", get_test_runner(blob, commitment)
+
+        def get_inputs():
+            commitment = spec.G1_POINT_AT_INFINITY
+            return VALID_BLOBS[4], commitment
+
+        yield "compute_challenge_case_commitment_at_infinity", get_test_runner(get_inputs)
 
 
 ###############################################################################


### PR DESCRIPTION
The alpha.6 release stalled in the reference test generation step because of this. When adding these, I forgot to use an input getter function, so it was computing the blob's commitment in the test collection phase. For some reason, this caused latest usage of `arkworks_G1.multiexp_unchecked` to completely halt. I think it has something to do with mixing up Rust's `rayon` and Python's threading [here](https://github.com/crate-crypto/py-arkworks-bls12381/blob/ce5f2cedd53a3cf7e1f9e35921b2fbbf43d55674/src/wrapper.rs#L87).

<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->
