### PR TITLE
Store full expected withdrawals in BeaconState while pending in ePBS

### DIFF
--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -99,7 +99,7 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         # [New in Gloas:EIP7732]
         latest_block_hash=pre.latest_execution_payload_header.block_hash,
         # [New in Gloas:EIP7732]
-        latest_withdrawals_root=Root(),
+        payload_expected_withdrawals=[],
     )
 
     return post

--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload.py
@@ -200,8 +200,9 @@ def setup_state_with_payload_bid(spec, state, builder_index=None, value=None, pr
     state.latest_execution_payload_bid = bid
 
     # Setup withdrawals root
-    empty_withdrawals = spec.List[spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD]()
-    state.latest_withdrawals_root = empty_withdrawals.hash_tree_root()
+    state.payload_expected_withdrawals = spec.List[
+        spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD
+    ]()
 
     # Add pending payment if value > 0
     if value > 0:

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -232,8 +232,9 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 
     if is_post_gloas(spec):
         state.execution_payload_availability = [0b1 for _ in range(spec.SLOTS_PER_HISTORICAL_ROOT)]
-        withdrawals = spec.List[spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD]()
-        state.latest_withdrawals_root = withdrawals.hash_tree_root()
+        state.payload_expected_withdrawals = spec.List[
+            spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD
+        ]()
         state.builder_pending_payments = [
             spec.BuilderPendingPayment() for _ in range(2 * spec.SLOTS_PER_EPOCH)
         ]


### PR DESCRIPTION
ePBS currently stores `latest_withdrawals_root` as a commitment to all withdrawals that have been deducted on CL but not yet credited on EL.

In unstable network environments, node operators sometimes need to reset their CL databases and re-sync from a checkpoint. With the system based on `latest_withdrawals_root`, the actual information about such pending but not yet credited withdrawals can be easily lost, prevent creation of new blocks without a sync mechanism to learn about pending withdrawals.

Additional sync mechanisms have historically proven tricky, e.g., for the pre-Pectra deposit mechanism, an additional snapshot needed syncing. Extra complexity can be avoided by just storing the full withdrawals rather than just their root.

