### PR TITLE
Run pytest tests in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,24 @@ jobs:
             exit 1
           fi
 
+      # Ensure framework tests pass
+      - name: Run tests for framework
+        run: |
+          cd consensus-specs
+          make test component=fw
+
+      # Ensure minimal tests pass
+      - name: Run tests for minimal
+        run: |
+          cd consensus-specs
+          make test component=pyspec preset=minimal
+
+      # Ensure mainnet tests pass
+      - name: Run tests for mainnet
+        run: |
+          cd consensus-specs
+          make test component=pyspec preset=mainnet
+
       # Write reference tests to the spec tests repo
       - name: Generate reference tests
         run: |


### PR DESCRIPTION
Now that the release action is stable again, we can/should run the pytest tests.

Reverts the following PR:

* https://github.com/ethereum/consensus-specs/pull/4610