### PR TITLE
Add two new ptc tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_payload_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_payload_attestation.py
@@ -3,8 +3,8 @@ from eth2spec.test.context import (
     default_activation_threshold,
     large_validator_set,
     single_phase,
-    spec_test,
     spec_state_test,
+    spec_test,
     with_custom_state,
     with_gloas_and_later,
     with_presets,
@@ -114,7 +114,9 @@ def prepare_signed_payload_attestation(
 def _get_ptc_from_indices(spec, state, slot, indices):
     slot = spec.Slot(slot)
     epoch = spec.compute_epoch_at_slot(slot)
-    seed = spec.hash(spec.get_seed(state, epoch, spec.DOMAIN_PTC_ATTESTER) + spec.uint_to_bytes(slot))
+    seed = spec.hash(
+        spec.get_seed(state, epoch, spec.DOMAIN_PTC_ATTESTER) + spec.uint_to_bytes(slot)
+    )
     return spec.compute_balance_weighted_selection(
         state, indices, seed, size=spec.PTC_SIZE, shuffle_indices=False
     )


### PR DESCRIPTION
Terence (prysm) [requested these on discord](https://discord.com/channels/595666850260713488/1465867289436885165):

> My optimized version of get_ptc had multiple consensus bugs that spec tests did not catch. I think it is worth updating the spec tests to cover the following invariants
> * There is more than one committee_per_slot
> * Sampling ended after i is greater than the active_validator_count

I generated these tests & Terence confirmed that they failed with the bug & passed with the fix:

<img width="885" height="1154" alt="image" src="https://github.com/user-attachments/assets/ce9ef2e4-76ab-4db0-b07f-3e5998eca4c2" />