### PR TITLE
Fix release drafter config so that it detects the last release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           name: ${{ steps.tag.outputs.name }}
           tag: ${{ steps.tag.outputs.name }}
-          commitish: ${{ github.sha }}
+          include-pre-releases: true
           prerelease: ${{ contains(steps.tag.outputs.name, '-') }}
           publish: false
         env:


### PR DESCRIPTION
Release drafter did not detect the previous release, so I think it was stuck adding every single PR to the release notes.

<img width="799" height="557" alt="image" src="https://github.com/user-attachments/assets/be62cdcb-585f-4fe3-b32a-b06db95d0a99" />
