### PR TITLE
Clean up Gloas specs (part 3)

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -655,10 +655,10 @@ out-of-range list access) are considered invalid. State transitions that cause a
 
 The post-state corresponding to a pre-state `state` and a signed execution
 payload envelope `signed_envelope` is defined as
-`process_execution_payload(state, signed_envelope)`. State transitions that
-trigger an unhandled exception (e.g. a failed `assert` or an out-of-range list
-access) are considered invalid. State transitions that cause an `uint64`
-overflow or underflow are also considered invalid.
+`process_execution_payload(state, signed_envelope, execution_engine)`. State
+transitions that trigger an unhandled exception (e.g. a failed `assert` or an
+out-of-range list access) are considered invalid. State transitions that cause
+an `uint64` overflow or underflow are also considered invalid.
 
 ### Modified `process_slot`
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -232,11 +232,13 @@ alias `bid` to be the committed `ExecutionPayloadBid` in
    blobs bundle constructed when constructing the bid. This field **MUST** have
    a `hash_tree_root` equal to `bid.blob_kzg_commitments_root`.
 
-After setting these parameters, the builder should run
-`process_execution_payload(state, envelope, verify=False)` and this function
-should not trigger an exception.
+After setting these parameters, the builder assembles
+`signed_execution_payload_envelope = SignedExecutionPayloadEnvelope(message=envelope, signature=BLSSignature())`,
+then verify that the envelope is valid with
+`process_execution_payload(state, signed_execution_payload_envelope, execution_engine, verify=False)`.
+This function should not trigger an exception.
 
-6. Set `state_root` to `hash_tree_root(state)`.
+7. Set `envelope.state_root` to `hash_tree_root(state)`.
 
 After preparing the `envelope` the builder should sign the envelope using:
 


### PR DESCRIPTION
This is an extension of the following PR:

* https://github.com/ethereum/consensus-specs/pull/4693

This PR focusses on the `builder.md` specifications.

* I didn't feel that "attributions" was a very good word for what builders do.
  * I've changed this to "activities" which I don't exactly love either.
  * Open to alternatives here.
* I tried to simplify some paragraphs. Less words the better.
* Use `engine_getPayloadV5` (new in fulu) instead of `engine_getPayloadV4`.
* Lots of other little improvements 🙂