### PR TITLE
fix: critical validation in preset loading

### DIFF
--- a/tests/core/pyspec/eth2spec/config/config_util.py
+++ b/tests/core/pyspec/eth2spec/config/config_util.py
@@ -37,7 +37,9 @@ def load_preset(preset_files: Iterable[Path | BinaryIO | TextIO]) -> dict[str, A
             duplicates = set(fork_preset.keys()).intersection(set(preset.keys()))
             raise Exception(f"duplicate config var(s) in preset files: {', '.join(duplicates)}")
         preset.update(fork_preset)
-    assert preset != {}
+    if not preset:
+        # Avoid assert for critical validation; ensure predictable error regardless of -O
+        raise ValueError("No preset values were loaded from the provided files")
     return parse_config_vars(preset)
 
 


### PR DESCRIPTION


## Description

Replace `assert` statement with explicit validation in `load_preset()` function to ensure reliable error handling regardless of Python optimization flags.

**Problem**: The `assert preset != {}` check can be silently removed when Python runs with `-O` optimization, potentially allowing empty presets to pass through without proper error reporting.

**Solution**: Replace assertion with explicit `ValueError` that provides clear error messaging and maintains consistent behavior across all Python execution modes.

