### PR TITLE
Fix non-deterministic test generation

### DIFF
--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_proposer_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_proposer_slashing.py
@@ -20,6 +20,7 @@ from eth2spec.test.phase0.block_processing.test_process_proposer_slashing import
 @spec_state_test
 def test_builder_payment_deletion_current_epoch(spec, state):
     """Test that builder pending payment is deleted when proposer is slashed in the same epoch as the proposal."""
+    random.seed(1234)
     # Advance past genesis epochs
     next_epoch(spec, state)
     next_epoch(spec, state)
@@ -55,6 +56,7 @@ def test_builder_payment_deletion_current_epoch(spec, state):
 @spec_state_test
 def test_builder_payment_deletion_previous_epoch(spec, state):
     """Test that builder pending payment is deleted when proposer is slashed in the epoch after the proposal."""
+    random.seed(5678)
     # Advance past genesis epochs
     next_epoch(spec, state)
     next_epoch(spec, state)
@@ -91,6 +93,7 @@ def test_builder_payment_deletion_previous_epoch(spec, state):
 @spec_state_test
 def test_builder_payment_deletion_too_late(spec, state):
     """Test that builder pending payment is NOT deleted when slashing comes more than two epochs after the proposal slot."""
+    random.seed(9012)
     # Advance past genesis epochs
     next_epoch(spec, state)
     next_epoch(spec, state)

--- a/tests/generators/runners/ssz_generic_cases/ssz_progressive_container.py
+++ b/tests/generators/runners/ssz_generic_cases/ssz_progressive_container.py
@@ -162,7 +162,7 @@ def invalid_cases():
             RandomizationMode.mode_one_count,
             RandomizationMode.mode_max_count,
         ]:
-            for i, modded_typ in enumerate(MODIFIED_PROGRESSIVE_CONTIANERS):
+            for i, modded_typ in enumerate(sorted(MODIFIED_PROGRESSIVE_CONTIANERS, key=lambda x: x.__name__)):
 
                 def the_test(rng=rng, mode=mode, typ=typ, modded_typ=modded_typ):
                     serialized = serialize(container_case_fn(rng, mode, modded_typ))


### PR DESCRIPTION
This PR fixes non-deterministic test generation that caused different outputs when running `make reftests` on different systems.

   ## Changes

   1. **Proposer slashing tests**: Added `random.seed()` calls at the start of three test functions to ensure deterministic slot selection
   2. **SSZ progressive containers**: Sorted the iteration over `MODIFIED_PROGRESSIVE_CONTIANERS` by class name to ensure consistent ordering

 

   Fixes #4639