### PR TITLE
Make builder's entire balance withdrawable for payments

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -781,13 +781,7 @@ def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], 
                 w.amount for w in withdrawals if w.validator_index == withdrawal.builder_index
             )
             balance = state.balances[withdrawal.builder_index] - total_withdrawn
-            builder = state.validators[withdrawal.builder_index]
-            if builder.slashed:
-                withdrawable_balance = min(balance, withdrawal.amount)
-            elif balance > MIN_ACTIVATION_BALANCE:
-                withdrawable_balance = min(balance - MIN_ACTIVATION_BALANCE, withdrawal.amount)
-            else:
-                withdrawable_balance = 0
+            withdrawable_balance = min(balance, withdrawal.amount)
 
             if withdrawable_balance > 0:
                 withdrawals.append(


### PR DESCRIPTION
I *really* do not like that the withdrawal amount can be less than the agreed upon payment amount with a proposer.

Consider the following situation:

* A builder has a 32.1 ETH balance, which will allow them to make a bid for 0.1 ETH.
* After their 0.1 ETH bid is accepted, the builder goes offline & incurs some penalties.
* By the time builder payment is processed, the builder only has 32.09 ETH.
* In this situation, the proposer would get 0.09 ETH, instead of 0.10 ETH.

This is unfair and should not be allowed. I would rather pull from the builder's activation balance than allow this to happen, just like any other penalty. Please note that this would not allow a builder to submit bids for more than their excess balance.
