### PR TITLE
Add script for identifying slow tests

### DIFF
--- a/scripts/analyze_test_times.py
+++ b/scripts/analyze_test_times.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Analyze pytest JUnit XML output to find the slowest tests.
 


### PR DESCRIPTION
This PR adds a script to analyze the execution time for individual tests. Fixes #4593.

It works by parsing the `tests/core/pyspec/test-reports/test_results.xml` file produced by running `make test` (the file is generated from `pytest --junitxml`).

I quickly drafted this script with some additional functionalities to gather opinions on which may be useful and what may be unnecessary and can be left out.

Example output:
<img width="1163" height="780" alt="Screenshot 2025-09-20 at 02 49 51" src="https://github.com/user-attachments/assets/aa1792d4-19de-49ae-ab49-f33b40e928b4" />

It also displays the total number of tests, and the distribution in each defined time bucket.

Available arguments:
1. `--slowest`: specify the top N slowest tests to display (default: 20).
2. `--longer-than`: display all the tests executed longer than N seconds.
3. `--save-csv`: save all the results into a CSV file for further analysis if needed.

<img width="1198" height="376" alt="Screenshot 2025-09-20 at 03 05 53" src="https://github.com/user-attachments/assets/1b1be80e-7911-4e15-a6eb-24ef972ed44d" />

<img width="1161" height="507" alt="Screenshot 2025-09-20 at 02 45 21" src="https://github.com/user-attachments/assets/04956c2e-04e5-4b32-9014-b5295a241abf" />