### PR TITLE
Enforce self build header signature to point of inf

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -949,10 +949,7 @@ def verify_execution_payload_header_signature(
 
 ```python
 def process_execution_payload_header(state: BeaconState, block: BeaconBlock) -> None:
-    # Verify the header signature
     signed_header = block.body.signed_execution_payload_header
-    assert verify_execution_payload_header_signature(state, signed_header)
-
     header = signed_header.message
     builder_index = header.builder_index
     builder = state.validators[builder_index]
@@ -962,9 +959,11 @@ def process_execution_payload_header(state: BeaconState, block: BeaconBlock) -> 
     # For self-builds, amount must be zero regardless of withdrawal credential prefix
     if builder_index == block.proposer_index:
         assert amount == 0
+        assert signed_header.signature == bls.G2_POINT_AT_INFINITY
     else:
         # Non-self builds require builder withdrawal credential
         assert has_builder_withdrawal_credential(builder)
+        assert verify_execution_payload_header_signature(state, signed_header)
 
     # Check that the builder is active, non-slashed, and has funds to cover the bid
     pending_payments = sum(

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -290,8 +290,11 @@ The following validations MUST pass before forwarding the
 - _[IGNORE]_ `header.parent_block_root` is the hash tree root of a known beacon
   block in fork choice.
 - _[IGNORE]_ `header.slot` is the current slot or the next slot.
-- _[REJECT]_ `signed_execution_payload_header.signature` is valid with respect
-  to the `header.builder_index`.
+- _[REJECT]_ `signed_execution_payload_header.signature` validation fails:
+  - For self-builds (when `header.builder_index == proposer_index`): signature
+    is not `bls.G2_POINT_AT_INFINITY`
+  - For external builds: signature is not valid with respect to the
+    `header.builder_index`
 
 ##### Attestation subnets
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -124,8 +124,10 @@ on top of a `state` must take the following actions:
   accepted `signed_execution_payload_header` from a builder. Proposer MAY obtain
   these signed messages by other off-protocol means.
 - The `signed_execution_payload_header` must satisfy the verification conditions
-  found in `process_execution_payload_header`, that is
-  - The header signature must be valid
+  found in `process_execution_payload_header`, that is:
+  - For external builders: The header signature must be valid
+  - For self-builds: The signature must be `bls.G2_POINT_AT_INFINITY` and the
+    bid amount must be zero
   - The builder balance can cover the header value
   - The header slot is for the proposal block slot
   - The header parent block hash equals the state's `latest_block_hash`.

--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload_header.py
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload_header.py
@@ -101,8 +101,15 @@ def prepare_signed_execution_payload_header(
     )
 
     if valid_signature:
-        privkey = privkeys[builder_index]
-        signature = spec.get_execution_payload_header_signature(state, header, privkey)
+        # Check if this is a self-build case
+        proposer_index = spec.get_beacon_proposer_index(state)
+        if builder_index == proposer_index:
+            # Self-builds must use G2_POINT_AT_INFINITY
+            signature = spec.bls.G2_POINT_AT_INFINITY
+        else:
+            # External builders use real signatures
+            privkey = privkeys[builder_index]
+            signature = spec.get_execution_payload_header_signature(state, header, privkey)
     else:
         # Invalid signature
         signature = spec.BLSSignature()


### PR DESCRIPTION
This PR enforces that signed self build's execution payload bid signatures to be point of inf. This decision was made during the EIP-7732 breakout:https://github.com/ethereum/pm/issues/1696. Teams generally agreed that this simplifies the beacon node and validator client workflow by removing an extra call and reducing server/client api implementations, while also eliminating the need for the beacon node to cache the payload through block proposing life cycle
