### PR TITLE
Disable pytest checks in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,24 +37,6 @@ jobs:
             exit 1
           fi
 
-      # Ensure framework tests pass
-      - name: Run tests for test framework
-        run: |
-          cd consensus-specs
-          make test component=fw
-
-      # Ensure minimal tests pass
-      - name: Run tests for minimal
-        run: |
-          cd consensus-specs
-          make test component=pyspec preset=minimal
-
-      # Ensure mainnet tests pass
-      - name: Run tests for mainnet
-        run: |
-          cd consensus-specs
-          make test component=pyspec preset=mainnet
-
       # Add support for large files
       - name: Install Git LFS
         run: |


### PR DESCRIPTION
Doing this because they are so slow (10+ hours combined).

Might re-enable in the future, after the v1.6.0-beta.0 release.