### PR TITLE
Remove epoch param in withdrawal functions

### DIFF
--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -363,9 +363,9 @@ def get_balance_after_withdrawals(
 def get_validators_sweep_withdrawals(
     state: BeaconState,
     withdrawal_index: WithdrawalIndex,
-    epoch: Epoch,
     prior_withdrawals: Sequence[Withdrawal],
 ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+    epoch = get_current_epoch(state)
     validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
     withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
 
@@ -411,13 +411,12 @@ def get_validators_sweep_withdrawals(
 
 ```python
 def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64]:
-    epoch = get_current_epoch(state)
     withdrawal_index = state.next_withdrawal_index
     withdrawals: List[Withdrawal] = []
 
     # Get validators sweep withdrawals
     validators_sweep_withdrawals, withdrawal_index, processed_validators_sweep_count = (
-        get_validators_sweep_withdrawals(state, withdrawal_index, epoch, withdrawals)
+        get_validators_sweep_withdrawals(state, withdrawal_index, withdrawals)
     )
     withdrawals.extend(validators_sweep_withdrawals)
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1209,9 +1209,9 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 def get_pending_partial_withdrawals(
     state: BeaconState,
     withdrawal_index: WithdrawalIndex,
-    epoch: Epoch,
     prior_withdrawals: Sequence[Withdrawal],
 ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+    epoch = get_current_epoch(state)
     withdrawals_limit = min(
         len(prior_withdrawals) + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
         MAX_WITHDRAWALS_PER_PAYLOAD - 1,
@@ -1255,9 +1255,9 @@ def get_pending_partial_withdrawals(
 def get_validators_sweep_withdrawals(
     state: BeaconState,
     withdrawal_index: WithdrawalIndex,
-    epoch: Epoch,
     prior_withdrawals: Sequence[Withdrawal],
 ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+    epoch = get_current_epoch(state)
     validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
     withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
 
@@ -1306,20 +1306,19 @@ def get_validators_sweep_withdrawals(
 
 ```python
 def get_expected_withdrawals(state: BeaconState) -> Tuple[Sequence[Withdrawal], uint64, uint64]:
-    epoch = get_current_epoch(state)
     withdrawal_index = state.next_withdrawal_index
     withdrawals: List[Withdrawal] = []
 
     # [New in Electra:EIP7251]
     # Get partial withdrawals
     partial_withdrawals, withdrawal_index, processed_partial_withdrawals_count = (
-        get_pending_partial_withdrawals(state, withdrawal_index, epoch, withdrawals)
+        get_pending_partial_withdrawals(state, withdrawal_index, withdrawals)
     )
     withdrawals.extend(partial_withdrawals)
 
     # Get validators sweep withdrawals
     validators_sweep_withdrawals, withdrawal_index, processed_validators_sweep_count = (
-        get_validators_sweep_withdrawals(state, withdrawal_index, epoch, withdrawals)
+        get_validators_sweep_withdrawals(state, withdrawal_index, withdrawals)
     )
     withdrawals.extend(validators_sweep_withdrawals)
 

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -782,9 +782,9 @@ def get_builder_withdrawable_balance(builder: Validator, balance: Gwei) -> Gwei:
 def get_builder_withdrawals(
     state: BeaconState,
     withdrawal_index: WithdrawalIndex,
-    epoch: Epoch,
     prior_withdrawals: Sequence[Withdrawal],
 ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
+    epoch = get_current_epoch(state)
     withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
 
     processed_count: uint64 = 0
@@ -824,26 +824,25 @@ def get_builder_withdrawals(
 def get_expected_withdrawals(
     state: BeaconState,
 ) -> Tuple[Sequence[Withdrawal], uint64, uint64, uint64]:
-    epoch = get_current_epoch(state)
     withdrawal_index = state.next_withdrawal_index
     withdrawals: List[Withdrawal] = []
 
     # [New in Gloas:EIP7732]
     # Get builder withdrawals
     builder_withdrawals, withdrawal_index, processed_builder_withdrawals_count = (
-        get_builder_withdrawals(state, withdrawal_index, epoch, withdrawals)
+        get_builder_withdrawals(state, withdrawal_index, withdrawals)
     )
     withdrawals.extend(builder_withdrawals)
 
     # Get partial withdrawals
     partial_withdrawals, withdrawal_index, processed_partial_withdrawals_count = (
-        get_pending_partial_withdrawals(state, withdrawal_index, epoch, withdrawals)
+        get_pending_partial_withdrawals(state, withdrawal_index, withdrawals)
     )
     withdrawals.extend(partial_withdrawals)
 
     # Get validators sweep withdrawals
     validators_sweep_withdrawals, withdrawal_index, processed_validators_sweep_count = (
-        get_validators_sweep_withdrawals(state, withdrawal_index, epoch, withdrawals)
+        get_validators_sweep_withdrawals(state, withdrawal_index, withdrawals)
     )
     withdrawals.extend(validators_sweep_withdrawals)
 


### PR DESCRIPTION
This shouldn't be passed as a parameter.