### PR TITLE
Payload Attestations due before `get_payload_attestation_due_ms`

### DIFF
--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -88,8 +88,8 @@ All validator responsibilities remain unchanged other than the following:
   this becomes a builder's duty.
 - Some attesters are selected per slot to become PTC members, these validators
   must broadcast `PayloadAttestationMessage` objects during the assigned slot
-  before the deadline of `get_payload_attestation_due_ms(epoch)` milliseconds into the
-  slot.
+  before the deadline of `get_payload_attestation_due_ms(epoch)` milliseconds
+  into the slot.
 
 ### Attestation
 


### PR DESCRIPTION
The spec specified that validators must broadcast `PayloadAttestationMessage` before the deadline of `get_attestation_due_ms(epoch)` milliseconds into the slot. 
It should be broadcasted before `get_payload_attestation_due_ms(epoch)` ms into the slot.