### PR TITLE
Improve fork comment check script

### DIFF
--- a/scripts/check_fork_comments.py
+++ b/scripts/check_fork_comments.py
@@ -63,6 +63,7 @@ def check_file(file_path):
 
             # Check if the fork comment is within a Python-style comment
             comment_start = match.start()
+            comment_end = match.end()
 
             # Find if there's a # before the fork comment on this line
             hash_pos = line.rfind("#", 0, comment_start)
@@ -81,6 +82,21 @@ def check_file(file_path):
                             "comment": match.group(),
                             "error_type": "inline_comment",
                             "message": f"Fork comment '{match.group()}' should be on its own line",
+                        }
+                    )
+                    continue
+
+                # Check if there's any non-whitespace content after the fork comment
+                content_after_comment = line[comment_end:].strip()
+                if content_after_comment:
+                    violations.append(
+                        {
+                            "file": file_path,
+                            "line": line_num,
+                            "content": line.strip(),
+                            "comment": match.group(),
+                            "error_type": "text_after_comment",
+                            "message": f"Text after fork comment should be on a separate line",
                         }
                     )
 

--- a/specs/_features/eip6800/beacon-chain.md
+++ b/specs/_features/eip6800/beacon-chain.md
@@ -175,16 +175,15 @@ def process_execution_payload(
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
     assert payload.timestamp == compute_time_at_slot(state, state.slot)
-
     # Verify commitments are under limit
     assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
 
-    # Verify the execution payload is valid
-    # Pass `versioned_hashes` to Execution Engine
-    # Pass `parent_beacon_block_root` to Execution Engine
+    # Compute list of versioned hashes
     versioned_hashes = [
         kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
     ]
+
+    # Verify the execution payload is valid
     assert execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(
             execution_payload=payload,

--- a/specs/_features/eip7928/beacon-chain.md
+++ b/specs/_features/eip7928/beacon-chain.md
@@ -159,10 +159,13 @@ def process_execution_payload(
         len(body.blob_kzg_commitments)
         <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
     )
-    # Verify the execution payload is valid
+
+    # Compute list of versioned hashes
     versioned_hashes = [
         kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
     ]
+
+    # Verify the execution payload is valid
     assert execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(
             execution_payload=payload,
@@ -171,6 +174,7 @@ def process_execution_payload(
             execution_requests=body.execution_requests,
         )
     )
+
     # Cache execution payload header
     state.latest_execution_payload_header = ExecutionPayloadHeader(
         parent_hash=payload.parent_hash,

--- a/specs/_features/eip8025/beacon-chain.md
+++ b/specs/_features/eip8025/beacon-chain.md
@@ -179,10 +179,12 @@ def process_execution_payload(
         # Stateless validation using execution proofs
         assert verify_execution_proofs(payload.parent_hash, payload.block_hash, state)
     else:
-        # Traditional validation - execute the payload
+        # Compute list of versioned hashes
         versioned_hashes = [
             kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
         ]
+
+        # Verify the execution payload is valid
         assert execution_engine.verify_and_notify_new_payload(
             NewPayloadRequest(
                 execution_payload=payload,

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -440,20 +440,23 @@ def process_execution_payload(
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
     assert payload.timestamp == compute_time_at_slot(state, state.slot)
-
-    # [New in Deneb:EIP4844] Verify commitments are under limit
+    # [New in Deneb:EIP4844]
+    # Verify commitments are under limit
     assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
 
-    # Verify the execution payload is valid
-    # [Modified in Deneb:EIP4844] Pass `versioned_hashes` to Execution Engine
-    # [Modified in Deneb:EIP4788] Pass `parent_beacon_block_root` to Execution Engine
+    # [New in Deneb:EIP4844]
+    # Compute list of versioned hashes
     versioned_hashes = [
         kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
     ]
+
+    # Verify the execution payload is valid
     assert execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(
             execution_payload=payload,
+            # [New in Deneb:EIP4844]
             versioned_hashes=versioned_hashes,
+            # [New in Deneb:EIP4788]
             parent_beacon_block_root=state.latest_block_header.parent_root,
         )
     )

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1278,7 +1278,8 @@ def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
     for withdrawal in expected_withdrawals:
         decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
 
-    # [New in Electra:EIP7251] Update pending partial withdrawals
+    # [New in Electra:EIP7251]
+    # Update pending partial withdrawals
     state.pending_partial_withdrawals = state.pending_partial_withdrawals[
         processed_partial_withdrawals_count:
     ]
@@ -1342,12 +1343,16 @@ def process_execution_payload(
     assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
     # Verify timestamp
     assert payload.timestamp == compute_time_at_slot(state, state.slot)
-    # [Modified in Electra:EIP7691] Verify commitments are under limit
+    # [Modified in Electra:EIP7691]
+    # Verify commitments are under limit
     assert len(body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK_ELECTRA
-    # Verify the execution payload is valid
+
+    # Compute list of versioned hashes
     versioned_hashes = [
         kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
     ]
+
+    # Verify the execution payload is valid
     assert execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(
             execution_payload=payload,
@@ -1357,6 +1362,7 @@ def process_execution_payload(
             execution_requests=body.execution_requests,
         )
     )
+
     # Cache execution payload header
     state.latest_execution_payload_header = ExecutionPayloadHeader(
         parent_hash=payload.parent_hash,

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -80,10 +80,13 @@ def process_execution_payload(
         len(body.blob_kzg_commitments)
         <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
     )
-    # Verify the execution payload is valid
+
+    # Compute list of versioned hashes
     versioned_hashes = [
         kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
     ]
+
+    # Verify the execution payload is valid
     assert execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(
             execution_payload=payload,
@@ -92,6 +95,7 @@ def process_execution_payload(
             execution_requests=body.execution_requests,
         )
     )
+
     # Cache execution payload header
     state.latest_execution_payload_header = ExecutionPayloadHeader(
         parent_hash=payload.parent_hash,


### PR DESCRIPTION
Add an additional check to `scripts/check_fork_comments.py` which ensures fork comments are on their own line.

This PR also improves comments, organization, and consistency in `process_execution_payload` functions.