### PR TITLE
Clean up old references to make pyspec

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies to venv
-        run: make pyspec
+        run: make _pyspec
 
       - name: Build docs
         run: make _copy_docs

--- a/tests/README.md
+++ b/tests/README.md
@@ -382,8 +382,7 @@ processes the attestation and returns the result.
 
 Attestations can't happen in the same block as the one about which they are
 attesting, or in a block that is after the block is finalized. This is specified
-as part of the specs, in the `process_attestation` function (which is created
-from the spec by the `make pyspec` command you ran earlier). Here is the
+as part of the specs, in the `process_attestation` function. Here is the
 relevant code fragment:
 
 ```python

--- a/tests/generators/compliance_runners/fork_choice/README.md
+++ b/tests/generators/compliance_runners/fork_choice/README.md
@@ -15,49 +15,34 @@ with a minor exception (new check added).
 
 This work was supported by a grant from the Ethereum Foundation.
 
-# Pre-requisites
-
-Install pyspec using the top-level Makefile, this will install necessary
-pre-requiesites.
-
-```
-> make pyspec
-```
-
 # Generating tests
 
 From the root directory:
 
 ```
-> python -m tests.generators.compliance_runners.fork_choice.test_gen -o ${test_dir} --fc-gen-config ${config}
+make comptests fc_gen_config=<config>
 ```
 
-where `config` can be either: `tiny`, `small` or \`standard.
-
-Or specify path to the configuration file directly:
-
-```
-> python -m tests.generators.compliance_runners.fork_choice.test_gen -o ${test_dir} --fc-gen-config-path ${config_path}
-```
-
-There are three configurations in the repo: [tiny](tiny/), [small](small/) and
-[standard](standard/).
+where `config` can be either: [`tiny`](tiny/), [`small`](small/) or
+[`standard`](standard/).
 
 # Running tests
 
 From the root directory:
 
 ```
-> python -m tests.generators.compliance_runners.fork_choice.test_run -i ${test_dir}
+make _pyspec  # Initialize virtual environment
+python -m tests.generators.compliance_runners.fork_choice.test_run -i ${test_dir}
 ```
 
 # Generating configurations
 
-Files in [tiny](tiny/), [small](small/) and [standard](standard/) are generated
-with [generate_test_instances.py](generate_test_instances.py), e.g.
+Files in [`tiny`](tiny/), [`small`](small/) and [`standard`](standard/) are
+generated with [`generate_test_instances.py`](generate_test_instances.py), e.g.
 
 ```
-> python -m tests.generators.compliance_runners.fork_choice.generate_test_instances
+make _pyspec  # Initialize virtual environment
+python -m tests.generators.compliance_runners.fork_choice.generate_test_instances
 ```
 
 But one normally doesn't need to generate them.


### PR DESCRIPTION
As of #4548 the `make pyspec` command is no more. This PR cleans up some references to it that I missed.
