### PR TITLE
Do not push files to consensus-spec-tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,28 +43,6 @@ jobs:
             exit 1
           fi
 
-      # Add support for large files
-      - name: Install Git LFS
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git-lfs
-          git lfs install
-
-      # Clone the repo with our PAT and delete old files
-      - name: Clone spec tests repo
-        run: |
-          rm -rf consensus-spec-tests
-          git clone https://x-access-token:${{ secrets.CONSENSUS_SPEC_TESTS_PAT }}@github.com/ethereum/consensus-spec-tests.git --branch=master --single-branch --no-tags
-          cd consensus-spec-tests
-          git rm -rf configs presets tests
-
-      # Write presets/configs to the spec tests repo
-      - name: Copy presets/configs
-        run: |
-          cd consensus-specs
-          cp -r presets/ ../consensus-spec-tests/presets
-          cp -r configs/ ../consensus-spec-tests/configs
-
       # Write reference tests to the spec tests repo
       - name: Generate reference tests
         run: |
@@ -78,21 +56,6 @@ jobs:
           tar -czvf general.tar.gz tests/general
           tar -czvf minimal.tar.gz tests/minimal
           tar -czvf mainnet.tar.gz tests/mainnet
-
-      # Commit the tests to the spec tests repo
-      # Cloned with PAT, so don't need to specify it here
-      - name: Push spec tests
-        run: |
-          cd consensus-spec-tests
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add --all
-          if ! git diff --cached --quiet; then
-            git commit -m "release ${{ github.ref_name }} tests"
-            git push origin HEAD:refs/heads/master
-          else
-            echo "No changes to commit"
-          fi
 
       # Publish the specs release. We use release-drafter to
       # organize PRs into the appropriate section based on PR labels
@@ -117,24 +80,3 @@ jobs:
             consensus-spec-tests/mainnet.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Finally, publish the spec tests release
-      # Requires a personal access token (PAT) with contents:read-write
-      - name: Publish spec tests release
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: "Spec tests for ${{ github.ref_name }}"
-          body: |
-            Spec tests for `${{ github.ref_name }}`.
-
-            Detailed changelog can be found in [`${{ github.ref_name }}` specs release](https://github.com/ethereum/consensus-specs/releases/tag/${{ github.ref_name }}).
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          draft: false
-          repository: ethereum/consensus-spec-tests
-          files: |
-            consensus-spec-tests/general.tar.gz
-            consensus-spec-tests/minimal.tar.gz
-            consensus-spec-tests/mainnet.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.CONSENSUS_SPEC_TESTS_PAT }}


### PR DESCRIPTION
I'm not sure how to fix this issue in the release action. Something is wrong with the runner or with git lfs.

<img width="2452" height="428" alt="image" src="https://github.com/user-attachments/assets/0102bc3c-cfbf-4f04-8a54-daf069765806" />

For this reason, this PR updates the release action to **not** push to the consensus-spec-tests repo. We can try to deprecate this repo. Spec tests are now included in the consensus-specs release. This should be a fairly small change for clients.