### PR TITLE
Disable ssz container invalid tests

### DIFF
--- a/tests/generators/runners/ssz_generic.py
+++ b/tests/generators/runners/ssz_generic.py
@@ -28,7 +28,7 @@ def get_test_cases() -> Iterable[TestCase]:
         ("boolean", "valid", ssz_boolean.valid_cases),
         ("boolean", "invalid", ssz_boolean.invalid_cases),
         ("containers", "valid", ssz_container.valid_cases),
-        ("containers", "invalid", ssz_container.invalid_cases),
+        # ("containers", "invalid", ssz_container.invalid_cases),
         ("progressive_bitlist", "valid", ssz_progressive_bitlist.valid_cases),
         ("progressive_bitlist", "invalid", ssz_progressive_bitlist.invalid_cases),
         ("uints", "valid", ssz_uints.valid_cases),


### PR DESCRIPTION
As their code is not actually generating invalid data, it is failing because it is a test that expect an exception.

Then we can re-enable when we do this: https://github.com/ethereum/consensus-specs/issues/4580