### PR TITLE
Remove pending status from tiebreaker

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -327,17 +327,14 @@ def should_extend_payload(store: Store, root: Root) -> bool:
 
 ```python
 def get_payload_status_tiebreaker(store: Store, node: ForkChoiceNode) -> uint8:
-    if node.payload_status == PAYLOAD_STATUS_PENDING or store.blocks[
-        node.root
-    ].slot + 1 != get_current_slot(store):
+    if store.blocks[node.root].slot + 1 != get_current_slot(store):
         return node.payload_status
+    # To decide on a payload from the previous slot, choose
+    # between FULL and EMPTY based on `should_extend_payload`
+    if node.payload_status == PAYLOAD_STATUS_EMPTY:
+        return 1
     else:
-        # To decide on a payload from the previous slot, choose
-        # between FULL and EMPTY based on `should_extend_payload`
-        if node.payload_status == PAYLOAD_STATUS_EMPTY:
-            return 1
-        else:
-            return 2 if should_extend_payload(store, node.root) else 0
+        return 2 if should_extend_payload(store, node.root) else 0
 ```
 
 ### New `should_apply_proposer_boost`

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -481,7 +481,7 @@ def get_head(store: Store) -> ForkChoiceNode:
         children = get_node_children(store, blocks, head)
         if len(children) == 0:
             return head
-        # Sort by latest attesting balance with ties broken lexicographically
+        # Sort by latest attesting balance with ties broken by root lexicographically, then payload status
         head = max(
             children,
             key=lambda child: (


### PR DESCRIPTION
The only call to get tiebreakers on the head run happens to compare weights and decide the best child from the result of `get_node_children`. 

This function returns a list of nodes with either all `PAYLOAD_STATUS_PENDING` or none of them with this status. Crucially, only one such node with pending status is returned per root, therefore the `lambda` in the tie-breaker must have been decided before either by the weight of the children or the root itself. 