### PR TITLE
Fix indexed payload attestation domain

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -475,7 +475,7 @@ def is_valid_indexed_payload_attestation(
 
     # Verify aggregate signature
     pubkeys = [state.validators[i].pubkey for i in indices]
-    domain = get_domain(state, DOMAIN_PTC_ATTESTER, None)
+    domain = get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(attestation.data.slot))
     signing_root = compute_signing_root(attestation.data, domain)
     return bls.FastAggregateVerify(pubkeys, signing_root, attestation.signature)
 ```


### PR DESCRIPTION
The epoch used to compute the domain in `is_valid_indexed_payload_attestation` was incorrect.

Also, this PR renames the parameter for simplicity.

See:

<img width="658" height="666" alt="image" src="https://github.com/user-attachments/assets/048dc5c9-f219-40e6-8ded-18ff5c69332a" />