### PR TITLE
Set `block_hash` in the latest bid during Gloas state upgrade

### DIFF
--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -74,7 +74,9 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         # [Modified in Gloas:EIP7732]
         # Removed `latest_execution_payload_header`
         # [New in Gloas:EIP7732]
-        latest_execution_payload_bid=ExecutionPayloadBid(),
+        latest_execution_payload_bid=ExecutionPayloadBid(
+            block_hash=pre.latest_execution_payload_header.block_hash,
+        ),
         next_withdrawal_index=pre.next_withdrawal_index,
         next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
         historical_summaries=pre.historical_summaries,


### PR DESCRIPTION
When processing the first Gloas block, we check if `is_parent_block_full` in order to process withdrawals. This will be false for the first block and lead to failed withdrawals root checking during payload processing. This PR implements the simplest solution by setting the `block_hash` in the bid during the state upgrade.
