### PR TITLE
Add check for PR title

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -118,7 +118,7 @@ jobs:
           fi
 
           # Check if ends with punctuation
-          if [[ "$PR_TITLE" =~ [.!?;,]$ ]]; then
+          if [[ "$PR_TITLE" =~ [.!?,\;]$ ]]; then
             echo "PR title must not end with punctuation"
             exit 1
           fi


### PR DESCRIPTION
This PR introduces another check for PRs. It ensures that PR titles are consistent.

 - Must be 68 characters or less
 - Must not have leading or trailing whitespace
 - Must not contain double spaces
 - Must start with a capital letter
 - Must not end with punctuation (. ! ? ; ,)
 - Must use imperative mood (e.g. "Fix" not "Fixed" or "Fixes")