### PR TITLE
Simplify Electra light client specs

### DIFF
--- a/specs/electra/light-client/sync-protocol.md
+++ b/specs/electra/light-client/sync-protocol.md
@@ -11,15 +11,13 @@
   - [Modified `finalized_root_gindex_at_slot`](#modified-finalized_root_gindex_at_slot)
   - [Modified `current_sync_committee_gindex_at_slot`](#modified-current_sync_committee_gindex_at_slot)
   - [Modified `next_sync_committee_gindex_at_slot`](#modified-next_sync_committee_gindex_at_slot)
-  - [Modified `get_lc_execution_root`](#modified-get_lc_execution_root)
 
 <!-- mdformat-toc end -->
 
 ## Introduction
 
 This upgrade updates light client data to include the Electra changes to the
-[`ExecutionPayload`](../beacon-chain.md) structure and to the generalized
-indices of surrounding containers. It extends the
+generalized indices of [`BeaconState`](../beacon-chain.md). It extends the
 [Deneb Light Client specifications](../../deneb/light-client/sync-protocol.md).
 The [fork document](./fork.md) explains how to upgrade existing Deneb based
 deployments to Electra.
@@ -93,60 +91,4 @@ def next_sync_committee_gindex_at_slot(slot: Slot) -> GeneralizedIndex:
     if epoch >= ELECTRA_FORK_EPOCH:
         return NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA
     return NEXT_SYNC_COMMITTEE_GINDEX
-```
-
-### Modified `get_lc_execution_root`
-
-```python
-def get_lc_execution_root(header: LightClientHeader) -> Root:
-    epoch = compute_epoch_at_slot(header.beacon.slot)
-
-    # [New in Electra]
-    if epoch >= ELECTRA_FORK_EPOCH:
-        return hash_tree_root(header.execution)
-
-    # [Modified in Electra]
-    if epoch >= DENEB_FORK_EPOCH:
-        execution_header = deneb.ExecutionPayloadHeader(
-            parent_hash=header.execution.parent_hash,
-            fee_recipient=header.execution.fee_recipient,
-            state_root=header.execution.state_root,
-            receipts_root=header.execution.receipts_root,
-            logs_bloom=header.execution.logs_bloom,
-            prev_randao=header.execution.prev_randao,
-            block_number=header.execution.block_number,
-            gas_limit=header.execution.gas_limit,
-            gas_used=header.execution.gas_used,
-            timestamp=header.execution.timestamp,
-            extra_data=header.execution.extra_data,
-            base_fee_per_gas=header.execution.base_fee_per_gas,
-            block_hash=header.execution.block_hash,
-            transactions_root=header.execution.transactions_root,
-            withdrawals_root=header.execution.withdrawals_root,
-            blob_gas_used=header.execution.blob_gas_used,
-            excess_blob_gas=header.execution.excess_blob_gas,
-        )
-        return hash_tree_root(execution_header)
-
-    if epoch >= CAPELLA_FORK_EPOCH:
-        execution_header = capella.ExecutionPayloadHeader(
-            parent_hash=header.execution.parent_hash,
-            fee_recipient=header.execution.fee_recipient,
-            state_root=header.execution.state_root,
-            receipts_root=header.execution.receipts_root,
-            logs_bloom=header.execution.logs_bloom,
-            prev_randao=header.execution.prev_randao,
-            block_number=header.execution.block_number,
-            gas_limit=header.execution.gas_limit,
-            gas_used=header.execution.gas_used,
-            timestamp=header.execution.timestamp,
-            extra_data=header.execution.extra_data,
-            base_fee_per_gas=header.execution.base_fee_per_gas,
-            block_hash=header.execution.block_hash,
-            transactions_root=header.execution.transactions_root,
-            withdrawals_root=header.execution.withdrawals_root,
-        )
-        return hash_tree_root(execution_header)
-
-    return Root()
 ```


### PR DESCRIPTION
The `ExecutionPayload` changes never made it live, so we don't need to manually convert Deneb originated payloads back to the Deneb type to retrieve the historical `hash_tree_root`.
