### PR TITLE
Update release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
 
 jobs:
   release:
@@ -33,15 +31,18 @@ jobs:
           enable-cache: true
           version: ${{ vars.UV_VERSION }}
 
-      # Check the tag matches the version
-      - name: Version check
+      # Tag the current commit
+      - name: Create tag
         run: |
-          tag="${{ github.ref_name }}"
           version="v$(cat consensus-specs/tests/core/pyspec/eth2spec/VERSION.txt)"
-          if [ "$tag" != "$version" ]; then
-            echo "Tag ($tag) does not match version ($version)"
+          cd consensus-specs
+          if git rev-parse "refs/tags/$version" >/dev/null 2>&1; then
+            echo "Error: Tag $version already exists"
             exit 1
           fi
+          git tag "$version"
+          git push origin "$version"
+          echo "Created and pushed tag $version"
 
       # Ensure framework tests pass
       - name: Run tests for framework

--- a/docs/docs/release.md
+++ b/docs/docs/release.md
@@ -4,7 +4,7 @@
 
 - [Introduction](#introduction)
 - [Bump the Version](#bump-the-version)
-- [Tag the Release](#tag-the-release)
+- [Publish the Release](#publish-the-release)
 - [Make an Announcement](#make-an-announcement)
 
 <!-- mdformat-toc end -->
@@ -16,7 +16,7 @@ release.
 
 ## Bump the Version
 
-Next, update the `VERSION.txt` file which contains the eth2spec version.
+First, update the `VERSION.txt` file which contains the eth2spec version.
 
 > [!TIP]
 > Click on the following link to open the GitHub editor for this file:
@@ -31,20 +31,24 @@ to 1.5.0-alpha.10").
 
 Next, click the "Propose changes" button and proceed to make the PR.
 
-## Tag the Release
+## Publish the Release
 
-Next, tag the latest commit to master. This will trigger the
-[automated release process](../../.github/workflows/release.yml).
+First, go to
+[Actions > Release](https://github.com/ethereum/consensus-specs/actions/workflows/release.yml).
 
-```bash
-git clone git@github.com:ethereum/consensus-specs.git
-cd consensus-specs
-git tag <version>
-git push origin <version>
-```
+Next, click the "Run workflow" dropdown box at the top right-hand corner.
 
-Several hours later, the consensus-specs release will be automatically published
-on GitHub.
+Next, click the green "Run workflow" button.
+
+> [!NOTE]
+> The release workflow will create a tag from `VERSION.txt` and fail if the tag
+> already exists. Many hours later, if successful, the consensus-specs release
+> will be automatically published on GitHub. The release action can take up to
+> 24 hours to run.
+
+> [!TIP]
+> If the release fails, delete the tag, fix the issue, and re-run the release
+> workflow.
 
 ## Make an Announcement
 


### PR DESCRIPTION
Currently, the release action is initiated when a new tag is published. That requires cloning the ethereum/consensus-specs repo, creating a tag, and pushing the tag. This is somewhat manual and unintuitive. With this PR, the release action is triggered by running the action in the GitHub Actions page.