### PR TITLE
Fix uploads in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,23 +75,24 @@ jobs:
           tar -czvf minimal.tar.gz tests/minimal
           tar -czvf mainnet.tar.gz tests/mainnet
 
-      # Publish the specs release. We use release-drafter to
+      # Create draft release. We use release-drafter to
       # organize PRs into the appropriate section based on PR labels
-      - name: Publish specs release
+      - name: Create draft release
         uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           name: ${{ github.ref_name }}
           tag: ${{ github.ref_name }}
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          publish: true
+          publish: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Upload spec test tarballs to the specs release
-      - name: Upload spec test tarballs
+      # Upload spec test tarballs and publish the release
+      - name: Upload spec test tarballs and publish
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             consensus-spec-tests/general.tar.gz
             consensus-spec-tests/minimal.tar.gz


### PR DESCRIPTION
In the last release, there was a bug that prevented the tarballs from being uploaded.

<img width="694" height="392" alt="image" src="https://github.com/user-attachments/assets/24a8371e-aac5-441b-8e88-9dbbc63a58e9" />

A recent change to `softprops/action-gh-release` (v2?) prevents the action from uploading files to published (non-draft) releases. So it created a draft release with the same name and uploaded the files there 🤦

This PR should fix things.