### PR TITLE
Port KZG 4844 test generation to pytest

### DIFF
--- a/tests/core/pyspec/eth2spec/test/deneb/kzg/test_compute_blob_kzg_proof.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/kzg/test_compute_blob_kzg_proof.py
@@ -1,0 +1,119 @@
+###############################################################################
+# Test cases for compute_blob_kzg_proof
+###############################################################################
+
+from eth_utils.hexadecimal import encode_hex
+
+from eth2spec.test.context import only_generator, single_phase, spec_test, with_phases
+from eth2spec.test.helpers.constants import DENEB
+from eth2spec.test.utils.kzg_tests import G1, INVALID_BLOBS, INVALID_G1_POINTS, VALID_BLOBS
+from tests.infra.manifest import manifest
+from tests.infra.template_test import template_test
+
+
+@template_test
+def _compute_blob_kzg_proof_case_valid_blob(blob_index):
+    blob = VALID_BLOBS[blob_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.compute_blob_kzg_proof(blob, commitment)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                },
+                "output": encode_hex(proof),
+            },
+        )
+
+    return (the_test, f"test_compute_blob_kzg_proof_case_valid_blob_{blob_index}")
+
+
+for blob_index in range(len(VALID_BLOBS)):
+    _compute_blob_kzg_proof_case_valid_blob(blob_index)
+
+
+@template_test
+def _compute_blob_kzg_proof_case_invalid_blob(blob_index):
+    blob = INVALID_BLOBS[blob_index]
+    commitment = G1
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        try:
+            proof = spec.compute_blob_kzg_proof(blob, commitment)
+        except Exception:
+            proof = None
+
+        # assert exception is thrown
+        assert proof == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_compute_blob_kzg_proof_case_invalid_blob_{blob_index}")
+
+
+for blob_index in range(len(INVALID_BLOBS)):
+    _compute_blob_kzg_proof_case_invalid_blob(blob_index)
+
+
+@template_test
+def _compute_blob_kzg_proof_case_invalid_commitment(commitment_index):
+    blob = VALID_BLOBS[1]
+    commitment = INVALID_G1_POINTS[commitment_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        try:
+            proof = spec.compute_blob_kzg_proof(blob, commitment)
+        except Exception:
+            proof = None
+
+        # assert exception is thrown
+        assert proof == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_compute_blob_kzg_proof_case_invalid_commitment_{commitment_index}")
+
+
+for commitment_index in range(len(INVALID_G1_POINTS)):
+    _compute_blob_kzg_proof_case_invalid_commitment(commitment_index)

--- a/tests/core/pyspec/eth2spec/test/deneb/kzg/test_compute_challenge.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/kzg/test_compute_challenge.py
@@ -1,0 +1,90 @@
+###############################################################################
+# Test cases for compute_challenge
+###############################################################################
+
+from eth_utils.hexadecimal import encode_hex
+
+from eth2spec.test.context import only_generator, single_phase, spec_test, with_phases
+from eth2spec.test.helpers.constants import DENEB
+from eth2spec.test.utils.kzg_tests import VALID_BLOBS
+from tests.infra.manifest import manifest
+from tests.infra.template_test import template_test
+
+
+@template_test
+def _compute_challenge_case_valid(blob_index):
+    blob = VALID_BLOBS[blob_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        commitment = spec.blob_to_kzg_commitment(blob)
+        challenge = spec.compute_challenge(blob, commitment)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                },
+                "output": encode_hex(spec.bls_field_to_bytes(challenge)),
+            },
+        )
+
+    return (the_test, f"test_compute_challenge_case_valid_{blob_index}")
+
+
+for blob_index in range(len(VALID_BLOBS)):
+    _compute_challenge_case_valid(blob_index)
+
+
+@manifest(preset_name="general", suite_name="kzg-mainnet")
+@only_generator("too slow")
+@with_phases([DENEB])
+@spec_test
+@single_phase
+def test_compute_challenge_case_mismatched_commitment(spec):
+    # Use commitment from a different blob
+    commitment = spec.blob_to_kzg_commitment(VALID_BLOBS[4])
+    blob = VALID_BLOBS[3]
+    challenge = spec.compute_challenge(blob, commitment)
+
+    yield (
+        "data",
+        "data",
+        {
+            "input": {
+                "blob": encode_hex(blob),
+                "commitment": encode_hex(commitment),
+            },
+            "output": encode_hex(spec.bls_field_to_bytes(challenge)),
+        },
+    )
+
+
+@manifest(preset_name="general", suite_name="kzg-mainnet")
+@only_generator("too slow")
+@with_phases([DENEB])
+@spec_test
+@single_phase
+def test_compute_challenge_case_commitment_at_infinity(spec):
+    commitment = spec.G1_POINT_AT_INFINITY
+    blob = VALID_BLOBS[4]
+    challenge = spec.compute_challenge(blob, commitment)
+
+    yield (
+        "data",
+        "data",
+        {
+            "input": {
+                "blob": encode_hex(blob),
+                "commitment": encode_hex(commitment),
+            },
+            "output": encode_hex(spec.bls_field_to_bytes(challenge)),
+        },
+    )

