### PR TITLE
eip7732: remove `latest_execution_payload_header` from beacon state

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -291,7 +291,7 @@ class BeaconBlockBody(Container):
 *Note*: The `BeaconState` is modified to track the last withdrawals honored in
 the CL. A new field `latest_execution_payload_bid` is added to track the state's
 slot builder's bid and replaces the old `latest_execution_payload_header` which
-no longer is tracked in the beacon state. Another addition is to track the last
+is no longer tracked in the beacon state. Another addition is to track the last
 committed block hash and the last slot that was full, that is in which there
 were both consensus and execution blocks included.
 
@@ -321,8 +321,8 @@ class BeaconState(Container):
     inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
-    # Removed `latest_execution_payload_header`
     # [New in Gloas:EIP7732]
+    # Removed `latest_execution_payload_header`
     latest_execution_payload_bid: ExecutionPayloadBid
     next_withdrawal_index: WithdrawalIndex
     next_withdrawal_validator_index: ValidatorIndex

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -290,10 +290,10 @@ class BeaconBlockBody(Container):
 
 *Note*: The `BeaconState` is modified to track the last withdrawals honored in
 the CL. A new field `latest_execution_payload_bid` is added to track the state's
-slot builder's bid. The `latest_execution_payload_header` remains unchanged from
-previous specs. Another addition is to track the last committed block hash and
-the last slot that was full, that is in which there were both consensus and
-execution blocks included.
+slot builder's bid and replaces the old `latest_execution_payload_header` which
+no longer is tracked in the beacon state. Another addition is to track the last
+committed block hash and the last slot that was full, that is in which there
+were both consensus and execution blocks included.
 
 ```python
 class BeaconState(Container):
@@ -321,7 +321,10 @@ class BeaconState(Container):
     inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
-    latest_execution_payload_header: ExecutionPayloadHeader
+    # [Removed in Gloas:EIP7732]
+    #  latest_execution_payload_header: ExecutionPayloadHeader
+    # [New in Gloas:EIP7732]
+    latest_execution_payload_bid: ExecutionPayloadBid
     next_withdrawal_index: WithdrawalIndex
     next_withdrawal_validator_index: ValidatorIndex
     historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
@@ -335,8 +338,6 @@ class BeaconState(Container):
     pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
     pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
     proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
-    # [New in Gloas:EIP7732]
-    latest_execution_payload_bid: ExecutionPayloadBid
     # [New in Gloas:EIP7732]
     execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
     # [New in Gloas:EIP7732]

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -321,8 +321,7 @@ class BeaconState(Container):
     inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
-    # [Removed in Gloas:EIP7732]
-    #  latest_execution_payload_header: ExecutionPayloadHeader
+    # Removed `latest_execution_payload_header`
     # [New in Gloas:EIP7732]
     latest_execution_payload_bid: ExecutionPayloadBid
     next_withdrawal_index: WithdrawalIndex

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -71,8 +71,8 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         inactivity_scores=pre.inactivity_scores,
         current_sync_committee=pre.current_sync_committee,
         next_sync_committee=pre.next_sync_committee,
-        # [Modified in Gloas:EIP7732]
-        latest_execution_payload_header=ExecutionPayloadHeader(),
+        # [Removed in Gloas:EIP7732]
+        # latest_execution_payload_header=ExecutionPayloadHeader(),
         # [New in Gloas:EIP7732]
         latest_execution_payload_bid=ExecutionPayloadBid(),
         next_withdrawal_index=pre.next_withdrawal_index,

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -71,8 +71,8 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         inactivity_scores=pre.inactivity_scores,
         current_sync_committee=pre.current_sync_committee,
         next_sync_committee=pre.next_sync_committee,
-        # Removed `latest_execution_payload_header`
         # [New in Gloas:EIP7732]
+        # Removed `latest_execution_payload_header`
         latest_execution_payload_bid=ExecutionPayloadBid(),
         next_withdrawal_index=pre.next_withdrawal_index,
         next_withdrawal_validator_index=pre.next_withdrawal_validator_index,

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -71,8 +71,7 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         inactivity_scores=pre.inactivity_scores,
         current_sync_committee=pre.current_sync_committee,
         next_sync_committee=pre.next_sync_committee,
-        # [Removed in Gloas:EIP7732]
-        # latest_execution_payload_header=ExecutionPayloadHeader(),
+        # Removed `latest_execution_payload_header`
         # [New in Gloas:EIP7732]
         latest_execution_payload_bid=ExecutionPayloadBid(),
         next_withdrawal_index=pre.next_withdrawal_index,

--- a/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_withdrawals.py
@@ -961,10 +961,7 @@ def test_partially_withdrawable_validator_legacy_max_plus_one(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     execution_payload = build_empty_execution_payload(spec, state)
     yield from run_withdrawals_processing(

--- a/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
@@ -282,10 +282,7 @@ def test_many_partial_withdrawals_in_epoch_transition(spec, state):
         )
         assert len(get_expected_withdrawals(spec, state)) == expected_count
         # Make parent block full in Gloas so withdrawals are processed
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
     else:
         assert len(get_expected_withdrawals(spec, state)) == spec.MAX_WITHDRAWALS_PER_PAYLOAD
 
@@ -340,10 +337,7 @@ def _perform_valid_withdrawal(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     pre_state = state.copy()
 
@@ -498,10 +492,7 @@ def test_top_up_to_fully_withdrawn_validator(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     next_epoch_via_block(spec, state)
     assert state.balances[validator_index] == 0

--- a/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
@@ -244,11 +244,8 @@ def test_partial_withdrawal_in_epoch_transition(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         # For Gloas, we need the parent block to be full to process withdrawals
-        # Set latest_block_hash to match latest_execution_payload_header.block_hash
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        # Set latest_block_hash to match latest_execution_payload_bid.block_hash
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     yield "pre", state
 

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawals.py
@@ -36,10 +36,9 @@ def test_success_mixed_fully_and_partial_withdrawable_compounding(spec, state):
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -66,10 +65,9 @@ def test_success_no_max_effective_balance_compounding(spec, state):
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -92,10 +90,9 @@ def test_success_no_excess_balance_compounding(spec, state):
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -119,10 +116,9 @@ def test_success_excess_balance_but_no_max_effective_balance_compounding(spec, s
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -144,10 +140,9 @@ def test_pending_withdrawals_one_skipped_one_effective(spec, state):
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     assert state.pending_partial_withdrawals == [pending_withdrawal_0, pending_withdrawal_1]
     yield from run_withdrawals_processing(
@@ -175,10 +170,9 @@ def test_pending_withdrawals_next_epoch(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -205,10 +199,9 @@ def test_pending_withdrawals_at_max(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -238,10 +231,9 @@ def test_pending_withdrawals_exiting_validator(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -271,10 +263,9 @@ def test_full_pending_withdrawals_but_first_skipped_exiting_validator(spec, stat
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -302,10 +293,9 @@ def test_pending_withdrawals_low_effective_balance(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -336,10 +326,9 @@ def test_full_pending_withdrawals_but_first_skipped_low_effective_balance(spec, 
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -365,10 +354,9 @@ def test_pending_withdrawals_no_excess_balance(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -398,10 +386,9 @@ def test_full_pending_withdrawals_but_first_skipped_no_excess_balance(spec, stat
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -443,10 +430,9 @@ def test_pending_withdrawals_with_ineffective_sweep_on_top(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -502,10 +488,9 @@ def test_pending_withdrawals_with_ineffective_sweep_on_top_2(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -557,10 +542,9 @@ def test_pending_withdrawals_with_effective_sweep_on_top(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -611,10 +595,9 @@ def test_pending_withdrawals_with_sweep_different_validator(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -663,10 +646,9 @@ def test_pending_withdrawals_mixed_with_sweep_and_fully_withdrawable(spec, state
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -715,10 +697,9 @@ def test_pending_withdrawals_at_max_mixed_with_sweep_and_fully_withdrawable(spec
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -755,10 +736,9 @@ def test_partially_withdrawable_validator_compounding_max_plus_one(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -785,10 +765,9 @@ def test_partially_withdrawable_validator_compounding_exact_max(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -821,10 +800,9 @@ def test_partially_withdrawable_validator_compounding_max_minus_one(spec, state)
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -857,10 +835,9 @@ def test_partially_withdrawable_validator_compounding_min_plus_one(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -893,10 +870,9 @@ def test_partially_withdrawable_validator_compounding_exact_min(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -929,10 +905,9 @@ def test_partially_withdrawable_validator_compounding_min_minus_one(spec, state)
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -972,10 +947,9 @@ def test_pending_withdrawals_two_partial_withdrawals_same_validator_1(spec, stat
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -1018,10 +992,9 @@ def test_pending_withdrawals_two_partial_withdrawals_same_validator_2(spec, stat
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,

--- a/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_apply_pending_deposit.py
+++ b/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_apply_pending_deposit.py
@@ -500,10 +500,7 @@ def test_apply_pending_deposit_success_top_up_to_withdrawn_validator(spec, state
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     next_epoch_via_block(spec, state)
     assert state.balances[validator_index] == 0

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -428,9 +428,6 @@ def build_randomized_execution_payload(spec, state, rng):
 
 
 def build_state_with_incomplete_transition(spec, state):
-    header = spec.ExecutionPayloadHeader()
-    state = build_state_with_execution_payload_header(spec, state, header)
-
     if is_post_gloas(spec):
         # In Gloas, we need to set up the execution payload bid instead
         kzgs = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK]()
@@ -439,7 +436,10 @@ def build_state_with_incomplete_transition(spec, state):
             value=spec.Gwei(0),
             blob_kzg_commitments_root=kzgs.hash_tree_root(),
         )
-        state.latest_execution_payload_bid = bid
+        state = build_state_with_execution_payload_bid(spec, state, bid)
+    else:
+        header = spec.ExecutionPayloadHeader()
+        state = build_state_with_execution_payload_header(spec, state, header)
 
     assert not spec.is_merge_transition_complete(state)
 

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -197,7 +197,7 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
     if is_post_gloas(spec):
         # Initialize the latest_execution_payload_bid
         genesis_block_body.signed_execution_payload_bid.message.block_hash = eth1_block_hash
-    elif is_post_bellatrix(spec): 
+    elif is_post_bellatrix(spec):
         # Initialize the execution payload header (with block number and genesis time set to 0)
         state.latest_execution_payload_header = get_sample_genesis_execution_payload_header(
             spec,

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
@@ -86,15 +86,16 @@ def test_chain_no_attestations(spec, state):
     check_head_against_root(spec, store, anchor_root)
     output_head_check(spec, store, test_steps)
 
+
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block_1 = build_empty_block_for_next_slot(spec, state)
-    signed_block_1 = state_transition_and_sign_block(spec, state, block_1)
+    signed_block_1 = state_transition_and_sign_block(spec, state.copy(), block_1)
     yield from tick_and_add_block(spec, store, signed_block_1, test_steps)
-    payload_state_transition(spec, store, signed_block_1.message)
+    state = payload_state_transition(spec, store, signed_block_1.message)
 
     # On receiving a block of next epoch
     block_2 = build_empty_block_for_next_slot(spec, state)
-    signed_block_2 = state_transition_and_sign_block(spec, state, block_2)
+    signed_block_2 = state_transition_and_sign_block(spec, state.copy(), block_2)
     yield from tick_and_add_block(spec, store, signed_block_2, test_steps)
     check_head_against_root(spec, store, spec.hash_tree_root(block_2))
     payload_state_transition(spec, store, signed_block_2.message)
@@ -162,17 +163,17 @@ def test_shorter_chain_but_heavier_weight(spec, state):
     long_state = genesis_state.copy()
     for _ in range(3):
         long_block = build_empty_block_for_next_slot(spec, long_state)
-        signed_long_block = state_transition_and_sign_block(spec, long_state, long_block)
+        signed_long_block = state_transition_and_sign_block(spec, long_state.copy(), long_block)
         yield from tick_and_add_block(spec, store, signed_long_block, test_steps)
-        payload_state_transition(spec, store, signed_long_block.message)
+        long_state = payload_state_transition(spec, store, signed_long_block.message)
 
     # build short tree
     short_state = genesis_state.copy()
     short_block = build_empty_block_for_next_slot(spec, short_state)
     short_block.body.graffiti = b"\x42" * 32
-    signed_short_block = state_transition_and_sign_block(spec, short_state, short_block)
+    signed_short_block = state_transition_and_sign_block(spec, short_state.copy(), short_block)
     yield from tick_and_add_block(spec, store, signed_short_block, test_steps)
-    payload_state_transition(spec, store, signed_short_block.message)
+    short_state = payload_state_transition(spec, store, signed_short_block.message)
 
     # Since the long chain has higher proposer_score at slot 1, the latest long block is the head
     check_head_against_root(spec, store, spec.hash_tree_root(long_block))

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
@@ -86,7 +86,6 @@ def test_chain_no_attestations(spec, state):
     check_head_against_root(spec, store, anchor_root)
     output_head_check(spec, store, test_steps)
 
-
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block_1 = build_empty_block_for_next_slot(spec, state)
     signed_block_1 = state_transition_and_sign_block(spec, state.copy(), block_1)

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_on_block.py
@@ -67,15 +67,15 @@ def test_basic(spec, state):
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block = build_empty_block_for_next_slot(spec, state)
-    signed_block = state_transition_and_sign_block(spec, state, block)
+    signed_block = state_transition_and_sign_block(spec, state.copy(), block)
     yield from tick_and_add_block(spec, store, signed_block, test_steps)
     check_head_against_root(spec, store, signed_block.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block.message)
+    state = payload_state_transition(spec, store, signed_block.message)
 
     # On receiving a block of next epoch
     store.time = current_time + spec.config.SECONDS_PER_SLOT * spec.SLOTS_PER_EPOCH
     block = build_empty_block(spec, state, state.slot + spec.SLOTS_PER_EPOCH)
-    signed_block = state_transition_and_sign_block(spec, state, block)
+    signed_block = state_transition_and_sign_block(spec, state.copy(), block)
     yield from tick_and_add_block(spec, store, signed_block, test_steps)
     check_head_against_root(spec, store, signed_block.message.hash_tree_root())
     payload_state_transition(spec, store, signed_block.message)
@@ -508,7 +508,7 @@ def test_proposer_boost(spec, state):
     state = genesis_state.copy()
     next_slots(spec, state, 3)
     block = build_empty_block_for_next_slot(spec, state)
-    signed_block = state_transition_and_sign_block(spec, state, block)
+    signed_block = state_transition_and_sign_block(spec, state.copy(), block)
 
     # Process block on timely arrival just before end of boost interval
     # Round up to nearest second
@@ -549,7 +549,7 @@ def test_proposer_boost(spec, state):
 
     next_slots(spec, state, 3)
     block = build_empty_block_for_next_slot(spec, state)
-    signed_block = state_transition_and_sign_block(spec, state, block)
+    signed_block = state_transition_and_sign_block(spec, state.copy(), block)
 
     # Process block on timely arrival at start of boost interval
     time = store.genesis_time + block.slot * spec.config.SECONDS_PER_SLOT


### PR DESCRIPTION
    Replace latest_execution_payload_header

    This PR replaces the field `latest_execution_payload_header` in the
    beacon state with the field `latest_execution_payload_bid`