### PR TITLE
Add note about `earliest_available_slot`

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -319,6 +319,18 @@ As seen by the client at the time of sending the message:
 - `earliest_available_slot`: The slot of earliest available block
   (`SignedBeaconBlock`).
 
+*Note*:
+According the the definition of `earliest_available_slot`:
+- If the node is NOT able to serve all sidecars throughout the entire sidecars
+  retention period (as defined by both `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`
+  and `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS`), but is able to serve all
+  blocks during this period, it should advertise the earliest slot from which it
+  can serve all sidecars.
+- If the node is able to serve all sidecars throughout the entire sidecars
+  retention period (as defined by both `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`
+  and `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS`), it should advertise the
+  earliest slot from which it can serve all blocks.
+
 ##### BlobSidecarsByRange v1
 
 **Protocol ID:** `/eth2/beacon_chain/req/blob_sidecars_by_range/1/`

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -319,8 +319,8 @@ As seen by the client at the time of sending the message:
 - `earliest_available_slot`: The slot of earliest available block
   (`SignedBeaconBlock`).
 
-*Note*:
-According the the definition of `earliest_available_slot`:
+*Note*: According the the definition of `earliest_available_slot`:
+
 - If the node is NOT able to serve all sidecars throughout the entire sidecars
   retention period (as defined by both `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`
   and `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS`), but is able to serve all

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -321,11 +321,11 @@ As seen by the client at the time of sending the message:
 
 *Note*: According the the definition of `earliest_available_slot`:
 
-- If the node is NOT able to serve all sidecars throughout the entire sidecars
+- If the node is able to serve all blocks throughout the entire sidecars
   retention period (as defined by both `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`
-  and `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS`), but is able to serve all
-  blocks during this period, it should advertise the earliest slot from which it
-  can serve all sidecars.
+  and `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS`), but is NOT able to serve
+  all sidecars during this period, it should advertise the earliest slot from
+  which it can serve all sidecars.
 - If the node is able to serve all sidecars throughout the entire sidecars
   retention period (as defined by both `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`
   and `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS`), it should advertise the


### PR DESCRIPTION
The formal definition of `earliest_available_slot` has led to some confusion regarding the implementation, and [requests for clarification](https://discord.com/channels/595666850260713488/1417614144705794115/1419585033022214144) have been made.

This is done in this pull request.


