### PR TITLE
Implement test_process_withdrawal for Gloas

### DIFF
--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_withdrawals.md
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_withdrawals.md
@@ -1,0 +1,161 @@
+# Report: `process_withdrawals` Input/Output Space
+
+Note: This is AI generated from the specs, and it is not the authoritative
+source of truth.
+
+## Function Signature
+
+```python
+def process_withdrawals(state: BeaconState) -> None
+```
+
+Location:
+[specs/gloas/beacon-chain.md:884-933](../../../../../../../specs/gloas/beacon-chain.md#L884-L933)
+
+______________________________________________________________________
+
+## Input Space (State Fields Read)
+
+| Field                                           | Type                                                                | Value Space                                                                                                                                                                                      | Purpose                                    |
+| ----------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| `state.slot`                                    | `Slot`                                                              | `uint64` ∈ [0, 2⁶⁴-1]. Derives `epoch = slot // SLOTS_PER_EPOCH`. Compared against all `withdrawable_epoch` fields.                                                                              | Compute current epoch                      |
+| `state.latest_execution_payload_bid.block_hash` | `Hash32`                                                            | `Bytes32`. **Bound to** `latest_block_hash`: must equal for function to execute (early exit if ≠).                                                                                               | Check if parent block was full             |
+| `state.latest_block_hash`                       | `Hash32`                                                            | `Bytes32`. **Bound to** `latest_execution_payload_bid.block_hash` for `is_parent_block_full()` check.                                                                                            | Compare with committed bid                 |
+| `state.next_withdrawal_index`                   | `WithdrawalIndex`                                                   | `uint64` ∈ [0, 2⁶⁴-1]. Monotonically increasing. Assigned to each withdrawal created.                                                                                                            | Starting withdrawal index                  |
+| `state.next_withdrawal_validator_index`         | `ValidatorIndex`                                                    | `uint64` ∈ \[0, `len(validators)`-1\]. **Bound to** `len(validators)`: wraps via modulo.                                                                                                         | Starting validator sweep position          |
+| `state.builder_pending_withdrawals`             | `List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]` | Length ∈ [0, 2²⁰]. Processed first. Max `MAX_WITHDRAWALS_PER_PAYLOAD - 1` can produce withdrawals.                                                                                               | Iterate and filter for builder withdrawals |
+| ↳ `.withdrawable_epoch`                         | `Epoch`                                                             | `uint64`. **Bound to** `state.slot`: withdrawal ready when `<= current_epoch`. If `>`, breaks processing loop.                                                                                   | Check if withdrawal is ready               |
+| ↳ `.builder_index`                              | `ValidatorIndex`                                                    | `uint64` ∈ \[0, `len(validators)`-1\]. **Index into** `validators[]` and `balances[]`. Must reference validator with `0x03` prefix.                                                              | Identify builder validator                 |
+| ↳ `.fee_recipient`                              | `ExecutionAddress`                                                  | `Bytes20`. Withdrawal destination. Independent of builder's own `withdrawal_credentials[12:]`.                                                                                                   | Withdrawal destination                     |
+| ↳ `.amount`                                     | `Gwei`                                                              | `uint64`. Requested amount. Actual = `min(amount, available_balance)` where available depends on slashed status.                                                                                 | Withdrawal amount                          |
+| `state.pending_partial_withdrawals`             | `List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]` | Length ∈ [0, 2²⁷]. Processed second. Max `MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP` (8) processed per block.                                                                                   | Iterate for partial withdrawals            |
+| ↳ `.withdrawable_epoch`                         | `Epoch`                                                             | `uint64`. **Bound to** `state.slot`: ready when `<= current_epoch`. If `>`, breaks processing loop.                                                                                              | Check if withdrawal is ready               |
+| ↳ `.validator_index`                            | `ValidatorIndex`                                                    | `uint64` ∈ \[0, `len(validators)`-1\]. **Index into** `validators[]` and `balances[]`.                                                                                                           | Identify validator                         |
+| ↳ `.amount`                                     | `Gwei`                                                              | `uint64`. Requested amount. Actual = `min(balance - MIN_ACTIVATION_BALANCE, amount)`.                                                                                                            | Withdrawal amount                          |
+| `state.balances[*]`                             | `Gwei`                                                              | `uint64` ∈ [0, 2⁶⁴-1]. **Same length as** `validators[]`. Must have excess over `MIN_ACTIVATION_BALANCE` (32 ETH) for non-slashed withdrawals.                                                   | Check available balance                    |
+| `state.validators`                              | `List[Validator, VALIDATOR_REGISTRY_LIMIT]`                         | Length ∈ [0, 2⁴⁰]. **Same length as** `balances[]`. All index references must be < len.                                                                                                          | Validator data                             |
+| ↳ `[*].slashed`                                 | `boolean`                                                           | `{True, False}`. **Affects** builder withdrawal: if `True`, payment requires `current_epoch >= withdrawable_epoch`; can withdraw full balance. If `False`, must retain `MIN_ACTIVATION_BALANCE`. | Affects withdrawal logic                   |
+| ↳ `[*].withdrawable_epoch`                      | `Epoch`                                                             | `uint64`. **Bound to** `state.slot` for: (1) slashed builder payment eligibility, (2) full withdrawal eligibility. Typically `FAR_FUTURE_EPOCH` if not exiting.                                  | For slashed builder check                  |
+| ↳ `[*].effective_balance`                       | `Gwei`                                                              | `uint64` ∈ [0, 2048 ETH]. **Constraint**: partial withdrawals require `>= MIN_ACTIVATION_BALANCE` (32 ETH).                                                                                      | Check sufficient balance                   |
+| ↳ `[*].exit_epoch`                              | `Epoch`                                                             | `uint64`. **Constraint**: partial withdrawals require `== FAR_FUTURE_EPOCH`. If set, validator is exiting and ineligible.                                                                        | Check if validator exiting                 |
+| ↳ `[*].withdrawal_credentials`                  | `Bytes32`                                                           | `Bytes32`. **Prefix byte**: `0x01`=ETH1, `0x02`=compounding, `0x03`=builder. **Bytes [12:32]** = execution address. Validators need `0x01`/`0x02`/`0x03` prefix for withdrawal eligibility.      | Extract withdrawal address (bytes [12:32]) |
+
+______________________________________________________________________
+
+## Output Space (State Fields Modified)
+
+| Field                                   | Type                                                                | Value Space                                                                                                                                                                                                                                       | Modification                                        |
+| --------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `state.payload_expected_withdrawals`    | `List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]`                     | Length ∈ \[0, `MAX_WITHDRAWALS_PER_PAYLOAD`\]. **Derived from** input `next_withdrawal_index` (sequential), pending lists, and validator sweep. Each `Withdrawal.amount` **bounded by** corresponding `balances[]` entry.                         | **Set** to computed withdrawals list                |
+| `state.balances[*]`                     | `Gwei`                                                              | `uint64`. **Decreased by** `payload_expected_withdrawals[*].amount` for each withdrawal's `validator_index`. New value = old value - withdrawal amount.                                                                                           | **Decreased** by withdrawal amounts                 |
+| `state.builder_pending_withdrawals`     | `List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]` | New length ≤ old length. **Bound to** input list: retains items where `is_builder_payment_withdrawable()` returned `False` from first N processed, plus all unprocessed items.                                                                    | **Filtered** - removes processed withdrawable items |
+| `state.pending_partial_withdrawals`     | `List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]` | New length = old length - `processed_partial_withdrawals_count`. **Bound to** input list: simple slice `[processed_count:]`.                                                                                                                      | **Sliced** - removes first N processed items        |
+| `state.next_withdrawal_index`           | `WithdrawalIndex`                                                   | New value = `payload_expected_withdrawals[-1].index + 1` if any withdrawals, else unchanged. **Bound to** `len(payload_expected_withdrawals)`.                                                                                                    | **Incremented** by number of withdrawals            |
+| `state.next_withdrawal_validator_index` | `ValidatorIndex`                                                    | **Bound to** `len(validators)` (wraps via modulo). If `len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD`: `(last_withdrawal.validator_index + 1) % len(validators)`. Else: `(old_value + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP) % len(validators)`. | **Updated** based on sweep progress                 |
+
+______________________________________________________________________
+
+## Early Exit Condition
+
+If `is_parent_block_full(state)` returns `False` (i.e.,
+`latest_execution_payload_bid.block_hash ≠ latest_block_hash`), the function
+returns immediately with **no state modifications**.
+
+______________________________________________________________________
+
+## Key Constants
+
+| Constant                                     | Value                | Description                           |
+| -------------------------------------------- | -------------------- | ------------------------------------- |
+| `MAX_WITHDRAWALS_PER_PAYLOAD`                | 16                   | Max withdrawals per execution payload |
+| `MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP`       | 16,384               | Max validators checked per sweep      |
+| `MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP` | 8                    | Max partial withdrawals processed     |
+| `VALIDATOR_REGISTRY_LIMIT`                   | 2⁴⁰ (≈1.1 trillion)  | Max validators in registry            |
+| `BUILDER_PENDING_WITHDRAWALS_LIMIT`          | 2²⁰ (1,048,576)      | Max pending builder withdrawals       |
+| `PENDING_PARTIAL_WITHDRAWALS_LIMIT`          | 2²⁷ (134,217,728)    | Max pending partial withdrawals       |
+| `MIN_ACTIVATION_BALANCE`                     | 32 ETH (32×10⁹ Gwei) | Minimum balance for active validator  |
+| `FAR_FUTURE_EPOCH`                           | 2⁶⁴-1                | Sentinel for "not set" epoch          |
+
+______________________________________________________________________
+
+## Key Cross-Field Constraints
+
+1. **Index Alignment**: `len(validators) == len(balances)` always. All validator
+   indices (`builder_index`, `validator_index`,
+   `next_withdrawal_validator_index`) must be `< len(validators)`.
+
+2. **Epoch Gating**: All `withdrawable_epoch` fields are compared against
+   `current_epoch = compute_epoch_at_slot(state.slot)`.
+
+3. **Balance Thresholds by Withdrawal Type**:
+
+   - **Builder (non-slashed)**:
+     `withdrawable_balance = min(balance - MIN_ACTIVATION_BALANCE, amount)` only
+     if `balance > MIN_ACTIVATION_BALANCE`
+   - **Builder (slashed)**: `withdrawable_balance = min(balance, amount)` (can
+     withdraw full balance)
+   - **Partial**: requires `effective_balance >= MIN_ACTIVATION_BALANCE` AND
+     `balance > MIN_ACTIVATION_BALANCE` AND `exit_epoch == FAR_FUTURE_EPOCH`
+   - **Full**: requires `has_execution_withdrawal_credential` AND
+     `withdrawable_epoch <= epoch` AND `balance > 0`
+
+4. **Processing Order & Caps** (combined constraint on output):
+
+   - Builder withdrawals: processed first, up to
+     `MAX_WITHDRAWALS_PER_PAYLOAD - 1`
+   - Partial withdrawals: processed second, capped by
+     `MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP`
+   - Validator sweep: processed last, capped by
+     `MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP`
+   - Total output: `MAX_WITHDRAWALS_PER_PAYLOAD`
+
+5. **Early Exit Binding**: Function executes only when
+   `latest_execution_payload_bid.block_hash == latest_block_hash`.
+
+______________________________________________________________________
+
+## Functions Called
+
+| Function                                    | Location                                                                              |
+| ------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `is_parent_block_full(state)`               | [beacon-chain.md:406-407](../../../../../../../specs/gloas/beacon-chain.md#L406-L407) |
+| `get_expected_withdrawals(state)`           | [beacon-chain.md:763-871](../../../../../../../specs/gloas/beacon-chain.md#L763-L871) |
+| `decrease_balance(state, index, amount)`    | Base spec                                                                             |
+| `is_builder_payment_withdrawable(state, w)` | [beacon-chain.md:749-757](../../../../../../../specs/gloas/beacon-chain.md#L749-L757) |
+
+______________________________________________________________________
+
+## Summary Diagram
+
+```
+                    ┌───────────────────────────────────────────────────────┐
+                    │                    INPUT (Read)                       │
+                    ├───────────────────────────────────────────────────────┤
+                    │ latest_execution_payload_bid.block_hash : Bytes32     │
+                    │ latest_block_hash                       : Bytes32     │
+                    │ slot                                    : uint64      │
+                    │ next_withdrawal_index                   : uint64      │
+                    │ next_withdrawal_validator_index         : uint64      │
+                    │ builder_pending_withdrawals[0..2²⁰]     : Container[] │
+                    │ pending_partial_withdrawals[0..2²⁷]     : Container[] │
+                    │ balances[0..2⁴⁰]                        : uint64[]    │
+                    │ validators[0..2⁴⁰]                      : Container[] │
+                    └─────────────────────────┬─────────────────────────────┘
+                                              │
+                                              ▼
+                    ┌───────────────────────────────────────────────────────┐
+                    │                process_withdrawals()                  │
+                    └─────────────────────────┬─────────────────────────────┘
+                                              │
+                                              ▼
+                    ┌───────────────────────────────────────────────────────┐
+                    │                   OUTPUT (Modified)                   │
+                    ├───────────────────────────────────────────────────────┤
+                    │ payload_expected_withdrawals[0..16]     : Container[] │
+                    │ balances[*]                             : uint64      │
+                    │ builder_pending_withdrawals             : Container[] │
+                    │ pending_partial_withdrawals             : Container[] │
+                    │ next_withdrawal_index                   : uint64      │
+                    │ next_withdrawal_validator_index         : uint64      │
+                    └───────────────────────────────────────────────────────┘
+```

--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_withdrawals.py
@@ -1,0 +1,1440 @@
+from tests.core.pyspec.eth2spec.test.context import (
+    spec_state_test,
+    with_gloas_and_later,
+)
+from tests.core.pyspec.eth2spec.test.helpers.withdrawals import (
+    set_compounding_withdrawal_credential_with_balance,
+)
+from tests.infra.helpers.withdrawals import (
+    assert_process_withdrawals,
+    prepare_process_withdrawals,
+)
+
+
+def run_gloas_withdrawals_processing(spec, state):
+    """
+    Minimal test harness for process_withdrawals.
+    All assertions are in assert_process_withdrawals.
+    """
+    pre_state = state.copy()
+    yield "pre", pre_state
+    spec.process_withdrawals(state)
+    yield "post", state
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_zero_withdrawals(spec, state):
+    """
+    Test processing when no withdrawals are expected.
+
+    Input State Configured:
+        - Default state with no pending withdrawals configured
+        - latest_block_hash == latest_execution_payload_bid.block_hash (parent block full)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Empty list (len=0)
+        - balances[*]: Unchanged
+        - next_withdrawal_index: Unchanged
+    """
+
+    # Initial state should have no withdrawals
+    expected_withdrawals_result = spec.get_expected_withdrawals(state)
+    assert len(expected_withdrawals_result[0]) == 0
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=0,
+        withdrawal_index_delta=0,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_single_full_withdrawal(spec, state):
+    """
+    Test processing a single full withdrawal.
+
+    Input State Configured:
+        - validators[0].withdrawable_epoch: <= current_epoch (validator is withdrawable)
+        - validators[0].withdrawal_credentials: Has execution withdrawal credential (0x01)
+        - balances[0]: > 0 (has balance to withdraw)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 withdrawal for validator 0
+        - balances[0]: 0 (full balance withdrawn)
+        - next_withdrawal_index: Incremented by 1
+    """
+    prepare_process_withdrawals(spec, state, full_withdrawal_indices=[0])
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={0: 0},
+        withdrawal_index_delta=1,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_single_partial_withdrawal(spec, state):
+    """
+    Test processing a single partial withdrawal.
+
+    Input State Configured:
+        - pending_partial_withdrawals: Contains 1 entry for validator 0
+        - pending_partial_withdrawals[0].withdrawable_epoch: <= current_epoch
+        - validators[0].effective_balance: >= MIN_ACTIVATION_BALANCE
+        - balances[0]: > MIN_ACTIVATION_BALANCE (has excess to withdraw)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 withdrawal for validator 0
+        - balances[0]: == max_effective_balance (excess withdrawn)
+        - next_withdrawal_index: Incremented by 1
+    """
+    prepare_process_withdrawals(spec, state, partial_withdrawal_indices=[0])
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={0: spec.get_max_effective_balance(state.validators[0])},
+        withdrawal_index_delta=1,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_mixed_full_and_partial_withdrawals(spec, state):
+    """
+    Test processing mixed full and partial withdrawals.
+
+    Input State Configured:
+        - validators[0,1].withdrawable_epoch: <= current_epoch (fully withdrawable)
+        - validators[0,1].withdrawal_credentials: Has execution withdrawal credential
+        - pending_partial_withdrawals: Contains entries for validators 2, 3
+        - balances[0..3]: Configured for respective withdrawal types
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 4 withdrawals (2 full + 2 partial)
+        - balances[0,1]: 0 (full withdrawals)
+        - balances[2,3]: == max_effective_balance (partial withdrawals)
+        - next_withdrawal_index: Incremented by 4
+    """
+
+    fully_withdrawable_indices = [0, 1]
+    partial_withdrawals_indices = [2, 3]
+    prepare_process_withdrawals(
+        spec,
+        state,
+        full_withdrawal_indices=fully_withdrawable_indices,
+        partial_withdrawal_indices=partial_withdrawals_indices,
+    )
+
+    expected_total = len(fully_withdrawable_indices) + len(partial_withdrawals_indices)
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=4,
+        balances={
+            0: 0,
+            1: 0,
+            2: spec.get_max_effective_balance(state.validators[2]),
+            3: spec.get_max_effective_balance(state.validators[3]),
+        },
+        withdrawal_index_delta=4,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_single_builder_withdrawal(spec, state):
+    """
+    Test processing a single builder withdrawal.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x03 prefix (builder credentials)
+        - builder_pending_withdrawals: Contains 1 entry for validator 0
+        - builder_pending_withdrawals[0].withdrawable_epoch: <= current_epoch
+        - builder_pending_withdrawals[0].amount: 1 ETH
+        - balances[0]: >= amount + MIN_ACTIVATION_BALANCE
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 builder withdrawal
+        - balances[0]: Decreased by withdrawal amount
+        - builder_pending_withdrawals: Reduced by 1 (processed entry removed)
+        - next_withdrawal_index: Incremented by 1
+    """
+    withdrawal_amount = spec.Gwei(1_000_000_000)
+    # Ensure sufficient balance before prepare_process_withdrawals
+    state.balances[0] = max(
+        state.balances[0],
+        withdrawal_amount + spec.MIN_ACTIVATION_BALANCE,
+    )
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=[0],
+        builder_withdrawal_amounts={0: withdrawal_amount},
+    )
+    pre_state = state.copy()
+    expected_post_balance = pre_state.balances[0] - withdrawal_amount
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={0: expected_post_balance},
+        builder_pending_delta=-1,
+        withdrawal_index_delta=1,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_multiple_builder_withdrawals(spec, state):
+    """
+    Test processing multiple builder withdrawals.
+
+    Input State Configured:
+        - validators[0,1,2].withdrawal_credentials: 0x03 prefix (builder credentials)
+        - builder_pending_withdrawals: Contains 3 entries for validators 0, 1, 2
+        - builder_pending_withdrawals[*].withdrawable_epoch: <= current_epoch
+        - builder_pending_withdrawals[*].amount: 0.5 ETH each
+        - balances[0,1,2]: >= amount + MIN_ACTIVATION_BALANCE
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 3 builder withdrawals
+        - balances[0,1,2]: Each decreased by 0.5 ETH
+        - builder_pending_withdrawals: Reduced by 3
+        - next_withdrawal_index: Incremented by 3
+    """
+    withdrawal_amount = spec.Gwei(500_000_000)
+    builder_indices = [0, 1, 2]
+    # Ensure sufficient balance before prepare_process_withdrawals
+    for i in builder_indices:
+        state.balances[i] = max(
+            state.balances[i],
+            withdrawal_amount + spec.MIN_ACTIVATION_BALANCE,
+        )
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=builder_indices,
+        builder_withdrawal_amounts={i: withdrawal_amount for i in builder_indices},
+    )
+    pre_state = state.copy()
+    expected_balances = {i: pre_state.balances[i] - withdrawal_amount for i in builder_indices}
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=3,
+        balances=expected_balances,
+        builder_pending_delta=-3,
+        withdrawal_index_delta=3,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_withdrawal_future_epoch(spec, state):
+    """
+    Test builder withdrawal not yet withdrawable (future epoch).
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x03 prefix (builder credentials)
+        - builder_pending_withdrawals: Contains 1 entry for validator 0
+        - builder_pending_withdrawals[0].withdrawable_epoch: current_epoch + 1 (FUTURE)
+        - balances[0]: >= amount + MIN_ACTIVATION_BALANCE
+
+    Output State Verified:
+        - payload_expected_withdrawals: Empty (withdrawal not ready)
+        - balances[0]: Unchanged
+        - builder_pending_withdrawals: Unchanged (not yet withdrawable)
+        - next_withdrawal_index: Unchanged
+    """
+    withdrawal_amount = spec.Gwei(1_000_000_000)
+    # Ensure sufficient balance before prepare_process_withdrawals
+    state.balances[0] = max(
+        state.balances[0],
+        withdrawal_amount + spec.MIN_ACTIVATION_BALANCE,
+    )
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=[0],
+        builder_withdrawal_amounts={0: withdrawal_amount},
+        builder_withdrawable_offsets={0: 1},  # Future epoch (current + 1)
+    )
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=0,
+        builder_pending_delta=0,
+        withdrawal_index_delta=0,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_withdrawal_slashed_validator(spec, state):
+    """
+    Test builder withdrawal with slashed validator.
+    Slashed validators cannot have builder withdrawals processed until
+    current_epoch >= withdrawable_epoch.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x03 prefix (builder credentials)
+        - validators[0].slashed: True
+        - validators[0].withdrawable_epoch: current_epoch + 10 (FUTURE)
+        - builder_pending_withdrawals: Contains 1 entry for validator 0
+        - builder_pending_withdrawals[0].withdrawable_epoch: <= current_epoch
+        - balances[0]: >= amount + MIN_ACTIVATION_BALANCE
+
+    Output State Verified:
+        - payload_expected_withdrawals: Empty (slashed validator not yet withdrawable)
+        - balances[0]: Unchanged
+        - builder_pending_withdrawals: Unchanged (blocked by slashed check)
+        - next_withdrawal_index: Unchanged
+    """
+    withdrawal_amount = spec.Gwei(1_000_000_000)
+    current_epoch = spec.get_current_epoch(state)
+
+    # Set up balance before prepare_process_withdrawals (credentials set via builder_credentials)
+    state.balances[0] = max(state.balances[0], withdrawal_amount + spec.MIN_ACTIVATION_BALANCE)
+
+    # Set validator as slashed with future withdrawable_epoch
+    state.validators[0].slashed = True
+    state.validators[0].withdrawable_epoch = current_epoch + 10
+
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=[0],
+        builder_withdrawal_amounts={0: withdrawal_amount},
+        builder_credentials=[0],
+    )
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=0,
+        builder_pending_delta=0,
+        withdrawal_index_delta=0,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_withdrawal_insufficient_balance(spec, state):
+    """
+    Test builder withdrawal with insufficient balance.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x03 prefix (builder credentials)
+        - builder_pending_withdrawals: Contains 1 entry requesting 5 ETH
+        - builder_pending_withdrawals[0].withdrawable_epoch: <= current_epoch
+        - balances[0]: MIN_ACTIVATION_BALANCE + 1 ETH (only 1 ETH available)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 withdrawal (capped to available balance)
+        - balances[0]: MIN_ACTIVATION_BALANCE (available excess withdrawn)
+        - builder_pending_withdrawals: Reduced by 1 (processed even if capped)
+        - next_withdrawal_index: Incremented by 1
+    """
+    withdrawal_amount = spec.Gwei(5_000_000_000)  # 5 ETH
+
+    # Set up builder credentials with insufficient balance (using builder_credentials without builder_indices)
+    prepare_process_withdrawals(spec, state, builder_credentials=[0])
+    state.balances[0] = spec.MIN_ACTIVATION_BALANCE + spec.Gwei(1_000_000_000)  # Only 1 ETH excess
+
+    # Manually add builder withdrawal (bypassing prepare_withdrawals balance assertion)
+    address = state.validators[0].withdrawal_credentials[12:]
+    state.builder_pending_withdrawals.append(
+        spec.BuilderPendingWithdrawal(
+            fee_recipient=address,
+            amount=withdrawal_amount,
+            builder_index=0,
+            withdrawable_epoch=spec.get_current_epoch(state),
+        )
+    )
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={0: spec.MIN_ACTIVATION_BALANCE},
+        builder_pending_delta=-1,
+        withdrawal_index_delta=1,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_mixed_withdrawal_types_priority_ordering(spec, state):
+    """
+    Test all three withdrawal types together with priority ordering verification.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x03 prefix (builder)
+        - builder_pending_withdrawals: Contains 1 entry for validator 0
+        - pending_partial_withdrawals: Contains 1 entry for validator 1
+        - validators[2].withdrawable_epoch: <= current_epoch (sweep/full withdrawal)
+        - balances[0,1,2]: Configured for respective withdrawal types
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 3 withdrawals in priority order:
+          [0] builder (validator 0), [1] pending partial (validator 1), [2] sweep (validator 2)
+        - balances[0,1,2]: Each decreased appropriately
+        - builder_pending_withdrawals: Reduced by 1
+        - pending_partial_withdrawals: Reduced by 1
+        - next_withdrawal_index: Incremented by 3
+    """
+
+    builder_index = 0
+    pending_index = 1
+    sweep_index = 2
+
+    # Set up balance (credentials set via builder_indices in prepare_process_withdrawals)
+    builder_amount = spec.Gwei(1_000_000_000)
+    state.balances[builder_index] = max(
+        state.balances[builder_index],
+        builder_amount + spec.MIN_ACTIVATION_BALANCE,
+    )
+
+    # Prepare all three withdrawal types (builder_credentials defaults to builder_indices)
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=[builder_index],
+        builder_withdrawal_amounts={builder_index: builder_amount},
+        pending_partial_indices=[pending_index],
+        full_withdrawal_indices=[sweep_index],
+    )
+
+    pre_state = state.copy()
+
+    expected_withdrawals, _, _ = spec.get_expected_withdrawals(state)
+    spec.process_withdrawals(state)
+
+    # Verify priority ordering: builder payments -> pending partial withdrawals -> exit/excess withdrawals
+    assert len(expected_withdrawals) == 3
+    assert expected_withdrawals[0].validator_index == builder_index  # Builder payments first
+    assert (
+        expected_withdrawals[1].validator_index == pending_index
+    )  # Pending partial withdrawals second
+    assert expected_withdrawals[2].validator_index == sweep_index  # Exit/excess withdrawals third
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=3,
+        withdrawal_order=[builder_index, pending_index, sweep_index],
+        builder_pending_delta=-1,
+        pending_partial_delta=-1,
+        withdrawal_index_delta=3,
+    )
+
+    yield "pre", pre_state
+    yield "post", state
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_maximum_withdrawals_per_payload_limit(spec, state):
+    """
+    Test that withdrawals respect MAX_WITHDRAWALS_PER_PAYLOAD limit.
+
+    Input State Configured:
+        - builder_pending_withdrawals: MAX/2 entries
+        - pending_partial_withdrawals: MAX/2 entries
+        - validators[*].withdrawable_epoch: MAX/2 validators fully withdrawable (sweep)
+        - Total withdrawals available > MAX_WITHDRAWALS_PER_PAYLOAD
+
+    Output State Verified:
+        - payload_expected_withdrawals: Exactly MAX_WITHDRAWALS_PER_PAYLOAD
+        - Some withdrawals remain unprocessed in builder_pending_withdrawals
+          and/or pending_partial_withdrawals
+        - next_withdrawal_index: Incremented by MAX_WITHDRAWALS_PER_PAYLOAD
+    """
+
+    # Add more withdrawals than the limit allows
+    num_builders = spec.MAX_WITHDRAWALS_PER_PAYLOAD // 2
+    num_pending = spec.MAX_WITHDRAWALS_PER_PAYLOAD // 2
+    num_sweep = spec.MAX_WITHDRAWALS_PER_PAYLOAD // 2
+
+    assert num_builders + num_pending + num_sweep <= len(state.validators), "Not enough validators for test"
+
+    builder_indices = list(range(num_builders))
+    pending_indices = list(range(num_builders, num_builders + num_pending))
+    sweep_indices = list(range(num_builders + num_pending, num_builders + num_pending + num_sweep))
+
+    # Set up balances (credentials set via builder_indices in prepare_process_withdrawals)
+    withdrawal_amount = spec.Gwei(1_000_000_000)
+    for i in builder_indices:
+        state.balances[i] = max(
+            state.balances[i],
+            withdrawal_amount + spec.MIN_ACTIVATION_BALANCE,
+        )
+
+    # Add all withdrawal types (builder_credentials defaults to builder_indices)
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=builder_indices,
+        builder_withdrawal_amounts={i: withdrawal_amount for i in builder_indices},
+        pending_partial_indices=pending_indices,
+        full_withdrawal_indices=sweep_indices,
+    )
+
+    # Should not exceed MAX_WITHDRAWALS_PER_PAYLOAD
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Verify some withdrawals remain unprocessed due to the limit
+    total_added = num_builders + num_pending + num_sweep
+    total_remaining = len(state.builder_pending_withdrawals) + len(
+        state.pending_partial_withdrawals
+    )
+    assert total_remaining > 0, "Some withdrawals should remain unprocessed"
+    assert total_added > spec.MAX_WITHDRAWALS_PER_PAYLOAD, "Test setup should exceed limit"
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=spec.MAX_WITHDRAWALS_PER_PAYLOAD,
+        withdrawal_index_delta=spec.MAX_WITHDRAWALS_PER_PAYLOAD,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_pending_withdrawals_processing(spec, state):
+    """
+    Test pending partial withdrawals processing.
+
+    Input State Configured:
+        - pending_partial_withdrawals: MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP entries
+        - pending_partial_withdrawals[*].withdrawable_epoch: <= current_epoch
+        - validators[*]: Configured for partial withdrawals
+        - No builder_pending_withdrawals
+
+    Output State Verified:
+        - payload_expected_withdrawals: MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+        - pending_partial_withdrawals: Empty (all processed)
+        - balances[*]: Each reduced to max_effective_balance
+        - next_withdrawal_index: Incremented by processed count
+    """
+
+    # Add enough pending withdrawals to test the limit
+    pending_indices = list(range(spec.MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP))
+    prepare_process_withdrawals(spec, state, pending_partial_indices=pending_indices)
+
+    # EIP-7732 limits pending withdrawals to min(MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP, MAX_WITHDRAWALS_PER_PAYLOAD - 1)
+    # In minimal config: min(2, 4-1) = 2, in mainnet config: min(8, 16-1) = 8
+    expected_withdrawals = spec.MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=expected_withdrawals,
+        pending_partial_delta=-int(expected_withdrawals),
+        withdrawal_index_delta=expected_withdrawals,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_early_return_empty_parent_block(spec, state):
+    """
+    Test early return when parent block is empty.
+
+    Input State Configured:
+        - latest_block_hash: != latest_execution_payload_bid.block_hash (parent block EMPTY)
+        - builder_pending_withdrawals: Contains entry for validator 0
+        - validators[1,2].withdrawable_epoch: <= current_epoch (fully withdrawable)
+        - balances[0,1,2]: Configured for withdrawals
+
+    Output State Verified:
+        - All state fields UNCHANGED (early exit triggered):
+          - payload_expected_withdrawals: Not set
+          - balances[*]: Unchanged
+          - builder_pending_withdrawals: Unchanged
+          - pending_partial_withdrawals: Unchanged
+          - next_withdrawal_index: Unchanged
+          - next_withdrawal_validator_index: Unchanged
+    """
+    # Set up withdrawals that would normally be processed
+    withdrawal_amount = spec.Gwei(1_000_000_000)
+    state.balances[0] = max(state.balances[0], withdrawal_amount + spec.MIN_ACTIVATION_BALANCE)
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=[0],
+        builder_withdrawal_amounts={0: withdrawal_amount},
+        full_withdrawal_indices=[1, 2],
+        parent_block_empty=True,
+    )
+
+    pre_state = state.copy()
+
+    # Process withdrawals - should return early and do nothing
+    spec.process_withdrawals(state)
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        all_state_unchanged=True,
+    )
+
+    yield "pre", pre_state
+    yield "post", state
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_compounding_validator_partial_withdrawal(spec, state):
+    """
+    Test compounding validator partial withdrawal support.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x02 prefix (compounding credentials)
+        - validators[0].effective_balance: MAX_EFFECTIVE_BALANCE_ELECTRA
+        - balances[0]: MAX_EFFECTIVE_BALANCE_ELECTRA + 1 ETH (excess)
+        - Validator is partially withdrawable (balance > max effective)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 withdrawal for validator 0
+        - balances[0]: == MAX_EFFECTIVE_BALANCE_ELECTRA (excess withdrawn)
+        - next_withdrawal_index: Incremented by 1
+    """
+    validator_index = 0
+    set_compounding_withdrawal_credential_with_balance(
+        spec,
+        state,
+        validator_index,
+        balance=spec.MAX_EFFECTIVE_BALANCE_ELECTRA + spec.Gwei(1_000_000_000),
+    )
+
+    assert spec.is_partially_withdrawable_validator(
+        state.validators[validator_index], state.balances[validator_index]
+    )
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={validator_index: spec.MAX_EFFECTIVE_BALANCE_ELECTRA},
+        withdrawal_index_delta=1,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_validator_not_yet_active(spec, state):
+    """
+    Test withdrawal processing with validator not yet active.
+
+    Input State Configured:
+        - validators[0].activation_epoch: current_epoch + 4 (NOT YET ACTIVE)
+        - pending_partial_withdrawals: Contains entry for validator 0
+        - balances[0]: > MIN_ACTIVATION_BALANCE (has excess)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 withdrawal (processed despite not active)
+        - balances[0]: == max_effective_balance
+        - Note: Withdrawals process regardless of validator active status
+    """
+    validator_index = 0
+    state.validators[validator_index].activation_epoch += 4
+    prepare_process_withdrawals(spec, state, partial_withdrawal_indices=[validator_index])
+
+    assert not spec.is_active_validator(
+        state.validators[validator_index], spec.get_current_epoch(state)
+    )
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={validator_index: spec.get_max_effective_balance(state.validators[validator_index])},
+        withdrawal_index_delta=1,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_validator_in_exit_queue(spec, state):
+    """
+    Test withdrawal processing with validator in exit queue.
+
+    Input State Configured:
+        - validators[1].exit_epoch: current_epoch + 1 (IN EXIT QUEUE, still active now)
+        - pending_partial_withdrawals: Contains entry for validator 1
+        - balances[1]: > MIN_ACTIVATION_BALANCE (has excess)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 withdrawal (processed for exiting validator)
+        - balances[1]: == max_effective_balance
+        - Note: Exit queue status does not block sweep partial withdrawals
+    """
+    validator_index = 1
+    state.validators[validator_index].exit_epoch = spec.get_current_epoch(state) + 1
+    prepare_process_withdrawals(spec, state, partial_withdrawal_indices=[validator_index])
+
+    assert spec.is_active_validator(
+        state.validators[validator_index], spec.get_current_epoch(state)
+    )
+    assert not spec.is_active_validator(
+        state.validators[validator_index], spec.get_current_epoch(state) + 1
+    )
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={validator_index: spec.get_max_effective_balance(state.validators[validator_index])},
+        withdrawal_index_delta=1,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_withdrawable_epoch_but_zero_balance(spec, state):
+    """
+    Test edge case: validator is withdrawable but has zero balance.
+
+    Input State Configured:
+        - validators[3].withdrawable_epoch: <= current_epoch (withdrawable)
+        - validators[3].effective_balance: MIN_ACTIVATION_BALANCE
+        - balances[3]: 0 (ZERO balance)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Empty (no withdrawal created for 0 balance)
+        - balances[3]: Remains 0
+        - Note: Full withdrawals require balance > 0
+    """
+    prepare_process_withdrawals(spec, state, full_withdrawal_indices=[3])
+    state.validators[3].effective_balance = spec.MIN_ACTIVATION_BALANCE
+    state.balances[3] = 0
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=0,
+        balances={3: 0},
+        withdrawal_index_delta=0,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_zero_effective_balance_but_nonzero_balance(spec, state):
+    """
+    Test edge case: validator has zero effective balance but nonzero actual balance.
+
+    Input State Configured:
+        - validators[4].withdrawable_epoch: <= current_epoch (withdrawable)
+        - validators[4].effective_balance: 0 (ZERO effective balance)
+        - balances[4]: MIN_ACTIVATION_BALANCE (has actual balance)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 withdrawal for validator 4
+        - balances[4]: 0 (full balance withdrawn)
+        - Note: Effective balance doesn't prevent full withdrawal if balance > 0
+    """
+    prepare_process_withdrawals(spec, state, full_withdrawal_indices=[4])
+    state.validators[4].effective_balance = 0
+    state.balances[4] = spec.MIN_ACTIVATION_BALANCE
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={4: 0},
+        withdrawal_index_delta=1,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_payments_exceed_limit_blocks_other_withdrawals(spec, state):
+    """
+    Test that when there are more than MAX_WITHDRAWALS_PER_PAYLOAD builder payments,
+    pending partial withdrawals are not processed.
+
+    Input State Configured:
+        - validators[0..N].withdrawal_credentials: 0x03 prefix (builder credentials)
+        - builder_pending_withdrawals: MAX_WITHDRAWALS_PER_PAYLOAD + 2 entries
+        - builder_pending_withdrawals[*].withdrawable_epoch: <= current_epoch
+        - balances[0..N]: >= amount + MIN_ACTIVATION_BALANCE
+
+    Output State Verified:
+        - payload_expected_withdrawals: Limited by MAX_WITHDRAWALS_PER_PAYLOAD
+        - builder_pending_withdrawals: Partially processed (some remain)
+        - Note: Builder payments are processed first; when they exceed limit,
+          pending partial and sweep withdrawals are blocked
+    """
+
+    # Add more builder payments than the limit to test prioritization
+    num_builders = spec.MAX_WITHDRAWALS_PER_PAYLOAD + 2  # 6 builders (more than limit of 4)
+    withdrawal_amount = spec.Gwei(1_000_000_000)
+
+    # Set up balances for all builders (credentials set via builder_indices in prepare_process_withdrawals)
+    builder_indices = list(range(num_builders))
+    for i in builder_indices:
+        state.balances[i] = max(state.balances[i], withdrawal_amount + spec.MIN_ACTIVATION_BALANCE)
+
+    # builder_credentials defaults to builder_indices
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=builder_indices,
+        builder_withdrawal_amounts={i: withdrawal_amount for i in builder_indices},
+    )
+
+    # Don't add any pending withdrawals for this test
+    # This test just verifies that builder payments work up to the limit
+
+    # Ensure no validators are eligible for sweep withdrawals
+    # by setting withdrawal credentials to non-withdrawable
+    for i in range(num_builders, len(state.validators)):
+        validator = state.validators[i]
+        if validator.withdrawal_credentials[0:1] == spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX:
+            # Keep ETH1 credentials but ensure balance is not above max_effective_balance
+            # to prevent full withdrawals
+            state.balances[i] = min(state.balances[i], spec.MAX_EFFECTIVE_BALANCE)
+
+    pre_state = state.copy()
+
+    # Should process builder payments up to the limit, but actual count depends on eligibility
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Verify builder queue was partially processed
+    # (some withdrawals should be processed, but not necessarily all due to eligibility constraints)
+    post_builder_count = len(state.builder_pending_withdrawals)
+    assert post_builder_count < len(pre_state.builder_pending_withdrawals), (
+        "Some builder withdrawals should have been processed"
+    )
+    processed_count = len(pre_state.builder_pending_withdrawals) - post_builder_count
+    assert processed_count <= spec.MAX_WITHDRAWALS_PER_PAYLOAD, "Should not exceed withdrawal limit"
+
+    # Complex assertion - keep verification outside assert_process_withdrawals
+    assert len(list(state.payload_expected_withdrawals)) <= spec.MAX_WITHDRAWALS_PER_PAYLOAD
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_no_builders_max_pending_with_sweep_spillover(spec, state):
+    """
+    Test no builder payments, MAX_WITHDRAWALS_PER_PAYLOAD pending partial withdrawals,
+    with sweep withdrawals available due to MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP limit.
+
+    Input State Configured:
+        - builder_pending_withdrawals: Empty (no builders)
+        - pending_partial_withdrawals: MAX_WITHDRAWALS_PER_PAYLOAD entries
+        - validators[N..N+3].withdrawable_epoch: <= current_epoch (sweep eligible)
+        - balances[*]: Configured for respective withdrawal types
+
+    Output State Verified:
+        - payload_expected_withdrawals: MAX_WITHDRAWALS_PER_PAYLOAD total
+          - MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP from pending queue
+          - Remaining slots filled by sweep withdrawals
+        - pending_partial_withdrawals: MAX - MAX_PENDING_PARTIALS remaining
+        - balances[sweep indices]: 0 (full withdrawals)
+        - Note: Pending partials capped by MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+    """
+
+    # Add MAX_WITHDRAWALS_PER_PAYLOAD pending partial withdrawals and sweep withdrawals
+    pending_indices = list(range(spec.MAX_WITHDRAWALS_PER_PAYLOAD))
+    sweep_start = spec.MAX_WITHDRAWALS_PER_PAYLOAD
+    sweep_indices = list(range(sweep_start, sweep_start + 3))
+
+    prepare_process_withdrawals(
+        spec,
+        state,
+        pending_partial_indices=pending_indices,
+        full_withdrawal_indices=sweep_indices,
+    )
+
+    # Should process MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP pending + remaining slots for sweep
+    expected_pending = spec.MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+    expected_sweep = spec.MAX_WITHDRAWALS_PER_PAYLOAD - expected_pending
+    expected_total = expected_pending + expected_sweep
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Verify remaining pending withdrawals not processed
+    remaining_pending = spec.MAX_WITHDRAWALS_PER_PAYLOAD - expected_pending
+    assert len(state.pending_partial_withdrawals) == remaining_pending
+
+    # Build balances dict for sweep validators
+    sweep_balances = {i: 0 for i in range(sweep_start, sweep_start + expected_sweep)}
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=expected_total,
+        balances=sweep_balances,
+        pending_partial_delta=-int(expected_pending),
+        withdrawal_index_delta=expected_total,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_no_builders_no_pending_max_sweep_withdrawals(spec, state):
+    """
+    Test no builder payments, no pending partial withdrawals,
+    MAX_WITHDRAWALS_PER_PAYLOAD sweep withdrawals.
+
+    Input State Configured:
+        - builder_pending_withdrawals: Empty
+        - pending_partial_withdrawals: Empty
+        - validators[0..MAX-1].withdrawable_epoch: <= current_epoch (all sweep eligible)
+        - balances[0..MAX-1]: > 0 (have balance to withdraw)
+
+    Output State Verified:
+        - payload_expected_withdrawals: MAX_WITHDRAWALS_PER_PAYLOAD (all sweep)
+        - balances[0..MAX-1]: 0 (all fully withdrawn)
+        - next_withdrawal_index: Incremented by MAX_WITHDRAWALS_PER_PAYLOAD
+    """
+
+    # Add MAX_WITHDRAWALS_PER_PAYLOAD sweep withdrawals
+    sweep_indices = list(range(spec.MAX_WITHDRAWALS_PER_PAYLOAD))
+    prepare_process_withdrawals(spec, state, full_withdrawal_indices=sweep_indices)
+
+    # All should be processed since no higher priority withdrawals exist
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Build balances dict for all sweep validators
+    sweep_balances = {i: 0 for i in range(spec.MAX_WITHDRAWALS_PER_PAYLOAD)}
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=spec.MAX_WITHDRAWALS_PER_PAYLOAD,
+        balances=sweep_balances,
+        withdrawal_index_delta=spec.MAX_WITHDRAWALS_PER_PAYLOAD,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_withdrawals_processed_first(spec, state):
+    """
+    Builder withdrawals should be processed before pending/regular withdrawals.
+    Verifies the priority ordering: builder > pending > sweep.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x03 prefix (builder)
+        - validators[0].effective_balance: MAX_EFFECTIVE_BALANCE_ELECTRA
+        - balances[0]: MAX_EFFECTIVE_BALANCE_ELECTRA + MIN_ACTIVATION_BALANCE
+        - builder_pending_withdrawals: Contains entry for validator 0
+        - validators[1].withdrawable_epoch: <= current_epoch (sweep eligible)
+
+    Output State Verified:
+        - payload_expected_withdrawals: 2 withdrawals in order:
+          [0] builder withdrawal (validator 0), [1] sweep withdrawal (validator 1)
+        - payload_expected_withdrawals[0].amount: MIN_ACTIVATION_BALANCE
+        - balances[0,1]: Decreased appropriately
+    """
+
+    builder_index = 0
+    regular_index = 1
+
+    # Set balance directly
+    state.validators[builder_index].effective_balance = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
+    state.balances[builder_index] = spec.MAX_EFFECTIVE_BALANCE_ELECTRA + spec.MIN_ACTIVATION_BALANCE
+
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=[builder_index],
+        full_withdrawal_indices=[regular_index],
+    )
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Verify priority ordering: builder first, then regular
+    withdrawals = list(state.payload_expected_withdrawals)
+    assert len(withdrawals) == 2
+    assert withdrawals[0].validator_index == builder_index
+    assert withdrawals[0].amount == spec.MIN_ACTIVATION_BALANCE
+    assert withdrawals[1].validator_index == regular_index
+
+    expected_builder_balance = pre_state.balances[builder_index] - spec.MIN_ACTIVATION_BALANCE
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=2,
+        withdrawal_order=[builder_index, regular_index],
+        balances={regular_index: 0, builder_index: expected_builder_balance},
+        builder_pending_delta=-1,
+        withdrawal_index_delta=2,
+        withdrawal_amounts={builder_index: spec.MIN_ACTIVATION_BALANCE},
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_uses_fee_recipient_address(spec, state):
+    """
+    Builder withdrawal should use fee_recipient address from BuilderPendingWithdrawal.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x03 prefix with custom address (0xab * 20)
+        - validators[0].effective_balance: MAX_EFFECTIVE_BALANCE_ELECTRA
+        - balances[0]: MAX_EFFECTIVE_BALANCE_ELECTRA + MIN_ACTIVATION_BALANCE
+        - builder_pending_withdrawals[0].fee_recipient: Custom address from credentials[12:]
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 builder withdrawal
+        - payload_expected_withdrawals[0].address: Custom fee_recipient address (0xab * 20)
+        - Note: Withdrawal uses fee_recipient from BuilderPendingWithdrawal, not fixed address
+    """
+
+    builder_index = 0
+    custom_address = b"\xab" * 20
+
+    # Set balance and credentials directly with custom address
+    state.validators[builder_index].effective_balance = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
+    state.balances[builder_index] = spec.MAX_EFFECTIVE_BALANCE_ELECTRA + spec.MIN_ACTIVATION_BALANCE
+    state.validators[builder_index].withdrawal_credentials = (
+        spec.BUILDER_WITHDRAWAL_PREFIX + b"\x00" * 11 + custom_address
+    )
+
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=[builder_index],
+        builder_credentials=[],  # Don't overwrite custom credentials
+    )
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Verify fee_recipient address is used
+    withdrawals = list(state.payload_expected_withdrawals)
+    builder_withdrawal = next((w for w in withdrawals if w.validator_index == builder_index), None)
+    assert builder_withdrawal is not None
+    assert builder_withdrawal.address == custom_address
+
+    expected_builder_balance = pre_state.balances[builder_index] - spec.MIN_ACTIVATION_BALANCE
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={builder_index: expected_builder_balance},
+        builder_pending_delta=-1,
+        withdrawal_index_delta=1,
+        withdrawal_addresses={builder_index: custom_address},
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_and_pending_leave_room_for_sweep(spec, state):
+    """
+    Test that builders + pending withdrawals leave room for sweep withdrawals.
+    When builders + pending = MAX-1, exactly 1 slot remains for sweep.
+
+    Input State Configured:
+        - validators[0..N-1].withdrawal_credentials: 0x03 prefix (builders)
+        - builder_pending_withdrawals: N entries (calculated to leave 1 slot)
+        - pending_partial_withdrawals: M entries (capped by MAX_PENDING_PARTIALS)
+        - validators[N+M+1].withdrawable_epoch: <= current_epoch (sweep eligible)
+        - Total builder + pending < MAX_WITHDRAWALS_PER_PAYLOAD
+
+    Output State Verified:
+        - payload_expected_withdrawals: builders + pending + 1 sweep
+        - Exactly 1 sweep withdrawal included in the payload
+        - Note: Tests the slot allocation between withdrawal types
+    """
+
+    assert spec.MAX_WITHDRAWALS_PER_PAYLOAD >= 3, (
+        "Test requires MAX_WITHDRAWALS_PER_PAYLOAD to be at least 3"
+    )
+
+    num_builders = 2 if spec.MAX_WITHDRAWALS_PER_PAYLOAD >= 4 else 1
+    num_pending = min(
+        spec.MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
+        spec.MAX_WITHDRAWALS_PER_PAYLOAD - num_builders - 1,
+    )
+
+    # Set up balances directly (credentials set via builder_indices in prepare_process_withdrawals)
+    for i in range(num_builders):
+        state.validators[i].effective_balance = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
+        state.balances[i] = spec.MAX_EFFECTIVE_BALANCE_ELECTRA + spec.MIN_ACTIVATION_BALANCE
+
+    if num_builders > 0:
+        builder_indices_list = list(range(num_builders))
+        prepare_process_withdrawals(
+            spec,
+            state,
+            builder_indices=builder_indices_list,
+        )
+
+    if num_pending > 0:
+        pending_indices = list(range(num_builders, num_builders + num_pending))
+        prepare_process_withdrawals(
+            spec,
+            state,
+            pending_partial_indices=pending_indices,
+        )
+
+    regular_index = num_builders + num_pending + 1
+    prepare_process_withdrawals(
+        spec,
+        state,
+        full_withdrawal_indices=[regular_index],
+    )
+
+    expected_total = num_builders + num_pending + 1
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Verify exactly 1 sweep withdrawal was included
+    withdrawals = list(state.payload_expected_withdrawals)
+    regular_withdrawals = [w for w in withdrawals if w.validator_index == regular_index]
+    assert len(regular_withdrawals) == 1, "Exactly 1 slot should remain for sweep withdrawal"
+
+    # Build parameters dict conditionally
+    assert_params = {
+        "withdrawal_count": expected_total,
+        "balances": {regular_index: 0},
+        "withdrawal_index_delta": expected_total,
+    }
+    if num_builders > 0:
+        assert_params["builder_pending_delta"] = -int(num_builders)
+    if num_pending > 0:
+        assert_params["pending_partial_delta"] = -int(num_pending)
+
+    assert_process_withdrawals(spec, state, pre_state, **assert_params)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_all_builder_withdrawals_invalid(spec, state):
+    """
+    All builders have insufficient balance, should process pending/regular instead.
+
+    Input State Configured:
+        - validators[0,1].withdrawal_credentials: 0x03 prefix (builder)
+        - validators[0,1].effective_balance: MIN_ACTIVATION_BALANCE
+        - balances[0,1]: MIN_ACTIVATION_BALANCE - 1 (INSUFFICIENT for builder withdrawal)
+        - builder_pending_withdrawals: 2 entries requesting MIN_ACTIVATION_BALANCE each
+        - validators[5].withdrawable_epoch: <= current_epoch (sweep eligible)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 1 sweep withdrawal (validator 5)
+        - Builder withdrawals with insufficient balance skipped
+        - balances[5]: 0 (full withdrawal processed)
+        - Note: When builder withdrawals are invalid, lower priority types are processed
+    """
+
+    current_epoch = spec.get_current_epoch(state)
+
+    # Set up 2 builders with insufficient balance (credentials set via builder_credentials)
+    prepare_process_withdrawals(spec, state, builder_credentials=[0, 1])
+    for i in range(2):
+        state.validators[i].effective_balance = spec.MIN_ACTIVATION_BALANCE
+        state.balances[i] = spec.MIN_ACTIVATION_BALANCE - spec.Gwei(1)
+        address = state.validators[i].withdrawal_credentials[12:]
+        state.builder_pending_withdrawals.append(
+            spec.BuilderPendingWithdrawal(
+                fee_recipient=address,
+                amount=spec.MIN_ACTIVATION_BALANCE,
+                builder_index=i,
+                withdrawable_epoch=current_epoch,
+            )
+        )
+
+    # Add a regular withdrawal
+    regular_index = 5
+    prepare_process_withdrawals(
+        spec,
+        state,
+        full_withdrawal_indices=[regular_index],
+    )
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Verify builders with insufficient balance were skipped, regular was processed
+    withdrawals = list(state.payload_expected_withdrawals)
+    assert any(w.validator_index == regular_index for w in withdrawals), (
+        "Regular sweep withdrawal should be processed"
+    )
+    for i in range(2):
+        assert not any(w.validator_index == i for w in withdrawals), (
+            f"Builder {i} with insufficient balance should not withdraw"
+        )
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=1,
+        balances={regular_index: 0},
+        no_withdrawal_indices=[0, 1],
+        withdrawal_index_delta=1,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_slashed_zero_balance(spec, state):
+    """
+    Slashed builder with 0 balance should be skipped.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x03 prefix (builder)
+        - validators[0].slashed: True
+        - validators[0].effective_balance: 0
+        - balances[0]: 0 (ZERO balance)
+        - builder_pending_withdrawals: 1 entry for validator 0
+
+    Output State Verified:
+        - payload_expected_withdrawals: Empty
+        - balances[0]: Remains 0
+        - builder_pending_withdrawals: Unchanged (skipped, not processed)
+        - Note: Slashed builder with 0 balance is skipped (nothing to withdraw)
+    """
+
+    builder_index = 0
+    current_epoch = spec.get_current_epoch(state)
+
+    # Set balance and credentials directly
+    prepare_process_withdrawals(spec, state, builder_credentials=[builder_index])
+    state.validators[builder_index].effective_balance = spec.Gwei(0)
+    state.balances[builder_index] = spec.Gwei(0)
+    state.validators[builder_index].slashed = True
+
+    address = state.validators[builder_index].withdrawal_credentials[12:]
+    state.builder_pending_withdrawals.append(
+        spec.BuilderPendingWithdrawal(
+            fee_recipient=address,
+            amount=spec.MIN_ACTIVATION_BALANCE,
+            builder_index=builder_index,
+            withdrawable_epoch=current_epoch,
+        )
+    )
+    pre_state = state.copy()
+
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    withdrawals = list(state.payload_expected_withdrawals)
+    builder_withdrawals = [w for w in withdrawals if w.validator_index == builder_index]
+    assert len(builder_withdrawals) == 0
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=0,
+        balances={builder_index: 0},
+        builder_pending_delta=0,
+        withdrawal_index_delta=0,
+        no_withdrawal_indices=[builder_index],
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_max_minus_one_plus_one_regular(spec, state):
+    """
+    Exactly MAX-1 builder withdrawals should leave exactly 1 slot for regular withdrawal.
+
+    Input State Configured:
+        - validators[0..MAX-2].withdrawal_credentials: 0x03 prefix (builders)
+        - validators[0..MAX-2].effective_balance: MAX_EFFECTIVE_BALANCE_ELECTRA
+        - balances[0..MAX-2]: MAX_EFFECTIVE_BALANCE_ELECTRA + MIN_ACTIVATION_BALANCE
+        - builder_pending_withdrawals: MAX-1 entries
+        - validators[MAX, MAX+1, MAX+2].withdrawable_epoch: <= current_epoch (sweep eligible)
+        - next_withdrawal_validator_index: Set to first sweep validator
+
+    Output State Verified:
+        - payload_expected_withdrawals: MAX_WITHDRAWALS_PER_PAYLOAD total
+          - MAX-1 builder withdrawals
+          - Exactly 1 sweep withdrawal (first in sweep order)
+        - Note: Builder cap at MAX-1 reserves 1 slot for other withdrawal types
+    """
+
+    num_builders = spec.MAX_WITHDRAWALS_PER_PAYLOAD - 1
+
+    # Set balances directly (credentials set via builder_indices in prepare_process_withdrawals)
+    for i in range(num_builders):
+        state.validators[i].effective_balance = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
+        state.balances[i] = spec.MAX_EFFECTIVE_BALANCE_ELECTRA + spec.MIN_ACTIVATION_BALANCE
+
+    builder_indices_list = list(range(num_builders))
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=builder_indices_list,
+    )
+
+    # Add multiple regular withdrawals, but only 1 should be processed
+    regular_indices = [num_builders + 1, num_builders + 2, num_builders + 3]
+    assert len(state.validators) >= max(regular_indices) + 1, (
+        f"Test requires at least {max(regular_indices) + 1} validators"
+    )
+
+    state.next_withdrawal_validator_index = regular_indices[0]
+
+    prepare_process_withdrawals(
+        spec,
+        state,
+        full_withdrawal_indices=regular_indices,
+    )
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Verify exactly 1 regular withdrawal when builders fill MAX-1 slots
+    withdrawals = list(state.payload_expected_withdrawals)
+    builder_withdrawals = [w for w in withdrawals if w.validator_index < num_builders]
+    assert len(builder_withdrawals) == num_builders
+    regular_withdrawals = [w for w in withdrawals if w.validator_index in regular_indices]
+    assert len(regular_withdrawals) == 1, (
+        "Should process exactly 1 regular withdrawal when builders fill MAX-1 slots"
+    )
+    assert regular_withdrawals[0].validator_index == regular_indices[0], (
+        "Should process the first regular withdrawal in sweep order"
+    )
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=spec.MAX_WITHDRAWALS_PER_PAYLOAD,
+        balances={regular_indices[0]: 0},
+        builder_pending_delta=-int(num_builders),
+        withdrawal_index_delta=spec.MAX_WITHDRAWALS_PER_PAYLOAD,
+        no_withdrawal_indices=regular_indices[1:],
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_wrong_credentials_still_processes(spec, state):
+    """
+    Builder pending withdrawal processes even with non-BUILDER_WITHDRAWAL_PREFIX.
+    get_expected_withdrawals does not validate the withdrawal credential prefix.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x02 prefix (COMPOUNDING, not builder)
+        - validators[0].effective_balance: MAX_EFFECTIVE_BALANCE_ELECTRA
+        - balances[0]: MAX_EFFECTIVE_BALANCE_ELECTRA + MIN_ACTIVATION_BALANCE
+        - builder_pending_withdrawals: 1 entry for validator 0 (manually added)
+        - validators[1].withdrawable_epoch: <= current_epoch (sweep eligible)
+
+    Output State Verified:
+        - payload_expected_withdrawals: Contains 2 withdrawals (builder + sweep)
+        - Builder withdrawal IS processed even with wrong credentials
+        - Note: get_expected_withdrawals does not validate credential prefix
+    """
+
+    builder_index = 0
+    regular_index = 1
+    current_epoch = spec.get_current_epoch(state)
+
+    # Set up compounding credentials (not builder credentials)
+    set_compounding_withdrawal_credential_with_balance(
+        spec,
+        state,
+        builder_index,
+        effective_balance=spec.MAX_EFFECTIVE_BALANCE_ELECTRA,
+        balance=spec.MAX_EFFECTIVE_BALANCE_ELECTRA + spec.MIN_ACTIVATION_BALANCE,
+    )
+
+    assert (
+        state.validators[builder_index].withdrawal_credentials[0:1]
+        != spec.BUILDER_WITHDRAWAL_PREFIX
+    ), "Validator should have non-builder credentials (0x02 compounding) for this test"
+
+    # Manually add builder pending withdrawal with wrong credentials
+    address = state.validators[builder_index].withdrawal_credentials[12:]
+    state.builder_pending_withdrawals.append(
+        spec.BuilderPendingWithdrawal(
+            fee_recipient=address,
+            amount=spec.MIN_ACTIVATION_BALANCE,
+            builder_index=builder_index,
+            withdrawable_epoch=current_epoch,
+        )
+    )
+
+    prepare_process_withdrawals(
+        spec,
+        state,
+        full_withdrawal_indices=[regular_index],
+    )
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    # Verify builder withdrawal processed even with wrong credentials
+    withdrawals = list(state.payload_expected_withdrawals)
+    builder_withdrawals = [w for w in withdrawals if w.validator_index == builder_index]
+    regular_withdrawals = [w for w in withdrawals if w.validator_index == regular_index]
+    assert len(builder_withdrawals) == 1, (
+        "Builder withdrawal IS processed even with wrong credentials - no validation in get_expected_withdrawals"
+    )
+    assert len(regular_withdrawals) == 1, "Regular withdrawal should also be processed"
+
+    expected_builder_balance = pre_state.balances[builder_index] - spec.MIN_ACTIVATION_BALANCE
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=2,
+        balances={regular_index: 0, builder_index: expected_builder_balance},
+        builder_pending_delta=-1,
+        withdrawal_index_delta=2,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_zero_withdrawal_amount(spec, state):
+    """
+    Builder withdrawal with amount = 0 should be skipped.
+
+    Input State Configured:
+        - validators[0].withdrawal_credentials: 0x03 prefix (builder)
+        - validators[0].effective_balance: MAX_EFFECTIVE_BALANCE_ELECTRA
+        - balances[0]: MAX_EFFECTIVE_BALANCE_ELECTRA (no excess above max)
+        - builder_pending_withdrawals: 1 entry with amount = 0
+
+    Output State Verified:
+        - payload_expected_withdrawals: Empty (zero-amount produces no output)
+        - balances[0]: Unchanged
+        - builder_pending_withdrawals: Reduced by 1 (entry consumed even with zero amount)
+    """
+
+    builder_index = 0
+
+    # Set balance directly (credentials set via builder_indices in prepare_process_withdrawals)
+    state.validators[builder_index].effective_balance = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
+    state.balances[builder_index] = spec.MAX_EFFECTIVE_BALANCE_ELECTRA  # No excess
+
+    prepare_process_withdrawals(
+        spec,
+        state,
+        builder_indices=[builder_index],
+        builder_withdrawal_amounts={builder_index: spec.Gwei(0)},
+    )
+    pre_state = state.copy()
+
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    withdrawals = list(state.payload_expected_withdrawals)
+    builder_withdrawals = [w for w in withdrawals if w.validator_index == builder_index]
+    assert len(builder_withdrawals) == 0
+
+    assert_process_withdrawals(
+        spec, state, pre_state,
+        withdrawal_count=0,
+        balance_deltas={builder_index: 0},
+        builder_pending_delta=-1,
+        withdrawal_index_delta=0,
+        no_withdrawal_indices=[builder_index],
+    )

