### PR TITLE
eip7732: swap `beacon_block_root` and `slot` in places in `DataColumnSidecar`

### DIFF
--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -172,8 +172,8 @@ def get_data_column_sidecars(
                 column=column_cells,
                 kzg_commitments=kzg_commitments,
                 kzg_proofs=column_proofs,
-                beacon_block_root=beacon_block_root,
                 slot=slot,
+                beacon_block_root=beacon_block_root,
             )
         )
     return sidecars

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -98,9 +98,9 @@ class DataColumnSidecar(Container):
     # [Modified in Gloas:EIP7732]
     # Removed `kzg_commitments_inclusion_proof`
     # [New in Gloas:EIP7732]
-    beacon_block_root: Root
-    # [New in Gloas:EIP7732]
     slot: Slot
+    # [New in Gloas:EIP7732]
+    beacon_block_root: Root
 ```
 
 ### Helpers


### PR DESCRIPTION
 This PR swaps `beacon_block_root` and `slot` in places in `DataColumnSidecar`.
 
Motivation: There are currently two versions of `DataColumnSidecar`. During deserialization from SSZ, it can be tricky to determine which container version to deserialize into. Having the same byte offset for the `slot` field in both versions allows clients to read the `slot` value from the bytes (and thus gain insight into the container version) before full deserialization.