### PR TITLE
Refactor `process_withdrawals`

### DIFF
--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -33,7 +33,7 @@
     - [New `get_sweep_withdrawals`](#new-get_sweep_withdrawals)
     - [New `get_expected_withdrawals`](#new-get_expected_withdrawals)
     - [New `apply_withdrawals`](#new-apply_withdrawals)
-    - [New `update_next_withdrawal_indices`](#new-update_next_withdrawal_indices)
+    - [New `update_next_withdrawal_index`](#new-update_next_withdrawal_index)
     - [New `update_next_withdrawal_validator_index`](#new-update_next_withdrawal_validator_index)
     - [New `process_withdrawals`](#new-process_withdrawals)
     - [Modified `process_execution_payload`](#modified-process_execution_payload)
@@ -433,7 +433,7 @@ def apply_withdrawals(state: BeaconState, withdrawals: Sequence[Withdrawal]) -> 
         decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
 ```
 
-#### New `update_next_withdrawal_indices`
+#### New `update_next_withdrawal_index`
 
 ```python
 def update_next_withdrawal_index(state: BeaconState, withdrawals: Sequence[Withdrawal]) -> None:
@@ -467,8 +467,8 @@ def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
     apply_withdrawals(state, withdrawals)
 
     # Update withdrawals fields in the state
-    update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
     update_next_withdrawal_index(state, withdrawals)
+    update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
 ```
 
 #### Modified `process_execution_payload`

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1355,11 +1355,11 @@ def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
     # Apply expected withdrawals
     apply_withdrawals(state, withdrawals)
 
-    # [Modified in Electra:EIP7251]
     # Update withdrawals fields in the state
+    update_next_withdrawal_index(state, withdrawals)
+    # [New in Electra:EIP7251]
     update_pending_partial_withdrawals(state, processed_partial_withdrawals_count)
     update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
-    update_next_withdrawal_index(state, withdrawals)
 ```
 
 #### Execution payload

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -916,13 +916,14 @@ def process_withdrawals(
     # Apply expected withdrawals
     apply_withdrawals(state, withdrawals)
 
-    # [Modified in Gloas:EIP7732]
     # Update withdrawals fields in the state
+    update_next_withdrawal_index(state, withdrawals)
+    # [New in Gloas:EIP7732]
     update_payload_expected_withdrawals(state, withdrawals)
+    # [New in Gloas:EIP7732]
     update_builder_pending_withdrawals(state, processed_builder_withdrawals_count)
     update_pending_partial_withdrawals(state, processed_partial_withdrawals_count)
     update_next_withdrawal_validator_index(state, processed_validators_sweep_count)
-    update_next_withdrawal_index(state, withdrawals)
 ```
 
 #### Execution payload bid


### PR DESCRIPTION
The `process_withdrawals` function would benefit from moving code into helper functions. When updating this function between forks (capella, electra, gloas) there is a lot of repetitive code which makes it a bit difficult to read.

PS: I want to refactor `get_expected_withdrawals` next.
