### PR TITLE
Always reinstall `eth2spec` for non-editable installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ VENV = .venv
 # Use editable installs for all non-generation targets, but use non-editable
 # installs for generators. More details: ethereum/consensus-specs#4633.
 UV_RUN    = uv run
-UV_RUN_NE = uv run --no-editable
+UV_RUN_NE = uv run --no-editable --reinstall-package=eth2spec
 
 # Sync dependencies using uv.
 _sync: MAYBE_VERBOSE := $(if $(filter true,$(verbose)),--verbose)


### PR DESCRIPTION
Adds `--reinstall-package=eth2spec` for `uv run` commands used with editable installs. This will ensure that `uv` doesn't used a cached version of `eth2spec` (consensus-specs) and ensure that the most recent version of repo source is used when generating test vectors during local development.

Follow-up fix to:
- #4627
 
and, in particular:
- #4634

<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->
