### PR TITLE
Remove two execution payload tests with blob commitments

### DIFF
--- a/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/gloas/block_processing/test_process_execution_payload.py
@@ -66,7 +66,6 @@ def prepare_execution_payload_envelope(
     state_root=None,
     execution_payload=None,
     execution_requests=None,
-    blob_kzg_commitments=None,
     valid_signature=True,
 ):
     """
@@ -98,9 +97,6 @@ def prepare_execution_payload_envelope(
                 spec.ConsolidationRequest, spec.MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
             ](),
         )
-
-    if blob_kzg_commitments is None:
-        blob_kzg_commitments = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK]()
 
     # Create a copy of state for computing state_root after execution payload processing
     if state_root is None:
@@ -167,7 +163,9 @@ def prepare_execution_payload_envelope(
     )
 
 
-def setup_state_with_payload_bid(spec, state, builder_index=None, value=None, prev_randao=None):
+def setup_state_with_payload_bid(
+    spec, state, builder_index=None, value=None, prev_randao=None, blob_kzg_commitments=None
+):
     """
     Helper to setup state with a committed execution payload bid.
     This simulates the state after process_execution_payload_bid has run.
@@ -181,8 +179,10 @@ def setup_state_with_payload_bid(spec, state, builder_index=None, value=None, pr
     if prev_randao is None:
         prev_randao = spec.get_randao_mix(state, spec.get_current_epoch(state))
 
+    if blob_kzg_commitments is None:
+        blob_kzg_commitments = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK]()
+
     # Create and set the latest execution payload bid
-    kzg_list = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK]()
     bid = spec.ExecutionPayloadBid(
         parent_block_hash=state.latest_block_hash,
         parent_block_root=state.latest_block_header.hash_tree_root(),
@@ -193,7 +193,7 @@ def setup_state_with_payload_bid(spec, state, builder_index=None, value=None, pr
         builder_index=builder_index,
         slot=state.slot,
         value=value,
-        blob_kzg_commitments=kzg_list,
+        blob_kzg_commitments=blob_kzg_commitments,
     )
     state.latest_execution_payload_bid = bid
 
@@ -375,18 +375,14 @@ def test_process_execution_payload_with_blob_commitments(spec, state):
     """
     builder_index = 0
 
-    setup_state_with_payload_bid(spec, state, builder_index, spec.Gwei(3000000))
-
-    # Create blob commitments
-    blob_kzg_commitments = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK](
-        [
-            spec.KZGCommitment(b"\x42" * 48),
-            spec.KZGCommitment(b"\x43" * 48),
-        ]
+    # Create bid with blob commitments
+    setup_state_with_payload_bid(
+        spec,
+        state,
+        builder_index,
+        spec.Gwei(3000000),
+        blob_kzg_commitments=[spec.KZGCommitment(b"\x42" * 48), spec.KZGCommitment(b"\x43" * 48)],
     )
-
-    # Update bid with correct blob commitments root
-    state.latest_execution_payload_bid.blob_kzg_commitments = blob_kzg_commitments
 
     execution_payload = build_empty_execution_payload(spec, state)
     execution_payload.block_hash = state.latest_execution_payload_bid.block_hash
@@ -398,7 +394,6 @@ def test_process_execution_payload_with_blob_commitments(spec, state):
         state,
         builder_index=builder_index,
         execution_payload=execution_payload,
-        blob_kzg_commitments=blob_kzg_commitments,
     )
 
     # Capture pre-state for payment verification
@@ -638,42 +633,6 @@ def test_process_execution_payload_wrong_builder_index(spec, state):
 @with_gloas_and_later
 @spec_state_test
 @always_bls
-def test_process_execution_payload_wrong_blob_commitments_root(spec, state):
-    """
-    Test wrong blob KZG commitments root fails with separate builder
-    """
-    builder_index = 0
-
-    setup_state_with_payload_bid(spec, state, builder_index, spec.Gwei(2800000))
-    original_blob_commitments = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK](
-        [spec.KZGCommitment(b"\x11" * 48)]
-    )
-    state.latest_execution_payload_bid.blob_kzg_commitments = original_blob_commitments
-
-    execution_payload = build_empty_execution_payload(spec, state)
-    execution_payload.block_hash = state.latest_execution_payload_bid.block_hash
-    execution_payload.gas_limit = state.latest_execution_payload_bid.gas_limit
-    execution_payload.parent_hash = state.latest_block_hash
-
-    # Use different blob commitments
-    wrong_blob_commitments = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK](
-        [spec.KZGCommitment(b"\x22" * 48)]
-    )
-
-    signed_envelope = prepare_execution_payload_envelope(
-        spec,
-        state,
-        builder_index=builder_index,
-        execution_payload=execution_payload,
-        blob_kzg_commitments=wrong_blob_commitments,
-    )
-
-    yield from run_execution_payload_processing(spec, state, signed_envelope, valid=False)
-
-
-@with_gloas_and_later
-@spec_state_test
-@always_bls
 def test_process_execution_payload_missing_expected_withdrawal(spec, state):
     """
     Verify payload rejected when it omits a withdrawal expected by the state.
@@ -851,64 +810,6 @@ def test_process_execution_payload_wrong_timestamp(spec, state):
     )
 
     yield from run_execution_payload_processing(spec, state, signed_envelope, valid=False)
