### PR TITLE
Add BIB specs

### DIFF
--- a/specs/_features/bib/beacon-chain.md
+++ b/specs/_features/bib/beacon-chain.md
@@ -172,7 +172,7 @@ def process_execution_payload(
     # Verify execution payload blobs count is valid
     assert body.execution_payload_blobs_count <= len(body.blob_kzg_commitments)
 
-    # [New in BIB]
+    # [Modified in BIB]
     # Compute versioned hashes
     versioned_hashes = [
         kzg_commitment_to_payload_blob_versioned_hash(commitment)


### PR DESCRIPTION
This PR introduces Block-in-Blobs (BIB), a protocol extension that allows execution payload body data to be committed and distributed via blobs. The proposal follows the direction outlined by @jihoonsong in this [document](https://hackmd.io/@jihoonsong/ryf5PrqEbg) with a few modifications, refactored for Fulu.

BIB is necessary to enable validators to verify execution payload body availability via KZG commitments without requiring direct access to the full payload body, paving the way toward more stateless block validation. This PR formalizes the required consensus changes, versioned hash semantics, and CL↔EL interface updates needed.

EL specs: https://github.com/ethereum/execution-apis/pull/736