### PR TITLE
Fix `is_builder_payment_withdrawable` function

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -754,7 +754,7 @@ def is_builder_payment_withdrawable(
     """
     builder = state.validators[withdrawal.builder_index]
     current_epoch = compute_epoch_at_slot(state.slot)
-    return not builder.slashed or builder.withdrawable_epoch >= current_epoch
+    return not builder.slashed or current_epoch >= builder.withdrawable_epoch
 ```
 
 ##### Modified `get_expected_withdrawals`


### PR DESCRIPTION
We were checking if the builder had not been slashed or if the withdrawable epoch was in the future compared to the current epoch.
We should check if the builder has not been slashed or if the current epoch is equal to or has passed the withdrawable epoch.