### PR TITLE
Maybe fix release push step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Upload spec test tarballs to the specs release
+      - name: Upload spec test tarballs
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            consensus-spec-tests/general.tar.gz
+            consensus-spec-tests/minimal.tar.gz
+            consensus-spec-tests/mainnet.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Finally, publish the spec tests release
       # Requires a personal access token (PAT) with contents:read-write
       - name: Publish spec tests release


### PR DESCRIPTION
The spec release is still failing to push the spec tests. Not sure why, but I think removing the `--depth=1` argument will fix it. It appears that it's referencing an object which it doesn't have. This used to work, not sure what changed. Maybe it had something to do with deterministic builds.

<img width="1226" height="214" alt="image" src="https://github.com/user-attachments/assets/32da2e98-43e4-4291-84d2-91ad5664c686" />

I've also added a step to include the release tarballs in the consensus-specs release.