-
-
-@with_gloas_and_later
-@spec_state_test
-@always_bls
-def test_process_execution_payload_max_blob_commitments_valid(spec, state):
-    """
-    Test max blob commitments is valid with separate builder (edge case)
-    """
-    builder_index = 0
-
-    setup_state_with_payload_bid(spec, state, builder_index, spec.Gwei(6000000))
-
-    execution_payload = build_empty_execution_payload(spec, state)
-    execution_payload.block_hash = state.latest_execution_payload_bid.block_hash
-    execution_payload.gas_limit = state.latest_execution_payload_bid.gas_limit
-    execution_payload.parent_hash = state.latest_block_hash
-
-    # Create exactly MAX_BLOBS_PER_BLOCK commitments (should be valid)
-    max_blob_commitments = [
-        spec.KZGCommitment(b"\x42" * 48) for _ in range(spec.config.MAX_BLOBS_PER_BLOCK)
-    ]
-    blob_kzg_commitments = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK](
-        max_blob_commitments
-    )
-
-    # Update committed bid to match
-    state.latest_execution_payload_bid.blob_kzg_commitments = blob_kzg_commitments
-
-    signed_envelope = prepare_execution_payload_envelope(
-        spec,
-        state,
-        builder_index=builder_index,
-        execution_payload=execution_payload,
-        blob_kzg_commitments=blob_kzg_commitments,
-    )
-
-    # Capture pre-state for payment verification
-    pre_payment = state.builder_pending_payments[
-        spec.SLOTS_PER_EPOCH + state.slot % spec.SLOTS_PER_EPOCH
-    ]
-    pre_pending_withdrawals_len = len(state.builder_pending_withdrawals)
-
-    yield from run_execution_payload_processing(spec, state, signed_envelope, valid=True)
-
-    # Verify builder payment was processed correctly
-    # 1. Verify pending withdrawal was added with correct amount
-    assert len(state.builder_pending_withdrawals) == pre_pending_withdrawals_len + 1
-    new_withdrawal = state.builder_pending_withdrawals[pre_pending_withdrawals_len]
-    assert new_withdrawal.amount == pre_payment.withdrawal.amount
-    assert new_withdrawal.builder_index == builder_index
-    assert new_withdrawal.fee_recipient == pre_payment.withdrawal.fee_recipient
-
-    # 2. Verify pending payment was cleared
-    cleared_payment = state.builder_pending_payments[
-        spec.SLOTS_PER_EPOCH + state.slot % spec.SLOTS_PER_EPOCH
-    ]
-    assert cleared_payment.withdrawal.amount == 0
 
 
 @with_gloas_and_later


### PR DESCRIPTION
These do not make sense to keep anymore. We should simply delete them.

* `test_process_execution_payload_wrong_blob_commitments_root` -- this is checking the bid, not the payload.
* `test_process_execution_payload_max_blob_commitments_valid` -- this check doesn't exist in `process_execution_payload` anymore.
