### PR TITLE
eip7732: use bid in block parent validation

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -168,8 +168,6 @@ regards to the `ExecutionPayload` are removed:
   - [IGNORE] The block's parent (defined by `block.parent_root`) passes all
     validation (including execution node verification of the
     `block.body.execution_payload`).
-- [REJECT] The block's parent (defined by `block.parent_root`) passes
-  validation.
 
 And instead the following validations are set in place with the alias
 `bid = signed_execution_payload_bid.message`:
@@ -178,8 +176,8 @@ And instead the following validations are set in place with the alias
   execution node **is complete**:
   - [REJECT] The block's execution payload parent (defined by
     `bid.parent_block_hash`) passes all validation.
-- [REJECT] The block's parent (defined by `bid.parent_block_root`) passes
-  validation.
+- [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the
+  block's parent (defined by `block.parent_root`).
 
 ###### `execution_payload`
 


### PR DESCRIPTION
<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What this PR does (but not how it does it)
* Why this PR is necessary, including context
-->

As validation around `block.parent_root`

https://github.com/ethereum/consensus-specs/blob/ca5f3cdb0c000ff7a5ed295b6d0387d41fab5b07/specs/gloas/p2p-interface.md#L171-L172 

is going to be removed in Gloas, I believe the new validation should be using `bid` instead 

https://github.com/ethereum/consensus-specs/blob/ca5f3cdb0c000ff7a5ed295b6d0387d41fab5b07/specs/gloas/p2p-interface.md#L181-L182

This PR aims to fix the added validation (the latter).

<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->
