### PR TITLE
Speed up test generation bootstrap

### DIFF
--- a/tests/generators/runners/ssz_generic_cases/ssz_container.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_container.py
@@ -186,35 +186,56 @@ def invalid_cases():
                         ("zeroed", lambda x: 0),
                         ("minus_one", lambda x: x - 1),
                     ]:
-                        serialized = mod_offset(
-                            b=serialize(container_case_fn(rng, mode, typ)),
-                            offset_index=offset_index,
-                            change=change,
+
+                        def the_test(
+                            rng=rng, mode=mode, typ=typ, offset_index=offset_index, change=change
+                        ):
+                            serialized = mod_offset(
+                                b=serialize(container_case_fn(rng, mode, typ)),
+                                offset_index=offset_index,
+                                change=change,
+                            )
+                            try:
+                                _ = deserialize(typ, serialized)
+                            except Exception:
+                                return serialized
+                            assert False  # should throw
+
+                        yield (
+                            f"{name}_{mode.to_name()}_offset_{offset_index}_{description}",
+                            invalid_test_case(the_test),
                         )
-                        try:
-                            _ = deserialize(typ, serialized)
-                        except Exception:
-                            yield (
-                                f"{name}_{mode.to_name()}_offset_{offset_index}_{description}",
-                                invalid_test_case(lambda serialized=serialized: serialized),
-                            )
                     if mode == RandomizationMode.mode_max_count:
-                        serialized = serialize(container_case_fn(rng, mode, typ))
-                        serialized = serialized + serialized[:3]
-                        try:
-                            _ = deserialize(typ, serialized)
-                        except Exception:
-                            yield (
-                                f"{name}_{mode.to_name()}_last_offset_{offset_index}_overflow",
-                                invalid_test_case(lambda serialized=serialized: serialized),
-                            )
+
+                        def the_test(
+                            rng=rng, mode=mode, typ=typ, offset_index=offset_index, change=change
+                        ):
+                            serialized = serialize(container_case_fn(rng, mode, typ))
+                            serialized = serialized + serialized[:3]
+                            try:
+                                _ = deserialize(typ, serialized)
+                            except Exception:
+                                return serialized
+                            assert False  # should throw
+
+                        yield (
+                            f"{name}_{mode.to_name()}_last_offset_{offset_index}_overflow",
+                            invalid_test_case(the_test),
+                        )
                     if mode == RandomizationMode.mode_one_count:
-                        serialized = serialize(container_case_fn(rng, mode, typ))
-                        serialized = serialized + serialized[:1]
-                        try:
-                            _ = deserialize(typ, serialized)
-                        except Exception:
-                            yield (
-                                f"{name}_{mode.to_name()}_last_offset_{offset_index}_wrong_byte_length",
-                                invalid_test_case(lambda serialized=serialized: serialized),
-                            )
+
+                        def the_test(
+                            rng=rng, mode=mode, typ=typ, offset_index=offset_index, change=change
+                        ):
+                            serialized = serialize(container_case_fn(rng, mode, typ))
+                            serialized = serialized + serialized[:1]
+                            try:
+                                _ = deserialize(typ, serialized)
+                            except Exception:
+                                return serialized
+                            assert False  # should throw
+
+                        yield (
+                            f"{name}_{mode.to_name()}_last_offset_{offset_index}_wrong_byte_length",
+                            invalid_test_case(the_test),
+                        )


### PR DESCRIPTION
By making the test run at test time instead of collection time in SSZ generic container.

This was first introduced here: https://github.com/ethereum/consensus-specs/pull/4541/files but that PR has more complications with other things