### PR TITLE
Improve reftests logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,11 +189,7 @@ help-verbose:
 ###############################################################################
 
 VENV = .venv
-
-# Use editable installs for all non-generation targets, but use non-editable
-# installs for generators. More details: ethereum/consensus-specs#4633.
-UV_RUN    = uv run
-UV_RUN_NE = uv run --no-editable
+UV_RUN = uv run
 
 # Sync dependencies using uv.
 _sync: MAYBE_VERBOSE := $(if $(filter true,$(verbose)),--verbose)
@@ -334,7 +330,7 @@ reftests: MAYBE_TESTS := $(if $(k),--cases $(subst ${COMMA}, ,$(k)))
 reftests: MAYBE_FORKS := $(if $(fork),--forks $(subst ${COMMA}, ,$(fork)))
 reftests: MAYBE_PRESETS := $(if $(preset),--presets $(subst ${COMMA}, ,$(preset)))
 reftests: _pyspec
-	@$(UV_RUN_NE) python -m tests.generators.main \
+	@$(UV_RUN) python -m tests.generators.main \
 		--output $(TEST_VECTOR_DIR) \
 		$(MAYBE_VERBOSE) \
 		$(MAYBE_THREADS) \
@@ -350,7 +346,7 @@ comptests: MAYBE_FORKS := $(if $(fork),--forks $(subst ${COMMA}, ,$(fork)))
 comptests: MAYBE_PRESETS := $(if $(preset),--presets $(subst ${COMMA}, ,$(preset)))
 comptests: MAYBE_SEED := $(if $(seed),--fc-gen-seed $(seed))
 comptests: _pyspec
