### PR TITLE
Use correct Container syntax in EIP-6800 spec

### DIFF
--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -133,7 +133,7 @@ class StemStateDiff(Container):
 class IPAProof(Container):
     cl: Vector[BanderwagonGroupElement, IPA_PROOF_DEPTH]
     cr: Vector[BanderwagonGroupElement, IPA_PROOF_DEPTH]
-    final_evaluation = BanderwagonFieldElement
+    final_evaluation: BanderwagonFieldElement
 ```
 
 #### `VerkleProof`


### PR DESCRIPTION
Update incorrect syntax for defining the IPAProof container (`=` vs `:`)
