### PR TITLE
docs: add Quick Start section to improve developer onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ specifications. Discussions about design rationale and proposed changes can be
 brought up and discussed as issues. Solidified, agreed-upon changes to the
 specifications can be made through pull requests.
 
+## Quick Start
+
+For developers and researchers looking to understand Ethereum's consensus layer:
+- **Validators**: See [validator guide](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/)
+- **Client Developers**: Check [client implementations](https://ethereum.org/en/developers/docs/nodes-and-clients/)
+- **Researchers**: Review [EIPs](https://eips.ethereum.org/) and [research papers](https://ethresear.ch/)
+
 ## Specifications
 
 Core specifications for Ethereum proof-of-stake clients can be found in


### PR DESCRIPTION
## Description

This PR adds a Quick Start section to the README to improve developer onboarding and make the repository more accessible to different types of users.

## Changes

- Added Quick Start section with targeted links for different user types
- Included validator guide, client implementations, and research resources
- Improved discoverability for developers and researchers
- Enhanced README structure and navigation

## Benefits

- **Validators**: Direct link to validator documentation
- **Client Developers**: Easy access to client implementation guides
- **Researchers**: Quick access to EIPs and research papers
- **New Contributors**: Better understanding of where to start

## Type of change

- [x] Documentation improvement
- [x] Developer experience enhancement

This improvement makes the consensus specs repository more welcoming to new contributors and helps users quickly find relevant resources for their specific needs.