### PR TITLE
Add pytest-durations plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ site
 
 # docker test results
 testResults
+
+# pytest durations
+pytest-durations.log

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,8 @@ test: _pyspec
 	@$(PYTHON_VENV) -m pytest \
 		$(MAYBE_PARALLEL) \
 		--capture=no \
+		--pytest-durations=20000 \
+		--pytest-durations-log=pytest-durations.log \
 		$(MAYBE_TEST) \
 		$(MAYBE_FORK) \
 		$(PRESET) \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 test = [
   "deepdiff==8.6.1",
   "pytest-cov==7.0.0",
+  "pytest-durations==1.6.1",
   "pytest-xdist==3.8.0",
   "pytest==8.4.2",
 ]


### PR DESCRIPTION
Fixes https://github.com/ethereum/consensus-specs/issues/4593.

Add this plugin that will output the duration of the tests in pytest to a file.

I tested it also in pytest multiprocessing mode.
