### PR TITLE
eip7732: fix zero-amount builder withdrawals

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -826,15 +826,16 @@ def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], 
             else:
                 withdrawable_balance = 0
 
-            withdrawals.append(
-                Withdrawal(
-                    index=withdrawal_index,
-                    validator_index=withdrawal.builder_index,
-                    address=withdrawal.fee_recipient,
-                    amount=withdrawable_balance,
+            if withdrawable_balance > 0:
+                withdrawals.append(
+                    Withdrawal(
+                        index=withdrawal_index,
+                        validator_index=withdrawal.builder_index,
+                        address=withdrawal.fee_recipient,
+                        amount=withdrawable_balance,
+                    )
                 )
-            )
-            withdrawal_index += WithdrawalIndex(1)
+                withdrawal_index += WithdrawalIndex(1)
         processed_builder_withdrawals_count += 1
 
     # Sweep for pending partial withdrawals


### PR DESCRIPTION
This update fixes an issue where builder withdrawals with a zero amount could be created, violating EIP-4895’s requirement that all withdrawals must have non-zero amounts. The change adds a guard to ensure builder withdrawals are only appended when the `withdrawable_balance` is greater than zero, aligning their behavior with standard validator withdrawals.

The problem occurred when a builder’s balance dropped to or below the `MIN_ACTIVATION_BALANCE` between bid creation and withdrawal processing, resulting in a zero-amount withdrawal being included in the execution payload. With this fix, such withdrawals are now excluded.