--- a/tests/core/pyspec/eth2spec/test/deneb/kzg/test_compute_kzg_proof.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/kzg/test_compute_kzg_proof.py
@@ -1,0 +1,127 @@
+###############################################################################
+# Test cases for compute_kzg_proof
+###############################################################################
+
+from eth_utils import encode_hex
+
+from eth2spec.test.context import only_generator, single_phase, spec_test, with_phases
+from eth2spec.test.helpers.constants import DENEB
+from eth2spec.test.utils.kzg_tests import (
+    INVALID_BLOBS,
+    INVALID_FIELD_ELEMENTS,
+    VALID_BLOBS,
+    VALID_FIELD_ELEMENTS,
+)
+from tests.infra.manifest import manifest
+from tests.infra.template_test import template_test
+
+
+@template_test
+def _compute_kzg_proof_case_valid(blob_index, z_index):
+    blob = VALID_BLOBS[blob_index]
+    z = VALID_FIELD_ELEMENTS[z_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        proof, y = spec.compute_kzg_proof(blob, z)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "z": encode_hex(z),
+                },
+                "output": (encode_hex(proof), encode_hex(y)),
+            },
+        )
+
+    return (the_test, f"test_compute_kzg_proof_case_valid_blob_{blob_index}_{z_index}")
+
+
+for blob_index in range(len(VALID_BLOBS)):
+    for z_index in range(len(VALID_FIELD_ELEMENTS)):
+        _compute_kzg_proof_case_valid(blob_index, z_index)
+
+
+@template_test
+def _compute_kzg_proof_case_invalid_blob(blob_index):
+    blob = INVALID_BLOBS[blob_index]
+    z = VALID_FIELD_ELEMENTS[0]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        try:
+            proof, y = spec.compute_kzg_proof(blob, z)
+            output = (encode_hex(proof), encode_hex(y))
+        except Exception:
+            output = None
+
+        # assert exception is thrown
+        assert output == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "z": encode_hex(z),
+                },
+                "output": output,
+            },
+        )
+
+    return (the_test, f"test_compute_kzg_proof_case_invalid_blob_{blob_index}")
+
+
+for blob_index in range(len(INVALID_BLOBS)):
+    _compute_kzg_proof_case_invalid_blob(blob_index)
+
+
+@template_test
+def _compute_kzg_proof_case_invalid_z(z_index):
+    blob = VALID_BLOBS[4]
+    z = INVALID_FIELD_ELEMENTS[z_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        try:
+            proof, y = spec.compute_kzg_proof(blob, z)
+            output = (encode_hex(proof), encode_hex(y))
+        except Exception:
+            output = None
+
+        # assert exception is thrown
+        assert output == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "z": encode_hex(z),
+                },
+                "output": output,
+            },
+        )
+
+    return (the_test, f"test_compute_kzg_proof_case_invalid_z_{z_index}")
+
+
+for z_index in range(len(INVALID_FIELD_ELEMENTS)):
+    _compute_kzg_proof_case_invalid_z(z_index)

