### PR TITLE
Allow multiple preferences from validators

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -343,8 +343,8 @@ The following validations MUST pass before forwarding the
   next epoch's portion of `state.proposer_lookahead` -- i.e.
   `is_valid_proposal_slot(state, preferences)` returns `True`.
 - _[IGNORE]_ The `signed_proposer_preferences` is the first valid message
-  received from the validator with index `preferences.validator_index` and the given
-  slot `preferences.slot`.
+  received from the validator with index `preferences.validator_index` and the
+  given slot `preferences.slot`.
 - _[REJECT]_ `signed_proposer_preferences.signature` is valid with respect to
   the validator's public key.
 


### PR DESCRIPTION
A proposer may propose twice in an epoch. There are validations that require the preference to be present, eg. when validating bids for this slot.