### PR TITLE
Reserve space for one validator sweep withdrawal

### DIFF
--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -384,6 +384,8 @@ def get_validators_sweep_withdrawals(
     epoch = get_current_epoch(state)
     validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
     withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+    # There must be at least one space reserved for validator sweep withdrawals
+    assert len(prior_withdrawals) < withdrawals_limit
 
     processed_count: uint64 = 0
     withdrawals: List[Withdrawal] = []

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1234,6 +1234,7 @@ def get_pending_partial_withdrawals(
         len(prior_withdrawals) + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
         MAX_WITHDRAWALS_PER_PAYLOAD - 1,
     )
+    assert len(prior_withdrawals) <= withdrawals_limit
 
     processed_count: uint64 = 0
     withdrawals: List[Withdrawal] = []
@@ -1278,6 +1279,8 @@ def get_validators_sweep_withdrawals(
     epoch = get_current_epoch(state)
     validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
     withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+    # There must be at least one space reserved for validator sweep withdrawals
+    assert len(prior_withdrawals) < withdrawals_limit
 
     processed_count: uint64 = 0
     withdrawals: List[Withdrawal] = []

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -862,6 +862,7 @@ def get_builder_withdrawals(
     prior_withdrawals: Sequence[Withdrawal],
 ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
     withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
+    assert len(prior_withdrawals) <= withdrawals_limit
 
     processed_count: uint64 = 0
     withdrawals: List[Withdrawal] = []
@@ -897,6 +898,7 @@ def get_builders_sweep_withdrawals(
     epoch = get_current_epoch(state)
     builders_limit = min(len(state.builders), MAX_BUILDERS_PER_WITHDRAWALS_SWEEP)
     withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
+    assert len(prior_withdrawals) <= withdrawals_limit
 
     processed_count: uint64 = 0
     withdrawals: List[Withdrawal] = []


### PR DESCRIPTION
In order for `update_next_withdrawal_validator_index` to function properly, the last withdrawal must be from the validator sweep (or empty).

https://github.com/ethereum/consensus-specs/blob/ea1b812e6c18d39e3c0e0d21b39d8f3f427208dd/specs/capella/beacon-chain.md?plain=1#L466-L480