### PR TITLE
build: Add dynamic Python version check to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,8 +191,12 @@ CODESPELL_VENV = $(VENV)/bin/codespell
 MDFORMAT_VENV = $(VENV)/bin/mdformat
 MKDOCS_VENV = $(VENV)/bin/mkdocs
 
+# Check that the Python version meets requirements from pyproject.toml
+_python_version_check:
+	@python3 scripts/check_python_version.py
+
 # Make a virtual environment.
-$(VENV):
+$(VENV): _python_version_check
 	@echo "Creating virtual environment"
 	@python3 -m venv $(VENV)
 	@$(PIP_VENV) install --quiet --upgrade uv

--- a/scripts/check_python_version.py
+++ b/scripts/check_python_version.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Check if the current Python version meets requirements from pyproject.toml
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def main():
+    """Check Python version against pyproject.toml requirements."""
+    # Read pyproject.toml from project root
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    if not pyproject_path.exists():
+        print("Error: pyproject.toml not found")
+        sys.exit(1)
+
+    content = pyproject_path.read_text()
+
+    # Extract requires-python line
+    match = re.search(r'requires-python\s*=\s*"([^"]*)"', content)
+    if not match:
+        print("Error: requires-python not found in pyproject.toml")
+        sys.exit(1)
+
+    required_version = match.group(1)
+
+    # Parse version requirements (e.g., ">=3.10,<4.0")
+    min_match = re.search(r">=([0-9.]+)", required_version)
+    max_match = re.search(r"<([0-9.]+)", required_version)
+
+    if not min_match:
+        print(f"Error: Could not parse minimum version from: {required_version}")
+        sys.exit(1)
+
+    min_version = tuple(map(int, min_match.group(1).split(".")))
+    current_version = sys.version_info[:2]
+
+    print(f"Required: {required_version}, Current: {current_version[0]}.{current_version[1]}")
+
+    # Check minimum version
+    if current_version < min_version:
+        print(
+            f"Error: Python {current_version[0]}.{current_version[1]} is not supported. Required: {required_version}"
+        )
+        sys.exit(1)
+
+    # Check maximum version if specified
+    if max_match:
+        max_version = tuple(map(int, max_match.group(1).split(".")))
+        if current_version >= max_version:
+            print(
+                f"Error: Python {current_version[0]}.{current_version[1]} is not supported. Required: {required_version}"
+            )
+            sys.exit(1)
+
+    print(f"✓ Python {current_version[0]}.{current_version[1]} meets requirements")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
build: add dynamic Python version check to Makefile

Add a Python version validation step to the Makefile that dynamically
reads version requirements from `pyproject.toml` and validates them
before creating the virtual environment. Previously, users encountered
ambiguous errors if they used an unsupported Python version. Now they
receive clear, early feedback about version compatibility.

Changes include:
- new `_python_version_check` Makefile rule that runs before `$(VENV)` creation
- dedicated `scripts/check_python_version.py` script to parse `pyproject.toml`
- dynamic parsing of version ranges (e.g., ">=3.10,<4.0")
- clear error messages for unsupported versions
- automatic adaptation when `pyproject.toml` version requirements change

Testing:
- verified version check works with Python 3.13 (supported)
- confirmed script follows project linting standards with ruff
- tested Makefile integration with venv creation

Fixes: https://github.com/ethereum/consensus-specs/issues/4576