### PR TITLE
Emit light client tests for Fulu

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/dumper.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/dumper.py
@@ -31,16 +31,17 @@ def get_cfg_yaml():
     cfg_yaml = YAML(pure=True)
     cfg_yaml.default_flow_style = False  # Emit separate line for each key
     cfg_yaml.width = 1024  # Do not wrap long lines
+    cfg_yaml.indent(mapping=2, sequence=4, offset=2)  # Indent BLOB_SCHEDULE
 
     def cfg_represent_bytes(self, data):
         return self.represent_int(encode_hex(data))
 
-    cfg_yaml.representer.add_representer(bytes, cfg_represent_bytes)
-
     def cfg_represent_quoted_str(self, data):
         return self.represent_scalar("tag:yaml.org,2002:str", data, style="'")
 
+    cfg_yaml.representer.add_representer(bytes, cfg_represent_bytes)
     cfg_yaml.representer.add_representer(context.quoted_str, cfg_represent_quoted_str)
+
     return cfg_yaml
 
 

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_data_collection.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_data_collection.py
@@ -1,10 +1,14 @@
 from eth2spec.test.context import (
     spec_state_test_with_matching_config,
+    with_config_overrides,
     with_light_client,
     with_presets,
 )
 from eth2spec.test.helpers.constants import (
     MINIMAL,
+)
+from eth2spec.test.helpers.light_client import (
+    sample_blob_schedule,
 )
 from eth2spec.test.helpers.light_client_data_collection import (
     add_new_block,
@@ -22,6 +26,12 @@ from eth2spec.test.helpers.light_client_data_collection import (
 
 
 @with_light_client
+@with_config_overrides(
+    {
+        "BLOB_SCHEDULE": sample_blob_schedule(initial_epoch=1, interval=1),
+    },
+    emit=False,
+)
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_light_client_data_collection(spec, state):

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
@@ -2,6 +2,7 @@ from eth2spec.test.context import (
     spec_state_test_with_matching_config,
     spec_test,
     with_all_phases_from_to,
+    with_config_overrides,
     with_light_client,
     with_matching_spec_config,
     with_presets,
@@ -21,6 +22,7 @@ from eth2spec.test.helpers.constants import (
 from eth2spec.test.helpers.light_client import (
     compute_start_slot_at_next_sync_committee_period,
     get_sync_aggregate,
+    sample_blob_schedule,
 )
 from eth2spec.test.helpers.light_client_sync import (
     emit_force_update,
@@ -35,6 +37,12 @@ from eth2spec.test.helpers.state import (
 
 
 @with_light_client
+@with_config_overrides(
+    {
+        "BLOB_SCHEDULE": sample_blob_schedule(),
+    },
+    emit=False,
+)
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_light_client_sync(spec, state):
@@ -281,6 +289,12 @@ def test_light_client_sync(spec, state):
 
 
 @with_light_client
+@with_config_overrides(
+    {
+        "BLOB_SCHEDULE": sample_blob_schedule(),
+    },
+    emit=False,
+)
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_supply_sync_committee_from_past_update(spec, state):
@@ -315,6 +329,12 @@ def test_supply_sync_committee_from_past_update(spec, state):
 
 
 @with_light_client
+@with_config_overrides(
+    {
+        "BLOB_SCHEDULE": sample_blob_schedule(),
+    },
+    emit=False,
+)
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_advance_finality_without_sync_committee(spec, state):
@@ -403,6 +423,12 @@ def test_advance_finality_without_sync_committee(spec, state):
 
 
 @with_light_client
+@with_config_overrides(
+    {
+        "BLOB_SCHEDULE": sample_blob_schedule(),
+    },
+    emit=False,
+)
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_light_client_sync_no_force_update(spec, state):

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from eth2spec.test.context import (
     spec_state_test_with_matching_config,
+    with_config_overrides,
     with_light_client,
     with_presets,
 )
@@ -12,6 +13,7 @@ from eth2spec.test.helpers.attestations import (
 from eth2spec.test.helpers.constants import MINIMAL
 from eth2spec.test.helpers.light_client import (
     create_update,
+    sample_blob_schedule,
 )
 from eth2spec.test.helpers.state import (
     next_slots,
@@ -30,6 +32,12 @@ def setup_test(spec, state):
 
 
 @with_light_client
+@with_config_overrides(
+    {
+        "BLOB_SCHEDULE": sample_blob_schedule(),
+    },
+    emit=False,
+)
 @spec_state_test_with_matching_config
 def test_process_light_client_update_not_timeout(spec, state):
     genesis_block, store = setup_test(spec, state)
@@ -62,6 +70,12 @@ def test_process_light_client_update_not_timeout(spec, state):
 
 
 @with_light_client
+@with_config_overrides(
+    {
+        "BLOB_SCHEDULE": sample_blob_schedule(),
+    },
+    emit=False,
+)
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_at_period_boundary(spec, state):
@@ -97,6 +111,12 @@ def test_process_light_client_update_at_period_boundary(spec, state):
 
 
 @with_light_client
+@with_config_overrides(
+    {
+        "BLOB_SCHEDULE": sample_blob_schedule(),
+    },
+    emit=False,
+)
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_timeout(spec, state):
@@ -132,6 +152,12 @@ def test_process_light_client_update_timeout(spec, state):
 
 
 @with_light_client
+@with_config_overrides(
+    {
+        "BLOB_SCHEDULE": sample_blob_schedule(),
+    },
+    emit=False,
+)
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_finality_updated(spec, state):

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -6,6 +6,7 @@ from random import Random
 from typing import Any
 
 import pytest
+from frozendict import frozendict
 from lru import LRU
 
 from eth2spec.utils import bls
@@ -662,20 +663,24 @@ class quoted_str(str):
     pass
 
 
+def _get_basic_value(v: Any) -> Any:
+    if isinstance(v, int):
+        return int(v)
+    elif isinstance(v, bytes):
+        return bytes(bytearray(v))
+    elif isinstance(v, list | tuple):
+        return list(_get_basic_value(v) for v in v)
+    elif isinstance(v, dict | frozendict):
+        return dict({k: _get_basic_value(v) for k, v in dict(v).items()})
+    else:
+        return quoted_str(v)
+
+
 def _get_basic_dict(ssz_dict: dict[str, Any]) -> dict[str, Any]:
     """
     Get dict of basic types from a dict of SSZ objects.
     """
-    result = {}
-    for k, v in ssz_dict.items():
-        if isinstance(v, int):
-            value = int(v)
-        elif isinstance(v, bytes):
-            value = bytes(bytearray(v))
-        else:
-            value = quoted_str(v)
-        result[k] = value
-    return result
+    return _get_basic_value(ssz_dict)
 
 
 def get_copy_of_spec(spec):

--- a/tests/core/pyspec/eth2spec/test/helpers/constants.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/constants.py
@@ -39,7 +39,7 @@ ALL_PHASES = (
     EIP7928,
 )
 # The forks that have light client specs
-LIGHT_CLIENT_TESTING_FORKS = [item for item in MAINNET_FORKS if item != PHASE0]
+LIGHT_CLIENT_TESTING_FORKS = [item for item in MAINNET_FORKS if item != PHASE0] + [FULU]
 # The forks that output to the test vectors.
 TESTGEN_FORKS = (*MAINNET_FORKS, FULU, GLOAS, EIP7805)
 # Forks allowed in the test runner `--fork` flag, to fail fast in case of typos

--- a/tests/core/pyspec/eth2spec/test/helpers/light_client.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/light_client.py
@@ -1,5 +1,7 @@
 from math import floor
 
+from frozendict import frozendict
+
 from eth2spec.test.helpers.constants import (
     CAPELLA,
     DENEB,
@@ -13,6 +15,16 @@ from eth2spec.test.helpers.sync_committee import (
     compute_aggregate_sync_committee_signature,
     compute_committee_indices,
 )
+
+
+def sample_blob_schedule(initial_epoch=5, interval=5):
+    max_blobs_per_block = [9, 100, 175, 200, 275, 300]
+    return tuple(
+        frozendict(
+            {"EPOCH": initial_epoch + i * interval, "MAX_BLOBS_PER_BLOCK": max_blobs_per_block}
+        )
+        for i, max_blobs_per_block in enumerate(max_blobs_per_block)
+    )
 
 
 def latest_finalized_root_gindex(spec):


### PR DESCRIPTION
Extend light client test vectors for Fulu, also ensuring that BPO are configured so that objects are properly parsed. Also fix config emitter to use correct BLOB_SCHEDULE format.