--- a/tests/infra/helpers/test_withdrawals.py
+++ b/tests/infra/helpers/test_withdrawals.py
@@ -2,7 +2,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests.infra.helpers.withdrawals import verify_withdrawals_post_state
+from tests.infra.helpers.withdrawals import (
+    prepare_process_withdrawals,
+    verify_withdrawals_post_state,
+)
 
 
 class TestVerifyWithdrawalsPostState:
@@ -188,3 +191,363 @@ class TestVerifyWithdrawalsPostState:
                         partial_withdrawals_indices=partial_withdrawals_indices,
                         pending_withdrawal_requests=None,
                     )
+
+
+class TestPrepareWithdrawals:
+    """Test suite for prepare_withdrawals function"""
+
+    def test_prepare_builder_withdrawals(self):
+        """Test setting up builder pending withdrawals"""
+        # Mock spec
+        spec = MagicMock()
+        spec.MIN_ACTIVATION_BALANCE = 32_000_000_000
+        spec.Gwei = int
+        spec.get_current_epoch.return_value = 100
+        spec.fork = "gloas"
+        spec.has_builder_withdrawal_credential.return_value = True
+        spec.BuilderPendingWithdrawal = MagicMock(side_effect=lambda **kwargs: kwargs)
+
+        # Mock state
+        state = MagicMock()
+        state.builder_pending_withdrawals = []
+        state.validators = [MagicMock() for _ in range(10)]
+        state.validators[0].withdrawal_credentials = b"\x03" + b"\x00" * 11 + b"\x42" * 20
+        state.validators[1].withdrawal_credentials = b"\x03" + b"\x00" * 11 + b"\x43" * 20
+        state.balances = [100_000_000_000] * 10  # Plenty of balance
+
+        with patch("tests.infra.helpers.withdrawals.is_post_gloas", return_value=True):
+            with patch("tests.infra.helpers.withdrawals.is_post_electra", return_value=True):
+                prepare_process_withdrawals(
+                    spec,
+                    state,
+                    builder_indices=[0, 1],
+                    builder_withdrawal_amounts={0: 1_000_000_000, 1: 2_000_000_000},
+                )
+
+        # Verify two builder pending withdrawals were added
+        assert len(state.builder_pending_withdrawals) == 2
+        assert state.builder_pending_withdrawals[0]["amount"] == 1_000_000_000
+        assert state.builder_pending_withdrawals[0]["builder_index"] == 0
+        assert state.builder_pending_withdrawals[1]["amount"] == 2_000_000_000
+        assert state.builder_pending_withdrawals[1]["builder_index"] == 1
+
+    def test_prepare_pending_partial_withdrawals(self):
+        """Test setting up pending partial withdrawals"""
+        # Mock spec
+        spec = MagicMock()
+        spec.Gwei = int
+        spec.fork = "electra"
+        spec.get_current_epoch.return_value = 100
+        spec.COMPOUNDING_WITHDRAWAL_PREFIX = b"\x02"
+        spec.MAX_EFFECTIVE_BALANCE_ELECTRA = 2048_000_000_000
+        spec.EFFECTIVE_BALANCE_INCREMENT = 1_000_000_000
+        spec.has_compounding_withdrawal_credential.return_value = True
+        spec.PendingPartialWithdrawal = MagicMock(side_effect=lambda **kwargs: kwargs)
+
+        # Mock state
+        state = MagicMock()
+        state.pending_partial_withdrawals = []
+        state.validators = [MagicMock() for _ in range(10)]
+        state.balances = [0] * 10
+
+        # Mock validators with compounding credentials
+        for v in state.validators:
+            v.withdrawal_credentials = b"\x02" + b"\x00" * 31
+            v.effective_balance = 0
+
+        with patch("tests.infra.helpers.withdrawals.is_post_gloas", return_value=False):
+            with patch("tests.infra.helpers.withdrawals.is_post_electra", return_value=True):
+                prepare_process_withdrawals(
+                    spec,
+                    state,
+                    pending_partial_indices=[2, 3],
+                    pending_partial_amounts={2: 500_000_000, 3: 600_000_000},
+                )
+
+        # Verify two pending partial withdrawals were added to state
+        assert len(state.pending_partial_withdrawals) == 2
+
+        # Verify withdrawal details
+        assert state.pending_partial_withdrawals[0]["validator_index"] == 2
+        assert state.pending_partial_withdrawals[0]["amount"] == 500_000_000
+        assert state.pending_partial_withdrawals[0]["withdrawable_epoch"] == 100
+
+        assert state.pending_partial_withdrawals[1]["validator_index"] == 3
+        assert state.pending_partial_withdrawals[1]["amount"] == 600_000_000
+        assert state.pending_partial_withdrawals[1]["withdrawable_epoch"] == 100
+
+        # Verify validator balances were set correctly
+        assert state.balances[2] == 32_000_000_000 + 500_000_000  # effective_balance + amount
+        assert state.balances[3] == 32_000_000_000 + 600_000_000
+
+    def test_prepare_full_and_partial_withdrawals(self):
+        """Test setting up full and partial withdrawals"""
+        # Mock spec
+        spec = MagicMock()
+        spec.Gwei = int
+        spec.fork = "capella"
+        spec.get_current_epoch.return_value = 100
+        spec.BLS_WITHDRAWAL_PREFIX = b"\x00"
+        spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX = b"\x01"
+        spec.MAX_EFFECTIVE_BALANCE = 32_000_000_000
+        spec.EFFECTIVE_BALANCE_INCREMENT = 1_000_000_000
+        spec.FAR_FUTURE_EPOCH = 2**64 - 1
+        spec.is_fully_withdrawable_validator.return_value = True
+        spec.is_partially_withdrawable_validator.return_value = True
+        spec.has_compounding_withdrawal_credential.return_value = False
+
+        # Mock state
+        state = MagicMock()
+        state.validators = [MagicMock() for _ in range(10)]
+        state.balances = [0] * 10
+
+        # Set up validators with BLS credentials (will be converted to ETH1)
+        for v in state.validators:
+            v.withdrawal_credentials = b"\x00" + b"\x00" * 31
+            v.effective_balance = 0
+            v.exit_epoch = spec.FAR_FUTURE_EPOCH
+            v.withdrawable_epoch = spec.FAR_FUTURE_EPOCH
+
+        with patch("tests.infra.helpers.withdrawals.is_post_gloas", return_value=False):
+            with patch("tests.infra.helpers.withdrawals.is_post_electra", return_value=False):
+                prepare_process_withdrawals(
+                    spec,
+                    state,
+                    full_withdrawal_indices=[4, 5],
+                    partial_withdrawal_indices=[6, 7],
+                    partial_excess_balances={7: 2_000_000_000},
+                )
+
+        # Verify full withdrawals: validators should be withdrawable
+        assert state.validators[4].withdrawable_epoch == 100
+        assert state.validators[4].exit_epoch <= 100
+        assert state.validators[4].withdrawal_credentials[0:1] == b"\x01"  # ETH1 prefix
+        assert state.balances[4] == 10_000_000_000  # Default balance set
+
+        assert state.validators[5].withdrawable_epoch == 100
+        assert state.validators[5].exit_epoch <= 100
+        assert state.validators[5].withdrawal_credentials[0:1] == b"\x01"
+        assert state.balances[5] == 10_000_000_000
+
+        # Verify partial withdrawals: validators should have excess balance
+        assert state.validators[6].withdrawal_credentials[0:1] == b"\x01"  # ETH1 prefix
+        assert state.balances[6] == spec.MAX_EFFECTIVE_BALANCE + 1_000_000_000
+        assert state.validators[6].effective_balance == spec.MAX_EFFECTIVE_BALANCE
+
+        assert state.validators[7].withdrawal_credentials[0:1] == b"\x01"
+        assert state.balances[7] == spec.MAX_EFFECTIVE_BALANCE + 2_000_000_000
+        assert state.validators[7].effective_balance == spec.MAX_EFFECTIVE_BALANCE
+
+    def test_prepare_withdrawals_builder_insufficient_balance(self):
+        """Test that insufficient balance for builder raises assertion"""
+        # Mock spec
+        spec = MagicMock()
+        spec.MIN_ACTIVATION_BALANCE = 32_000_000_000
+        spec.Gwei = int
+        spec.get_current_epoch.return_value = 100
+        spec.has_builder_withdrawal_credential.return_value = True
+
+        # Mock state with insufficient balance
+        state = MagicMock()
+        state.builder_pending_withdrawals = []
+        state.validators = [MagicMock() for _ in range(10)]
+        state.validators[0].withdrawal_credentials = b"\x03" + b"\x00" * 11 + b"\x42" * 20
+        state.balances = [1_000_000_000] * 10  # Insufficient balance
+
+        with patch("tests.infra.helpers.withdrawals.is_post_gloas", return_value=True):
+            with pytest.raises(AssertionError, match="needs balance"):
+                prepare_process_withdrawals(
+                    spec,
+                    state,
+                    builder_indices=[0],
+                    builder_withdrawal_amounts={0: 10_000_000_000},
+                )
+
+    def test_prepare_withdrawals_with_future_epochs(self):
+        """Test setting up withdrawals with future withdrawable epochs"""
+        # Mock spec
+        spec = MagicMock()
+        spec.MIN_ACTIVATION_BALANCE = 32_000_000_000
+        spec.Gwei = int
+        spec.get_current_epoch.return_value = 100
+        spec.has_builder_withdrawal_credential.return_value = True
+        spec.BuilderPendingWithdrawal = MagicMock(side_effect=lambda **kwargs: kwargs)
+        spec.BLS_WITHDRAWAL_PREFIX = b"\x00"
+        spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX = b"\x01"
+        spec.MAX_EFFECTIVE_BALANCE = 32_000_000_000
+        spec.EFFECTIVE_BALANCE_INCREMENT = 1_000_000_000
+        spec.FAR_FUTURE_EPOCH = 2**64 - 1
+        spec.COMPOUNDING_WITHDRAWAL_PREFIX = b"\x02"
+        spec.MAX_EFFECTIVE_BALANCE_ELECTRA = 2048_000_000_000
+        spec.has_compounding_withdrawal_credential.return_value = True
+        spec.PendingPartialWithdrawal = MagicMock(side_effect=lambda **kwargs: kwargs)
+        spec.is_fully_withdrawable_validator.return_value = True
+        spec.fork = "gloas"  # Set the fork to gloas
+
+        # Mock state
+        state = MagicMock()
+        state.builder_pending_withdrawals = []
+        state.pending_partial_withdrawals = []
+        state.validators = [MagicMock() for _ in range(10)]
+        state.balances = [100_000_000_000] * 10  # Plenty of balance
+
+        # Set up validators with appropriate credentials
+        for i, v in enumerate(state.validators):
+            if i < 3:  # First 3 for builder withdrawals
+                v.withdrawal_credentials = b"\x03" + b"\x00" * 11 + bytes([0x42 + i]) + b"\x00" * 19
+            else:  # Others for partial withdrawals
+                v.withdrawal_credentials = b"\x02" + b"\x00" * 31
+                v.effective_balance = 0
+            v.exit_epoch = spec.FAR_FUTURE_EPOCH
+            v.withdrawable_epoch = spec.FAR_FUTURE_EPOCH
+
+        with patch("tests.infra.helpers.withdrawals.is_post_gloas", return_value=True):
+            with patch("tests.infra.helpers.withdrawals.is_post_electra", return_value=True):
+                prepare_process_withdrawals(
+                    spec,
+                    state,
+                    builder_indices=[0, 1, 2],
+                    builder_withdrawal_amounts={
+                        0: 1_000_000_000,
+                        1: 2_000_000_000,
+                        2: 3_000_000_000,
+                    },
+                    builder_withdrawable_offsets={
+                        0: 0,
+                        1: 5,
+                        2: 10,
+                    },  # Current, +5 epochs, +10 epochs
+                    pending_partial_indices=[3, 4],
+                    pending_partial_amounts={3: 500_000_000, 4: 600_000_000},
+                    pending_partial_withdrawable_offsets={3: 2, 4: 7},  # +2 epochs, +7 epochs
+                    full_withdrawal_indices=[5, 6],
+                    full_withdrawable_offsets={5: 3, 6: 15},  # +3 epochs, +15 epochs
+                )
+
+        # Verify builder pending withdrawals with future epochs
+        assert len(state.builder_pending_withdrawals) == 3
+        assert state.builder_pending_withdrawals[0]["withdrawable_epoch"] == 100  # Current epoch
+        assert state.builder_pending_withdrawals[1]["withdrawable_epoch"] == 105  # +5 epochs
+        assert state.builder_pending_withdrawals[2]["withdrawable_epoch"] == 110  # +10 epochs
+
+        # Verify pending partial withdrawals with future epochs
+        assert len(state.pending_partial_withdrawals) == 2
+        assert state.pending_partial_withdrawals[0]["withdrawable_epoch"] == 102  # +2 epochs
+        assert state.pending_partial_withdrawals[1]["withdrawable_epoch"] == 107  # +7 epochs
+
+        # Verify full withdrawals with future epochs
+        assert state.validators[5].withdrawable_epoch == 103  # +3 epochs
+        assert state.validators[6].withdrawable_epoch == 115  # +15 epochs
+
+    def test_builder_credentials_defaults_to_builder_indices(self):
+        """Test that builder_credentials=None uses builder_indices for setting credentials"""
+        spec = MagicMock()
+        spec.MIN_ACTIVATION_BALANCE = 32_000_000_000
+        spec.Gwei = int
+        spec.get_current_epoch.return_value = 100
+        spec.has_builder_withdrawal_credential.side_effect = (
+            lambda v: v.withdrawal_credentials[0:1] == b"\x03"
+        )
+        spec.BuilderPendingWithdrawal = MagicMock(side_effect=lambda **kwargs: kwargs)
+        spec.BUILDER_WITHDRAWAL_PREFIX = b"\x03"
+
+        state = MagicMock()
+        state.builder_pending_withdrawals = []
+        state.validators = [MagicMock() for _ in range(10)]
+        state.balances = [100_000_000_000] * 10
+
+        # Set up validators with ETH1 credentials (not builder)
+        for v in state.validators:
+            v.withdrawal_credentials = b"\x01" + b"\x00" * 31
+
+        with patch("tests.infra.helpers.withdrawals.is_post_gloas", return_value=True):
+            with patch("tests.infra.helpers.withdrawals.is_post_electra", return_value=True):
+                prepare_process_withdrawals(
+                    spec,
+                    state,
+                    builder_indices=[0, 1],
+                    # builder_credentials=None (default)
+                )
+
+        # Validators 0 and 1 should now have builder credentials
+        assert state.validators[0].withdrawal_credentials[0:1] == b"\x03"
+        assert state.validators[1].withdrawal_credentials[0:1] == b"\x03"
+        # Other validators should remain unchanged
+        assert state.validators[2].withdrawal_credentials[0:1] == b"\x01"
+
+    def test_builder_credentials_different_from_builder_indices(self):
+        """Test that builder_credentials can set credentials on validators without pending withdrawals"""
+        spec = MagicMock()
+        spec.MIN_ACTIVATION_BALANCE = 32_000_000_000
+        spec.Gwei = int
+        spec.get_current_epoch.return_value = 100
+        spec.has_builder_withdrawal_credential.side_effect = (
+            lambda v: v.withdrawal_credentials[0:1] == b"\x03"
+        )
+        spec.BuilderPendingWithdrawal = MagicMock(side_effect=lambda **kwargs: kwargs)
+        spec.BUILDER_WITHDRAWAL_PREFIX = b"\x03"
+
+        state = MagicMock()
+        state.builder_pending_withdrawals = []
+        state.validators = [MagicMock() for _ in range(10)]
+        state.balances = [100_000_000_000] * 10
+
+        # Set up validators with ETH1 credentials (not builder)
+        for v in state.validators:
+            v.withdrawal_credentials = b"\x01" + b"\x00" * 31
+
+        with patch("tests.infra.helpers.withdrawals.is_post_gloas", return_value=True):
+            with patch("tests.infra.helpers.withdrawals.is_post_electra", return_value=True):
+                prepare_process_withdrawals(
+                    spec,
+                    state,
+                    builder_indices=[],  # No pending withdrawals
+                    builder_credentials=[2, 3, 4],  # But set credentials on these validators
+                )
+
+        # Validators 2, 3, 4 should have builder credentials (from builder_credentials)
+        assert state.validators[2].withdrawal_credentials[0:1] == b"\x03"
+        assert state.validators[3].withdrawal_credentials[0:1] == b"\x03"
+        assert state.validators[4].withdrawal_credentials[0:1] == b"\x03"
+        # Other validators should remain unchanged
+        assert state.validators[0].withdrawal_credentials[0:1] == b"\x01"
+        assert state.validators[1].withdrawal_credentials[0:1] == b"\x01"
+
+    def test_prepare_withdrawals_parent_block_full_default(self):
+        """Test that parent_block_full=True (default) sets parent block as full"""
+        spec = MagicMock()
+        spec.Gwei = int
+        spec.get_current_epoch.return_value = 100
+
+        state = MagicMock()
+        state.latest_block_hash = b"\x00" * 32
+        state.latest_execution_payload_bid = MagicMock()
+        state.latest_execution_payload_bid.block_hash = b"\x00" * 32
+
+        with patch("tests.infra.helpers.withdrawals.is_post_gloas", return_value=True):
+            with patch("tests.infra.helpers.withdrawals.is_post_electra", return_value=True):
+                prepare_process_withdrawals(spec, state)
+
+        # Both hashes should match and be non-zero (parent block full)
+        assert state.latest_block_hash == state.latest_execution_payload_bid.block_hash
+        assert state.latest_block_hash != b"\x00" * 32
+
+    def test_prepare_withdrawals_parent_block_empty(self):
+        """Test that parent_block_empty=True sets parent block as empty"""
+        spec = MagicMock()
+        spec.Gwei = int
+        spec.get_current_epoch.return_value = 100
+
+        state = MagicMock()
+        state.latest_block_hash = b"\x01" * 32
+        state.latest_execution_payload_bid = MagicMock()
+        state.latest_execution_payload_bid.block_hash = b"\x01" * 32
+
+        with patch("tests.infra.helpers.withdrawals.is_post_gloas", return_value=True):
+            with patch("tests.infra.helpers.withdrawals.is_post_electra", return_value=True):
+                prepare_process_withdrawals(spec, state, parent_block_empty=True)
+
+        # latest_block_hash should be zeros, bid.block_hash should be non-zero (mismatch = empty)
+        assert state.latest_block_hash == b"\x00" * 32
+        assert state.latest_execution_payload_bid.block_hash == b"\x01" * 32
+        assert state.latest_block_hash != state.latest_execution_payload_bid.block_hash