--- a/tests/core/pyspec/eth2spec/test/deneb/kzg/test_verify_blob_kzg_proof.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/kzg/test_verify_blob_kzg_proof.py
@@ -1,0 +1,316 @@
+###############################################################################
+# Test cases for verify_blob_kzg_proof
+###############################################################################
+
+from eth_utils.hexadecimal import encode_hex
+
+from eth2spec.test.context import only_generator, single_phase, spec_test, with_phases
+from eth2spec.test.helpers.constants import DENEB
+from eth2spec.test.utils.kzg_tests import (
+    BLOB_ALL_TWOS,
+    BLOB_ALL_ZEROS,
+    BLOB_RANDOM_VALID1,
+    bls_add_one,
+    G1,
+    INVALID_BLOBS,
+    INVALID_G1_POINTS,
+    VALID_BLOBS,
+)
+from tests.infra.manifest import manifest
+from tests.infra.template_test import template_test
+
+
+@template_test
+def _verify_blob_kzg_proof_case_correct_proof(blob_index):
+    blob = VALID_BLOBS[blob_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.compute_blob_kzg_proof(blob, commitment)
+
+        assert spec.verify_blob_kzg_proof(blob, commitment, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                    "proof": encode_hex(proof),
+                },
+                "output": True,
+            },
+        )
+
+    return (the_test, f"test_verify_blob_kzg_proof_case_correct_proof_{blob_index}")
+
+
+for blob_index in range(len(VALID_BLOBS)):
+    _verify_blob_kzg_proof_case_correct_proof(blob_index)
+
+
+@template_test
+def _verify_blob_kzg_proof_case_incorrect_proof(blob_index):
+    blob = VALID_BLOBS[blob_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof_orig = spec.compute_blob_kzg_proof(blob, commitment)
+        proof = bls_add_one(proof_orig)
+
+        assert not spec.verify_blob_kzg_proof(blob, commitment, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                    "proof": encode_hex(proof),
+                },
+                "output": False,
+            },
+        )
+
+    return (the_test, f"test_verify_blob_kzg_proof_case_incorrect_proof_{blob_index}")
+
+
+for blob_index in range(len(VALID_BLOBS)):
+    _verify_blob_kzg_proof_case_incorrect_proof(blob_index)
+
+
+@template_test
+def _verify_blob_kzg_proof_case_incorrect_proof_point_at_infinity():
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob = BLOB_RANDOM_VALID1
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.G1_POINT_AT_INFINITY
+
+        assert not spec.verify_blob_kzg_proof(blob, commitment, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                    "proof": encode_hex(proof),
+                },
+                "output": False,
+            },
+        )
+
+    return (the_test, "test_verify_blob_kzg_proof_case_incorrect_proof_point_at_infinity")
+
+
+_verify_blob_kzg_proof_case_incorrect_proof_point_at_infinity()
+
+
+@template_test
+def _verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly():
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob = BLOB_ALL_ZEROS
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.G1_POINT_AT_INFINITY
+
+        assert spec.verify_blob_kzg_proof(blob, commitment, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                    "proof": encode_hex(proof),
+                },
+                "output": True,
+            },
+        )
+
+    return (
+        the_test,
+        "test_verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly",
+    )
+
+
+_verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly()
+
+
+@template_test
+def _verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly():
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob = BLOB_ALL_TWOS
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.G1_POINT_AT_INFINITY
+
+        assert spec.verify_blob_kzg_proof(blob, commitment, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                    "proof": encode_hex(proof),
+                },
+                "output": True,
+            },
+        )
+
+    return (
+        the_test,
+        "test_verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly",
+    )
+
+
+_verify_blob_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly()
+
+
+@template_test
+def _verify_blob_kzg_proof_case_invalid_blob(blob_index):
+    blob = INVALID_BLOBS[blob_index]
+    proof = G1
+    commitment = G1
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        try:
+            result = spec.verify_blob_kzg_proof(blob, commitment, proof)
+        except Exception:
+            result = None
+
+        # assert exception is thrown
+        assert result == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                    "proof": encode_hex(proof),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_verify_blob_kzg_proof_case_invalid_blob_{blob_index}")
+
+
+for blob_index in range(len(INVALID_BLOBS)):
+    _verify_blob_kzg_proof_case_invalid_blob(blob_index)
+
+
+@template_test
+def _verify_blob_kzg_proof_case_invalid_commitment(commitment_index):
+    blob = VALID_BLOBS[1]
+    commitment = INVALID_G1_POINTS[commitment_index]
+    proof = G1
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        try:
+            result = spec.verify_blob_kzg_proof(blob, commitment, proof)
+        except Exception:
+            result = None
+
+        # assert exception is thrown
+        assert result == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                    "proof": encode_hex(proof),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_verify_blob_kzg_proof_case_invalid_commitment_{commitment_index}")
+
+
+for commitment_index in range(len(INVALID_G1_POINTS)):
+    _verify_blob_kzg_proof_case_invalid_commitment(commitment_index)
+
+
+@template_test
+def _verify_blob_kzg_proof_case_invalid_proof(proof_index):
+    blob = VALID_BLOBS[1]
+    commitment = G1
+    proof = INVALID_G1_POINTS[proof_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        try:
+            result = spec.verify_blob_kzg_proof(blob, commitment, proof)
+        except Exception:
+            result = None
+
+        # assert exception is thrown
+        assert result == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blob": encode_hex(blob),
+                    "commitment": encode_hex(commitment),
+                    "proof": encode_hex(proof),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_verify_blob_kzg_proof_case_invalid_proof_{proof_index}")
+
+
+for proof_index in range(len(INVALID_G1_POINTS)):
+    _verify_blob_kzg_proof_case_invalid_proof(proof_index)

--- a/tests/core/pyspec/eth2spec/test/deneb/kzg/test_verify_blob_kzg_proof_batch.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/kzg/test_verify_blob_kzg_proof_batch.py
@@ -1,0 +1,365 @@
+###############################################################################
+# Test cases for verify_blob_kzg_proof_batch
+###############################################################################
+
+from eth2spec.test.context import only_generator, single_phase, spec_test, with_phases
+from eth2spec.test.helpers.constants import DENEB
+from eth2spec.test.utils.kzg_tests import (
+    BLOB_RANDOM_VALID1,
+    bls_add_one,
+    encode_hex_list,
+    INVALID_BLOBS,
+    INVALID_G1_POINTS,
+    VALID_BLOBS,
+)
+from tests.infra.manifest import manifest
+from tests.infra.template_test import template_test
+
+
+@template_test
+def _verify_blob_kzg_proof_batch_case(length):
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blobs = VALID_BLOBS[:length]
+        commitments = [spec.blob_to_kzg_commitment(blob) for blob in blobs]
+        proofs = [spec.compute_blob_kzg_proof(blob, commitments[i]) for i, blob in enumerate(blobs)]
+
+        assert spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blobs": encode_hex_list(blobs),
+                    "commitments": encode_hex_list(commitments),
+                    "proofs": encode_hex_list(proofs),
+                },
+                "output": True,
+            },
+        )
+
+    return (the_test, f"test_verify_blob_kzg_proof_batch_case_{length}")
+
+
+for length in range(len(VALID_BLOBS)):
+    _verify_blob_kzg_proof_batch_case(length)
+
+
+@template_test
+def _verify_blob_kzg_proof_batch_case_incorrect_proof_add_one():
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blobs = VALID_BLOBS
+        commitments = [spec.blob_to_kzg_commitment(blob) for blob in blobs]
+        proofs = [spec.compute_blob_kzg_proof(blob, commitments[i]) for i, blob in enumerate(blobs)]
+        # Add one to the first proof, so that it's incorrect
+        proofs = [bls_add_one(proofs[0])] + proofs[1:]
+
+        assert not spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blobs": encode_hex_list(blobs),
+                    "commitments": encode_hex_list(commitments),
+                    "proofs": encode_hex_list(proofs),
+                },
+                "output": False,
+            },
+        )
+
+    return (the_test, "test_verify_blob_kzg_proof_batch_case_incorrect_proof_add_one")
+
+
+_verify_blob_kzg_proof_batch_case_incorrect_proof_add_one()
+
+
+@template_test
+def _verify_blob_kzg_proof_batch_case_incorrect_proof_point_at_infinity():
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blobs = [BLOB_RANDOM_VALID1]
+        commitments = [spec.blob_to_kzg_commitment(blob) for blob in blobs]
+        # Use the wrong proof
+        proofs = [spec.G1_POINT_AT_INFINITY]
+
+        assert not spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blobs": encode_hex_list(blobs),
+                    "commitments": encode_hex_list(commitments),
+                    "proofs": encode_hex_list(proofs),
+                },
+                "output": False,
+            },
+        )
+
+    return (the_test, "test_verify_blob_kzg_proof_batch_case_incorrect_proof_point_at_infinity")
+
+
+_verify_blob_kzg_proof_batch_case_incorrect_proof_point_at_infinity()
+
+
+@template_test
+def _verify_blob_kzg_proof_batch_case_invalid_blob(blob_index):
+    invalid_blob = INVALID_BLOBS[blob_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blobs = VALID_BLOBS
+        commitments = [spec.blob_to_kzg_commitment(blob) for blob in blobs]
+        proofs = [spec.compute_blob_kzg_proof(blob, commitments[i]) for i, blob in enumerate(blobs)]
+        # Insert an invalid blob into the middle
+        blobs = VALID_BLOBS[:4] + [invalid_blob] + VALID_BLOBS[5:]
+
+        try:
+            spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
+            assert False, "Expected exception"
+        except Exception:
+            pass  # Expected exception
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blobs": encode_hex_list(blobs),
+                    "commitments": encode_hex_list(commitments),
+                    "proofs": encode_hex_list(proofs),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_verify_blob_kzg_proof_batch_case_invalid_blob_{blob_index}")
+
+
+for blob_index in range(len(INVALID_BLOBS)):
+    _verify_blob_kzg_proof_batch_case_invalid_blob(blob_index)
+
+
+@template_test
+def _verify_blob_kzg_proof_batch_case_invalid_commitment(commitment_index):
+    invalid_commitment = INVALID_G1_POINTS[commitment_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blobs = VALID_BLOBS
+        commitments = [spec.blob_to_kzg_commitment(blob) for blob in blobs]
+        proofs = [spec.compute_blob_kzg_proof(blob, commitments[i]) for i, blob in enumerate(blobs)]
+        # Replace first commitment with an invalid commitment
+        commitments = [invalid_commitment] + commitments[1:]
+
+        try:
+            spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
+            assert False, "Expected exception"
+        except Exception:
+            pass  # Expected exception
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blobs": encode_hex_list(blobs),
+                    "commitments": encode_hex_list(commitments),
+                    "proofs": encode_hex_list(proofs),
+                },
+                "output": None,
+            },
+        )
+
+    return (
+        the_test,
+        f"test_verify_blob_kzg_proof_batch_case_invalid_commitment_{commitment_index}",
+    )
+
+
+for commitment_index in range(len(INVALID_G1_POINTS)):
+    _verify_blob_kzg_proof_batch_case_invalid_commitment(commitment_index)
+
+
+@template_test
+def _verify_blob_kzg_proof_batch_case_invalid_proof(proof_index):
+    invalid_proof = INVALID_G1_POINTS[proof_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blobs = VALID_BLOBS
+        commitments = [spec.blob_to_kzg_commitment(blob) for blob in blobs]
+        proofs = [spec.compute_blob_kzg_proof(blob, commitments[i]) for i, blob in enumerate(blobs)]
+        # Replace first proof with an invalid proof
+        proofs = [invalid_proof] + proofs[1:]
+
+        try:
+            spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
+            assert False, "Expected exception"
+        except Exception:
+            pass  # Expected exception
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blobs": encode_hex_list(blobs),
+                    "commitments": encode_hex_list(commitments),
+                    "proofs": encode_hex_list(proofs),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_verify_blob_kzg_proof_batch_case_invalid_proof_{proof_index}")
+
+
+for proof_index in range(len(INVALID_G1_POINTS)):
+    _verify_blob_kzg_proof_batch_case_invalid_proof(proof_index)
+
+
+@template_test
+def _verify_blob_kzg_proof_batch_case_blob_length_different():
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blobs = VALID_BLOBS
+        commitments = [spec.blob_to_kzg_commitment(blob) for blob in blobs]
+        proofs = [spec.compute_blob_kzg_proof(blob, commitments[i]) for i, blob in enumerate(blobs)]
+        # Delete the last blob
+        blobs = blobs[:-1]
+
+        try:
+            spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
+            assert False, "Expected exception"
+        except Exception:
+            pass  # Expected exception
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blobs": encode_hex_list(blobs),
+                    "commitments": encode_hex_list(commitments),
+                    "proofs": encode_hex_list(proofs),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, "test_verify_blob_kzg_proof_batch_case_blob_length_different")
+
+
+_verify_blob_kzg_proof_batch_case_blob_length_different()
+
+
+@template_test
+def _verify_blob_kzg_proof_batch_case_commitment_length_different():
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blobs = VALID_BLOBS
+        commitments = [spec.blob_to_kzg_commitment(blob) for blob in blobs]
+        proofs = [spec.compute_blob_kzg_proof(blob, commitments[i]) for i, blob in enumerate(blobs)]
+        # Delete the last commitment
+        commitments = commitments[:-1]
+
+        try:
+            spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
+            assert False, "Expected exception"
+        except Exception:
+            pass  # Expected exception
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blobs": encode_hex_list(blobs),
+                    "commitments": encode_hex_list(commitments),
+                    "proofs": encode_hex_list(proofs),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, "test_verify_blob_kzg_proof_batch_case_commitment_length_different")
+
+
+_verify_blob_kzg_proof_batch_case_commitment_length_different()
+
+
+@template_test
+def _verify_blob_kzg_proof_batch_case_proof_length_different():
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blobs = VALID_BLOBS
+        commitments = [spec.blob_to_kzg_commitment(blob) for blob in blobs]
+        proofs = [spec.compute_blob_kzg_proof(blob, commitments[i]) for i, blob in enumerate(blobs)]
+        # Delete the last proof
+        proofs = proofs[:-1]
+
+        try:
+            spec.verify_blob_kzg_proof_batch(blobs, commitments, proofs)
+            assert False, "Expected exception"
+        except Exception:
+            pass  # Expected exception
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "blobs": encode_hex_list(blobs),
+                    "commitments": encode_hex_list(commitments),
+                    "proofs": encode_hex_list(proofs),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, "test_verify_blob_kzg_proof_batch_case_proof_length_different")
+
+
+_verify_blob_kzg_proof_batch_case_proof_length_different()

