### PR TITLE
Fix `filter_block_tree` note to use `checkpoint.root`

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -331,7 +331,7 @@ def get_voting_source(store: Store, block_root: Root) -> Checkpoint:
 
 *Note*: External calls to `filter_block_tree` (i.e., any calls that are not made
 by the recursive logic in this function) MUST set `block_root` to
-`store.justified_checkpoint`.
+`store.justified_checkpoint.root`.
 
 ```python
 def filter_block_tree(store: Store, block_root: Root, blocks: Dict[Root, BeaconBlock]) -> bool:


### PR DESCRIPTION
Update doc note for external calls to filter_block_tree to specify block_root must be set to store.justified_checkpoint.root (was store.justified_checkpoint).