--- a/tests/infra/helpers/withdrawals.py
+++ b/tests/infra/helpers/withdrawals.py
@@ -1,4 +1,305 @@
-from tests.core.pyspec.eth2spec.test.helpers.forks import is_post_electra, is_post_gloas
+from eth2spec.test.helpers.forks import is_post_electra, is_post_gloas
+
+
+def set_parent_block_full(spec, state):
+    """
+    Helper to set state indicating parent block was full.
+    """
+    state.latest_block_hash = state.latest_execution_payload_bid.block_hash
+
+    # For testing purposes, ensure we have a block hash
+    if state.latest_block_hash == b"\x00" * 32:
+        state.latest_block_hash = b"\x01" * 32
+        state.latest_execution_payload_bid.block_hash = state.latest_block_hash
+
+
+def set_parent_block_empty(spec, state):
+    """
+    Helper to set state indicating parent block was empty.
+    """
+    state.latest_block_hash = b"\x00" * 32
+    state.latest_execution_payload_bid.block_hash = b"\x01" * 32
+
+
+def prepare_process_withdrawals(
+    spec,
+    state,
+    builder_indices=[],
+    pending_partial_indices=[],
+    full_withdrawal_indices=[],
+    partial_withdrawal_indices=[],
+    builder_withdrawal_amounts=None,
+    pending_partial_amounts=None,
+    partial_excess_balances=None,
+    builder_withdrawable_offsets=None,
+    pending_partial_withdrawable_offsets=None,
+    full_withdrawable_offsets=None,
+    builder_credentials=None,
+    parent_block_full=True,
+    parent_block_empty=False,
+):
+    """
+    Populate the state with all three types of withdrawals based on configuration.
+
+    Args:
+        spec: The spec object
+        state: The beacon state to modify
+        builder_indices: List of validator indices to add builder pending withdrawals for
+        pending_partial_indices: List of validator indices to set up with pending partial withdrawals
+        full_withdrawal_indices: List of validator indices to set up as fully withdrawable
+        partial_withdrawal_indices: List of validator indices to set up as partially withdrawable
+        builder_withdrawal_amounts: Single amount or dict[ValidatorIndex, Gwei] for builder withdrawals
+                                    (default: MIN_ACTIVATION_BALANCE for each)
+        pending_partial_amounts: Single amount or dict[ValidatorIndex, Gwei] for pending partial withdrawals
+                                 (default: 1_000_000_000 for each)
+        partial_excess_balances: Single amount or dict[ValidatorIndex, Gwei] for partial withdrawals
+                                 (default: 1_000_000_000 for each)
+        builder_withdrawable_offsets: Single offset or dict[ValidatorIndex, int] for builder withdrawals
+                                      (default: 0, i.e., withdrawable immediately)
+        pending_partial_withdrawable_offsets: Single offset or dict[ValidatorIndex, int] for pending partial
+                                             withdrawals (default: 0, i.e., withdrawable immediately)
+        full_withdrawable_offsets: Single offset or dict[ValidatorIndex, int] for full withdrawals
+                                  (default: 0, i.e., withdrawable immediately)
+        builder_credentials: List of validator indices to set builder withdrawal credentials on
+                            (default: None, which uses builder_indices)
+        parent_block_full: If True, set state to indicate parent block was full (default: True)
+        parent_block_empty: If True, set state to indicate parent block was empty (default: False)
+                           Takes precedence over parent_block_full if both are True
+    """
+    # Set parent block state (Gloas+)
+    if is_post_gloas(spec):
+        if parent_block_empty:
+            set_parent_block_empty(spec, state)
+        elif parent_block_full:
+            set_parent_block_full(spec, state)
+
+    # Import here to avoid circular imports
+    from tests.core.pyspec.eth2spec.test.helpers.withdrawals import (  # noqa: PLC0415
+        prepare_pending_withdrawal,
+        set_builder_withdrawal_credential,
+        set_validator_fully_withdrawable,
+        set_validator_partially_withdrawable,
+    )
+
+    current_epoch = spec.get_current_epoch(state)
+
+    # Helper to get parameter value from single value, dict, or None
+    def get_param_value(param, validator_index, default):
+        """
+        Extract a value from a parameter that can be:
+        - None: returns the default value
+        - A single value (int/Gwei): returns that value for all validator indices
+        - A dict: returns the value for the given validator_index (or default if not present)
+        """
+        if param is None:
+            return default
+        if isinstance(param, (int, type(spec.Gwei(0)))):
+            return param
+        return param.get(validator_index, default)
+
+    # Set builder withdrawal credentials (Gloas+)
+    if is_post_gloas(spec):
+        credentials_indices = (
+            builder_credentials if builder_credentials is not None else builder_indices
+        )
+        for validator_index in credentials_indices:
+            set_builder_withdrawal_credential(spec, state, validator_index)
+
+    # Set up builder pending withdrawals (Gloas+)
+    if is_post_gloas(spec) and builder_indices:
+        for validator_index in builder_indices:
+            amount = get_param_value(
+                builder_withdrawal_amounts, validator_index, spec.MIN_ACTIVATION_BALANCE
+            )
+            epoch_offset = get_param_value(builder_withdrawable_offsets, validator_index, 0)
+
+            # Verify the validator is already set up as a builder
+            validator = state.validators[validator_index]
+            assert spec.has_builder_withdrawal_credential(validator), (
+                f"Validator {validator_index} must have builder withdrawal credentials. "
+                f"Use set_builder_withdrawal_credential() or set_builder_withdrawal_credential_with_balance() first."
+            )
+
+            # Verify the builder has sufficient balance
+            assert state.balances[validator_index] >= amount + spec.MIN_ACTIVATION_BALANCE, (
+                f"Validator {validator_index} needs balance >= {amount + spec.MIN_ACTIVATION_BALANCE}, "
+                f"but has {state.balances[validator_index]}"
+            )
+
+            # Add builder pending withdrawal
+            address = validator.withdrawal_credentials[12:]
+            state.builder_pending_withdrawals.append(
+                spec.BuilderPendingWithdrawal(
+                    fee_recipient=address,
+                    amount=amount,
+                    builder_index=validator_index,
+                    withdrawable_epoch=current_epoch + epoch_offset,  # Can be in the future
+                )
+            )
+
+    # Set up pending partial withdrawals (Electra+)
+    if is_post_electra(spec) and pending_partial_indices:
+        for validator_index in pending_partial_indices:
+            amount = get_param_value(pending_partial_amounts, validator_index, 1_000_000_000)
+            epoch_offset = get_param_value(pending_partial_withdrawable_offsets, validator_index, 0)
+
+            prepare_pending_withdrawal(
+                spec,
+                state,
+                validator_index,
+                amount=amount,
+                withdrawable_epoch=current_epoch + epoch_offset,  # Can be in the future
+            )
+
+    # Set up full withdrawals
+    for validator_index in full_withdrawal_indices:
+        epoch_offset = get_param_value(full_withdrawable_offsets, validator_index, 0)
+        set_validator_fully_withdrawable(
+            spec,
+            state,
+            validator_index,
+            withdrawable_epoch=current_epoch + epoch_offset,  # Can be in the future
+        )
+
+    # Set up partial withdrawals
+    for validator_index in partial_withdrawal_indices:
+        excess_balance = get_param_value(partial_excess_balances, validator_index, 1_000_000_000)
+
+        set_validator_partially_withdrawable(
+            spec,
+            state,
+            validator_index,
+            excess_balance=excess_balance,
+        )
+
+
+def assert_process_withdrawals(
+    spec,
+    state,
+    pre_state,
+    withdrawal_count=None,
+    balances=None,
+    balance_deltas=None,
+    builder_pending_delta=None,
+    pending_partial_delta=None,
+    withdrawal_index_delta=None,
+    validator_index_delta=None,
+    withdrawal_order=None,
+    withdrawal_amounts=None,
+    withdrawal_addresses=None,
+    no_withdrawal_indices=None,
+    all_state_unchanged=None,
+):
+    """
+    Assert expected outcomes from process_withdrawals.
+
+    INVARIANT CHECKS (always run automatically):
+    - Balance decreases match withdrawal amounts for ALL withdrawals
+    - state.payload_expected_withdrawals matches spec.get_expected_withdrawals()
+    - Queue lengths never increase inappropriately
+
+    TEST-SPECIFIC CHECKS (controlled by parameters):
+    - withdrawal_count: Exact number of withdrawals
+    - balances/balance_deltas: Specific validator balance checks
+    - builder_pending_delta/pending_partial_delta: Exact queue changes
+    - withdrawal_index_delta/validator_index_delta: Index advancement
+    - withdrawal_order/amounts/addresses: Withdrawal content verification
+
+    Naming convention:
+    - No prefix: explicit values (balances, withdrawal_count, withdrawal_order, etc.)
+    - *_delta suffix: changes from pre_state (builder_pending_delta, balance_deltas, etc.)
+    """
+    # Early exit check (skip all invariant checks)
+    if all_state_unchanged:
+        assert state.balances == pre_state.balances
+        assert state.next_withdrawal_index == pre_state.next_withdrawal_index
+        assert state.next_withdrawal_validator_index == pre_state.next_withdrawal_validator_index
+        assert len(state.builder_pending_withdrawals) == len(pre_state.builder_pending_withdrawals)
+        assert len(state.pending_partial_withdrawals) == len(pre_state.pending_partial_withdrawals)
+        return
+
+    # Get expected withdrawals for invariant checks
+    expected_withdrawals, _, _ = spec.get_expected_withdrawals(pre_state)
+    withdrawals = list(state.payload_expected_withdrawals)
+
+    # INVARIANT: Verify payload_expected_withdrawals matches expected
+    expected_list = spec.List[spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD](expected_withdrawals)
+    assert list(withdrawals) == list(expected_list), \
+        "state.payload_expected_withdrawals must match spec.get_expected_withdrawals()"
+
+    # INVARIANT: Balance decreases for all withdrawals
+    for withdrawal in expected_withdrawals:
+        validator_index = withdrawal.validator_index
+        pre_balance = pre_state.balances[validator_index]
+        post_balance = state.balances[validator_index]
+        assert post_balance == pre_balance - withdrawal.amount, \
+            f"Validator {validator_index} balance must decrease by withdrawal amount"
+
+    # INVARIANT: Queue lengths never increase
+    assert len(state.pending_partial_withdrawals) <= len(pre_state.pending_partial_withdrawals), \
+        "pending_partial_withdrawals queue must not grow"
+    assert len(state.builder_pending_withdrawals) <= len(pre_state.builder_pending_withdrawals), \
+        "builder_pending_withdrawals queue must not grow"
+
+    # Withdrawal count verification
+    if withdrawal_count is not None:
+        assert len(withdrawals) == withdrawal_count
+
+    # Balance verification - explicit values
+    if balances is not None:
+        for validator_idx, expected_balance in balances.items():
+            assert state.balances[validator_idx] == expected_balance, \
+                f"Validator {validator_idx}: expected balance {expected_balance}, got {state.balances[validator_idx]}"
+
+    # Balance verification - deltas
+    if balance_deltas is not None:
+        for validator_idx, delta in balance_deltas.items():
+            expected = pre_state.balances[validator_idx] + delta
+            assert state.balances[validator_idx] == expected, \
+                f"Validator {validator_idx}: expected balance {expected}, got {state.balances[validator_idx]}"
+
+    # Queue state - deltas from pre_state
+    if builder_pending_delta is not None:
+        expected = len(pre_state.builder_pending_withdrawals) + builder_pending_delta
+        assert len(state.builder_pending_withdrawals) == expected
+
+    if pending_partial_delta is not None:
+        expected = len(pre_state.pending_partial_withdrawals) + pending_partial_delta
+        assert len(state.pending_partial_withdrawals) == expected
+
+    # Index state - deltas from pre_state
+    if withdrawal_index_delta is not None:
+        expected = pre_state.next_withdrawal_index + withdrawal_index_delta
+        assert state.next_withdrawal_index == expected
+
+    if validator_index_delta is not None:
+        num_validators = len(pre_state.validators)
+        expected = (pre_state.next_withdrawal_validator_index + validator_index_delta) % num_validators
+        assert state.next_withdrawal_validator_index == expected
+
+    # Withdrawal ordering
+    if withdrawal_order is not None:
+        actual_order = [w.validator_index for w in withdrawals]
+        assert actual_order == withdrawal_order
+
+    # Withdrawal content
+    if withdrawal_amounts is not None:
+        for validator_idx, expected_amount in withdrawal_amounts.items():
+            matching = [w for w in withdrawals if w.validator_index == validator_idx]
+            assert len(matching) == 1, f"Expected exactly 1 withdrawal for validator {validator_idx}"
+            assert matching[0].amount == expected_amount
+
+    if withdrawal_addresses is not None:
+        for validator_idx, expected_address in withdrawal_addresses.items():
+            matching = [w for w in withdrawals if w.validator_index == validator_idx]
+            assert len(matching) == 1
+            assert matching[0].address == expected_address
+
+    # No withdrawal verification
+    if no_withdrawal_indices is not None:
+        for idx in no_withdrawal_indices:
+            assert not any(w.validator_index == idx for w in withdrawals), \
+                f"Validator {idx} should not have a withdrawal"
 
 
 def get_expected_withdrawals(spec, state):


### PR DESCRIPTION
It includes 29 tests.

Perhaps out of sync with https://github.com/ethereum/consensus-specs/pull/4787 