### PR TITLE
Remove "under active development" sentences

### DIFF
--- a/specs/_features/eip6914/beacon-chain.md
+++ b/specs/_features/eip6914/beacon-chain.md
@@ -23,7 +23,7 @@ validator records. Refers to
 [EIP-6914](https://github.com/ethereum/EIPs/pull/6914).
 
 *Note*: This specification is built upon
-[Capella](../../capella/beacon-chain.md) and is under active development.
+[Capella](../../capella/beacon-chain.md).
 
 ## Preset
 

--- a/specs/_features/eip7441/beacon-chain.md
+++ b/specs/_features/eip7441/beacon-chain.md
@@ -30,7 +30,7 @@ This document details the beacon chain additions and changes of to support the
 EIP-7441 (Whisk SSLE).
 
 *Note*: This specification is built upon
-[capella](../../capella/beacon-chain.md) and is under active development.
+[Capella](../../capella/beacon-chain.md).
 
 ## Constants
 

--- a/specs/_features/eip7805/beacon-chain.md
+++ b/specs/_features/eip7805/beacon-chain.md
@@ -27,8 +27,8 @@ inclusion. Refers to the following posts:
 
 - [Fork-Choice enforced Inclusion Lists (FOCIL): A simple committee-based inclusion list proposal](https://ethresear.ch/t/fork-choice-enforced-inclusion-lists-focil-a-simple-committee-based-inclusion-list-proposal/19870/1)
 - [FOCIL CL & EL workflow](https://ethresear.ch/t/focil-cl-el-workflow/20526)
-  *Note*: This specification is built upon [Fulu](../../fulu/beacon-chain.md)
-  and is under active development.
+
+*Note*: This specification is built upon [Fulu](../../fulu/beacon-chain.md).
 
 ## Constants
 

--- a/specs/_features/eip7928/beacon-chain.md
+++ b/specs/_features/eip7928/beacon-chain.md
@@ -20,8 +20,7 @@
 
 ## Introduction
 
-*Note*: This specification is built upon [Fulu](../../fulu/beacon-chain.md) and
-is under active development.
+*Note*: This specification is built upon [Fulu](../../fulu/beacon-chain.md).
 
 ## Custom types
 

--- a/specs/_features/eip8025/beacon-chain.md
+++ b/specs/_features/eip8025/beacon-chain.md
@@ -32,8 +32,7 @@
 This document contains the consensus specs for EIP-8025. This enables stateless
 validation of execution payloads through cryptographic proofs.
 
-*Note*: This specification is built upon [Fulu](../../fulu/beacon-chain.md) and
-is under active development.
+*Note*: This specification is built upon [Fulu](../../fulu/beacon-chain.md).
 
 *Note*: This specification assumes the reader is familiar with the
 [public zkEVM methods exposed](./zkevm.md).

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -120,8 +120,7 @@ Electra is a consensus-layer upgrade containing a number of features. Including:
   outside Attestation
 - [EIP-7691](https://eips.ethereum.org/EIPS/eip-7691): Blob throughput increase
 
-*Note*: This specification is built upon [Deneb](../deneb/beacon-chain.md) and
-is under active development.
+*Note*: This specification is built upon [Deneb](../deneb/beacon-chain.md).
 
 ## Constants
 

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -31,8 +31,7 @@
 
 ## Introduction
 
-*Note*: This specification is built upon [Electra](../electra/beacon-chain.md)
-and is under active development.
+*Note*: This specification is built upon [Electra](../electra/beacon-chain.md).
 
 ## Configuration
 

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -82,8 +82,7 @@
 This is the beacon chain specification of the enshrined proposer builder
 separation feature.
 
-*Note*: This specification is built upon [Fulu](../fulu/beacon-chain.md) and is
-under active development.
+*Note*: This specification is built upon [Fulu](../fulu/beacon-chain.md).
 
 This feature adds new staked consensus participants called *Builders* and new
 honest validators duties called *payload timeliness attestations*. The slot is


### PR DESCRIPTION
Many of these are *not* under active development. I don't see the value in these statements anymore. We have the "this document is a work-in-progress for researchers and implementers" sentence at the top of everything that's not stable.