### PR TITLE
Restart workers periodically to prevent memory accumulation

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
@@ -284,7 +284,8 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
                         skipped.value += 1
                     completed.value += 1
             else:
-                pool = Pool(processes=args.threads)
+                # Restart workers periodically to prevent memory accumulation
+                pool = Pool(processes=args.threads, maxtasksperchild=100)
                 try:
                     for result in pool.uimap(worker_function, inputs):
                         if result == "skipped":


### PR DESCRIPTION
I'm pretty sure the reference test generation working functions are accumulating memory and this is why the runner is running out of memory. I tested locally and found that this did make a difference. I will merge this & see if it solves our issue.

I think switching to pytest might solve the underlying issue, not sure. I believe this issue popped up now because etan's PR added many new SSZ tests and that pushed it over the limit. 