### PR TITLE
Fix decorator order in light client tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_data_collection.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_data_collection.py
@@ -26,12 +26,12 @@ from eth2spec.test.helpers.light_client_data_collection import (
 
 
 @with_light_client
-@spec_state_test_with_matching_config
 @with_config_overrides(
     {
         "BLOB_SCHEDULE": sample_blob_schedule(initial_epoch=1, interval=1),
     },
 )
+@spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_light_client_data_collection(spec, state):
     # Start test

--- a/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth2spec/test/altair/light_client/test_sync.py
@@ -37,12 +37,12 @@ from eth2spec.test.helpers.state import (
 
 
 @with_light_client
-@spec_state_test_with_matching_config
 @with_config_overrides(
     {
         "BLOB_SCHEDULE": sample_blob_schedule(),
     },
 )
+@spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_light_client_sync(spec, state):
     # Start test
@@ -288,12 +288,12 @@ def test_light_client_sync(spec, state):
 
 
 @with_light_client
-@spec_state_test_with_matching_config
 @with_config_overrides(
     {
         "BLOB_SCHEDULE": sample_blob_schedule(),
     },
 )
+@spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_supply_sync_committee_from_past_update(spec, state):
     # Advance the chain, so that a `LightClientUpdate` from the past is available
@@ -327,12 +327,12 @@ def test_supply_sync_committee_from_past_update(spec, state):
 
 
 @with_light_client
-@spec_state_test_with_matching_config
 @with_config_overrides(
     {
         "BLOB_SCHEDULE": sample_blob_schedule(),
     },
 )
+@spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_advance_finality_without_sync_committee(spec, state):
     # Start test
@@ -420,12 +420,12 @@ def test_advance_finality_without_sync_committee(spec, state):
 
 
 @with_light_client
-@spec_state_test_with_matching_config
 @with_config_overrides(
     {
         "BLOB_SCHEDULE": sample_blob_schedule(),
     },
 )
+@spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_light_client_sync_no_force_update(spec, state):
     """Test that force update does not occur before timeout threshold is reached.

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py
@@ -32,12 +32,12 @@ def setup_test(spec, state):
 
 
 @with_light_client
-@spec_state_test_with_matching_config
 @with_config_overrides(
     {
         "BLOB_SCHEDULE": sample_blob_schedule(),
     },
 )
+@spec_state_test_with_matching_config
 def test_process_light_client_update_not_timeout(spec, state):
     genesis_block, store = setup_test(spec, state)
 
@@ -69,12 +69,12 @@ def test_process_light_client_update_not_timeout(spec, state):
 
 
 @with_light_client
-@spec_state_test_with_matching_config
 @with_config_overrides(
     {
         "BLOB_SCHEDULE": sample_blob_schedule(),
     },
 )
+@spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_at_period_boundary(spec, state):
     genesis_block, store = setup_test(spec, state)
@@ -109,12 +109,12 @@ def test_process_light_client_update_at_period_boundary(spec, state):
 
 
 @with_light_client
-@spec_state_test_with_matching_config
 @with_config_overrides(
     {
         "BLOB_SCHEDULE": sample_blob_schedule(),
     },
 )
+@spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_timeout(spec, state):
     genesis_block, store = setup_test(spec, state)
@@ -149,12 +149,12 @@ def test_process_light_client_update_timeout(spec, state):
 
 
 @with_light_client
-@spec_state_test_with_matching_config
 @with_config_overrides(
     {
         "BLOB_SCHEDULE": sample_blob_schedule(),
     },
 )
+@spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_finality_updated(spec, state):
     _, store = setup_test(spec, state)


### PR DESCRIPTION
I gave bad advice to a new contributor. We "fixed" one issue & broke something else. See this link for context:

* https://github.com/ethereum/consensus-specs/pull/4652#issuecomment-3431755054

This PR simply reverts the changes from that PR. The fix in the following PR is the correct fix:

* https://github.com/ethereum/consensus-specs/pull/4658