### PR TITLE
eip7732: fix signed envelope yields for execution payload tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/bellatrix/block_processing/test_process_execution_payload.py
@@ -55,13 +55,13 @@ def run_execution_payload_processing(
             message=envelope,
             signature=signature,
         )
+        yield "signed_envelope", signed_envelope
     else:
         body = spec.BeaconBlockBody(execution_payload=execution_payload)
+        yield "body", body
 
     yield "pre", state
     yield "execution", {"execution_valid": execution_valid}
-    if not is_post_gloas(spec):
-        yield "body", body
 
     called_new_block = False
 


### PR DESCRIPTION
Seems that we have to make a change to the bellatrix `run_execution_payload_processing` helper too. See:

* https://github.com/ethereum/consensus-specs/pull/4622

These tests are missing the `signed_envelope.ssz_snappy` file:

<img width="1590" height="270" alt="image" src="https://github.com/user-attachments/assets/3ca799e1-266a-46ab-8568-8ba339facfad" />

