### PR TITLE
Use custom runners for everything

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     steps:
       - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     permissions:
       actions: write
       issues: write

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted-ghr-custom, size-s-x64, profile-consensusSpecs]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
There's currently an incident with actions & the `ubuntu-latest` actions are not working while our custom ones are. It would be best if we converted everything to use custom runners.

<img width="998" height="582" alt="image" src="https://github.com/user-attachments/assets/ab5f7434-f5c2-407f-8ec8-6337cf67dec3" />