### PR TITLE
eip7732: remove `latest_execution_payload_header`

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -291,7 +291,7 @@ class BeaconBlockBody(Container):
 *Note*: The `BeaconState` is modified to track the last withdrawals honored in
 the CL. A new field `latest_execution_payload_bid` is added to track the state's
 slot builder's bid and replaces the old `latest_execution_payload_header` which
-no longer is tracked in the beacon state. Another addition is to track the last
+is no longer tracked in the beacon state. Another addition is to track the last
 committed block hash and the last slot that was full, that is in which there
 were both consensus and execution blocks included.
 
@@ -321,6 +321,7 @@ class BeaconState(Container):
     inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
+    # [Modified in Gloas:EIP7732]
     # Removed `latest_execution_payload_header`
     # [New in Gloas:EIP7732]
     latest_execution_payload_bid: ExecutionPayloadBid

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -290,10 +290,10 @@ class BeaconBlockBody(Container):
 
 *Note*: The `BeaconState` is modified to track the last withdrawals honored in
 the CL. A new field `latest_execution_payload_bid` is added to track the state's
-slot builder's bid. The `latest_execution_payload_header` remains unchanged from
-previous specs. Another addition is to track the last committed block hash and
-the last slot that was full, that is in which there were both consensus and
-execution blocks included.
+slot builder's bid and replaces the old `latest_execution_payload_header` which
+no longer is tracked in the beacon state. Another addition is to track the last
+committed block hash and the last slot that was full, that is in which there
+were both consensus and execution blocks included.
 
 ```python
 class BeaconState(Container):
@@ -321,7 +321,10 @@ class BeaconState(Container):
     inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
-    latest_execution_payload_header: ExecutionPayloadHeader
+    # [Removed in Gloas:EIP7732]
+    #  latest_execution_payload_header: ExecutionPayloadHeader
+    # [New in Gloas:EIP7732]
+    latest_execution_payload_bid: ExecutionPayloadBid
     next_withdrawal_index: WithdrawalIndex
     next_withdrawal_validator_index: ValidatorIndex
     historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
@@ -335,8 +338,6 @@ class BeaconState(Container):
     pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
     pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
     proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
-    # [New in Gloas:EIP7732]
-    latest_execution_payload_bid: ExecutionPayloadBid
     # [New in Gloas:EIP7732]
     execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
     # [New in Gloas:EIP7732]

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -321,8 +321,7 @@ class BeaconState(Container):
     inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
-    # [Removed in Gloas:EIP7732]
-    #  latest_execution_payload_header: ExecutionPayloadHeader
+    # Removed `latest_execution_payload_header`
     # [New in Gloas:EIP7732]
     latest_execution_payload_bid: ExecutionPayloadBid
     next_withdrawal_index: WithdrawalIndex

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -71,8 +71,8 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         inactivity_scores=pre.inactivity_scores,
         current_sync_committee=pre.current_sync_committee,
         next_sync_committee=pre.next_sync_committee,
-        # [Modified in Gloas:EIP7732]
-        latest_execution_payload_header=ExecutionPayloadHeader(),
+        # [Removed in Gloas:EIP7732]
+        # latest_execution_payload_header=ExecutionPayloadHeader(),
         # [New in Gloas:EIP7732]
         latest_execution_payload_bid=ExecutionPayloadBid(),
         next_withdrawal_index=pre.next_withdrawal_index,

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -71,6 +71,7 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         inactivity_scores=pre.inactivity_scores,
         current_sync_committee=pre.current_sync_committee,
         next_sync_committee=pre.next_sync_committee,
+        # [Modified in Gloas:EIP7732]
         # Removed `latest_execution_payload_header`
         # [New in Gloas:EIP7732]
         latest_execution_payload_bid=ExecutionPayloadBid(),

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -71,8 +71,7 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         inactivity_scores=pre.inactivity_scores,
         current_sync_committee=pre.current_sync_committee,
         next_sync_committee=pre.next_sync_committee,
-        # [Removed in Gloas:EIP7732]
-        # latest_execution_payload_header=ExecutionPayloadHeader(),
+        # Removed `latest_execution_payload_header`
         # [New in Gloas:EIP7732]
         latest_execution_payload_bid=ExecutionPayloadBid(),
         next_withdrawal_index=pre.next_withdrawal_index,

--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -326,10 +326,12 @@ def run_non_empty_transactions_test(spec, state):
     execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
-    assert (
-        state.latest_execution_payload_header.transactions_root
-        == execution_payload.transactions.hash_tree_root()
-    )
+
+    if not is_post_gloas(spec):
+        assert (
+            state.latest_execution_payload_header.transactions_root
+            == execution_payload.transactions.hash_tree_root()
+        )
 
 
 @with_all_phases_from_to(BELLATRIX, GLOAS)
@@ -355,10 +357,12 @@ def run_zero_length_transaction_test(spec, state):
     execution_payload.block_hash = compute_el_block_hash(spec, execution_payload, state)
 
     yield from run_execution_payload_processing(spec, state, execution_payload)
-    assert (
-        state.latest_execution_payload_header.transactions_root
-        == execution_payload.transactions.hash_tree_root()
-    )
+
+    if not is_post_gloas(spec):
+        assert (
+            state.latest_execution_payload_header.transactions_root
+            == execution_payload.transactions.hash_tree_root()
+        )
 
 
 @with_all_phases_from_to(BELLATRIX, GLOAS)
@@ -380,8 +384,8 @@ def run_randomized_non_validated_execution_fields_test(spec, state, rng, executi
     execution_payload = build_randomized_execution_payload(spec, state, rng)
 
     if is_post_gloas(spec):
-        state.latest_execution_payload_header.block_hash = execution_payload.block_hash
-        state.latest_execution_payload_header.gas_limit = execution_payload.gas_limit
+        state.latest_execution_payload_bid.block_hash = execution_payload.block_hash
+        state.latest_execution_payload_bid.gas_limit = execution_payload.gas_limit
         state.latest_block_hash = execution_payload.parent_hash
 
     yield from run_execution_payload_processing(

--- a/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/capella/block_processing/test_process_withdrawals.py
@@ -961,10 +961,7 @@ def test_partially_withdrawable_validator_legacy_max_plus_one(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     execution_payload = build_empty_execution_payload(spec, state)
     yield from run_withdrawals_processing(

--- a/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
@@ -282,10 +282,7 @@ def test_many_partial_withdrawals_in_epoch_transition(spec, state):
         )
         assert len(get_expected_withdrawals(spec, state)) == expected_count
         # Make parent block full in Gloas so withdrawals are processed
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
     else:
         assert len(get_expected_withdrawals(spec, state)) == spec.MAX_WITHDRAWALS_PER_PAYLOAD
 
@@ -340,10 +337,7 @@ def _perform_valid_withdrawal(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     pre_state = state.copy()
 
@@ -498,10 +492,7 @@ def test_top_up_to_fully_withdrawn_validator(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     next_epoch_via_block(spec, state)
     assert state.balances[validator_index] == 0

--- a/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/capella/sanity/test_blocks.py
@@ -244,11 +244,8 @@ def test_partial_withdrawal_in_epoch_transition(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         # For Gloas, we need the parent block to be full to process withdrawals
-        # Set latest_block_hash to match latest_execution_payload_header.block_hash
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        # Set latest_block_hash to match latest_execution_payload_bid.block_hash
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     yield "pre", state
 

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawals.py
@@ -36,10 +36,9 @@ def test_success_mixed_fully_and_partial_withdrawable_compounding(spec, state):
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -66,10 +65,9 @@ def test_success_no_max_effective_balance_compounding(spec, state):
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -92,10 +90,9 @@ def test_success_no_excess_balance_compounding(spec, state):
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -119,10 +116,9 @@ def test_success_excess_balance_but_no_max_effective_balance_compounding(spec, s
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -144,10 +140,9 @@ def test_pending_withdrawals_one_skipped_one_effective(spec, state):
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     assert state.pending_partial_withdrawals == [pending_withdrawal_0, pending_withdrawal_1]
     yield from run_withdrawals_processing(
@@ -175,10 +170,9 @@ def test_pending_withdrawals_next_epoch(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -205,10 +199,9 @@ def test_pending_withdrawals_at_max(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -238,10 +231,9 @@ def test_pending_withdrawals_exiting_validator(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -271,10 +263,9 @@ def test_full_pending_withdrawals_but_first_skipped_exiting_validator(spec, stat
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -302,10 +293,9 @@ def test_pending_withdrawals_low_effective_balance(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -336,10 +326,9 @@ def test_full_pending_withdrawals_but_first_skipped_low_effective_balance(spec, 
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -365,10 +354,9 @@ def test_pending_withdrawals_no_excess_balance(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -398,10 +386,9 @@ def test_full_pending_withdrawals_but_first_skipped_no_excess_balance(spec, stat
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -443,10 +430,9 @@ def test_pending_withdrawals_with_ineffective_sweep_on_top(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -502,10 +488,9 @@ def test_pending_withdrawals_with_ineffective_sweep_on_top_2(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -557,10 +542,9 @@ def test_pending_withdrawals_with_effective_sweep_on_top(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -611,10 +595,9 @@ def test_pending_withdrawals_with_sweep_different_validator(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -663,10 +646,9 @@ def test_pending_withdrawals_mixed_with_sweep_and_fully_withdrawable(spec, state
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -715,10 +697,9 @@ def test_pending_withdrawals_at_max_mixed_with_sweep_and_fully_withdrawable(spec
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -755,10 +736,9 @@ def test_partially_withdrawable_validator_compounding_max_plus_one(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -785,10 +765,9 @@ def test_partially_withdrawable_validator_compounding_exact_max(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -821,10 +800,9 @@ def test_partially_withdrawable_validator_compounding_max_minus_one(spec, state)
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -857,10 +835,9 @@ def test_partially_withdrawable_validator_compounding_min_plus_one(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -893,10 +870,9 @@ def test_partially_withdrawable_validator_compounding_exact_min(spec, state):
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -929,10 +905,9 @@ def test_partially_withdrawable_validator_compounding_min_minus_one(spec, state)
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -972,10 +947,9 @@ def test_pending_withdrawals_two_partial_withdrawals_same_validator_1(spec, stat
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,
@@ -1018,10 +992,9 @@ def test_pending_withdrawals_two_partial_withdrawals_same_validator_2(spec, stat
     execution_payload = build_empty_execution_payload(spec, state)
 
     if is_post_gloas(spec):
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+    else:
         state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
 
     yield from run_withdrawals_processing(
         spec,

--- a/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/electra/block_processing/test_process_withdrawals.py
@@ -37,8 +37,6 @@ def test_success_mixed_fully_and_partial_withdrawable_compounding(spec, state):
 
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -66,8 +64,6 @@ def test_success_no_max_effective_balance_compounding(spec, state):
 
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -91,8 +87,6 @@ def test_success_no_excess_balance_compounding(spec, state):
 
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -117,8 +111,6 @@ def test_success_excess_balance_but_no_max_effective_balance_compounding(spec, s
 
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -141,8 +133,6 @@ def test_pending_withdrawals_one_skipped_one_effective(spec, state):
 
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     assert state.pending_partial_withdrawals == [pending_withdrawal_0, pending_withdrawal_1]
     yield from run_withdrawals_processing(
@@ -171,8 +161,6 @@ def test_pending_withdrawals_next_epoch(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -200,8 +188,6 @@ def test_pending_withdrawals_at_max(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -232,8 +218,6 @@ def test_pending_withdrawals_exiting_validator(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -264,8 +248,6 @@ def test_full_pending_withdrawals_but_first_skipped_exiting_validator(spec, stat
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -294,8 +276,6 @@ def test_pending_withdrawals_low_effective_balance(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -327,8 +307,6 @@ def test_full_pending_withdrawals_but_first_skipped_low_effective_balance(spec, 
 
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -355,8 +333,6 @@ def test_pending_withdrawals_no_excess_balance(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec, state, execution_payload, num_expected_withdrawals=0
@@ -387,8 +363,6 @@ def test_full_pending_withdrawals_but_first_skipped_no_excess_balance(spec, stat
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -431,8 +405,6 @@ def test_pending_withdrawals_with_ineffective_sweep_on_top(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -489,8 +461,6 @@ def test_pending_withdrawals_with_ineffective_sweep_on_top_2(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -543,8 +513,6 @@ def test_pending_withdrawals_with_effective_sweep_on_top(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -596,8 +564,6 @@ def test_pending_withdrawals_with_sweep_different_validator(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -647,8 +613,6 @@ def test_pending_withdrawals_mixed_with_sweep_and_fully_withdrawable(spec, state
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -698,8 +662,6 @@ def test_pending_withdrawals_at_max_mixed_with_sweep_and_fully_withdrawable(spec
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -737,8 +699,6 @@ def test_partially_withdrawable_validator_compounding_max_plus_one(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -766,8 +726,6 @@ def test_partially_withdrawable_validator_compounding_exact_max(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -801,8 +759,6 @@ def test_partially_withdrawable_validator_compounding_max_minus_one(spec, state)
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -836,8 +792,6 @@ def test_partially_withdrawable_validator_compounding_min_plus_one(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -871,8 +825,6 @@ def test_partially_withdrawable_validator_compounding_exact_min(spec, state):
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -906,8 +858,6 @@ def test_partially_withdrawable_validator_compounding_min_minus_one(spec, state)
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -948,8 +898,6 @@ def test_pending_withdrawals_two_partial_withdrawals_same_validator_1(spec, stat
 
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,
@@ -993,8 +941,6 @@ def test_pending_withdrawals_two_partial_withdrawals_same_validator_2(spec, stat
 
     if is_post_gloas(spec):
         state.latest_block_hash = state.latest_execution_payload_bid.block_hash
-    else:
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
 
     yield from run_withdrawals_processing(
         spec,

--- a/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_apply_pending_deposit.py
+++ b/tests/core/pyspec/eth2spec/test/electra/epoch_processing/pending_deposits/test_apply_pending_deposit.py
@@ -500,10 +500,7 @@ def test_apply_pending_deposit_success_top_up_to_withdrawn_validator(spec, state
 
     # Make parent block full in Gloas so withdrawals are processed
     if is_post_gloas(spec):
-        state.latest_block_hash = state.latest_execution_payload_header.block_hash
-        state.latest_execution_payload_bid.block_hash = (
-            state.latest_execution_payload_header.block_hash
-        )
+        state.latest_block_hash = state.latest_execution_payload_bid.block_hash
 
     next_epoch_via_block(spec, state)
     assert state.balances[validator_index] == 0

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -12,7 +12,6 @@ from eth2spec.test.helpers.keys import privkeys
 from eth2spec.test.helpers.state import (
     next_epoch,
     next_slot,
-    payload_state_transition_no_store,
     state_transition_and_sign_block,
 )
 from eth2spec.utils import bls
@@ -303,7 +302,6 @@ def next_slots_with_attestations(
             participation_fn,
         )
         signed_blocks.append(signed_block)
-        payload_state_transition_no_store(spec, post_state, signed_block.message)
 
     return state, signed_blocks, post_state
 

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -18,7 +18,7 @@ from eth2spec.test.helpers.eip7441 import (
 )
 from eth2spec.test.helpers.execution_payload import (
     build_empty_execution_payload,
-    build_empty_signed_execution_payload_header,
+    build_empty_signed_execution_payload_bid,
 )
 from eth2spec.test.helpers.forks import (
     is_post_altair,
@@ -131,8 +131,8 @@ def build_empty_block(spec, state, slot=None, proposer_index=None):
         empty_block.body.sync_aggregate.sync_committee_signature = spec.G2_POINT_AT_INFINITY
 
     if is_post_gloas(spec):
-        signed_header = build_empty_signed_execution_payload_header(spec, state)
-        empty_block.body.signed_execution_payload_bid = signed_header
+        signed_bid = build_empty_signed_execution_payload_bid(spec, state)
+        empty_block.body.signed_execution_payload_bid = signed_bid
         return empty_block
 
     if is_post_bellatrix(spec):

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -322,7 +322,7 @@ def build_empty_post_gloas_execution_payload_bid(spec, state):
     # Set block_hash to a different value than spec.Hash32(),
     # to distinguish it from the genesis block hash and have
     # is_parent_node_full correctly return False
-    empty_payload_hash = spec.Hash32(b'\x01' + b'\x00' * 31)
+    empty_payload_hash = spec.Hash32(b"\x01" + b"\x00" * 31)
     return spec.ExecutionPayloadBid(
         parent_block_hash=state.latest_block_hash,
         parent_block_root=parent_block_root,

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -319,10 +319,14 @@ def build_empty_post_gloas_execution_payload_bid(spec, state):
     kzg_list = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK]()
     # Use self-build: builder_index is the same as the beacon proposer index
     builder_index = spec.get_beacon_proposer_index(state)
+    # Set block_hash to a different value than spec.Hash32(),
+    # to distinguish it from the genesis block hash and have
+    # is_parent_node_full correctly return False
+    empty_payload_hash = spec.Hash32(b'\x01' + b'\x00' * 31)
     return spec.ExecutionPayloadBid(
         parent_block_hash=state.latest_block_hash,
         parent_block_root=parent_block_root,
-        block_hash=spec.Hash32(),
+        block_hash=empty_payload_hash,
         fee_recipient=spec.ExecutionAddress(),
         gas_limit=spec.uint64(0),
         builder_index=builder_index,
@@ -332,7 +336,7 @@ def build_empty_post_gloas_execution_payload_bid(spec, state):
     )
 
 
-def build_empty_signed_execution_payload_header(spec, state):
+def build_empty_signed_execution_payload_bid(spec, state):
     if not is_post_gloas(spec):
         return
     message = build_empty_post_gloas_execution_payload_bid(spec, state)
@@ -343,7 +347,7 @@ def build_empty_signed_execution_payload_header(spec, state):
         signature = spec.G2_POINT_AT_INFINITY
     else:
         privkey = privkeys[message.builder_index]
-        signature = spec.get_execution_payload_header_signature(state, message, privkey)
+        signature = spec.get_execution_payload_bid_signature(state, message, privkey)
 
     return spec.SignedExecutionPayloadBid(
         message=message,

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -428,9 +428,6 @@ def build_randomized_execution_payload(spec, state, rng):
 
 
 def build_state_with_incomplete_transition(spec, state):
-    header = spec.ExecutionPayloadHeader()
-    state = build_state_with_execution_payload_header(spec, state, header)
-
     if is_post_gloas(spec):
         # In Gloas, we need to set up the execution payload bid instead
         kzgs = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK]()
@@ -439,7 +436,10 @@ def build_state_with_incomplete_transition(spec, state):
             value=spec.Gwei(0),
             blob_kzg_commitments_root=kzgs.hash_tree_root(),
         )
-        state.latest_execution_payload_bid = bid
+        state = build_state_with_execution_payload_bid(spec, state, bid)
+    else:
+        header = spec.ExecutionPayloadHeader()
+        state = build_state_with_execution_payload_header(spec, state, header)
 
     assert not spec.is_merge_transition_complete(state)
 

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -11,11 +11,6 @@ from eth2spec.test.helpers.attestations import (
     state_transition_with_full_block,
 )
 from eth2spec.test.helpers.forks import is_post_fulu, is_post_gloas
-from eth2spec.test.helpers.state import (
-    payload_state_transition,
-    payload_state_transition_no_store,
-)
-
 
 def check_head_against_root(spec, store, root):
     head = spec.get_head(store)
@@ -130,7 +125,7 @@ def tick_and_add_block(
     is_optimistic=False,
     blob_data: BlobData | None = None,
 ):
-    pre_state = get_store_full_state(spec, store, signed_block.message.parent_root)
+    pre_state = store.block_states[signed_block.message.parent_root]
     if merge_block:
         assert spec.is_merge_transition_block(pre_state, signed_block.message.body)
 
@@ -216,8 +211,6 @@ def get_genesis_forkchoice_store_and_block(spec, genesis_state):
             genesis_state.latest_block_hash
         )
     store = spec.get_forkchoice_store(genesis_state, genesis_block)
-    if is_post_gloas(spec):
-        store.execution_payload_states = store.block_states.copy()
     return store, genesis_block
 
 
@@ -273,13 +266,6 @@ def run_on_block(spec, store, signed_block, valid=True):
     spec.on_block(store, signed_block)
     root = signed_block.message.hash_tree_root()
     assert store.blocks[root] == signed_block.message
-
-
-def get_store_full_state(spec, store, root):
-    if is_post_gloas(spec):
-        return store.execution_payload_states[root]
-    return store.block_states[root]
-
 
 def add_block(
     spec,
@@ -473,18 +459,11 @@ def apply_next_epoch_with_attestations(
     for signed_block in new_signed_blocks:
         block = signed_block.message
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
-        payload_state_transition(spec, store, signed_block.message)
         block_root = block.hash_tree_root()
         assert store.blocks[block_root] == block
         last_signed_block = signed_block
 
-    if is_post_gloas(spec):
-        assert (
-            store.execution_payload_states[block_root].hash_tree_root()
-            == post_state.hash_tree_root()
-        )
-    else:
-        assert store.block_states[block_root].hash_tree_root() == post_state.hash_tree_root()
+    assert store.block_states[block_root].hash_tree_root() == post_state.hash_tree_root()
 
     return post_state, store, last_signed_block
 
@@ -498,18 +477,11 @@ def apply_next_slots_with_attestations(
     for signed_block in new_signed_blocks:
         block = signed_block.message
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
-        payload_state_transition(spec, store, signed_block.message)
         block_root = block.hash_tree_root()
         assert store.blocks[block_root] == block
         last_signed_block = signed_block
 
-    if is_post_gloas(spec):
-        assert (
-            store.execution_payload_states[block_root].hash_tree_root()
-            == post_state.hash_tree_root()
-        )
-    else:
-        assert store.block_states[block_root].hash_tree_root() == post_state.hash_tree_root()
+    assert store.block_states[block_root].hash_tree_root() == post_state.hash_tree_root()
 
     return post_state, store, last_signed_block
 
@@ -537,7 +509,6 @@ def find_next_justifying_slot(spec, state, fill_cur_epoch, fill_prev_epoch, part
             participation_fn,
         )
         signed_blocks.append(signed_block)
-        payload_state_transition_no_store(spec, temp_state, signed_block.message)
 
         if is_ready_to_justify(spec, temp_state):
             justifying_slot = temp_state.slot

--- a/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fork_choice.py
@@ -12,6 +12,7 @@ from eth2spec.test.helpers.attestations import (
 )
 from eth2spec.test.helpers.forks import is_post_fulu, is_post_gloas
 
+
 def check_head_against_root(spec, store, root):
     head = spec.get_head(store)
     if is_post_gloas(spec):
@@ -266,6 +267,7 @@ def run_on_block(spec, store, signed_block, valid=True):
     spec.on_block(store, signed_block)
     root = signed_block.message.hash_tree_root()
     assert store.blocks[root] == signed_block.message
+
 
 def add_block(
     spec,

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -197,7 +197,7 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
     if is_post_gloas(spec):
         # Initialize the latest_execution_payload_bid
         genesis_block_body.signed_execution_payload_bid.message.block_hash = eth1_block_hash
-    elif is_post_bellatrix(spec): 
+    elif is_post_bellatrix(spec):
         # Initialize the execution payload header (with block number and genesis time set to 0)
         state.latest_execution_payload_header = get_sample_genesis_execution_payload_header(
             spec,

--- a/tests/core/pyspec/eth2spec/test/helpers/state.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/state.py
@@ -5,7 +5,7 @@ from remerkleable.byte_arrays import Bytes32
 
 from eth2spec.test.context import expect_assertion_error
 from eth2spec.test.helpers.block import apply_empty_block, sign_block, transition_unsigned_block
-from eth2spec.test.helpers.forks import is_post_altair, is_post_gloas
+from eth2spec.test.helpers.forks import is_post_altair
 from eth2spec.test.helpers.voluntary_exits import get_unslashed_exited_validators
 from eth2spec.utils.hash_function import hash
 from eth2spec.utils.ssz.ssz_impl import uint_to_bytes
@@ -89,6 +89,7 @@ def get_state_root(spec, state, slot) -> bytes:
     """
     assert slot < state.slot <= slot + spec.SLOTS_PER_HISTORICAL_ROOT
     return state.state_roots[slot % spec.SLOTS_PER_HISTORICAL_ROOT]
+
 
 def state_transition_and_sign_block(spec, state, block, expect_fail=False):
     """

--- a/tests/core/pyspec/eth2spec/test/helpers/state.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/state.py
@@ -90,27 +90,6 @@ def get_state_root(spec, state, slot) -> bytes:
     assert slot < state.slot <= slot + spec.SLOTS_PER_HISTORICAL_ROOT
     return state.state_roots[slot % spec.SLOTS_PER_HISTORICAL_ROOT]
 
-
-def payload_state_transition_no_store(spec, state, block):
-    if is_post_gloas(spec):
-        # cache the latest block header
-        previous_state_root = state.hash_tree_root()
-        if state.latest_block_header.state_root == spec.Root():
-            state.latest_block_header.state_root = previous_state_root
-        # also perform the state transition as if the payload was revealed
-        state.latest_block_hash = block.body.signed_execution_payload_bid.message.block_hash
-    return state
-
-
-def payload_state_transition(spec, store, block):
-    root = block.hash_tree_root()
-    state = store.block_states[root].copy()
-    if is_post_gloas(spec):
-        payload_state_transition_no_store(spec, state, block)
-        store.execution_payload_states[root] = state
-    return state
-
-
 def state_transition_and_sign_block(spec, state, block, expect_fail=False):
     """
     State transition via the provided ``block``

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_ex_ante.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_ex_ante.py
@@ -26,7 +26,6 @@ from eth2spec.test.helpers.fork_choice import (
 )
 from eth2spec.test.helpers.forks import is_post_gloas
 from eth2spec.test.helpers.state import (
-    payload_state_transition,
     state_transition_and_sign_block,
 )
 
@@ -36,7 +35,6 @@ def _apply_base_block_a(spec, state, store, test_steps):
     block = build_empty_block(spec, state, slot=state.slot + 1)
     signed_block_a = state_transition_and_sign_block(spec, state, block)
     yield from tick_and_add_block(spec, store, signed_block_a, test_steps)
-    payload_state_transition(spec, store, signed_block_a.message)
     head = spec.get_head(store)
     expected_root = signed_block_a.message.hash_tree_root()
     if is_post_gloas(spec):
@@ -104,12 +102,10 @@ def test_ex_ante_vanilla(spec, state):
     on_tick_and_append_step(spec, store, time, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_c.message)
 
     # Block B received at N+2 — C is head due to proposer score boost
     yield from add_block(spec, store, signed_block_b, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_b.message)
 
     # Attestation_1 received at N+2 — C is head
     yield from add_attestation(spec, store, attestation, test_steps)
@@ -186,12 +182,10 @@ def test_ex_ante_attestations_is_greater_than_proposer_boost_with_boost(spec, st
     on_tick_and_append_step(spec, store, time, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_c.message)
 
     # Block B received at N+2 — C is head due to proposer score boost
     yield from add_block(spec, store, signed_block_b, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_c.message)
 
     # Attestation_set_1 at slot `N + 1` voting for block B
     proposer_boost_root = signed_block_b.message.hash_tree_root()
@@ -271,19 +265,16 @@ def test_ex_ante_sandwich_without_attestations(spec, state):
     on_tick_and_append_step(spec, store, time, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_c.message)
 
     # Block B received at N+2 — C is head, it has proposer score boost
     yield from add_block(spec, store, signed_block_b, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_b.message)
 
     # Block D received at N+3 - D is head, it has proposer score boost
     time = state_d.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
     on_tick_and_append_step(spec, store, time, test_steps)
     yield from add_block(spec, store, signed_block_d, test_steps)
     check_head_against_root(spec, store, signed_block_d.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_d.message)
 
     yield "steps", test_steps
 
@@ -355,12 +346,10 @@ def test_ex_ante_sandwich_with_honest_attestation(spec, state):
     on_tick_and_append_step(spec, store, time, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_c.message)
 
     # Block B received at N+2 — C is head, it has proposer score boost
     yield from add_block(spec, store, signed_block_b, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_b.message)
 
     # Attestation_1 received at N+3 — C is head
     time = state_d.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
@@ -371,7 +360,6 @@ def test_ex_ante_sandwich_with_honest_attestation(spec, state):
     # Block D received at N+3 - D is head, it has proposer score boost
     yield from add_block(spec, store, signed_block_d, test_steps)
     check_head_against_root(spec, store, signed_block_d.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_d.message)
 
     yield "steps", test_steps
 
@@ -429,12 +417,10 @@ def test_ex_ante_sandwich_with_boost_not_sufficient(spec, state):
     on_tick_and_append_step(spec, store, time, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_c.message)
 
     # Block B received at N+2 — C is head, it has proposer score boost
     yield from add_block(spec, store, signed_block_b, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_b.message)
 
     # Attestation_set_1 at N+2 voting for block C
     proposer_boost_root = signed_block_c.message.hash_tree_root()
@@ -467,6 +453,5 @@ def test_ex_ante_sandwich_with_boost_not_sufficient(spec, state):
     # Block D received at N+3 - C is head, D's boost not sufficient!
     yield from add_block(spec, store, signed_block_d, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
-    payload_state_transition(spec, store, signed_block_d.message)
 
     yield "steps", test_steps

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
@@ -37,7 +37,6 @@ from eth2spec.test.helpers.forks import (
 from eth2spec.test.helpers.state import (
     next_epoch,
     next_slots,
-    payload_state_transition,
     state_transition_and_sign_block,
 )
 
@@ -90,14 +89,12 @@ def test_chain_no_attestations(spec, state):
     block_1 = build_empty_block_for_next_slot(spec, state)
     signed_block_1 = state_transition_and_sign_block(spec, state, block_1)
     yield from tick_and_add_block(spec, store, signed_block_1, test_steps)
-    payload_state_transition(spec, store, signed_block_1.message)
 
     # On receiving a block of next epoch
     block_2 = build_empty_block_for_next_slot(spec, state)
     signed_block_2 = state_transition_and_sign_block(spec, state, block_2)
     yield from tick_and_add_block(spec, store, signed_block_2, test_steps)
     check_head_against_root(spec, store, spec.hash_tree_root(block_2))
-    payload_state_transition(spec, store, signed_block_2.message)
     output_head_check(spec, store, test_steps)
 
     yield "steps", test_steps
@@ -133,9 +130,7 @@ def test_split_tie_breaker_no_attestations(spec, state):
     on_tick_and_append_step(spec, store, time, test_steps)
 
     yield from add_block(spec, store, signed_block_1, test_steps)
-    payload_state_transition(spec, store, signed_block_1.message)
     yield from add_block(spec, store, signed_block_2, test_steps)
-    payload_state_transition(spec, store, signed_block_2.message)
 
     highest_root = max(spec.hash_tree_root(block_1), spec.hash_tree_root(block_2))
     check_head_against_root(spec, store, highest_root)
@@ -164,7 +159,6 @@ def test_shorter_chain_but_heavier_weight(spec, state):
         long_block = build_empty_block_for_next_slot(spec, long_state)
         signed_long_block = state_transition_and_sign_block(spec, long_state, long_block)
         yield from tick_and_add_block(spec, store, signed_long_block, test_steps)
-        payload_state_transition(spec, store, signed_long_block.message)
 
     # build short tree
     short_state = genesis_state.copy()
@@ -172,7 +166,6 @@ def test_shorter_chain_but_heavier_weight(spec, state):
     short_block.body.graffiti = b"\x42" * 32
     signed_short_block = state_transition_and_sign_block(spec, short_state, short_block)
     yield from tick_and_add_block(spec, store, signed_short_block, test_steps)
-    payload_state_transition(spec, store, signed_short_block.message)
 
     # Since the long chain has higher proposer_score at slot 1, the latest long block is the head
     check_head_against_root(spec, store, spec.hash_tree_root(long_block))
@@ -211,7 +204,6 @@ def test_filtered_block_tree(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     for signed_block in signed_blocks:
         yield from add_block(spec, store, signed_block, test_steps)
-        payload_state_transition(spec, store, signed_block.message)
 
     assert store.justified_checkpoint == state.current_justified_checkpoint
 
@@ -226,10 +218,7 @@ def test_filtered_block_tree(spec, state):
     #
 
     # build a chain without attestations off of previous justified block
-    if is_post_gloas(spec):
-        non_viable_state = store.execution_payload_states[store.justified_checkpoint.root].copy()
-    else:
-        non_viable_state = store.block_states[store.justified_checkpoint.root].copy()
+    non_viable_state = store.block_states[store.justified_checkpoint.root].copy()
 
     # ensure that next wave of votes are for future epoch
     next_epoch(spec, non_viable_state)
@@ -260,7 +249,6 @@ def test_filtered_block_tree(spec, state):
 
     # include rogue block and associated attestations in the store
     yield from add_block(spec, store, signed_rogue_block, test_steps)
-    payload_state_transition(spec, store, signed_rogue_block.message)
 
     for attestation in attestations:
         yield from tick_and_run_on_attestation(spec, store, attestation, test_steps)
@@ -381,13 +369,11 @@ def test_discard_equivocations_on_attester_slashing(spec, state):
 
     # Process block_1
     yield from add_block(spec, store, signed_block_1, test_steps)
-    payload_state_transition(spec, store, signed_block_1.message)
     assert store.proposer_boost_root == spec.Root()
     check_head_against_root(spec, store, spec.hash_tree_root(block_1))
 
     # Process block_2 head should switch to block_2
     yield from add_block(spec, store, signed_block_2, test_steps)
-    payload_state_transition(spec, store, signed_block_2.message)
     assert store.proposer_boost_root == spec.Root()
     check_head_against_root(spec, store, spec.hash_tree_root(block_2))
 
@@ -448,8 +434,6 @@ def test_discard_equivocations_slashed_validator_censoring(spec, state):
 
     # Get a new store with the anchor state & anchor block
     store = spec.get_forkchoice_store(anchor_state, anchor_block)
-    if is_post_gloas(spec):
-        store.execution_payload_states = store.block_states.copy()
 
     # Now generate the store checks
     current_time = anchor_state.slot * spec.config.SECONDS_PER_SLOT + store.genesis_time
@@ -473,9 +457,7 @@ def test_discard_equivocations_slashed_validator_censoring(spec, state):
 
     # Add both blocks to the store
     yield from tick_and_add_block(spec, store, signed_block_1, test_steps)
-    payload_state_transition(spec, store, signed_block_1.message)
     yield from tick_and_add_block(spec, store, signed_block_2, test_steps)
-    payload_state_transition(spec, store, signed_block_2.message)
 
     # Find out which block will win in tie breaking
     if spec.hash_tree_root(block_1) < spec.hash_tree_root(block_2):
@@ -571,7 +553,6 @@ def test_voting_source_within_two_epoch(spec, state):
     # Now add the fork to the store
     for signed_block in signed_blocks:
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
-        payload_state_transition(spec, store, signed_block.message)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 5
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 4
     assert store.finalized_checkpoint.epoch == 3
@@ -661,7 +642,6 @@ def test_voting_source_beyond_two_epoch(spec, state):
     # Now add the fork to the store
     for signed_block in signed_blocks:
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
-        payload_state_transition(spec, store, signed_block.message)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 6
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 5
     assert store.finalized_checkpoint.epoch == 4
@@ -760,7 +740,6 @@ def test_incorrect_finalized(spec, state):
     # Now add the fork to the store
     for signed_block in signed_blocks:
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
-        payload_state_transition(spec, store, signed_block.message)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 7
     assert store.justified_checkpoint.epoch == 6
     assert store.finalized_checkpoint.epoch == 3

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_withholding.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_withholding.py
@@ -17,10 +17,7 @@ from eth2spec.test.helpers.fork_choice import (
     check_head_against_root,
     find_next_justifying_slot,
     get_genesis_forkchoice_store_and_block,
-    get_store_full_state,
     on_tick_and_append_step,
-    payload_state_transition,
-    payload_state_transition_no_store,
     tick_and_add_block,
 )
 from eth2spec.test.helpers.state import (
@@ -68,14 +65,13 @@ def test_withholding_attack(spec, state):
     for signed_block in signed_blocks[:-1]:
         current_root = signed_block.message.hash_tree_root()
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
-        payload_state_transition(spec, store, signed_block.message)
         check_head_against_root(spec, store, current_root)
     head_root = signed_blocks[-2].message.hash_tree_root()
     check_head_against_root(spec, store, head_root)
     assert spec.compute_epoch_at_slot(state.slot) == 4
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 4
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
-    state = get_store_full_state(spec, store, head_root).copy()
+    state = store.block_states[head_root].copy()
 
     # Create an honest chain in epoch 5 that includes the justifying attestations from the attack block
     next_epoch(spec, state)
@@ -86,14 +82,12 @@ def test_withholding_attack(spec, state):
     for _ in range(2):
         signed_block = state_transition_with_full_block(spec, honest_state, True, False)
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
-        honest_state = payload_state_transition(spec, store, signed_block.message).copy()
     # Create final block in the honest chain that includes the justifying attestations from the attack block
     honest_block = build_empty_block_for_next_slot(spec, honest_state)
     honest_block.body.attestations = signed_attack_block.message.body.attestations
     signed_honest_block = state_transition_and_sign_block(spec, honest_state, honest_block)
     # Add the honest block to the store
     yield from tick_and_add_block(spec, store, signed_honest_block, test_steps)
-    payload_state_transition(spec, store, signed_honest_block.message)
     check_head_against_root(spec, store, signed_honest_block.message.hash_tree_root())
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 5
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
@@ -164,8 +158,7 @@ def test_withholding_attack_unviable_honest_chain(spec, state):
     for signed_block in signed_blocks[:-1]:
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
         check_head_against_root(spec, store, signed_block.message.hash_tree_root())
-        payload_state_transition(spec, store, signed_block.message)
-    state = get_store_full_state(spec, store, signed_block.message.hash_tree_root()).copy()
+    state = store.block_states[signed_block.message.hash_tree_root()].copy()
     assert spec.compute_epoch_at_slot(state.slot) == 5
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 5
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
@@ -177,11 +170,9 @@ def test_withholding_attack_unviable_honest_chain(spec, state):
     # Create two blocks in the honest chain with full attestations, and add to the store
     for _ in range(2):
         signed_block = state_transition_with_full_block(spec, state, True, False)
-        payload_state_transition_no_store(spec, state, signed_block.message)
         assert state.current_justified_checkpoint.epoch == 3
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
         check_head_against_root(spec, store, signed_block.message.hash_tree_root())
-        payload_state_transition(spec, store, signed_block.message)
     # Create final block in the honest chain that includes the justifying attestations from the attack block
     honest_block = build_empty_block_for_next_slot(spec, state)
     honest_block.body.attestations = signed_attack_block.message.body.attestations
@@ -190,7 +181,6 @@ def test_withholding_attack_unviable_honest_chain(spec, state):
     assert state.current_justified_checkpoint.epoch == 3
     # Add the honest block to the store
     yield from tick_and_add_block(spec, store, signed_honest_block, test_steps)
-    payload_state_transition(spec, store, signed_honest_block.message)
     current_epoch = spec.compute_epoch_at_slot(spec.get_current_slot(store))
     assert current_epoch == 6
     # assert store.voting_source[honest_block_root].epoch == 3
@@ -207,7 +197,6 @@ def test_withholding_attack_unviable_honest_chain(spec, state):
 
     # Upon revealing the withheld attack block, it should become the head
     yield from tick_and_add_block(spec, store, signed_attack_block, test_steps)
-    payload_state_transition(spec, store, signed_attack_block.message)
     # The attack block is pulled up and store.justified_checkpoint is updated
     assert store.justified_checkpoint.epoch == 5
     attack_block_root = signed_attack_block.message.hash_tree_root()

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -30,7 +30,7 @@ from eth2spec.test.helpers.constants import MINIMAL, PHASE0
 from eth2spec.test.helpers.deposits import prepare_state_and_deposit
 from eth2spec.test.helpers.execution_payload import (
     build_empty_execution_payload,
-    build_empty_signed_execution_payload_header,
+    build_empty_signed_execution_payload_bid,
     compute_el_block_hash,
     compute_el_block_hash_for_block,
 )
@@ -225,7 +225,7 @@ def test_invalid_parent_from_same_slot(spec, state):
     child_block.parent_root = state.latest_block_header.hash_tree_root()
 
     if is_post_gloas(spec):
-        child_block.body.signed_execution_payload_bid = build_empty_signed_execution_payload_header(
+        child_block.body.signed_execution_payload_bid = build_empty_signed_execution_payload_bid(
             spec, state
         )
     elif is_post_bellatrix(spec):


### PR DESCRIPTION
Same as #4597, but taking a different approach to passing the old fork-choice tests.
Instead of adding "empty payload state transitions" (doing a payload state transition for each beacon block, though there are no actual payloads), this PR simply treats all beacon blocks as having a missing payload, so everything looks exactly as before from a fork-choice perspective (there are only beacon blocks). 

The one thing to be careful about is that `on_block` uses `store.execution_payload_states[block_root]` when `is_parent_node_full` returns `True`, which is the case whenever the `block.body.signed_execution_payload_bid.message.parent_block_hash == parent.body.signed_execution_payload_bid.message.block_hash`. Since we do not have any payloads, and thus no `execution_payload_states` either, we cannot have these two block hashes being the same. This would never occur with real payloads, but can occur by just setting hashes to `spec.Hash32()` as was done in the tests, both for the genesis `block_hash` and for all subsequent `execution_payload_bid.block_hash`. Doing so for the genesis block would in particular also mean that `state.latest_block_hash` continues to have this value throughout the tests (since no actual payload is ever processed), and that `execution_payload_bid.parent_block_hash` is then also always set to this, since it is (correctly) set to `state.latest_block_hash`.

To fix this, `build_empty_post_gloas_execution_payload_bid` sets the `execution_payload_bid.block_hash` to `spec.Hash32(b'\x01' + b'\x00' * 31)` instead of `spec.Hash32()`. This way, we have:
- Genesis block with `execution_payload_bid.block_hash == spec.Hash32()`
- All other blocks with `execution_payload_bid.block_hash == spec.Hash32(b'\x01' + b'\x00' * 31)` 
- `state.latest_block_hash == spec.Hash32()` (throughout)
- `execution_payload_bid.parent_block_hash == state.latest_block_hash == spec.Hash32()`

Basically all blocks after Genesis attempt to include the same (fictitious) payload with hash `spec.Hash32(b'\x01' + b'\x00' * 31)`, but it is always missing, and the latest payload is always the (also fictitious) genesis payload with hash `spec.Hash32()`. 

Note that testing with payloads was anyway not what these tests were written for, and should be done with separate gloas tests.

