### PR TITLE
docs: fix broken link

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/README.md
+++ b/tests/core/pyspec/eth2spec/gen_helpers/README.md
@@ -4,7 +4,7 @@
 
 A util to quickly write new test suite generators with.
 
-See [Generators documentation](../../../../generators/README.md) for integration
+See [Generators documentation](../../../../generators) for integration
 details.
 
 Options:


### PR DESCRIPTION
../../../../generators/README.md - this link was 404

../../../../generators - this link works and this link is correct! - this kind of link is also used in tests/README.md