-	@$(UV_RUN_NE) python -m tests.generators.compliance_runners.fork_choice.test_gen \
+	@$(UV_RUN) python -m tests.generators.compliance_runners.fork_choice.test_gen \
 		--output $(COMP_TEST_VECTOR_DIR) \
 		--fc-gen-config $(FC_GEN_CONFIG) \
 		$(MAYBE_THREADS) \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ generator = [
   "filelock==3.19.1",
   "minizinc==0.10.0",
   "pathos==0.3.4",
+  "psutil==7.1.0",
   "pytest==8.4.2",
   "python-snappy==0.7.3",
   "rich==14.1.0",

--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
@@ -6,6 +6,7 @@ import uuid
 from collections.abc import Iterable
 from typing import Any
 
+import psutil
 from pathos.multiprocessing import ProcessingPool as Pool
 from rich import box
 from rich.console import Console
@@ -121,7 +122,7 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
     def debug_print(msg):
         """Only print if verbose is enabled."""
         if args.verbose:
-            print(msg)
+            print(msg, flush=True)
 
     console = Console()
     dumper = Dumper()
@@ -135,16 +136,12 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
         total_found += 1
         # Check if the test case should be filtered out
         if len(args.runners) != 0 and test_case.runner_name not in args.runners:
-            debug_print(f"Filtered: {test_case.get_identifier()}")
             continue
         if len(args.presets) != 0 and test_case.preset_name not in args.presets:
-            debug_print(f"Filtered: {test_case.get_identifier()}")
             continue
         if len(args.forks) != 0 and test_case.fork_name not in args.forks:
-            debug_print(f"Filtered: {test_case.get_identifier()}")
             continue
         if len(args.cases) != 0 and not any(s in test_case.case_name for s in args.cases):
-            debug_print(f"Filtered: {test_case.get_identifier()}")
             continue
 
         # Set the output dir and add this to out list
@@ -166,16 +163,59 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
         """Execute a test case and update active tests."""
         test_case, active_tests = data
         key = (uuid.uuid4(), test_case.get_identifier())
-        active_tests[key] = time.time()
+        test_start = time.time()
+        active_tests[key] = test_start
+
+        debug_print(f"Starting: {test_case.get_identifier()}")
+
         try:
             execute_test(test_case, dumper)
-            debug_print(f"Generated: {test_case.get_identifier()}")
+            elapsed = time.time() - test_start
+            debug_print(f"Generated: {test_case.get_identifier()} (took {elapsed:.2f}s)")
             return "generated"
         except SkippedTest:
-            debug_print(f"Skipped: {test_case.get_identifier()}")
+            elapsed = time.time() - test_start
+            debug_print(f"Skipped: {test_case.get_identifier()} (took {elapsed:.2f}s)")
             return "skipped"
         finally:
             del active_tests[key]
+
+    def periodic_status_print(active_tests, total_tasks, completed, skipped, interval=300):
+        """Print status updates periodically in verbose mode."""
+        process = psutil.Process()
+        while completed.value < total_tasks:
+            time.sleep(interval)
+            remaining = total_tasks - completed.value
+            if remaining > 0:
+                active_count = len(active_tests)
+                # Get system-wide and process memory stats
+                vm = psutil.virtual_memory()
+                total_memory_mb = vm.total / 1024 / 1024
+                system_used_mb = vm.used / 1024 / 1024
+                # Include main process + all child processes (worker pool)
+                process_rss_mb = process.memory_info().rss / 1024 / 1024
+                for child in process.children(recursive=True):
+                    try:
+                        process_rss_mb += child.memory_info().rss / 1024 / 1024
+                    except (psutil.NoSuchProcess, psutil.AccessDenied):
+                        pass
+
+                debug_print(
+                    f"Progress: {completed.value}/{total_tasks} completed, "
+                    f"{skipped.value} skipped, {active_count} active, "
+                    f"{remaining} remaining, elapsed {time_since(start_time)}"
+                )
+                debug_print(
+                    f"Memory: "
+                    f"this process {process_rss_mb:.0f}MB, "
+                    f"all processes {system_used_mb:.0f}MB, "
+                    f"total available {total_memory_mb:.0f}MB"
+                )
+                if active_tests:
+                    for key, start_time_test in list(active_tests.items()):
+                        debug_print(
+                            f"  - Active: {key[1]} (running for {time_since(start_time_test)})"
+                        )
 
     def display_active_tests(active_tests, total_tasks, completed, skipped, width):
         """Display a table of active tests."""
@@ -211,47 +251,69 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
                 time.sleep(0.25)
 
     # Generate all of the test cases
-    with multiprocessing.Manager() as manager:
-        active_tests = manager.dict()
-        completed = manager.Value("i", 0)
-        skipped = manager.Value("i", 0)
-        width = max([len(t.get_identifier()) for t in selected_test_cases])
+    try:
+        with multiprocessing.Manager() as manager:
+            active_tests = manager.dict()
+            completed = manager.Value("i", 0)
+            skipped = manager.Value("i", 0)
+            width = max([len(t.get_identifier()) for t in selected_test_cases])
 
-        if not args.verbose:
-            display_thread = threading.Thread(
-                target=display_active_tests,
-                args=(active_tests, len(selected_test_cases), completed, skipped, width),
-                daemon=True,
-            )
-            display_thread.start()
+            if not args.verbose:
+                display_thread = threading.Thread(
+                    target=display_active_tests,
+                    args=(active_tests, len(selected_test_cases), completed, skipped, width),
+                    daemon=True,
+                )
+                display_thread.start()
+            else:
+                # Start periodic status printing in verbose mode
+                status_thread = threading.Thread(
+                    target=periodic_status_print,
+                    args=(active_tests, len(selected_test_cases), completed, skipped),
+                    daemon=True,
+                )
+                status_thread.start()
 
-        # Map each test case to a thread worker
-        inputs = [(t, active_tests) for t in selected_test_cases]
+            # Map each test case to a thread worker
+            inputs = [(t, active_tests) for t in selected_test_cases]
 
-        if args.threads == 1:
-            for input in inputs:
-                result = worker_function(input)
-                if result == "skipped":
-                    skipped.value += 1
-                completed.value += 1
-        else:
-            for result in Pool(processes=args.threads).uimap(worker_function, inputs):
-                if result == "skipped":
-                    skipped.value += 1
-                completed.value += 1
+            if args.threads == 1:
+                for input in inputs:
+                    result = worker_function(input)
+                    if result == "skipped":
+                        skipped.value += 1
+                    completed.value += 1
+            else:
+                pool = Pool(processes=args.threads)
+                try:
+                    for result in pool.uimap(worker_function, inputs):
+                        if result == "skipped":
+                            skipped.value += 1
+                        completed.value += 1
+                except KeyboardInterrupt:
+                    # Terminate pool immediately on interrupt
+                    pool.terminate()
+                    pool.join()
+                    raise
+                else:
+                    # Normal cleanup when completed
+                    pool.close()
+                    pool.join()
 
-        if not args.verbose:
-            display_thread.join()
+            if not args.verbose:
+                display_thread.join()
 
-        elapsed = round(time.time() - start_time, 2)
+            elapsed = round(time.time() - start_time, 2)
 
-        # Display final summary using rich
-        total_selected = len(selected_test_cases)
-        total_completed = completed.value - skipped.value
-        total_skipped = skipped.value
+            # Display final summary using rich
+            total_selected = len(selected_test_cases)
+            total_completed = completed.value - skipped.value
+            total_skipped = skipped.value
 
-    display_test_summary(
-        console, total_found, total_selected, total_completed, total_skipped, elapsed
-    )
+        display_test_summary(
+            console, total_found, total_selected, total_completed, total_skipped, elapsed
+        )
 
-    debug_print(f"Completed generation of {tests_prefix} in {elapsed} seconds")
+        debug_print(f"Completed generation of {tests_prefix} in {elapsed} seconds")
+    except KeyboardInterrupt:
+        return

--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/utils.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/utils.py
@@ -1,5 +1,4 @@
 import functools
-import os
 import signal
 import time
 
@@ -7,11 +6,11 @@ from rich.console import Console
 
 
 def install_sigint_handler(console: Console) -> None:
-    """On Ctrl-C, show the cursor and exit immediately."""
+    """On Ctrl-C, show the cursor and allow cleanup to run."""
 
     def _handle_sigint(signum, frame):
         console.show_cursor()
-        os._exit(0)
+        raise KeyboardInterrupt
 
     signal.signal(signal.SIGINT, _handle_sigint)
 

--- a/uv.lock
+++ b/uv.lock
@@ -467,6 +467,7 @@ generator = [
     { name = "filelock" },
     { name = "minizinc" },
     { name = "pathos" },
+    { name = "psutil" },
     { name = "pytest" },
     { name = "python-snappy" },
     { name = "rich" },
@@ -515,6 +516,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.20" },
     { name = "mypy", marker = "extra == 'lint'", specifier = "==1.18.2" },
     { name = "pathos", marker = "extra == 'generator'", specifier = "==0.3.4" },
+    { name = "psutil", marker = "extra == 'generator'", specifier = "==7.1.0" },
     { name = "py-arkworks-bls12381", specifier = "==0.3.8" },
     { name = "py-ecc", specifier = "==8.0.0" },
     { name = "pycryptodome", specifier = "==3.23.0" },
@@ -1193,6 +1195,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/46/9e9f2ae7e8e284acbde6ab36f7f4a35b273519a60c0ed419af2da780d49f/ppft-1.7.7.tar.gz", hash = "sha256:f3f77448cfe24c2b8d2296b6d8732280b25041a3f3e1f551856c6451d3e01b96", size = 136272, upload-time = "2025-04-16T01:47:40.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/23/6aef7c24f4ee6f765aeaaaa3bf24cfdb0730a20336a02b1a061d227d84be/ppft-1.7.7-py3-none-any.whl", hash = "sha256:fb7524db110682de886b4bb5b08f7bf6a38940566074ef2f62521cbbd3864676", size = 56764, upload-time = "2025-04-16T01:47:39.453Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/31/4723d756b59344b643542936e37a31d1d3204bcdc42a7daa8ee9eb06fb50/psutil-7.1.0.tar.gz", hash = "sha256:655708b3c069387c8b77b072fc429a57d0e214221d01c0a772df7dfedcb3bcd2", size = 497660, upload-time = "2025-09-17T20:14:52.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/62/ce4051019ee20ce0ed74432dd73a5bb087a6704284a470bb8adff69a0932/psutil-7.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76168cef4397494250e9f4e73eb3752b146de1dd950040b29186d0cce1d5ca13", size = 245242, upload-time = "2025-09-17T20:14:56.126Z" },
+    { url = "https://files.pythonhosted.org/packages/38/61/f76959fba841bf5b61123fbf4b650886dc4094c6858008b5bf73d9057216/psutil-7.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:5d007560c8c372efdff9e4579c2846d71de737e4605f611437255e81efcca2c5", size = 246682, upload-time = "2025-09-17T20:14:58.25Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7a/37c99d2e77ec30d63398ffa6a660450b8a62517cabe44b3e9bae97696e8d/psutil-7.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22e4454970b32472ce7deaa45d045b34d3648ce478e26a04c7e858a0a6e75ff3", size = 287994, upload-time = "2025-09-17T20:14:59.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/de/04c8c61232f7244aa0a4b9a9fbd63a89d5aeaf94b2fc9d1d16e2faa5cbb0/psutil-7.1.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c70e113920d51e89f212dd7be06219a9b88014e63a4cec69b684c327bc474e3", size = 291163, upload-time = "2025-09-17T20:15:01.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/58/c4f976234bf6d4737bc8c02a81192f045c307b72cf39c9e5c5a2d78927f6/psutil-7.1.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d4a113425c037300de3ac8b331637293da9be9713855c4fc9d2d97436d7259d", size = 293625, upload-time = "2025-09-17T20:15:04.492Z" },
+    { url = "https://files.pythonhosted.org/packages/79/87/157c8e7959ec39ced1b11cc93c730c4fb7f9d408569a6c59dbd92ceb35db/psutil-7.1.0-cp37-abi3-win32.whl", hash = "sha256:09ad740870c8d219ed8daae0ad3b726d3bf9a028a198e7f3080f6a1888b99bca", size = 244812, upload-time = "2025-09-17T20:15:07.462Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/b44c4f697276a7a95b8e94d0e320a7bf7f3318521b23de69035540b39838/psutil-7.1.0-cp37-abi3-win_amd64.whl", hash = "sha256:57f5e987c36d3146c0dd2528cd42151cf96cd359b9d67cfff836995cc5df9a3d", size = 247965, upload-time = "2025-09-17T20:15:09.673Z" },
+    { url = "https://files.pythonhosted.org/packages/26/65/1070a6e3c036f39142c2820c4b52e9243246fcfc3f96239ac84472ba361e/psutil-7.1.0-cp37-abi3-win_arm64.whl", hash = "sha256:6937cb68133e7c97b6cc9649a570c9a18ba0efebed46d8c5dae4c07fa1b67a07", size = 244971, upload-time = "2025-09-17T20:15:12.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Use editable installs so we can test changes.
* Remove "Filtered" prints which can be like 100k prints.
* Print a status every 5 minutes:

<img width="978" height="203" alt="image" src="https://github.com/user-attachments/assets/9644d68d-469c-4fc9-aaf0-ccd65ff48620" />

* Fix residual python processes after ctrl-C'ing reference test generation.
  * A side effect of this is these prints. Unavoidable:

<img width="226" height="141" alt="image" src="https://github.com/user-attachments/assets/0f316a1b-029e-44b7-87f9-83f7d2139442" />
