### PR TITLE
Process same-slot slashings before builder payments in Gloas

### DIFF
--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload_bid.py
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload_bid.py
@@ -384,10 +384,13 @@ def test_process_block_then_slash_non_timely_builder(spec, state):
     )
 
     block.body.signed_execution_payload_bid = signed_bid
+    yield "pre", state
+    yield "block", block
     spec.process_block(state, block)
     # Slash validator
     spec.slash_validator(state, builder_index)
-
+    yield "post", state
+    
     payment_slot = spec.SLOTS_PER_EPOCH + (block.slot % spec.SLOTS_PER_EPOCH)
     payment = state.builder_pending_payments[payment_slot]
     assert payment.withdrawal.amount == value


### PR DESCRIPTION
Fix processing of same-slot slashings before builder payments in Gloas (#4561)

Related to #4561 

Slashing currently only succeeds when the validator is slashed after the block has been processed.
This behavior fails earlier because of the assert not builder.slashed check in process_execution_payload_bid(state, block).
Reordering the internal function calls within process_block. For example, evaluating process_block_header at the end, does not resolve the issue, as the slashing condition is still enforced before the builder payment is applied.