### PR TITLE
Remove deprecated `INTERVALS_PER_SLOT` constant

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -105,9 +105,9 @@ handlers must not modify `store`.
 
 ### Constant
 
-| Name                              | Value           |
-| --------------------------------- | --------------- |
-| `BASIS_POINTS`                    | `uint64(10000)` |
+| Name           | Value           |
+| -------------- | --------------- |
+| `BASIS_POINTS` | `uint64(10000)` |
 
 ### Configuration
 


### PR DESCRIPTION
<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What this PR does (but not how it does it)
* Why this PR is necessary, including context
-->
## Description:
Given that `interval_per_slot` in phase0 is not mentioned in any code in the specs or the config itself, can we just remove it from the fork choice spec to avoid confusion? I'm realizing that Lighthouse uses this variable in its internal slot timing and may need to refactor away from it to make it easier to implement the new GLOAS timing configs such as:

`ATTESTATION_DUE_BPS_GLOAS`,`AGGREGATE_DUE_BPS_GLOAS`,`SYNC_MESSAGE_DUE_BPS_GLOAS`,`CONTRIBUTION_DUE_BPS_GLOAS`,`PAYLOAD_ATTESTATION_DUE_BPS`