### PR TITLE
Expand `CompatibleUnion` deserialization error handling

### DIFF
--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -330,9 +330,12 @@ non-exhaustive list:
 - More elements than a list limit allows. Part of enforcing consensus.
 - An out-of-bounds selected index in an `Union`.
 - An out-of-bounds type selector in a `CompatibleUnion`.
-- Incomplete data in a `CompatibleUnion` where the input is shorter than required for the selected type.
-- Corrupted input in a `CompatibleUnion` where the data contains invalid values or malformed content.
-- Inner type validation failures in a `CompatibleUnion` where the deserialized data fails validation for the selected type.
+- Incomplete data in a `CompatibleUnion` where the input is shorter than
+  required for the selected type.
+- Corrupted input in a `CompatibleUnion` where the data contains invalid values
+  or malformed content.
+- Inner type validation failures in a `CompatibleUnion` where the deserialized
+  data fails validation for the selected type.
 
 Efficient algorithms for computing this object can be found in
 [the implementations](#implementations).


### PR DESCRIPTION
Add missing error cases to CompatibleUnion deserialization specification:

- Incomplete data handling
- Corrupted input validation  
- Inner type validation failures

Syncs changes from [EIP-8016](https://github.com/ethereum/EIPs/pull/10631#pullrequestreview-3387127329) 