### PR TITLE
Fix deposit root field name in Eth1 data section

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -446,7 +446,7 @@ contract) and deposit count after execution of the corresponding Eth1 block. If
 over half of the block proposers in the current Eth1 voting period vote for the
 same `eth1_data` then `state.eth1_data` updates immediately allowing new
 deposits to be processed. Each deposit in `block.body.deposits` must verify
-against `state.eth1_data.eth1_deposit_root`.
+against `state.eth1_data.deposit_root`.
 
 ###### `get_eth1_data`
 


### PR DESCRIPTION
The Eth1Data container definition in beacon-chain.md specifies the field
as 'deposit_root', not 'eth1_deposit_root'. This correction ensures
consistency with the actual container structure and prevents potential
confusion or errors when implementing validator logic.
