### PR TITLE
Restore randomized blocks test generator

### DIFF
--- a/tests/infra/block_randomized.py
+++ b/tests/infra/block_randomized.py
@@ -83,11 +83,13 @@ ScenarioDict = dict[str, Any]
 
 def transition_to_id_string(transition: TransitionDict) -> str:
     """Generate human-readable ID string for a transition."""
-    return ",".join([
-        f"epochs:{transition['epochs_to_skip']}",
-        f"slots:{transition['slots_to_skip']}",
-        f"with-block:{transition['block_producer']}",
-    ])
+    return ",".join(
+        [
+            f"epochs:{transition['epochs_to_skip']}",
+            f"slots:{transition['slots_to_skip']}",
+            f"with-block:{transition['block_producer']}",
+        ]
+    )
 
 
 def scenario_to_id_string(scenario: ScenarioDict) -> str:
@@ -134,8 +136,7 @@ class ScenarioGenerator:
         # Generate randomized skip combinations
         all_skips = list(itertools.product(epochs_set, slots_set))
         randomized_skips = (
-            self._rng.sample(all_skips, len(all_skips))
-            for _ in range(BLOCK_TRANSITIONS_COUNT)
+            self._rng.sample(all_skips, len(all_skips)) for _ in range(BLOCK_TRANSITIONS_COUNT)
         )
 
         # Build block transitions from combinations
@@ -158,9 +159,7 @@ class ScenarioGenerator:
 
         return scenarios
 
-    def _flatten_transitions(
-        self, combo: tuple[Any, ...]
-    ) -> list[TransitionDict]:
+    def _flatten_transitions(self, combo: tuple[Any, ...]) -> list[TransitionDict]:
         """Flatten nested transition structure."""
         leak_transition = combo[0]
         result = [leak_transition]
@@ -224,7 +223,7 @@ from eth2spec.test.utils.randomized_block_tests import (
     run_generated_randomized_test,
 )'''
 
-    TEST_TEMPLATE: ClassVar[str] = '''
+    TEST_TEMPLATE: ClassVar[str] = """
 @only_generator("randomized test for broad coverage, not point-to-point CI")
 @with_phases([{phase}])
 @with_custom_state(
@@ -242,7 +241,7 @@ def test_randomized_{index}(spec, state):
         spec,
         state,
         scenario,
-    )'''
+    )"""
 
     def __init__(self, fork_name: str, state_randomizer_name: str) -> None:
         self._fork_name = fork_name
@@ -333,9 +332,7 @@ class RandomizedTestGenerator:
 
     def __init__(self, fork: str) -> None:
         if fork not in self.FORK_CONFIGS:
-            raise ValueError(
-                f"Unknown fork: {fork}. Available: {list(self.FORK_CONFIGS.keys())}"
-            )
+            raise ValueError(f"Unknown fork: {fork}. Available: {list(self.FORK_CONFIGS.keys())}")
         self._fork = fork
         self._config = self.FORK_CONFIGS[fork]
 

--- a/tests/infra/test_block_randomized.py
+++ b/tests/infra/test_block_randomized.py
@@ -2,11 +2,6 @@
 Unit tests for the block_randomized module.
 """
 
-import os
-import subprocess
-import sys
-from pathlib import Path
-
 import pytest
 
 from eth2spec.test.utils.randomized_block_tests import random_block
@@ -132,8 +127,9 @@ class TestScenarioGenerator:
         # The scenarios should have different orderings
         # Compare by converting to id strings after normalizing callables
         def scenario_key(s: dict) -> str:
-            return str([(t.get("epochs_to_skip"), t.get("slots_to_skip"))
-                       for t in s["transitions"]])
+            return str(
+                [(t.get("epochs_to_skip"), t.get("slots_to_skip")) for t in s["transitions"]]
+            )
 
         keys1 = [scenario_key(s) for s in scenarios1]
         keys2 = [scenario_key(s) for s in scenarios2]

--- a/tests/infra/yield_generator.py
+++ b/tests/infra/yield_generator.py
@@ -77,6 +77,7 @@ def vector_test(fn):
     if inspect.isgeneratorfunction(fn):
         # Lazy import to avoid circular dependency with eth2spec.test.context
         from eth2spec.test import context  # noqa: PLC0415
+
         if not context.is_pytest:
             return wrapper_generator
         else:


### PR DESCRIPTION
 + This was removed in https://github.com/ethereum/consensus-specs/pull/4317
 + Also fixed a small bug in tests/infra/yield_generator.py that was found while doing this
 + After this is merged, we can work on adding Gloas to this.

Note: you can check the generator works exactly as before by running it, should generate the same test suites that are already commited.