### PR TITLE
Add off-protocol value to the bid

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -199,7 +199,7 @@ class ExecutionPayloadBid(Container):
     builder_index: ValidatorIndex
     slot: Slot
     value: Gwei
-    el_payment: Gwei
+    execution_payment: Gwei
     blob_kzg_commitments_root: Root
 ```
 

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -281,7 +281,7 @@ The following validations MUST pass before forwarding the
   `BUILDER_WITHDRAWAL_PREFIX` -- i.e.
   `is_builder_withdrawal_credential(state.validators[bid.builder_index].withdrawal_credentials)`
   returns `True`.
-- _[REJECT]_ `bid.el_payment` is non-zero.
+- _[REJECT]_ `bid.execution_payment` is zero.
 - _[IGNORE]_ this is the first signed bid seen with a valid signature from the
   given builder for this slot.
 - _[IGNORE]_ this bid is the highest value bid seen for the corresponding slot


### PR DESCRIPTION
Add off protocol payment value to the bid instead of relying on the Builder API. Also disallow this off-protocol payments on P2P bids. 