### PR TITLE
Add payload data availability vote to the store

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -104,7 +104,6 @@ on `validate_on_attestation`.
 def update_latest_messages(
     store: Store, attesting_indices: Sequence[ValidatorIndex], attestation: Attestation
 ) -> None:
-    # [Modified in Gloas:EIP7732]
     slot = attestation.data.slot
     beacon_block_root = attestation.data.beacon_block_root
     payload_present = attestation.data.index == 1


### PR DESCRIPTION
Adds the payload data availability bit from PTC attestations to the store so that nodes can use the PTC to signal data availability in case they are not supernodes. 