### PR TITLE
Fix block gossip rule typo

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -205,11 +205,6 @@ regards to the `ExecutionPayload` are removed:
 
 And instead the following validations are set in place with the alias
 `bid = block.body.signed_execution_payload_bid.message`:
-
-- If `execution_payload` verification of block's execution payload parent by an
-  execution node **is complete**:
-  - [REJECT] The block's execution payload parent (defined by
-    `bid.parent_block_root`) passes all validation.
 - [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the
   block's parent (defined by `block.parent_root`).
 


### PR DESCRIPTION
IMU the bid's parent block validation rule is redundant since there's already a Phase0 check of the parent block validation https://github.com/ethereum/consensus-specs/blob/6070972f148bc3d9417e90418f97cb7f5a9a6417/specs/phase0/p2p-interface.md?plain=1#L453-L454 and the new rule:
```
- [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the
  block's parent (defined by `block.parent_root`).
```
makes this checks implicit for the bid's parent block