### PR TITLE
Only require nodes to publish custody columns from reconstruction

### DIFF
--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -244,11 +244,13 @@ columns from other peers.
 
 ## Reconstruction and cross-seeding
 
-If the node obtains more than 50% of all the columns, it SHOULD reconstruct the
-full data matrix via the `recover_matrix` helper. Nodes MAY delay this
-reconstruction allowing time for other columns to arrive over the network. If
-delaying reconstruction, nodes may use a random delay in order to desynchronize
-reconstruction among nodes, thus reducing overall CPU load.
+If the node custodies more than 50% of columns, and has obtained at least 50% of
+all columns, it SHOULD reconstruct the full data matrix via the `recover_matrix`
+helper to obtain the remaining columns needed for its custody requirements.
+Nodes MAY delay this reconstruction allowing time for other columns to arrive
+over the network. If delaying reconstruction, nodes may use a random delay in
+order to desynchronize reconstruction among nodes, thus reducing overall CPU
+load.
 
 Once the node obtains a column through reconstruction, the node MUST expose the
 new column as if it had received it over the network. If the node is subscribed

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -244,21 +244,20 @@ columns from other peers.
 
 ## Reconstruction and cross-seeding
 
-If the node obtains 50%+ of all the columns, it SHOULD reconstruct the full data
-matrix via the `recover_matrix` helper. Nodes MAY delay this reconstruction
-allowing time for other columns to arrive over the network. If delaying
-reconstruction, nodes may use a random delay in order to desynchronize
+If the node obtains more than 50% of all the columns, it SHOULD reconstruct the
+full data matrix via the `recover_matrix` helper. Nodes MAY delay this
+reconstruction allowing time for other columns to arrive over the network. If
+delaying reconstruction, nodes may use a random delay in order to desynchronize
 reconstruction among nodes, thus reducing overall CPU load.
 
 Once the node obtains a column through reconstruction, the node MUST expose the
 new column as if it had received it over the network. If the node is subscribed
 to the subnet corresponding to the column, it MUST send the reconstructed
 `DataColumnSidecar` to its topic mesh neighbors. If instead the node is not
-subscribed to the corresponding subnet, it SHOULD still expose the availability
-of the `DataColumnSidecar` as part of the gossip emission process. After
-exposing the reconstructed `DataColumnSidecar` to the network, the node MAY
-delete the `DataColumnSidecar` if it is not part of the node's custody
-requirement.
+subscribed to the corresponding subnet, it MAY still expose the availability of
+the `DataColumnSidecar` as part of the gossip emission process. After exposing
+the reconstructed `DataColumnSidecar` to the network, the node MAY delete the
+`DataColumnSidecar` if it is not part of the node's custody requirement.
 
 *Note*: A node always maintains a matrix view of the rows and columns they are
 following, able to cross-reference and cross-seed in either direction.


### PR DESCRIPTION
<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What this PR does (but not how it does it)
* Why this PR is necessary, including context
-->

This PR lowers the cross seeding requirements for non-supernodes, to only require publishing recovered custody columns (instead of all recovered columns) after reconstruction.

The spec currently says:
https://github.com/ethereum/consensus-specs/blob/927073b0aafc958aef4689010fb4f97d22813015/specs/fulu/das-core.md?plain=1#L253-L261

However I think its unfair for nodes custodying less than 128 ciolumns to publish all columns instead of just its sampling columns, because they might actually end up using more outbound bandwidth than a supernode every time it performs reconstruction.

* A supernode only publishes reconstructed columns that it hasn't observed via gossip.
* A non-supernode will have to publish **everything** that it doesn't custody, because it wouldn't have seen any of the non sampling columns on gossip. This means a node custdoying 65 columns will always publish at least 64 (63 non custody + at least 1 missing custody column) columns every time it reconstructs.

My preference would be making publishing to non-custody subnets optional, so that non-supernodes are not required to publish the same amount of data as supernodes after reconstruction. The impact to the network should be minimal, because we can safely assume supernode exists on a live network. On a separate note, longer term it would be ideal to reduce / eliminate the dependency on supernodes via partial 1D or 2D reconstruction and partial gossip column messages.
