### PR TITLE
In the release action, use `git rm` to start fresh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           rm -rf consensus-spec-tests
           git clone https://x-access-token:${{ secrets.CONSENSUS_SPEC_TESTS_PAT }}@github.com/ethereum/consensus-spec-tests.git --branch=master --single-branch --no-tags
           cd consensus-spec-tests
-          rm -rf configs presets tests
+          git rm -rf configs presets tests
 
       # Write presets/configs to the spec tests repo
       - name: Copy presets/configs
@@ -86,7 +86,7 @@ jobs:
           cd consensus-spec-tests
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add -A
+          git add --all
           if ! git diff --cached --quiet; then
             git commit -m "release ${{ github.ref_name }} tests"
             git push origin HEAD:refs/heads/master


### PR DESCRIPTION
Maybe the push is failing with that error (see #4675) because we're simply deleting the files.

Also, expand one option (`-A` to `--all`) for readability.