--- a/tests/core/pyspec/eth2spec/test/deneb/kzg/test_verify_kzg_proof.py
+++ b/tests/core/pyspec/eth2spec/test/deneb/kzg/test_verify_kzg_proof.py
@@ -1,0 +1,388 @@
+###############################################################################
+# Test cases for verify_kzg_proof
+###############################################################################
+
+from eth_utils import encode_hex
+
+from eth2spec.test.context import only_generator, single_phase, spec_test, with_phases
+from eth2spec.test.helpers.constants import DENEB
+from eth2spec.test.utils.kzg_tests import (
+    BLOB_ALL_TWOS,
+    BLOB_ALL_ZEROS,
+    BLOB_RANDOM_VALID1,
+    bls_add_one,
+    INVALID_FIELD_ELEMENTS,
+    INVALID_G1_POINTS,
+    VALID_BLOBS,
+    VALID_FIELD_ELEMENTS,
+)
+from tests.infra.manifest import manifest
+from tests.infra.template_test import template_test
+
+
+@template_test
+def _verify_kzg_proof_case_correct_proof(blob_index, z_index):
+    blob = VALID_BLOBS[blob_index]
+    z = VALID_FIELD_ELEMENTS[z_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        proof, y = spec.compute_kzg_proof(blob, z)
+        commitment = spec.blob_to_kzg_commitment(blob)
+
+        assert spec.verify_kzg_proof(commitment, z, y, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "commitment": encode_hex(commitment),
+                    "z": encode_hex(z),
+                    "y": encode_hex(y),
+                    "proof": encode_hex(proof),
+                },
+                "output": True,
+            },
+        )
+
+    return (the_test, f"test_verify_kzg_proof_case_correct_proof_{blob_index}_{z_index}")
+
+
+for blob_index in range(len(VALID_BLOBS)):
+    for z_index in range(len(VALID_FIELD_ELEMENTS)):
+        _verify_kzg_proof_case_correct_proof(blob_index, z_index)
+
+
+@template_test
+def _verify_kzg_proof_case_incorrect_proof(blob_index, z_index):
+    blob = VALID_BLOBS[blob_index]
+    z = VALID_FIELD_ELEMENTS[z_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        proof_orig, y = spec.compute_kzg_proof(blob, z)
+        proof = bls_add_one(proof_orig)
+        commitment = spec.blob_to_kzg_commitment(blob)
+
+        assert not spec.verify_kzg_proof(commitment, z, y, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "commitment": encode_hex(commitment),
+                    "z": encode_hex(z),
+                    "y": encode_hex(y),
+                    "proof": encode_hex(proof),
+                },
+                "output": False,
+            },
+        )
+
+    return (the_test, f"test_verify_kzg_proof_case_incorrect_proof_{blob_index}_{z_index}")
+
+
+for blob_index in range(len(VALID_BLOBS)):
+    for z_index in range(len(VALID_FIELD_ELEMENTS)):
+        _verify_kzg_proof_case_incorrect_proof(blob_index, z_index)
+
+
+@template_test
+def _verify_kzg_proof_case_incorrect_proof_point_at_infinity(z_index):
+    z = VALID_FIELD_ELEMENTS[z_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob = BLOB_RANDOM_VALID1
+        _, y = spec.compute_kzg_proof(blob, z)
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.G1_POINT_AT_INFINITY
+
+        assert not spec.verify_kzg_proof(commitment, z, y, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "commitment": encode_hex(commitment),
+                    "z": encode_hex(z),
+                    "y": encode_hex(y),
+                    "proof": encode_hex(proof),
+                },
+                "output": False,
+            },
+        )
+
+    return (the_test, f"test_verify_kzg_proof_case_incorrect_proof_point_at_infinity_{z_index}")
+
+
+for z_index in range(len(VALID_FIELD_ELEMENTS)):
+    _verify_kzg_proof_case_incorrect_proof_point_at_infinity(z_index)
+
+
+@template_test
+def _verify_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly(z_index):
+    z = VALID_FIELD_ELEMENTS[z_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob = BLOB_ALL_ZEROS
+        _, y = spec.compute_kzg_proof(blob, z)
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.G1_POINT_AT_INFINITY
+
+        assert spec.verify_kzg_proof(commitment, z, y, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "commitment": encode_hex(commitment),
+                    "z": encode_hex(z),
+                    "y": encode_hex(y),
+                    "proof": encode_hex(proof),
+                },
+                "output": True,
+            },
+        )
+
+    return (
+        the_test,
+        f"test_verify_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly_{z_index}",
+    )
+
+
+for z_index in range(len(VALID_FIELD_ELEMENTS)):
+    _verify_kzg_proof_case_correct_proof_point_at_infinity_for_zero_poly(z_index)
+
+
+@template_test
+def _verify_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly(z_index):
+    z = VALID_FIELD_ELEMENTS[z_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob = BLOB_ALL_TWOS
+        _, y = spec.compute_kzg_proof(blob, z)
+        commitment = spec.blob_to_kzg_commitment(blob)
+        proof = spec.G1_POINT_AT_INFINITY
+
+        assert spec.verify_kzg_proof(commitment, z, y, proof)
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "commitment": encode_hex(commitment),
+                    "z": encode_hex(z),
+                    "y": encode_hex(y),
+                    "proof": encode_hex(proof),
+                },
+                "output": True,
+            },
+        )
+
+    return (
+        the_test,
+        f"test_verify_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly_{z_index}",
+    )
+
+
+for z_index in range(len(VALID_FIELD_ELEMENTS)):
+    _verify_kzg_proof_case_correct_proof_point_at_infinity_for_twos_poly(z_index)
+
+
+@template_test
+def _verify_kzg_proof_case_invalid_commitment(commitment_index):
+    commitment = INVALID_G1_POINTS[commitment_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob, z = VALID_BLOBS[2], VALID_FIELD_ELEMENTS[1]
+        proof, y = spec.compute_kzg_proof(blob, z)
+
+        try:
+            output = spec.verify_kzg_proof(commitment, z, y, proof)
+        except Exception:
+            output = None
+
+        # assert exception is thrown
+        assert output == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "commitment": encode_hex(commitment),
+                    "z": encode_hex(z),
+                    "y": encode_hex(y),
+                    "proof": encode_hex(proof),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_verify_kzg_proof_case_invalid_commitment_{commitment_index}")
+
+
+for commitment_index in range(len(INVALID_G1_POINTS)):
+    _verify_kzg_proof_case_invalid_commitment(commitment_index)
+
+
+@template_test
+def _verify_kzg_proof_case_invalid_z(z_index):
+    z = INVALID_FIELD_ELEMENTS[z_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob, validz = VALID_BLOBS[4], VALID_FIELD_ELEMENTS[1]
+        proof, y = spec.compute_kzg_proof(blob, validz)
+        commitment = spec.blob_to_kzg_commitment(blob)
+
+        try:
+            output = spec.verify_kzg_proof(commitment, z, y, proof)
+        except Exception:
+            output = None
+
+        # assert exception is thrown
+        assert output == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "commitment": encode_hex(commitment),
+                    "z": encode_hex(z),
+                    "y": encode_hex(y),
+                    "proof": encode_hex(proof),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_verify_kzg_proof_case_invalid_z_{z_index}")
+
+
+for z_index in range(len(INVALID_FIELD_ELEMENTS)):
+    _verify_kzg_proof_case_invalid_z(z_index)
+
+
+@template_test
+def _verify_kzg_proof_case_invalid_y(y_index):
+    y = INVALID_FIELD_ELEMENTS[y_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob, z = VALID_BLOBS[4], VALID_FIELD_ELEMENTS[1]
+        proof, _ = spec.compute_kzg_proof(blob, z)
+        commitment = spec.blob_to_kzg_commitment(blob)
+
+        try:
+            output = spec.verify_kzg_proof(commitment, z, y, proof)
+        except Exception:
+            output = None
+
+        # assert exception is thrown
+        assert output == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "commitment": encode_hex(commitment),
+                    "z": encode_hex(z),
+                    "y": encode_hex(y),
+                    "proof": encode_hex(proof),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_verify_kzg_proof_case_invalid_y_{y_index}")
+
+
+for y_index in range(len(INVALID_FIELD_ELEMENTS)):
+    _verify_kzg_proof_case_invalid_y(y_index)
+
+
+@template_test
+def _verify_kzg_proof_case_invalid_proof(proof_index):
+    proof = INVALID_G1_POINTS[proof_index]
+
+    @manifest(preset_name="general", suite_name="kzg-mainnet")
+    @only_generator("too slow")
+    @with_phases([DENEB])
+    @spec_test
+    @single_phase
+    def the_test(spec):
+        blob, z = VALID_BLOBS[2], VALID_FIELD_ELEMENTS[1]
+        _, y = spec.compute_kzg_proof(blob, z)
+        commitment = spec.blob_to_kzg_commitment(blob)
+
+        try:
+            output = spec.verify_kzg_proof(commitment, z, y, proof)
+        except Exception:
+            output = None
+
+        # assert exception is thrown
+        assert output == None
+
+        yield (
+            "data",
+            "data",
+            {
+                "input": {
+                    "commitment": encode_hex(commitment),
+                    "z": encode_hex(z),
+                    "y": encode_hex(y),
+                    "proof": encode_hex(proof),
+                },
+                "output": None,
+            },
+        )
+
+    return (the_test, f"test_verify_kzg_proof_case_invalid_proof_{proof_index}")
+
+
+for proof_index in range(len(INVALID_G1_POINTS)):
+    _verify_kzg_proof_case_invalid_proof(proof_index)

--- a/tests/formats/kzg_4844/verify_kzg_proof.md
+++ b/tests/formats/kzg_4844/verify_kzg_proof.md
@@ -13,7 +13,7 @@ input:
   z: Bytes32 -- bytes encoding the BLS field element at which the polynomial should be evaluated
   y: Bytes32 -- the claimed result of the evaluation
   proof: KZGProof -- The KZG proof
-output: bool -- true (valid proof) or false (incorrect proof)
+output: bool -- true (valid proof) or false (incorrect proof), None if exception is thrown by verify_kzg_proof
 ```
 
 - `z` here is encoded as a string: hexadecimal encoding of `32` bytes

--- a/tests/generators/runners/kzg_4844_legacy.py
+++ b/tests/generators/runners/kzg_4844_legacy.py
@@ -651,6 +651,7 @@ def case_compute_challenge():
 
 
 def get_test_cases() -> Iterable[TestCase]:
+    return []
     test_case_fns = [
         ("compute_kzg_proof", case_compute_kzg_proof),
         ("verify_kzg_proof", case_verify_kzg_proof),

--- a/tests/generators/runners/kzg_7594.py
+++ b/tests/generators/runners/kzg_7594.py
@@ -1010,6 +1010,7 @@ def case_compute_verify_cell_kzg_proof_batch_challenge():
 
 
 def get_test_cases() -> Iterable[TestCase]:
+    return []
     test_case_fns = [
         ("compute_cells", case_compute_cells),
         ("compute_cells_and_kzg_proofs", case_compute_cells_and_kzg_proofs),


### PR DESCRIPTION
It does what it says.

Comparing the generated files with `diff -qr` produces:

```
Only in consensus-spec-tests/new/general/deneb/kzg: blob_to_kzg_commitment
```

which make sense because that was ported already and it is only in the pytest version.

Note: I have left the non-pytest version commented out so you can check the generated files yourself. I will remove it once it is approved.