### PR TITLE
Run `process_builder_pending_payments` before effective balance updates

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -693,6 +693,8 @@ def process_epoch(state: BeaconState) -> None:
     process_eth1_data_reset(state)
     process_pending_deposits(state)
     process_pending_consolidations(state)
+    # [New in Gloas:EIP7732]
+    process_builder_pending_payments(state)
     process_effective_balance_updates(state)
     process_slashings_reset(state)
     process_randao_mixes_reset(state)
@@ -700,8 +702,6 @@ def process_epoch(state: BeaconState) -> None:
     process_participation_flag_updates(state)
     process_sync_committee_updates(state)
     process_proposer_lookahead(state)
-    # [New in Gloas:EIP7732]
-    process_builder_pending_payments(state)
 ```
 
 #### New `process_builder_pending_payments`


### PR DESCRIPTION
Long form reasoning on this change in the discord [chat](https://discord.com/channels/595666850260713488/874767108809031740/1436395151655305389)

TLDR:
Move `process_builder_pending_payments` to run before `process_effective_balance_updates` in `process_epoch`. This makes `compute_exit_epoch_and_update_churn` use the current epoch effective balances, matching `process_execution_payload` behavior and avoiding inconsistent updates to `state.exit_balance_to_consume` and `state.earliest_exit_epoch`
