### PR TITLE
Test: verify get_custody_groups optimization #4461

### DIFF
--- a/tests/core/pyspec/eth2spec/test/fulu/unittests/test_custody.py
+++ b/tests/core/pyspec/eth2spec/test/fulu/unittests/test_custody.py
@@ -68,3 +68,23 @@ def test_compute_columns_for_custody_group_out_of_bound_custody_group(spec):
     expect_assertion_error(
         lambda: spec.compute_columns_for_custody_group(spec.config.NUMBER_OF_CUSTODY_GROUPS)
     )
+
+
+@with_fulu_and_later
+@spec_test
+@single_phase
+def test_get_custody_groups_optimization(spec):
+    """
+    Verify optimization skips computation if all groups are custodied.
+    """
+    node_id = 12345
+    # We ask for the MAXIMUM number of groups
+    custody_group_count = spec.config.NUMBER_OF_CUSTODY_GROUPS
+
+    result = spec.get_custody_groups(node_id, custody_group_count)
+
+    # The optimization should return a perfect sequential list: [0, 1, 2, ... 127]
+    expected = [spec.CustodyIndex(i) for i in range(spec.config.NUMBER_OF_CUSTODY_GROUPS)]
+
+    assert len(result) == spec.config.NUMBER_OF_CUSTODY_GROUPS
+    assert result == expected


### PR DESCRIPTION
### Description

This PR adds a unit test to verify the optimisation logic within the `get_custody_groups` helper function in the Fulu specification.

Specifically, it tests that when `custody_group_count` is equal to `NUMBER_OF_CUSTODY_GROUPS`, the function bypasses the deterministic sampling loop and immediately returns a complete, sorted list of all custody indices (`[0, 1, ... 127]`). This ensures the optimisation path is active and returns the expected structure.

### Checklist
* [] Update documentation (N/A)
* [x] Add tests for new functionality
* [x] Run `make lint` to check formatting
* [x] Run `make test` to check tests

### Relations

Fixes #4461