### PR TITLE
Use `head_state` for epoch boundary root note

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -651,7 +651,7 @@ Set `attestation_data.beacon_block_root = hash_tree_root(head_block)`.
 
 - Let `start_slot = compute_start_slot_at_epoch(get_current_epoch(head_state))`.
 - Let
-  `epoch_boundary_block_root = hash_tree_root(head_block) if start_slot == head_state.slot else get_block_root(state, get_current_epoch(head_state))`.
+  `epoch_boundary_block_root = hash_tree_root(head_block) if start_slot == head_state.slot else get_block_root(head_state, get_current_epoch(head_state))`.
 
 #### Construct attestation
 


### PR DESCRIPTION
The FFG section in the honest validator spec described looking up `epoch_boundary_block_root` with `get_block_root(state, get_current_epoch(head_state))` while all preceding steps consistently use `head_state.` Although this does not change the computed value, the mixed naming is confusing for implementers and suggests the wrong state object is being referenced.