### PR TITLE
Pass `aggregate.committee_bits` to `get_committee_indices`

### DIFF
--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -100,7 +100,7 @@ The derivation of the `message-id` remains stable.
 
 Assuming the alias `aggregate = signed_aggregate_and_proof.message.aggregate`:
 
-The following convenience variables are re-defined
+The following convenience variables are re-defined:
 
 - `index = get_committee_indices(aggregate.committee_bits)[0]`
 

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -105,7 +105,7 @@ The following convenience variables are re-defined
 The following validations are added:
 
 - [REJECT] `len(committee_indices) == 1`, where
-  `committee_indices = get_committee_indices(aggregate)`.
+  `committee_indices = get_committee_indices(aggregate.committee_bits)`.
 - [REJECT] `aggregate.data.index == 0`
 
 ###### `blob_sidecar_{subnet_id}`

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -98,6 +98,8 @@ The derivation of the `message-id` remains stable.
 
 ###### `beacon_aggregate_and_proof`
 
+Assuming the alias `aggregate = signed_aggregate_and_proof.message.aggregate`:
+
 The following convenience variables are re-defined
 
 - `index = get_committee_indices(aggregate.committee_bits)[0]`


### PR DESCRIPTION
Correct the beacon_aggregate_and_proof validation to call get_committee_indices(aggregate.committee_bits) instead of get_committee_indices(aggregate). Electra defines get_committee_indices to accept a committee bitvector and all related code paths and tests use .committee_bits. This change aligns the networking spec with the Electra attestation format introduced by EIP-7549 and avoids implementer confusion.