### PR TITLE
Fix __init__.py to import available preset instead of hardcoded mainnet

### DIFF
--- a/pysetup/generate_specs.py
+++ b/pysetup/generate_specs.py
@@ -241,9 +241,13 @@ def generate_fork_specs(
         if verbose:
             print(f"    Wrote: {output_file} ({len(spec_str):,} bytes)")
 
-    # Create __init__.py that imports mainnet as default
+    # Create __init__.py that imports an available preset as default
+    default_target_name = next(
+        (target.name for target in build_targets if target.name == "mainnet"),
+        build_targets[0].name,
+    )
     init_file = out_dir / "__init__.py"
-    init_file.write_text("from . import mainnet as spec  # noqa:F401\n")
+    init_file.write_text(f"from . import {default_target_name} as spec  # noqa:F401\n")
 
     if verbose:
         print(f"  Wrote: {init_file}")


### PR DESCRIPTION


This PR fixes a bug where `__init__.py` files generated by `generate_specs.py` always import `mainnet`, even when the `mainnet` preset is not included in the build targets. This causes `ImportError` when importing the spec module if only custom presets (e.g., `minimal`) are generated.

The fix dynamically selects the default import target: it prefers `mainnet` if available, otherwise falls back to the first build target. This ensures the generated package is always importable regardless of which presets are built.

