### PR TITLE
Use proper integer encoding for Union in SSZ

### DIFF
--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -474,7 +474,7 @@ value. Parsers may ignore additional JSON fields.
 | `ProgressiveList[byte]`               | hex-byte-string | `"0x1122"`                               |
 | `Bitlist[N]`                          | hex-byte-string | `"0x1122"`                               |
 | `ProgressiveBitlist`                  | hex-byte-string | `"0x1122"`                               |
-| `Union[type_0, type_1, ...]`          | selector-object | `{ "selector": number, "data": type_N }` |
+| `Union[type_0, type_1, ...]`          | selector-object | `{ "selector": string, "data": type_N }` |
 | `CompatibleUnion({selector: type})`   | selector-object | `{ "selector": string, "data": type }`   |
 
 Integers are encoded as strings to avoid loss of precision in 64-bit values.


### PR DESCRIPTION
From "Integers are encoded as strings", it follows that the numeric "selector" of `Union` should also be encoded like that. Note that `Union`'s JSON encoding is currently unused. Portal uses it only for binary serialization.
