### PR TITLE
Modify `BlobSidecar` for Gloas

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -59,10 +59,10 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 #### Modified `BlobSidecar`
 
 *Note*: The `signed_block_header` and `kzg_commitments_inclusion_proof` fields
-have been removed from `BlobSidecar` in Gloas as header and inclusion
-proof verifications are no longer required in ePBS. Instead, sidecars are
-validated by checking that the hash of `kzg_commitments` matches what is
-committed in the builder's bid for the corresponding `beacon_block_root`.
+have been removed from `BlobSidecar` in Gloas as header and inclusion proof
+verifications are no longer required in ePBS. Instead, sidecars are validated by
+checking that the hash of `kzg_commitments` matches what is committed in the
+builder's bid for the corresponding `beacon_block_root`.
 
 ```python
 class BlobSidecar(Container):


### PR DESCRIPTION
`DataColumnSidecar` has been modified for Gloas but these changes also need to be upstreamed to `BlobSidecar`. Even though `BlobSidecar` is no longer transmitted over p2p, nodes still have the ability to reconstruct blobs from columns. In order to keep this functionality, `BlobSidecar` should also be modified to reflect the changes made to `DataColumnSidecar`.
