### PR TITLE
Refactor `get_ancestor` in Gloas

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -244,13 +244,14 @@ def get_ancestor(store: Store, root: Root, slot: Slot) -> ForkChoiceNode:
         return ForkChoiceNode(root=root, payload_status=PAYLOAD_STATUS_PENDING)
 
     parent = store.blocks[block.parent_root]
-    if parent.slot > slot:
-        return get_ancestor(store, block.parent_root, slot)
-    else:
-        return ForkChoiceNode(
-            root=block.parent_root,
-            payload_status=get_parent_payload_status(store, block),
-        )
+    while parent.slot > slot:
+        block = parent
+        parent = store.blocks[block.parent_root]
+
+    return ForkChoiceNode(
+        root=block.parent_root,
+        payload_status=get_parent_payload_status(store, block),
+    )
 ```
 
 ### Modified `get_checkpoint_block`


### PR DESCRIPTION
This PR improves the readability of the modified `get_ancestor` in Gloas.

`get_ancestor` in Phase0 does only one job: find and return the root of a block that is `block.slot <= slot`.

`get_ancestor` in Gloas is modified to do two jobs: 1) return `root` and `PAYLOAD_STATUS_PENDING` if the block with the given `root` has `block.slot <= slot`, otherwise 2) find and return the root of a block and its payload status that is `block.slot <= slot`.

The first condition cannot be met during a recursion and hence it doesn't need to be part of it. Thus, I think using iteration here makes what this function does a bit clearer.