### PR TITLE
eip7732: add gossip rule for old payloads

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -228,8 +228,8 @@ The following validations MUST pass before forwarding the
   the block is retrieved).
 - _[IGNORE]_ The node has not seen another valid
   `SignedExecutionPayloadEnvelope` for this block root from this builder.
-- _[IGNORE]_ The envelope is from a slot greater than the latest finalized slot
-  -- i.e. validate that
+- _[IGNORE]_ The envelope is from a slot greater than or equal to the latest
+  finalized slot -- i.e. validate that
   `envelope.slot >= compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)`
 
 Let `block` be the block with `envelope.beacon_block_root`. Let `bid` alias


### PR DESCRIPTION
This additional gossip rule is needed on the `ExecutionPayloadEnvelope` per [today's breakout room call](https://github.com/ethereum/pm/issues/1759)