### PR TITLE
fix(phase0): validate WS checkpoint against epoch-start block root

### DIFF
--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -182,7 +182,7 @@ def is_within_weak_subjectivity_period(
     store: Store, ws_state: BeaconState, ws_checkpoint: Checkpoint
 ) -> bool:
     # Clients may choose to validate the input state against the input Weak Subjectivity Checkpoint
-    assert ws_state.latest_block_header.state_root == ws_checkpoint.root
+    assert get_block_root(ws_state, ws_checkpoint.epoch) == ws_checkpoint.root
     assert compute_epoch_at_slot(ws_state.slot) == ws_checkpoint.epoch
 
     ws_period = compute_weak_subjectivity_period(ws_state)


### PR DESCRIPTION
- Replace state root vs checkpoint root comparison with block root at epoch start via get_block_root(ws_state, ws_checkpoint.epoch).
- ws_checkpoint.root is a block root, not a state root; comparing it to latest_block_header.state_root is semantically wrong and can pass/fail incorrectly depending on caching and slot progression.
- This aligns WS checkpoint validation with Checkpoint semantics elsewhere in the specs, where checkpoint roots are block roots at epoch boundaries.