### PR TITLE
Fix `aggregate.aggregation_bits` alias

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -474,7 +474,7 @@ We define the following variables for convenience:
 - `aggregate_and_proof = signed_aggregate_and_proof.message`
 - `aggregate = aggregate_and_proof.aggregate`
 - `index = aggregate.data.index`
-- `aggregation_bits = attestation.aggregation_bits`
+- `aggregation_bits = aggregate.aggregation_bits`
 
 The following validations MUST pass before forwarding the
 `signed_aggregate_and_proof` on the network.


### PR DESCRIPTION
Fixed incorrect variable name. Was declared aggregate = aggregate_and_proof.aggregate, then write 
aggregation_bits = attestation.aggregation_bits.
There is no attestation variable here so corrected to aggregate.aggregation_bits