### PR TITLE
Advertise execution proof awareness in metadata and ENR

### DIFF
--- a/specs/_features/eip8025/p2p-interface.md
+++ b/specs/_features/eip8025/p2p-interface.md
@@ -163,8 +163,8 @@ are unchanged from the Altair p2p networking document.
 A new field is added to the ENR under the key `eproof` to facilitate discovery
 of nodes that are aware of optional execution proofs.
 
-| Key      | Value                                     |
-| -------- | ----------------------------------------- |
+| Key      | Value                                    |
+| -------- | ---------------------------------------- |
 | `eproof` | Execution layer proof awareness, `uint8` |
 
 A node is considered optional execution proof–aware if the `eproof` key is


### PR DESCRIPTION
This pull requests modifies [EIP-8025](https://eips.ethereum.org/EIPS/eip-8025) metadata and ENR to advertise execution proof awareness.
