### PR TITLE
Only create ssz_static tests in generator mode

### DIFF
--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -307,7 +307,7 @@ is_pytest = True
 def dump_skipping_message(reason: str) -> None:
     message = f"[Skipped test] {reason}"
     if is_pytest:
-        pytest.skip(message)
+        pytest.skip(message, allow_module_level=True)
     else:
         raise SkippedTest(message)
 

--- a/tests/core/pyspec/eth2spec/test/phase0/ssz_static/test_ssz_static.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/ssz_static/test_ssz_static.py
@@ -4,6 +4,7 @@ from random import Random
 
 from eth2spec.debug import encode, random_value
 from eth2spec.test.context import (
+    only_generator,
     single_phase,
     spec_targets,
     spec_test,
@@ -73,6 +74,7 @@ def _template_ssz_static_tests(
     return (the_test, f"test_{unique_name}")
 
 
+@only_generator("too slow")
 def _create_test_cases():
     """
     Create test cases for all SSZ types in all forks and both presets.


### PR DESCRIPTION
This should fix the crazy slow tests. It seems that `_create_test_case` is just crazy slow. When we have more time, we should investigate why this is exactly. I suspect there are just so many test cases that it takes forever.

My "dumb solution" is to skip calling `_create_test_cases` outside of generator mode.

Related to:

* #4573
* #4584