### PR TITLE
Add test for unexpected withdrawal in ePBS

### DIFF
--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload.py
@@ -991,6 +991,7 @@ def test_process_execution_payload_execution_engine_invalid(spec, state):
         spec, state, signed_envelope, valid=False, execution_valid=False
     )
 
+
 @with_gloas_and_later
 @spec_state_test
 @always_bls


### PR DESCRIPTION
Add test for exception when the builder includes one unexpected withdrawal in the execution payload (ePBS).

Cherry-picked from https://github.com/etan-status/consensus-specs/pull/2