### PR TITLE
Fix incorrect ordering of `row_index`/`column_index`

### DIFF
--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -152,8 +152,8 @@ def compute_matrix(blobs: Sequence[Blob]) -> Sequence[MatrixEntry]:
                 MatrixEntry(
                     cell=cell,
                     kzg_proof=proof,
-                    row_index=blob_index,
                     column_index=cell_index,
+                    row_index=blob_index,
                 )
             )
     return matrix
@@ -181,8 +181,8 @@ def recover_matrix(
                 MatrixEntry(
                     cell=cell,
                     kzg_proof=proof,
-                    row_index=blob_index,
                     column_index=cell_index,
+                    row_index=blob_index,
                 )
             )
     return matrix


### PR DESCRIPTION
<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What this PR does (but not how it does it)
* Why this PR is necessary, including context
-->

This incorrect ordering was confusing and can cause clients to implement wrongly the following functions.

According to the structure, `row_index` should be the 4th parameter:

https://github.com/ethereum/consensus-specs/blob/fe399cfdb665f0e70f40d78eff8fbc773998ae70/specs/fulu/das-core.md?plain=1#L89-L93

<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->

