### PR TITLE
Update testnet genesis state descriptions

### DIFF
--- a/specs/_features/eip6800/fork.md
+++ b/specs/_features/eip6800/fork.md
@@ -31,8 +31,8 @@ Warning: this configuration is not definitive.
 
 The fork is triggered at epoch `EIP6800_FORK_EPOCH`.
 
-Note that for the pure eip6800 networks, we don't apply `upgrade_to_eip6800`
-since it starts with the eip6800 version logic.
+*Note*: For the pure eip6800 networks, the `upgrade_to_eip6800` function is
+applied to transition the genesis state to this fork.
 
 ### Upgrading the state
 

--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -28,8 +28,8 @@ the Altair hard fork, introducing light client support and other improvements.
 
 The fork is triggered at epoch `ALTAIR_FORK_EPOCH`.
 
-Note that for the pure Altair networks, we don't apply `upgrade_to_altair` since
-it starts with Altair version logic.
+*Note*: For the pure Altair networks, the `upgrade_to_altair` function is
+applied to transition the genesis state to this fork.
 
 ### Upgrading the state
 

--- a/specs/bellatrix/fork.md
+++ b/specs/bellatrix/fork.md
@@ -30,8 +30,8 @@ finality, deposits, active validator count, etc. may be part of the decision
 process to trigger the fork. For now we assume the condition will be triggered
 at epoch `BELLATRIX_FORK_EPOCH`.
 
-Note that for the pure Bellatrix networks, we don't apply `upgrade_to_bellatrix`
-since it starts with Bellatrix version logic.
+*Note*: For the pure Bellatrix networks, the `upgrade_to_bellatrix` function is
+applied to transition the genesis state to this fork.
 
 ### Upgrading the state
 

--- a/specs/capella/fork.md
+++ b/specs/capella/fork.md
@@ -27,8 +27,8 @@ This document describes the process of the Capella upgrade.
 
 The fork is triggered at epoch `CAPELLA_FORK_EPOCH`.
 
-Note that for the pure Capella networks, we don't apply `upgrade_to_capella`
-since it starts with Capella version logic.
+*Note*: For the pure Capella networks, the `upgrade_to_capella` function is
+applied to transition the genesis state to this fork.
 
 ### Upgrading the state
 

--- a/specs/deneb/fork.md
+++ b/specs/deneb/fork.md
@@ -29,8 +29,8 @@ Warning: this configuration is not definitive.
 
 The fork is triggered at epoch `DENEB_FORK_EPOCH`.
 
-Note that for the pure Deneb networks, we don't apply `upgrade_to_deneb` since
-it starts with Deneb version logic.
+*Note*: For the pure Deneb networks, the `upgrade_to_deneb` function is applied
+to transition the genesis state to this fork.
 
 ### Upgrading the state
 

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -29,8 +29,8 @@ Warning: this configuration is not definitive.
 
 The fork is triggered at epoch `ELECTRA_FORK_EPOCH`.
 
-Note that for the pure Electra networks, we don't apply `upgrade_to_electra`
-since it starts with Electra version logic.
+*Note*: For the pure Electra networks, the `upgrade_to_electra` function is
+applied to transition the genesis state to this fork.
 
 ### Upgrading the state
 

--- a/specs/fulu/fork.md
+++ b/specs/fulu/fork.md
@@ -47,8 +47,8 @@ def initialize_proposer_lookahead(
 
 The fork is triggered at epoch `FULU_FORK_EPOCH`.
 
-Note that for the pure Fulu networks, we don't apply `upgrade_to_fulu` since it
-starts with Fulu version logic.
+*Note*: For the pure Fulu networks, the `upgrade_to_fulu` function is applied to
+transition the genesis state to this fork.
 
 ### Upgrading the state
 


### PR DESCRIPTION
Updated documentation comments in fork documents about `upgrade_to_<fork>` function usage.

Fixes #4720 