### PR TITLE
Update fork choice store to use milliseconds

### DIFF
--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -151,7 +151,7 @@ def should_override_forkchoice_update(store: Store, head_root: Root) -> bool:
 
     # Check the head weight only if the attestations from the head slot have already been applied.
     # Implementations may want to do this in different ways, e.g. by advancing
-    # `store.time` early, or by counting queued attestations during the head block's slot.
+    # `store.time_ms` early, or by counting queued attestations during the head block's slot.
     if current_slot > head_block.slot:
         head_weak = is_head_weak(store, head_root)
         parent_strong = is_parent_strong(store, head_root)

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -537,8 +537,7 @@ def get_head(store: Store) -> ForkChoiceNode:
 ```python
 def record_block_timeliness(store: Store, root: Root) -> None:
     block = store.blocks[root]
-    ms_since_genesis = store.time_ms - store.genesis_time_ms
-    time_into_slot_ms = ms_since_genesis % SLOT_DURATION_MS
+    time_into_slot_ms = compute_time_into_slot_ms(store)
     epoch = get_current_store_epoch(store)
     attestation_threshold_ms = get_attestation_due_ms(epoch)
     # [New in Gloas:EIP7732]

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -129,8 +129,8 @@ execution payload has not been revealed or has not been included on chain.
 ```python
 @dataclass
 class Store(object):
-    time: uint64
-    genesis_time: uint64
+    time_ms: uint64
+    genesis_time_ms: uint64
     justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
     unrealized_justified_checkpoint: Checkpoint
@@ -166,8 +166,8 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
     finalized_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
     proposer_boost_root = Root()
     return Store(
-        time=uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000),
-        genesis_time=anchor_state.genesis_time,
+        time_ms=compute_time_at_slot_ms(anchor_state, anchor_state.slot),
+        genesis_time_ms=seconds_to_milliseconds(anchor_state.genesis_time),
         justified_checkpoint=justified_checkpoint,
         finalized_checkpoint=finalized_checkpoint,
         unrealized_justified_checkpoint=justified_checkpoint,
@@ -537,8 +537,8 @@ def get_head(store: Store) -> ForkChoiceNode:
 ```python
 def record_block_timeliness(store: Store, root: Root) -> None:
     block = store.blocks[root]
-    seconds_since_genesis = store.time - store.genesis_time
-    time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
+    ms_since_genesis = store.time_ms - store.genesis_time_ms
+    time_into_slot_ms = ms_since_genesis % SLOT_DURATION_MS
     epoch = get_current_store_epoch(store)
     attestation_threshold_ms = get_attestation_due_ms(epoch)
     # [New in Gloas:EIP7732]

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -112,8 +112,8 @@ inclusion list constraints.
 ```python
 @dataclass
 class Store(object):
-    time: uint64
-    genesis_time: uint64
+    time_ms: uint64
+    genesis_time_ms: uint64
     justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
     unrealized_justified_checkpoint: Checkpoint
@@ -148,8 +148,8 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
     finalized_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
     proposer_boost_root = Root()
     return Store(
-        time=uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000),
-        genesis_time=anchor_state.genesis_time,
+        time_ms=compute_time_at_slot_ms(anchor_state, anchor_state.slot),
+        genesis_time_ms=seconds_to_milliseconds(anchor_state.genesis_time),
         justified_checkpoint=justified_checkpoint,
         finalized_checkpoint=finalized_checkpoint,
         unrealized_justified_checkpoint=justified_checkpoint,
@@ -276,8 +276,8 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     """
     inclusion_list = signed_inclusion_list.message
 
-    seconds_since_genesis = store.time - store.genesis_time
-    time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
+    ms_since_genesis = store.time_ms - store.genesis_time_ms
+    time_into_slot_ms = ms_since_genesis % SLOT_DURATION_MS
     epoch = get_current_store_epoch(store)
     view_freeze_cutoff_ms = get_view_freeze_cutoff_ms(epoch)
     is_before_view_freeze_cutoff = time_into_slot_ms < view_freeze_cutoff_ms

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -276,8 +276,7 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     """
     inclusion_list = signed_inclusion_list.message
 
-    ms_since_genesis = store.time_ms - store.genesis_time_ms
-    time_into_slot_ms = ms_since_genesis % SLOT_DURATION_MS
+    time_into_slot_ms = compute_time_into_slot_ms(store)
     epoch = get_current_store_epoch(store)
     view_freeze_cutoff_ms = get_view_freeze_cutoff_ms(epoch)
     is_before_view_freeze_cutoff = time_into_slot_ms < view_freeze_cutoff_ms

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -73,6 +73,9 @@
     - [`compute_shuffled_index`](#compute_shuffled_index)
     - [`compute_proposer_index`](#compute_proposer_index)
     - [`compute_committee`](#compute_committee)
+    - [`seconds_to_milliseconds`](#seconds_to_milliseconds)
+    - [`milliseconds_to_seconds`](#milliseconds_to_seconds)
+    - [`compute_time_at_slot_ms`](#compute_time_at_slot_ms)
     - [`compute_time_at_slot`](#compute_time_at_slot)
     - [`compute_epoch_at_slot`](#compute_epoch_at_slot)
     - [`compute_start_slot_at_epoch`](#compute_start_slot_at_epoch)
@@ -872,15 +875,51 @@ def compute_committee(
     ]
 ```
 
+#### `seconds_to_milliseconds`
+
+```python
+def seconds_to_milliseconds(seconds: uint64) -> uint64:
+    """
+    Convert seconds to milliseconds with overflow protection.
+    Returns ``UINT64_MAX`` if the result would overflow.
+    """
+    if seconds > UINT64_MAX // 1000:
+        return UINT64_MAX
+    return seconds * 1000
+```
+
+#### `milliseconds_to_seconds`
+
+```python
+def milliseconds_to_seconds(milliseconds: uint64) -> uint64:
+    """
+    Convert milliseconds to seconds.
+    """
+    return milliseconds // 1000
+```
+
+#### `compute_time_at_slot_ms`
+
+*Note*: This function is unsafe with respect to overflows and underflows.
+
+```python
+def compute_time_at_slot_ms(state: BeaconState, slot: Slot) -> uint64:
+    """
+    Compute the time in milliseconds at ``slot`` from the genesis time in ``state``.
+    """
+    return seconds_to_milliseconds(state.genesis_time) + SLOT_DURATION_MS * (slot - GENESIS_SLOT)
+```
+
 #### `compute_time_at_slot`
 
 *Note*: This function is unsafe with respect to overflows and underflows.
 
 ```python
 def compute_time_at_slot(state: BeaconState, slot: Slot) -> uint64:
-    slots_since_genesis = slot - GENESIS_SLOT
-    seconds_per_slot = SLOT_DURATION_MS // 1000
-    return uint64(state.genesis_time + slots_since_genesis * seconds_per_slot)
+    """
+    Compute the time in seconds at ``slot`` from the genesis time in ``state``.
+    """
+    return milliseconds_to_seconds(compute_time_at_slot_ms(state, slot))
 ```
 
 #### `compute_epoch_at_slot`

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -879,7 +879,8 @@ def compute_committee(
 ```python
 def compute_time_at_slot(state: BeaconState, slot: Slot) -> uint64:
     slots_since_genesis = slot - GENESIS_SLOT
-    return uint64(state.genesis_time + slots_since_genesis * SLOT_DURATION_MS // 1000)
+    seconds_per_slot = SLOT_DURATION_MS // 1000
+    return uint64(state.genesis_time + slots_since_genesis * seconds_per_slot)
 ```
 
 #### `compute_epoch_at_slot`

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -29,6 +29,8 @@
     - [`update_checkpoints`](#update_checkpoints)
     - [`update_unrealized_checkpoints`](#update_unrealized_checkpoints)
     - [`seconds_to_milliseconds`](#seconds_to_milliseconds)
+    - [`milliseconds_to_seconds`](#milliseconds_to_seconds)
+    - [`compute_time_at_slot_ms`](#compute_time_at_slot_ms)
     - [`get_slot_component_duration_ms`](#get_slot_component_duration_ms)
     - [`get_attestation_due_ms`](#get_attestation_due_ms)
     - [`get_proposer_reorg_cutoff_ms`](#get_proposer_reorg_cutoff_ms)
@@ -75,8 +77,8 @@ The head block root associated with a `store` is defined as `get_head(store)`.
 At genesis, let `store = get_forkchoice_store(genesis_state, genesis_block)` and
 update `store` by running:
 
-- `on_tick(store, time)` whenever `time > store.time` where `time` is the
-  current Unix time
+- `on_tick(store, time_ms)` whenever `time_ms > store.time_ms` where `time_ms`
+  is the current Unix time in milliseconds
 - `on_block(store, block)` whenever a block `block: SignedBeaconBlock` is
   received
 - `on_attestation(store, attestation)` whenever an attestation `attestation` is
@@ -167,8 +169,8 @@ algorithm. The important fields being tracked are described below:
 ```python
 @dataclass
 class Store(object):
-    time: uint64
-    genesis_time: uint64
+    time_ms: uint64
+    genesis_time_ms: uint64
     justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
     unrealized_justified_checkpoint: Checkpoint
@@ -203,8 +205,8 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
     finalized_checkpoint = Checkpoint(epoch=anchor_epoch, root=anchor_root)
     proposer_boost_root = Root()
     return Store(
-        time=uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000),
-        genesis_time=anchor_state.genesis_time,
+        time_ms=compute_time_at_slot_ms(anchor_state, anchor_state.slot),
+        genesis_time_ms=seconds_to_milliseconds(anchor_state.genesis_time),
         justified_checkpoint=justified_checkpoint,
         finalized_checkpoint=finalized_checkpoint,
         unrealized_justified_checkpoint=justified_checkpoint,
@@ -222,7 +224,7 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
 
 ```python
 def get_slots_since_genesis(store: Store) -> int:
-    return (store.time - store.genesis_time) * 1000 // SLOT_DURATION_MS
+    return (store.time_ms - store.genesis_time_ms) // SLOT_DURATION_MS
 ```
 
 #### `get_current_slot`
@@ -486,6 +488,20 @@ def seconds_to_milliseconds(seconds: uint64) -> uint64:
     return seconds * 1000
 ```
 
+#### `milliseconds_to_seconds`
+
+```python
+def milliseconds_to_seconds(milliseconds: uint64) -> uint64:
+    return milliseconds // 1000
+```
+
+#### `compute_time_at_slot_ms`
+
+```python
+def compute_time_at_slot_ms(state: BeaconState, slot: Slot) -> uint64:
+    return seconds_to_milliseconds(state.genesis_time) + SLOT_DURATION_MS * (slot - GENESIS_SLOT)
+```
+
 #### `get_slot_component_duration_ms`
 
 ```python
@@ -556,8 +572,8 @@ def is_finalization_ok(store: Store, slot: Slot) -> bool:
 
 ```python
 def is_proposing_on_time(store: Store) -> bool:
-    seconds_since_genesis = store.time - store.genesis_time
-    time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
+    ms_since_genesis = store.time_ms - store.genesis_time_ms
+    time_into_slot_ms = ms_since_genesis % SLOT_DURATION_MS
     epoch = get_current_store_epoch(store)
     proposer_reorg_cutoff_ms = get_proposer_reorg_cutoff_ms(epoch)
     return time_into_slot_ms <= proposer_reorg_cutoff_ms
@@ -689,11 +705,11 @@ def compute_pulled_up_tip(store: Store, block_root: Root) -> None:
 ##### `on_tick_per_slot`
 
 ```python
-def on_tick_per_slot(store: Store, time: uint64) -> None:
+def on_tick_per_slot(store: Store, time_ms: uint64) -> None:
     previous_slot = get_current_slot(store)
 
     # Update store time
-    store.time = time
+    store.time_ms = time_ms
 
     current_slot = get_current_slot(store)
 
@@ -790,8 +806,8 @@ def update_latest_messages(
 ```python
 def record_block_timeliness(store: Store, root: Root) -> None:
     block = store.blocks[root]
-    seconds_since_genesis = store.time - store.genesis_time
-    time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
+    ms_since_genesis = store.time_ms - store.genesis_time_ms
+    time_into_slot_ms = ms_since_genesis % SLOT_DURATION_MS
     epoch = get_current_store_epoch(store)
     attestation_threshold_ms = get_attestation_due_ms(epoch)
     is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
@@ -824,16 +840,14 @@ def update_proposer_boost_root(store: Store, root: Root) -> None:
 #### `on_tick`
 
 ```python
-def on_tick(store: Store, time: uint64) -> None:
-    # If the ``store.time`` falls behind, while loop catches up slot by slot
+def on_tick(store: Store, time_ms: uint64) -> None:
+    # If the ``store.time_ms`` falls behind, while loop catches up slot by slot
     # to ensure that every previous slot is processed with ``on_tick_per_slot``
-    tick_slot = (time - store.genesis_time) * 1000 // SLOT_DURATION_MS
+    tick_slot = (time_ms - store.genesis_time_ms) // SLOT_DURATION_MS
     while get_current_slot(store) < tick_slot:
-        previous_time = (
-            store.genesis_time + (get_current_slot(store) + 1) * SLOT_DURATION_MS // 1000
-        )
-        on_tick_per_slot(store, previous_time)
-    on_tick_per_slot(store, time)
+        previous_time_ms = store.genesis_time_ms + (get_current_slot(store) + 1) * SLOT_DURATION_MS
+        on_tick_per_slot(store, previous_time_ms)
+    on_tick_per_slot(store, time_ms)
 ```
 
 #### `on_block`

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -28,9 +28,9 @@
     - [`get_head`](#get_head)
     - [`update_checkpoints`](#update_checkpoints)
     - [`update_unrealized_checkpoints`](#update_unrealized_checkpoints)
-    - [`seconds_to_milliseconds`](#seconds_to_milliseconds)
-    - [`milliseconds_to_seconds`](#milliseconds_to_seconds)
-    - [`compute_time_at_slot_ms`](#compute_time_at_slot_ms)
+    - [`compute_store_slot_at_time_ms`](#compute_store_slot_at_time_ms)
+    - [`compute_store_time_at_slot_ms`](#compute_store_time_at_slot_ms)
+    - [`compute_time_into_slot_ms`](#compute_time_into_slot_ms)
     - [`get_slot_component_duration_ms`](#get_slot_component_duration_ms)
     - [`get_attestation_due_ms`](#get_attestation_due_ms)
     - [`get_proposer_reorg_cutoff_ms`](#get_proposer_reorg_cutoff_ms)
@@ -224,7 +224,7 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
 
 ```python
 def get_slots_since_genesis(store: Store) -> int:
-    return (store.time_ms - store.genesis_time_ms) // SLOT_DURATION_MS
+    return compute_store_slot_at_time_ms(store, store.time_ms) - GENESIS_SLOT
 ```
 
 #### `get_current_slot`
@@ -475,31 +475,34 @@ def update_unrealized_checkpoints(
         store.unrealized_finalized_checkpoint = unrealized_finalized_checkpoint
 ```
 
-#### `seconds_to_milliseconds`
+#### `compute_store_slot_at_time_ms`
 
 ```python
-def seconds_to_milliseconds(seconds: uint64) -> uint64:
+def compute_store_slot_at_time_ms(store: Store, time_ms: uint64) -> Slot:
     """
-    Convert seconds to milliseconds with overflow protection.
-    Returns ``UINT64_MAX`` if the result would overflow.
+    Compute the slot at ``time_ms`` from the genesis time in ``store``.
     """
-    if seconds > UINT64_MAX // 1000:
-        return UINT64_MAX
-    return seconds * 1000
+    return Slot(GENESIS_SLOT + (time_ms - store.genesis_time_ms) // SLOT_DURATION_MS)
 ```
 
-#### `milliseconds_to_seconds`
+#### `compute_store_time_at_slot_ms`
 
 ```python
-def milliseconds_to_seconds(milliseconds: uint64) -> uint64:
-    return milliseconds // 1000
+def compute_store_time_at_slot_ms(store: Store, slot: Slot) -> uint64:
+    """
+    Compute the time in milliseconds at ``slot`` from the genesis time in ``store``.
+    """
+    return store.genesis_time_ms + SLOT_DURATION_MS * (slot - GENESIS_SLOT)
 ```
 
-#### `compute_time_at_slot_ms`
+#### `compute_time_into_slot_ms`
 
 ```python
-def compute_time_at_slot_ms(state: BeaconState, slot: Slot) -> uint64:
-    return seconds_to_milliseconds(state.genesis_time) + SLOT_DURATION_MS * (slot - GENESIS_SLOT)
+def compute_time_into_slot_ms(store: Store) -> uint64:
+    """
+    Compute the elapsed time in milliseconds into the current slot.
+    """
+    return store.time_ms - compute_store_time_at_slot_ms(store, get_current_slot(store))
 ```
 
 #### `get_slot_component_duration_ms`
@@ -572,8 +575,7 @@ def is_finalization_ok(store: Store, slot: Slot) -> bool:
 
 ```python
 def is_proposing_on_time(store: Store) -> bool:
-    ms_since_genesis = store.time_ms - store.genesis_time_ms
-    time_into_slot_ms = ms_since_genesis % SLOT_DURATION_MS
+    time_into_slot_ms = compute_time_into_slot_ms(store)
     epoch = get_current_store_epoch(store)
     proposer_reorg_cutoff_ms = get_proposer_reorg_cutoff_ms(epoch)
     return time_into_slot_ms <= proposer_reorg_cutoff_ms
@@ -806,8 +808,7 @@ def update_latest_messages(
 ```python
 def record_block_timeliness(store: Store, root: Root) -> None:
     block = store.blocks[root]
-    ms_since_genesis = store.time_ms - store.genesis_time_ms
-    time_into_slot_ms = ms_since_genesis % SLOT_DURATION_MS
+    time_into_slot_ms = compute_time_into_slot_ms(store)
     epoch = get_current_store_epoch(store)
     attestation_threshold_ms = get_attestation_due_ms(epoch)
     is_before_attesting_interval = time_into_slot_ms < attestation_threshold_ms
@@ -843,9 +844,9 @@ def update_proposer_boost_root(store: Store, root: Root) -> None:
 def on_tick(store: Store, time_ms: uint64) -> None:
     # If the ``store.time_ms`` falls behind, while loop catches up slot by slot
     # to ensure that every previous slot is processed with ``on_tick_per_slot``
-    tick_slot = (time_ms - store.genesis_time_ms) // SLOT_DURATION_MS
+    tick_slot = compute_store_slot_at_time_ms(store, time_ms)
     while get_current_slot(store) < tick_slot:
-        previous_time_ms = store.genesis_time_ms + (get_current_slot(store) + 1) * SLOT_DURATION_MS
+        previous_time_ms = compute_store_time_at_slot_ms(store, Slot(get_current_slot(store) + 1))
         on_tick_per_slot(store, previous_time_ms)
     on_tick_per_slot(store, time_ms)
 ```

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -77,8 +77,8 @@ optimistically imported blocks which have only received a `NOT_VALIDATED`
 designation from an execution engine (i.e., they are not known to be
 `INVALIDATED` or `VALID`).
 
-Let `current_slot: Slot` be `(time - genesis_time) * 1000 // SLOT_DURATION_MS`
-where `time` is the UNIX time according to the local system clock.
+Let `current_slot: Slot` be `get_current_slot(store)` from the fork choice
+store.
 
 ```python
 @dataclass

--- a/tests/core/pyspec/eth_consensus_specs/test/bellatrix/fork_choice/test_on_merge_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/bellatrix/fork_choice/test_on_merge_block.py
@@ -59,9 +59,9 @@ def test_all_valid(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     pow_block_parent = prepare_random_pow_block(spec, rng=Random(1234))
     pow_block_parent.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
@@ -96,9 +96,9 @@ def test_block_lookup_failed(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     pow_block = prepare_random_pow_block(spec, rng=Random(1234))
     pow_block.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(1)
@@ -136,9 +136,9 @@ def test_too_early_for_merge(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     pow_block_parent = prepare_random_pow_block(spec, rng=Random(1234))
     pow_block_parent.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY - uint256(2)
@@ -173,9 +173,9 @@ def test_too_late_for_merge(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     pow_block_parent = prepare_random_pow_block(spec, rng=Random(1234))
     pow_block_parent.total_difficulty = spec.config.TERMINAL_TOTAL_DIFFICULTY

--- a/tests/core/pyspec/eth_consensus_specs/test/bellatrix/fork_choice/test_should_override_forkchoice_update.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/bellatrix/fork_choice/test_should_override_forkchoice_update.py
@@ -39,9 +39,9 @@ def test_should_override_forkchoice_update__false(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block = build_empty_block_for_next_slot(spec, state)
@@ -56,8 +56,8 @@ def test_should_override_forkchoice_update__false(spec, state):
     next_slot(spec, state)
     slot = state.slot
 
-    current_time = slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
 
     should_override = spec.should_override_forkchoice_update(store, head_root)
     assert not should_override
@@ -85,15 +85,15 @@ def test_should_override_forkchoice_update__true(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -128,15 +128,13 @@ def test_should_override_forkchoice_update__true(spec, state):
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     # Make the head block late
-    # Round up to nearest second
     epoch = spec.get_current_store_epoch(store)
     attestation_due_ms = spec.get_attestation_due_ms(epoch)
-    attesting_cutoff = (attestation_due_ms + 999) // 1000
-    current_time = (
-        state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time + attesting_cutoff
+    current_time_ms = (
+        state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms + attestation_due_ms
     )
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     yield from tick_and_add_block(spec, store, signed_block, test_steps)
     assert spec.get_current_slot(store) == block.slot

--- a/tests/core/pyspec/eth_consensus_specs/test/bellatrix/sync/test_optimistic.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/bellatrix/sync/test_optimistic.py
@@ -46,10 +46,10 @@ def test_from_syncing_to_invalid(spec, state):
 
     next_epoch(spec, state)
 
-    current_time = (
+    current_time_ms = (
         spec.SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY * 10 + state.slot
-    ) * spec.config.SLOT_DURATION_MS // 1000 + fc_store.genesis_time
-    on_tick_and_append_step(spec, fc_store, current_time, test_steps)
+    ) * spec.config.SLOT_DURATION_MS + fc_store.genesis_time_ms
+    on_tick_and_append_step(spec, fc_store, current_time_ms, test_steps)
 
     # Block 0
     block_0 = build_empty_block_for_next_slot(spec, state)

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/fork_choice/test_on_block.py
@@ -30,9 +30,9 @@ def test_simple_blob_data(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block, blobs, _, blob_kzg_proofs = get_block_with_blob(spec, state, rng=rng)
@@ -65,9 +65,9 @@ def test_invalid_incorrect_proof(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block, blobs, _, _ = get_block_with_blob(spec, state, rng=rng)
@@ -95,9 +95,9 @@ def test_invalid_data_unavailable(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block, _, _, _ = get_block_with_blob(spec, state, rng=rng)
@@ -125,9 +125,9 @@ def test_invalid_wrong_proofs_length(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block, blobs, _, _ = get_block_with_blob(spec, state, rng=rng)
@@ -155,9 +155,9 @@ def test_invalid_wrong_blobs_length(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block, _, _, blob_kzg_proofs = get_block_with_blob(spec, state, rng=rng)

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/fork_choice/test_on_block.py
@@ -59,9 +59,9 @@ def test_on_block_peerdas__ok(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     _, _, _, signed_block, sidecars, kzg_commitments = get_block_with_blob_and_sidecars(
@@ -98,9 +98,9 @@ def run_on_block_peerdas_invalid_test(spec, state, fn):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     _, _, _, signed_block, sidecars, kzg_commitments = get_block_with_blob_and_sidecars(
         spec, state, rng=rng, blob_count=2

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -174,15 +174,10 @@ def tick_and_add_block(
     if merge_block:
         assert spec.is_merge_transition_block(pre_state, signed_block.message.body)
 
-    block_time = (
-        pre_state.genesis_time + signed_block.message.slot * spec.config.SLOT_DURATION_MS // 1000
-    )
-    while store.time < block_time:
-        time = (
-            pre_state.genesis_time
-            + (spec.get_current_slot(store) + 1) * spec.config.SLOT_DURATION_MS // 1000
-        )
-        on_tick_and_append_step(spec, store, time, test_steps)
+    block_time_ms = spec.compute_time_at_slot_ms(pre_state, signed_block.message.slot)
+    while store.time_ms < block_time_ms:
+        time_ms = spec.compute_time_at_slot_ms(pre_state, spec.get_current_slot(store) + 1)
+        on_tick_and_append_step(spec, store, time_ms, test_steps)
 
     post_state = yield from add_block(
         spec,
@@ -225,10 +220,12 @@ def add_attestations(spec, store, attestations, test_steps, is_from_block=False)
 
 def tick_and_run_on_attestation(spec, store, attestation, test_steps, is_from_block=False):
     # Make get_current_slot(store) >= attestation.data.slot + 1
-    min_time_to_include = (attestation.data.slot + 1) * spec.config.SLOT_DURATION_MS // 1000
-    if store.time < min_time_to_include:
-        spec.on_tick(store, min_time_to_include)
-        test_steps.append({"tick": int(min_time_to_include)})
+    min_time_to_include_ms = (
+        store.genesis_time_ms + (attestation.data.slot + 1) * spec.config.SLOT_DURATION_MS
+    )
+    if store.time_ms < min_time_to_include_ms:
+        spec.on_tick(store, min_time_to_include_ms)
+        test_steps.append({"tick": int(spec.milliseconds_to_seconds(min_time_to_include_ms))})
 
     yield from add_attestation(spec, store, attestation, test_steps, is_from_block)
 
@@ -292,10 +289,10 @@ def get_sidecar_file_name(sidecar: DataColumnSidecar) -> str:
     return f"column_{encode_hex(sidecar.hash_tree_root())}"
 
 
-def on_tick_and_append_step(spec, store, time, test_steps):
-    assert time >= store.time
-    spec.on_tick(store, time)
-    test_steps.append({"tick": int(time)})
+def on_tick_and_append_step(spec, store, time_ms, test_steps):
+    assert time_ms >= store.time_ms
+    spec.on_tick(store, time_ms)
+    test_steps.append({"tick": int(spec.milliseconds_to_seconds(time_ms))})
     output_store_checks(spec, store, test_steps)
 
 
@@ -448,7 +445,7 @@ def output_head_check(spec, store, test_steps):
 
 def output_store_checks(spec, store, test_steps, with_viable_for_head_weights=False):
     checks = {
-        "time": int(store.time),
+        "time": int(spec.milliseconds_to_seconds(store.time_ms)),
         "head": get_formatted_head_output(spec, store),
         "justified_checkpoint": {
             "epoch": int(store.justified_checkpoint.epoch),

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -174,9 +174,9 @@ def tick_and_add_block(
     if merge_block:
         assert spec.is_merge_transition_block(pre_state, signed_block.message.body)
 
-    block_time_ms = spec.compute_time_at_slot_ms(pre_state, signed_block.message.slot)
+    block_time_ms = spec.compute_store_time_at_slot_ms(store, signed_block.message.slot)
     while store.time_ms < block_time_ms:
-        time_ms = spec.compute_time_at_slot_ms(pre_state, spec.get_current_slot(store) + 1)
+        time_ms = spec.compute_store_time_at_slot_ms(store, spec.get_current_slot(store) + 1)
         on_tick_and_append_step(spec, store, time_ms, test_steps)
 
     post_state = yield from add_block(
@@ -220,9 +220,7 @@ def add_attestations(spec, store, attestations, test_steps, is_from_block=False)
 
 def tick_and_run_on_attestation(spec, store, attestation, test_steps, is_from_block=False):
     # Make get_current_slot(store) >= attestation.data.slot + 1
-    min_time_to_include_ms = (
-        store.genesis_time_ms + (attestation.data.slot + 1) * spec.config.SLOT_DURATION_MS
-    )
+    min_time_to_include_ms = spec.compute_store_time_at_slot_ms(store, attestation.data.slot + 1)
     if store.time_ms < min_time_to_include_ms:
         spec.on_tick(store, min_time_to_include_ms)
         test_steps.append({"tick": int(spec.milliseconds_to_seconds(min_time_to_include_ms))})

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
@@ -334,12 +334,12 @@ def test_inclusion_list_store_view_freeze_cutoff(spec, state):
 
         # Advance time to after the view freeze cutoff.
         epoch = spec.get_current_store_epoch(forkchoice_store)
-        view_freeze_cutoff_ceiling = spec.get_view_freeze_cutoff_ms(epoch) // 1000 + 1
-        assert view_freeze_cutoff_ceiling < spec.config.SLOT_DURATION_MS // 1000
+        view_freeze_cutoff_ms = spec.get_view_freeze_cutoff_ms(epoch) + 1
+        assert view_freeze_cutoff_ms < spec.config.SLOT_DURATION_MS
 
-        time = forkchoice_store.time + view_freeze_cutoff_ceiling
-        spec.on_tick(forkchoice_store, time)
-        assert forkchoice_store.time == time
+        time_ms = forkchoice_store.time_ms + view_freeze_cutoff_ms
+        spec.on_tick(forkchoice_store, time_ms)
+        assert forkchoice_store.time_ms == time_ms
 
         # An IL received after the view freeze cutoff should be ignored.
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_3)

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_ex_ante.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_ex_ante.py
@@ -64,9 +64,9 @@ def test_ex_ante_vanilla(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving block A at slot `N`
     yield from _apply_base_block_a(spec, state, store, test_steps)
@@ -98,8 +98,8 @@ def test_ex_ante_vanilla(spec, state):
     sign_attestation(spec, state_b, attestation)
 
     # Block C received at N+2 — C is head
-    time = state_c.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = state_c.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
 
@@ -159,9 +159,9 @@ def test_ex_ante_attestations_is_greater_than_proposer_boost_with_boost(spec, st
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving block A at slot `N`
     yield from _apply_base_block_a(spec, state, store, test_steps)
@@ -178,8 +178,8 @@ def test_ex_ante_attestations_is_greater_than_proposer_boost_with_boost(spec, st
     signed_block_c = state_transition_and_sign_block(spec, state_c, block)
 
     # Block C received at N+2 — C is head
-    time = state_c.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = state_c.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
 
@@ -237,9 +237,9 @@ def test_ex_ante_sandwich_without_attestations(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving block A at slot `N`
     yield from _apply_base_block_a(spec, state, store, test_steps)
@@ -261,8 +261,8 @@ def test_ex_ante_sandwich_without_attestations(spec, state):
     signed_block_d = state_transition_and_sign_block(spec, state_d, block)
 
     # Block C received at N+2 — C is head
-    time = state_c.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = state_c.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
 
@@ -271,8 +271,8 @@ def test_ex_ante_sandwich_without_attestations(spec, state):
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
 
     # Block D received at N+3 - D is head, it has proposer score boost
-    time = state_d.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = state_d.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block_d, test_steps)
     check_head_against_root(spec, store, signed_block_d.message.hash_tree_root())
 
@@ -303,9 +303,9 @@ def test_ex_ante_sandwich_with_honest_attestation(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving block A at slot `N`
     yield from _apply_base_block_a(spec, state, store, test_steps)
@@ -342,8 +342,8 @@ def test_ex_ante_sandwich_with_honest_attestation(spec, state):
     signed_block_d = state_transition_and_sign_block(spec, state_d, block)
 
     # Block C received at N+2 — C is head
-    time = state_c.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = state_c.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
 
@@ -352,8 +352,8 @@ def test_ex_ante_sandwich_with_honest_attestation(spec, state):
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
 
     # Attestation_1 received at N+3 — C is head
-    time = state_d.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = state_d.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_attestation(spec, store, attestation, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
 
@@ -389,9 +389,9 @@ def test_ex_ante_sandwich_with_boost_not_sufficient(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving block A at slot `N`
     yield from _apply_base_block_a(spec, state, store, test_steps)
@@ -413,8 +413,8 @@ def test_ex_ante_sandwich_with_boost_not_sufficient(spec, state):
     signed_block_d = state_transition_and_sign_block(spec, state_d, block)
 
     # Block C received at N+2 — C is head
-    time = state_c.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = state_c.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block_c, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
 
@@ -445,8 +445,8 @@ def test_ex_ante_sandwich_with_boost_not_sufficient(spec, state):
 
     # Attestation_1 received at N+3 — B is head because B's attestation_score > C's proposer_score.
     # (B's proposer_score = C's attestation_score = 0)
-    time = state_d.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = state_d.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_attestation(spec, store, attestation, test_steps)
     check_head_against_root(spec, store, signed_block_c.message.hash_tree_root())
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_get_head.py
@@ -59,7 +59,7 @@ def test_genesis(spec, state):
     test_steps.append(
         {
             "checks": {
-                "genesis_time": int(store.genesis_time),
+                "genesis_time": int(store.genesis_time_ms),
                 "head": get_formatted_head_output(spec, store),
             }
         }
@@ -129,8 +129,8 @@ def test_split_tie_breaker_no_attestations(spec, state):
     signed_block_2 = state_transition_and_sign_block(spec, block_2_state, block_2)
 
     # Tick time past slot 1 so proposer score boost does not apply
-    time = store.genesis_time + (block_2.slot + 1) * spec.config.SLOT_DURATION_MS // 1000
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = spec.compute_time_at_slot_ms(genesis_state, block_2.slot + 1)
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
 
     yield from add_block(spec, store, signed_block_1, test_steps)
     yield from add_block(spec, store, signed_block_2, test_steps)
@@ -203,8 +203,8 @@ def test_filtered_block_tree(spec, state):
     assert state.current_justified_checkpoint.epoch > prev_state.current_justified_checkpoint.epoch
 
     # tick time forward and add blocks and attestations to store
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = spec.compute_time_at_slot_ms(state, state.slot)
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     for signed_block in signed_blocks:
         yield from add_block(spec, store, signed_block, test_steps)
 
@@ -245,10 +245,8 @@ def test_filtered_block_tree(spec, state):
             attestations.append(attestation)
 
     # tick time forward to be able to include up to the latest attestation
-    current_time = (
-        attestations[-1].data.slot + 1
-    ) * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = spec.compute_time_at_slot_ms(state, attestations[-1].data.slot + 1)
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
 
     # include rogue block and associated attestations in the store
     yield from add_block(spec, store, signed_rogue_block, test_steps)
@@ -296,8 +294,8 @@ def test_proposer_boost_correct_head(spec, state):
     assert spec.hash_tree_root(block_1) < spec.hash_tree_root(block_2)
 
     # Tick to block_1 slot time
-    time = store.genesis_time + block_1.slot * spec.config.SLOT_DURATION_MS // 1000
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = spec.compute_time_at_slot_ms(genesis_state, block_1.slot)
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
 
     # Process block_2
     yield from add_block(spec, store, signed_block_2, test_steps)
@@ -311,8 +309,8 @@ def test_proposer_boost_correct_head(spec, state):
     check_head_against_root(spec, store, spec.hash_tree_root(block_1))
 
     # After block_1.slot, the head should revert to block_2
-    time = store.genesis_time + (block_1.slot + 1) * spec.config.SLOT_DURATION_MS // 1000
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = spec.compute_time_at_slot_ms(genesis_state, block_1.slot + 1)
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     assert store.proposer_boost_root == spec.Root()
     check_head_against_root(spec, store, spec.hash_tree_root(block_2))
     output_head_check(spec, store, test_steps)
@@ -367,8 +365,8 @@ def test_discard_equivocations_on_attester_slashing(spec, state):
     assert spec.hash_tree_root(block_1) < spec.hash_tree_root(block_2)
 
     # Tick to (block_eqv.slot + 2) slot time
-    time = store.genesis_time + (block_eqv.slot + 2) * spec.config.SLOT_DURATION_MS // 1000
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = spec.compute_time_at_slot_ms(genesis_state, block_eqv.slot + 2)
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
 
     # Process block_1
     yield from add_block(spec, store, signed_block_1, test_steps)
@@ -439,9 +437,9 @@ def test_discard_equivocations_slashed_validator_censoring(spec, state):
     store = spec.get_forkchoice_store(anchor_state, anchor_block)
 
     # Now generate the store checks
-    current_time = anchor_state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = spec.compute_time_at_slot_ms(anchor_state, anchor_state.slot)
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # Create two competing blocks at eqv_slot
     next_slots(spec, state, eqv_slot - state.slot - 1)
@@ -474,8 +472,8 @@ def test_discard_equivocations_slashed_validator_censoring(spec, state):
     assert block_low_root < block_high_root
 
     # Tick to next slot so proposer boost does not apply
-    current_time = store.genesis_time + (block_1.slot + 1) * spec.config.SLOT_DURATION_MS // 1000
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = spec.compute_time_at_slot_ms(anchor_state, block_1.slot + 1)
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
 
     # Check that block with higher root wins
     check_head_against_root(spec, store, block_high_root)
@@ -513,15 +511,15 @@ def test_voting_source_within_two_epoch(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = spec.compute_time_at_slot_ms(state, state.slot)
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -597,15 +595,15 @@ def test_voting_source_beyond_two_epoch(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = spec.compute_time_at_slot_ms(state, state.slot)
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -698,12 +696,12 @@ def test_incorrect_finalized(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield 'anchor_state', state
     yield 'anchor_block', anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
-    on_tick_and_append_step(spec, store, store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000, test_steps)
+    on_tick_and_append_step(spec, store, store.genesis_time_ms + state.slot * spec.config.SLOT_DURATION_MS, test_steps)
 
     # Fill epoch 1 to 4
     for _ in range(4):

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_get_proposer_head.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_get_proposer_head.py
@@ -38,9 +38,9 @@ def test_basic_is_head_root(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block = build_empty_block_for_next_slot(spec, state)
@@ -55,8 +55,8 @@ def test_basic_is_head_root(spec, state):
     next_slot(spec, state)
     slot = state.slot
 
-    current_time = slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     proposer_head = spec.get_proposer_head(store, head_root, slot)
     assert proposer_head == head_root
 
@@ -80,15 +80,15 @@ def test_basic_is_parent_root(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -123,15 +123,13 @@ def test_basic_is_parent_root(spec, state):
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     # Make the head block late
-    # Round up to nearest second
     epoch = spec.get_current_store_epoch(store)
     attestation_due_ms = spec.get_attestation_due_ms(epoch)
-    attesting_cutoff = (attestation_due_ms + 999) // 1000
-    current_time = (
-        state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time + attesting_cutoff
+    current_time_ms = (
+        state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms + attestation_due_ms
     )
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     yield from tick_and_add_block(spec, store, signed_block, test_steps)
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_on_block.py
@@ -64,9 +64,9 @@ def test_basic(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
     block = build_empty_block_for_next_slot(spec, state)
@@ -75,7 +75,7 @@ def test_basic(spec, state):
     check_head_against_root(spec, store, signed_block.message.hash_tree_root())
 
     # On receiving a block of next epoch
-    store.time = current_time + spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH // 1000
+    store.time_ms = current_time_ms + spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH
     block = build_empty_block(spec, state, state.slot + spec.SLOTS_PER_EPOCH)
     signed_block = state_transition_and_sign_block(spec, state, block)
     yield from tick_and_add_block(spec, store, signed_block, test_steps)
@@ -95,16 +95,16 @@ def test_on_block_checkpoints(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # Run for 1 epoch with full attestations
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -119,7 +119,7 @@ def test_on_block_checkpoints(spec, state):
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -143,9 +143,9 @@ def test_on_block_future_block(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # Do NOT tick time to `GENESIS_SLOT + 1` slot
     # Fail receiving block of `GENESIS_SLOT + 1` slot
@@ -164,9 +164,9 @@ def test_on_block_bad_parent_root(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # Fail receiving block of `GENESIS_SLOT + 1` slot
     block = build_empty_block_for_next_slot(spec, state)
@@ -198,9 +198,9 @@ def test_on_block_before_finalized(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # Fork
     another_state = state.copy()
@@ -235,9 +235,9 @@ def test_on_block_finalized_skip_slots(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # Fill epoch 0 and the first slot of epoch 1
     state, store, _ = yield from apply_next_slots_with_attestations(
@@ -288,9 +288,9 @@ def test_on_block_finalized_skip_slots_not_in_skip_chain(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # Fill epoch 0 and the first slot of epoch 1
     state, store, _ = yield from apply_next_slots_with_attestations(
@@ -350,9 +350,9 @@ def test_new_finalized_slot_is_not_justified_checkpoint_ancestor(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield 'anchor_state', state
     yield 'anchor_block', anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # ----- Process state
     # Goal: make `store.finalized_checkpoint.epoch == 0` and `store.justified_checkpoint.epoch == 3`
@@ -436,9 +436,9 @@ def test_new_finalized_slot_is_justified_checkpoint_ancestor(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     # Process state
     next_epoch(spec, state)
@@ -511,18 +511,11 @@ def test_proposer_boost(spec, state):
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     # Process block on timely arrival just before end of boost interval
-    # Round up to nearest second
     epoch = spec.get_current_store_epoch(store)
     late_block_cutoff_ms = spec.get_attestation_due_ms(epoch)
-    late_block_cutoff = (late_block_cutoff_ms + 999) // 1000
-    time = (
-        store.genesis_time
-        + block.slot * spec.config.SLOT_DURATION_MS // 1000
-        + late_block_cutoff
-        - 1
-    )
+    time_ms = spec.compute_time_at_slot_ms(state, block.slot) + late_block_cutoff_ms - 1
 
-    on_tick_and_append_step(spec, store, time, test_steps)
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block, test_steps)
     assert store.proposer_boost_root == spec.hash_tree_root(block)
     if is_post_gloas(spec):
@@ -535,12 +528,8 @@ def test_proposer_boost(spec, state):
         assert spec.get_weight(store, spec.hash_tree_root(block)) > 0
 
     # Ensure that boost is removed after slot is over
-    time = (
-        store.genesis_time
-        + block.slot * spec.config.SLOT_DURATION_MS // 1000
-        + spec.config.SLOT_DURATION_MS // 1000
-    )
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = spec.compute_time_at_slot_ms(state, block.slot) + spec.config.SLOT_DURATION_MS
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     assert store.proposer_boost_root == spec.Root()
     if is_post_gloas(spec):
         node = spec.ForkChoiceNode(
@@ -556,8 +545,8 @@ def test_proposer_boost(spec, state):
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     # Process block on timely arrival at start of boost interval
-    time = store.genesis_time + block.slot * spec.config.SLOT_DURATION_MS // 1000
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = spec.compute_time_at_slot_ms(state, block.slot)
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block, test_steps)
     assert store.proposer_boost_root == spec.hash_tree_root(block)
     if is_post_gloas(spec):
@@ -570,12 +559,8 @@ def test_proposer_boost(spec, state):
         assert spec.get_weight(store, spec.hash_tree_root(block)) > 0
 
     # Ensure that boost is removed after slot is over
-    time = (
-        store.genesis_time
-        + block.slot * spec.config.SLOT_DURATION_MS // 1000
-        + spec.config.SLOT_DURATION_MS // 1000
-    )
-    on_tick_and_append_step(spec, store, time, test_steps)
+    time_ms = spec.compute_time_at_slot_ms(state, block.slot) + spec.config.SLOT_DURATION_MS
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     assert store.proposer_boost_root == spec.Root()
     if is_post_gloas(spec):
         node = spec.ForkChoiceNode(
@@ -615,15 +600,11 @@ def test_proposer_boost_root_same_slot_untimely_block(spec, state):
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     # Process block on untimely arrival in the same slot
-    # Round up to nearest second
     epoch = spec.get_current_store_epoch(store)
     late_block_cutoff_ms = spec.get_attestation_due_ms(epoch)
-    late_block_cutoff = (late_block_cutoff_ms + 999) // 1000
-    time = (
-        store.genesis_time + block.slot * spec.config.SLOT_DURATION_MS // 1000 + late_block_cutoff
-    )
+    time_ms = spec.compute_time_at_slot_ms(state, block.slot) + late_block_cutoff_ms
 
-    on_tick_and_append_step(spec, store, time, test_steps)
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block, test_steps)
 
     assert store.proposer_boost_root == spec.Root()
@@ -658,18 +639,11 @@ def test_proposer_boost_is_first_block(spec, state):
     signed_block_a = state_transition_and_sign_block(spec, state, block_a)
 
     # Process block on timely arrival just before end of boost interval
-    # Round up to nearest second
     epoch = spec.get_current_store_epoch(store)
     late_block_cutoff_ms = spec.get_attestation_due_ms(epoch)
-    late_block_cutoff = (late_block_cutoff_ms + 999) // 1000
-    time = (
-        store.genesis_time
-        + block_a.slot * spec.config.SLOT_DURATION_MS // 1000
-        + late_block_cutoff
-        - 1
-    )
+    time_ms = spec.compute_time_at_slot_ms(state, block_a.slot) + late_block_cutoff_ms - 1
 
-    on_tick_and_append_step(spec, store, time, test_steps)
+    on_tick_and_append_step(spec, store, time_ms, test_steps)
     yield from add_block(spec, store, signed_block_a, test_steps)
     # `proposer_boost_root` is now `block_a`
     assert store.proposer_boost_root == spec.hash_tree_root(block_a)
@@ -725,9 +699,9 @@ def test_justification_withholding(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     for _ in range(2):
         next_epoch(spec, state)
@@ -809,9 +783,9 @@ def test_justification_withholding_reverse_order(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     for _ in range(2):
         next_epoch(spec, state)
@@ -892,15 +866,15 @@ def test_justification_update_beginning_of_epoch(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -921,8 +895,8 @@ def test_justification_update_beginning_of_epoch(spec, state):
 
     # Tick store to the start of the next epoch
     slot = spec.get_current_slot(store) + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH)
-    current_time = slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 5
 
     # Now add the blocks & check that justification update was triggered
@@ -947,15 +921,15 @@ def test_justification_update_end_of_epoch(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -977,8 +951,8 @@ def test_justification_update_end_of_epoch(spec, state):
     # Tick store to the last slot of the next epoch
     slot = spec.get_current_slot(store) + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH)
     slot = slot + spec.SLOTS_PER_EPOCH - 1
-    current_time = slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 5
 
     # Now add the blocks & check that justification update was triggered
@@ -1003,15 +977,15 @@ def test_incompatible_justification_update_start_of_epoch(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -1059,8 +1033,8 @@ def test_incompatible_justification_update_start_of_epoch(spec, state):
 
     # Tick store to the last slot of the next epoch
     slot = another_state.slot + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH)
-    current_time = slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 8
 
     # Now add the blocks & check that justification update was triggered
@@ -1098,15 +1072,15 @@ def test_incompatible_justification_update_end_of_epoch(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -1155,8 +1129,8 @@ def test_incompatible_justification_update_end_of_epoch(spec, state):
     # Tick store to the last slot of the next epoch
     slot = another_state.slot + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH)
     slot = slot + spec.SLOTS_PER_EPOCH - 1
-    current_time = slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 8
 
     # Now add the blocks & check that justification update was triggered
@@ -1193,15 +1167,15 @@ def test_justified_update_not_realized_finality(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -1285,15 +1259,15 @@ def test_justified_update_monotonic(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -1380,15 +1354,15 @@ def test_justified_update_always_if_better(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -1463,15 +1437,15 @@ def test_pull_up_past_epoch_block(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -1491,8 +1465,8 @@ def test_pull_up_past_epoch_block(spec, state):
 
     # Tick store to the next epoch
     next_epoch(spec, state)
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 5
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
     assert store.finalized_checkpoint.epoch == 2
@@ -1520,15 +1494,15 @@ def test_not_pull_up_current_epoch_block(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -1544,8 +1518,8 @@ def test_not_pull_up_current_epoch_block(spec, state):
 
     # Skip to the next epoch
     next_epoch(spec, state)
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(state.slot) == 5
 
     # Create a chain within epoch 5 that contains a justification for epoch 5
@@ -1575,15 +1549,15 @@ def test_pull_up_on_tick(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -1599,8 +1573,8 @@ def test_pull_up_on_tick(spec, state):
 
     # Skip to the next epoch
     next_epoch(spec, state)
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(state.slot) == 5
 
     # Create a chain within epoch 5 that contains a justification for epoch 5
@@ -1618,8 +1592,8 @@ def test_pull_up_on_tick(spec, state):
 
     # Now tick the store to the next epoch and check that pull-up tip updates were applied
     next_epoch(spec, state)
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(state.slot) == 6
     assert store.justified_checkpoint.epoch == 5
     # There's no new finality, so no finality updates expected

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_reorg.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_reorg.py
@@ -57,15 +57,15 @@ def test_simple_attempted_reorg_without_enough_ffg_votes(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -149,8 +149,8 @@ def test_simple_attempted_reorg_without_enough_ffg_votes(spec, state):
 
     # tick to the prior of the epoch boundary
     slot = state.slot + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH) - 1
-    current_time = slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 4
     # chain `y` reminds the winner
@@ -158,8 +158,8 @@ def test_simple_attempted_reorg_without_enough_ffg_votes(spec, state):
 
     # to next block
     next_epoch(spec, state)
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 5
     check_head_against_root(spec, store, signed_block_y.message.hash_tree_root())
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
@@ -174,15 +174,15 @@ def _run_delayed_justification(spec, state, attempted_reorg, is_justifying_previ
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -244,8 +244,8 @@ def _run_delayed_justification(spec, state, attempted_reorg, is_justifying_previ
     attestations_for_y = list(
         get_valid_attestations_at_slot(temp_state, spec, signed_block_y.message.slot)
     )
-    current_time = temp_state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = temp_state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     yield from add_attestations(spec, store, attestations_for_y, test_steps)
     check_head_against_root(spec, store, signed_block_y.message.hash_tree_root())
 
@@ -262,8 +262,8 @@ def _run_delayed_justification(spec, state, attempted_reorg, is_justifying_previ
         # next epoch
         state = state_b.copy()
         next_epoch(spec, state)
-        current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-        on_tick_and_append_step(spec, store, current_time, test_steps)
+        current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+        on_tick_and_append_step(spec, store, current_time_ms, test_steps)
 
     # no reorg
     check_head_against_root(spec, store, signed_block_y.message.hash_tree_root())
@@ -304,15 +304,15 @@ def _run_include_votes_of_another_empty_chain(
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -433,8 +433,8 @@ def _run_include_votes_of_another_empty_chain(
 
     # to next epoch
     next_epoch(spec, state)
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 5
 
     y_voting_source_epoch = spec.get_voting_source(
@@ -465,8 +465,8 @@ def _run_include_votes_of_another_empty_chain(
 
     # to next epoch
     next_epoch(spec, state)
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 6
 
     y_voting_source_epoch = spec.get_voting_source(

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_withholding.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_withholding.py
@@ -38,15 +38,15 @@ def test_withholding_attack(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -96,10 +96,8 @@ def test_withholding_attack(spec, state):
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
 
     # Tick to the next slot so proposer boost is not a factor in choosing the head
-    current_time = (
-        honest_block.slot + 1
-    ) * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = (honest_block.slot + 1) * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     check_head_against_root(spec, store, signed_honest_block.message.hash_tree_root())
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 5
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
@@ -112,8 +110,8 @@ def test_withholding_attack(spec, state):
 
     # Even after going to the next epoch, the honest block should remain the head
     slot = spec.get_current_slot(store) + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH)
-    current_time = slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 6
     check_head_against_root(spec, store, signed_honest_block.message.hash_tree_root())
 
@@ -133,15 +131,15 @@ def test_withholding_attack_unviable_honest_chain(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     yield "anchor_state", state
     yield "anchor_block", anchor_block
-    current_time = state.slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-    assert store.time == current_time
+    current_time_ms = state.slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
+    assert store.time_ms == current_time_ms
 
     next_epoch(spec, state)
     on_tick_and_append_step(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         test_steps,
     )
 
@@ -197,10 +195,8 @@ def test_withholding_attack_unviable_honest_chain(spec, state):
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
 
     # Tick to the next slot so proposer boost is not a factor in choosing the head
-    current_time = (
-        honest_block.slot + 1
-    ) * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = (honest_block.slot + 1) * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     check_head_against_root(spec, store, honest_block_root)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 6
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
@@ -214,8 +210,8 @@ def test_withholding_attack_unviable_honest_chain(spec, state):
 
     # After going to the next epoch, the honest block should become the head
     slot = spec.get_current_slot(store) + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH)
-    current_time = slot * spec.config.SLOT_DURATION_MS // 1000 + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
+    current_time_ms = slot * spec.config.SLOT_DURATION_MS + store.genesis_time_ms
+    on_tick_and_append_step(spec, store, current_time_ms, test_steps)
     assert spec.compute_epoch_at_slot(spec.get_current_slot(store)) == 7
     # assert store.voting_source[honest_block_root].epoch == 5
     check_head_against_root(spec, store, honest_block_root)

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/fork_choice/test_on_attestation.py
@@ -44,7 +44,7 @@ def run_on_attestation(spec, state, store, attestation, valid=True):
 @spec_state_test
 def test_on_attestation_current_epoch(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    spec.on_tick(store, store.time + spec.config.SLOT_DURATION_MS * 2 // 1000)
+    spec.on_tick(store, store.time_ms + spec.config.SLOT_DURATION_MS * 2)
 
     block = build_empty_block_for_next_slot(spec, state)
     signed_block = state_transition_and_sign_block(spec, state, block)
@@ -63,7 +63,7 @@ def test_on_attestation_current_epoch(spec, state):
 @spec_state_test
 def test_on_attestation_previous_epoch(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    spec.on_tick(store, store.time + spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH // 1000)
+    spec.on_tick(store, store.time_ms + spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH)
 
     block = build_empty_block_for_next_slot(spec, state)
     signed_block = state_transition_and_sign_block(spec, state, block)
@@ -84,8 +84,8 @@ def test_on_attestation_past_epoch(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
 
     # move time forward 2 epochs
-    time = store.time + 2 * spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH // 1000
-    spec.on_tick(store, time)
+    time_ms = store.time_ms + 2 * spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH
+    spec.on_tick(store, time_ms)
 
     # create and store block from 3 epochs ago
     block = build_empty_block_for_next_slot(spec, state)
@@ -104,7 +104,7 @@ def test_on_attestation_past_epoch(spec, state):
 @spec_state_test
 def test_on_attestation_mismatched_target_and_slot(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    spec.on_tick(store, store.time + spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH // 1000)
+    spec.on_tick(store, store.time_ms + spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH)
 
     block = build_empty_block_for_next_slot(spec, state)
     signed_block = state_transition_and_sign_block(spec, state, block)
@@ -127,9 +127,7 @@ def test_on_attestation_mismatched_target_and_slot(spec, state):
 @spec_state_test
 def test_on_attestation_inconsistent_target_and_head(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    spec.on_tick(
-        store, store.time + 2 * spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH // 1000
-    )
+    spec.on_tick(store, store.time_ms + 2 * spec.config.SLOT_DURATION_MS * spec.SLOTS_PER_EPOCH)
 
     # Create chain 1 as empty chain between genesis and start of 1st epoch
     target_state_1 = state.copy()
@@ -169,8 +167,8 @@ def test_on_attestation_inconsistent_target_and_head(spec, state):
 @spec_state_test
 def test_on_attestation_target_block_not_in_store(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    time = store.time + spec.config.SLOT_DURATION_MS * (spec.SLOTS_PER_EPOCH + 1) // 1000
-    spec.on_tick(store, time)
+    time_ms = store.time_ms + spec.config.SLOT_DURATION_MS * (spec.SLOTS_PER_EPOCH + 1)
+    spec.on_tick(store, time_ms)
 
     # move to immediately before next epoch to make block new target
     next_epoch = spec.get_current_epoch(state) + 1
@@ -191,8 +189,8 @@ def test_on_attestation_target_block_not_in_store(spec, state):
 @spec_state_test
 def test_on_attestation_target_checkpoint_not_in_store(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    time = store.time + spec.config.SLOT_DURATION_MS * (spec.SLOTS_PER_EPOCH + 1) // 1000
-    spec.on_tick(store, time)
+    time_ms = store.time_ms + spec.config.SLOT_DURATION_MS * (spec.SLOTS_PER_EPOCH + 1)
+    spec.on_tick(store, time_ms)
 
     # move to immediately before next epoch to make block new target
     next_epoch = spec.get_current_epoch(state) + 1
@@ -216,8 +214,8 @@ def test_on_attestation_target_checkpoint_not_in_store(spec, state):
 @spec_state_test
 def test_on_attestation_target_checkpoint_not_in_store_diff_slot(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    time = store.time + spec.config.SLOT_DURATION_MS * (spec.SLOTS_PER_EPOCH + 1) // 1000
-    spec.on_tick(store, time)
+    time_ms = store.time_ms + spec.config.SLOT_DURATION_MS * (spec.SLOTS_PER_EPOCH + 1)
+    spec.on_tick(store, time_ms)
 
     # move to two slots before next epoch to make target block one before an empty slot
     next_epoch = spec.get_current_epoch(state) + 1
@@ -243,8 +241,8 @@ def test_on_attestation_target_checkpoint_not_in_store_diff_slot(spec, state):
 @spec_state_test
 def test_on_attestation_beacon_block_not_in_store(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    time = store.time + spec.config.SLOT_DURATION_MS * (spec.SLOTS_PER_EPOCH + 1) // 1000
-    spec.on_tick(store, time)
+    time_ms = store.time_ms + spec.config.SLOT_DURATION_MS * (spec.SLOTS_PER_EPOCH + 1)
+    spec.on_tick(store, time_ms)
 
     # move to immediately before next epoch to make block new target
     next_epoch = spec.get_current_epoch(state) + 1
@@ -272,8 +270,8 @@ def test_on_attestation_beacon_block_not_in_store(spec, state):
 @spec_state_test
 def test_on_attestation_future_epoch(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    time = store.time + 3 * spec.config.SLOT_DURATION_MS // 1000
-    spec.on_tick(store, time)
+    time_ms = store.time_ms + 3 * spec.config.SLOT_DURATION_MS
+    spec.on_tick(store, time_ms)
 
     block = build_empty_block_for_next_slot(spec, state)
     signed_block = state_transition_and_sign_block(spec, state, block)
@@ -292,8 +290,8 @@ def test_on_attestation_future_epoch(spec, state):
 @spec_state_test
 def test_on_attestation_future_block(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    time = store.time + spec.config.SLOT_DURATION_MS * 5 // 1000
-    spec.on_tick(store, time)
+    time_ms = store.time_ms + spec.config.SLOT_DURATION_MS * 5
+    spec.on_tick(store, time_ms)
 
     block = build_empty_block_for_next_slot(spec, state)
     signed_block = state_transition_and_sign_block(spec, state, block)
@@ -312,8 +310,8 @@ def test_on_attestation_future_block(spec, state):
 @spec_state_test
 def test_on_attestation_same_slot(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    time = store.time + spec.config.SLOT_DURATION_MS // 1000
-    spec.on_tick(store, time)
+    time_ms = store.time_ms + spec.config.SLOT_DURATION_MS
+    spec.on_tick(store, time_ms)
 
     block = build_empty_block_for_next_slot(spec, state)
     signed_block = state_transition_and_sign_block(spec, state, block)
@@ -328,8 +326,8 @@ def test_on_attestation_same_slot(spec, state):
 @spec_state_test
 def test_on_attestation_invalid_attestation(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    time = store.time + 3 * spec.config.SLOT_DURATION_MS // 1000
-    spec.on_tick(store, time)
+    time_ms = store.time_ms + 3 * spec.config.SLOT_DURATION_MS
+    spec.on_tick(store, time_ms)
 
     block = build_empty_block_for_next_slot(spec, state)
     signed_block = state_transition_and_sign_block(spec, state, block)

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/fork_choice/test_on_tick.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/fork_choice/test_on_tick.py
@@ -10,12 +10,12 @@ from eth_consensus_specs.test.helpers.state import (
 )
 
 
-def run_on_tick(spec, store, time, new_justified_checkpoint=False):
+def run_on_tick(spec, store, time_ms, new_justified_checkpoint=False):
     previous_justified_checkpoint = store.justified_checkpoint
 
-    spec.on_tick(store, time)
+    spec.on_tick(store, time_ms)
 
-    assert store.time == time
+    assert store.time_ms == time_ms
 
     if new_justified_checkpoint:
         assert store.justified_checkpoint.epoch > previous_justified_checkpoint.epoch
@@ -28,7 +28,7 @@ def run_on_tick(spec, store, time, new_justified_checkpoint=False):
 @spec_state_test
 def test_basic(spec, state):
     store = get_genesis_forkchoice_store(spec, state)
-    run_on_tick(spec, store, store.time + 1)
+    run_on_tick(spec, store, store.time_ms + 1)
 
 
 """
@@ -61,7 +61,7 @@ def test_update_justified_single_on_store_finalized_chain(spec, state):
     run_on_tick(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
         new_justified_checkpoint=True
     )
 """
@@ -113,5 +113,5 @@ def test_update_justified_single_not_on_store_finalized_chain(spec, state):
     run_on_tick(
         spec,
         store,
-        store.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000,
+        spec.compute_time_at_slot_ms(state, state.slot),
     )

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -51,11 +51,11 @@ types:
 
 #### `on_tick` execution step
 
-The parameter that is required for executing `on_tick(store, time)`.
+The parameter that is required for executing `on_tick(store, time_ms)`.
 
 ```yaml
 {
-    tick: int       -- to execute `on_tick(store, time)`.
+    tick: int       -- to execute `on_tick(store, time_ms)`.
     valid: bool     -- optional, default to `true`.
                        If it's `false`, this execution step is expected to be invalid.
 }
@@ -197,8 +197,8 @@ head: {
     slot: int,
     root: string,             -- Encoded 32-byte value from get_head(store)
 }
-time: int                     -- store.time
-genesis_time: int             -- store.genesis_time
+time: int                     -- milliseconds_to_seconds(store.time_ms)
+genesis_time: int             -- milliseconds_to_seconds(store.genesis_time_ms)
 justified_checkpoint: {
     epoch: int,               -- Integer value from store.justified_checkpoint.epoch
     root: string,             -- Encoded 32-byte value from store.justified_checkpoint.root

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
@@ -267,12 +267,13 @@ def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTest
     blocks = [ProtocolMessage(block) for block in signed_blocks]
 
     current_epoch_slot = spec.compute_start_slot_at_epoch(model_params["current_epoch"])
-    current_epoch_time = (
-        state.genesis_time + current_epoch_slot * spec.config.SLOT_DURATION_MS // 1000
+    current_epoch_time_ms = (
+        spec.seconds_to_milliseconds(state.genesis_time)
+        + current_epoch_slot * spec.config.SLOT_DURATION_MS
     )
 
     test_data = FCTestData(
-        meta, anchor_block, anchor_state, blocks, store_final_time=current_epoch_time
+        meta, anchor_block, anchor_state, blocks, store_final_time=current_epoch_time_ms
     )
     target_block_root = spec.hash_tree_root(
         post_block_tips[target_block].beacon_state.latest_block_header

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -291,19 +291,19 @@ def make_events(spec, test_data: FCTestData) -> list[tuple[int, object, bool]]:
     Makes test events from `test_data`'s blocks, attestations and slashings, sorted by an effective slot.
     Each event is a triple ('tick'|'block'|'attestation'|'attester_slashing', message, valid).
     """
-    genesis_time = test_data.anchor_state.genesis_time
+    genesis_time_ms = spec.seconds_to_milliseconds(test_data.anchor_state.genesis_time)
     test_events = []
 
-    def slot_to_time(slot):
-        return slot * spec.config.SLOT_DURATION_MS // 1000 + genesis_time
+    def slot_to_time_ms(slot):
+        return slot * spec.config.SLOT_DURATION_MS + genesis_time_ms
 
-    def add_tick_step(time):
-        test_events.append(("tick", time, None))
+    def add_tick_step(time_ms):
+        test_events.append(("tick", time_ms, None))
 
     def add_message_step(kind, message):
         test_events.append((kind, message.payload, message.valid))
 
-    add_tick_step(slot_to_time(test_data.anchor_state.slot))
+    add_tick_step(slot_to_time_ms(test_data.anchor_state.slot))
     slot = test_data.anchor_state.slot
 
     def get_seffective_slot(message):
@@ -328,10 +328,10 @@ def make_events(spec, test_data: FCTestData) -> list[tuple[int, object, bool]]:
         event_slot = get_seffective_slot(event)
         while slot < event_slot:
             slot += 1
-            add_tick_step(slot_to_time(slot))
+            add_tick_step(slot_to_time_ms(slot))
         add_message_step(event_kind, ProtocolMessage(message, valid))
 
-    if slot is None or slot_to_time(slot) < test_data.store_final_time:
+    if slot is None or slot_to_time_ms(slot) < test_data.store_final_time:
         add_tick_step(test_data.store_final_time)
 
     return test_events
@@ -421,15 +421,15 @@ def yield_fork_choice_test_events(
             return False
 
     # record initial tick
-    on_tick_and_append_step(spec, store, store.time, test_steps)
+    on_tick_and_append_step(spec, store, store.time_ms, test_steps)
 
     for event in test_events:
         event_kind = event[0]
         if event_kind == "tick":
-            _, time, _ = event
-            if time > store.time:
-                on_tick_and_append_step(spec, store, time, test_steps)
-                assert store.time == time
+            _, time_ms, _ = event
+            if time_ms > store.time_ms:
+                on_tick_and_append_step(spec, store, time_ms, test_steps)
+                assert store.time_ms == time_ms
         elif event_kind == "block":
             _, signed_block, valid = event
             if valid is None:

--- a/tests/generators/compliance_runners/fork_choice/instantiators/mutation_operators.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/mutation_operators.py
@@ -76,9 +76,9 @@ def mutate_test_vector(rnd, initial_tv, cnt, debug=False):
 
 
 class MutationOps:
-    def __init__(self, start_time, seconds_per_slot, shift_bounds=(-2, 4)):
+    def __init__(self, start_time, slot_duration_ms, shift_bounds=(-2, 4)):
         self.start_time = int(start_time)
-        self.seconds_per_slot = int(seconds_per_slot)
+        self.slot_duration_ms = int(slot_duration_ms)
         self.shift_bounds = shift_bounds
 
     def apply_shift(self, tv, idx, delta):
@@ -103,8 +103,8 @@ class MutationOps:
     def rand_shift(self, time: int, rnd: random.Random) -> int:
         assert time >= self.start_time
         neg_shift, pos_shift = self.shift_bounds
-        min_shift = max(self.start_time - time, neg_shift * self.seconds_per_slot)
-        max_shift = pos_shift * self.seconds_per_slot
+        min_shift = max(self.start_time - time, neg_shift * self.slot_duration_ms)
+        max_shift = pos_shift * self.slot_duration_ms
         if rnd.randint(0, 1) == 0:
             return rnd.randint(min_shift, 0)
         else:

--- a/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
@@ -75,13 +75,11 @@ class MessageScheduler:
 
     def process_tick(self, time_ms) -> list:
         applied_events = []
-        SLOT_DURATION_MS = self.spec.config.SLOT_DURATION_MS
         assert time_ms >= self.store.time_ms
-        tick_slot = (time_ms - self.store.genesis_time_ms) // SLOT_DURATION_MS
+        tick_slot = self.spec.compute_store_slot_at_time_ms(self.store, time_ms)
         while self.spec.get_current_slot(self.store) < tick_slot:
-            previous_time_ms = (
-                self.store.genesis_time_ms
-                + (self.spec.get_current_slot(self.store) + 1) * SLOT_DURATION_MS
+            previous_time_ms = self.spec.compute_store_time_at_slot_ms(
+                self.store, self.spec.Slot(self.spec.get_current_slot(self.store) + 1)
             )
             self.spec.on_tick(self.store, previous_time_ms)
             applied_events.append(

--- a/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
@@ -73,19 +73,19 @@ class MessageScheduler:
             else:
                 return applied_events
 
-    def process_tick(self, time) -> list:
+    def process_tick(self, time_ms) -> list:
         applied_events = []
         SLOT_DURATION_MS = self.spec.config.SLOT_DURATION_MS
-        assert time >= self.store.time
-        tick_slot = (time - self.store.genesis_time) * 1000 // SLOT_DURATION_MS
+        assert time_ms >= self.store.time_ms
+        tick_slot = (time_ms - self.store.genesis_time_ms) // SLOT_DURATION_MS
         while self.spec.get_current_slot(self.store) < tick_slot:
-            previous_time = (
-                self.store.genesis_time
-                + (self.spec.get_current_slot(self.store) + 1) * SLOT_DURATION_MS // 1000
+            previous_time_ms = (
+                self.store.genesis_time_ms
+                + (self.spec.get_current_slot(self.store) + 1) * SLOT_DURATION_MS
             )
-            self.spec.on_tick(self.store, previous_time)
+            self.spec.on_tick(self.store, previous_time_ms)
             applied_events.append(
-                ("tick", previous_time, self.spec.get_current_slot(self.store) < tick_slot)
+                ("tick", previous_time_ms, self.spec.get_current_slot(self.store) < tick_slot)
             )
             applied_events.extend(self.purge_queue())
         return applied_events

--- a/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
@@ -134,7 +134,7 @@ def yield_mutation_test_case(spec, state, test_kind, solution, debug, seed, mut_
         return yield_fork_choice_test_events(spec, store, test_data, events, debug)
     else:
         test_vector = events_to_test_vector(events)
-        mops = MutationOps(store.time, spec.config.SLOT_DURATION_MS // 1000)
+        mops = MutationOps(store.time_ms, spec.config.SLOT_DURATION_MS)
         mutated_vector, mutations = mops.rand_mutations(test_vector, 4, random.Random(mut_seed))
 
         test_data.meta["mut_seed"] = mut_seed
@@ -202,17 +202,19 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
     scheduler = MessageScheduler(spec, store)
 
     # record first tick
-    on_tick_and_append_step(spec, store, store.time, test_steps)
+    on_tick_and_append_step(spec, store, store.time_ms, test_steps)
 
     for kind, data, _ in events:
         if kind == "tick":
-            time = data
-            if time > store.time:
-                applied_events = scheduler.process_tick(time)
+            time_ms = data
+            if time_ms > store.time_ms:
+                applied_events = scheduler.process_tick(time_ms)
                 if record_recovery_messages:
                     for event_kind, event_data, recovery in applied_events:
                         if event_kind == "tick":
-                            test_steps.append({"tick": int(event_data)})
+                            test_steps.append(
+                                {"tick": int(spec.milliseconds_to_seconds(event_data))}
+                            )
                         elif event_kind == "block":
                             assert recovery
                             _block_id = get_block_file_name(event_data)
@@ -227,11 +229,11 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
                             assert False
                 else:
                     assert False
-                if time > store.time:
+                if time_ms > store.time_ms:
                     # inside a slot
-                    on_tick_and_append_step(spec, store, time, test_steps)
+                    on_tick_and_append_step(spec, store, time_ms, test_steps)
                 else:
-                    assert time == store.time
+                    assert time_ms == store.time_ms
                     output_store_checks(spec, store, test_steps)
         elif kind == "block":
             block = data
@@ -281,11 +283,9 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
             output_store_checks(spec, store, test_steps)
         else:
             raise ValueError(f"not implemented {kind}")
-    next_slot_time = (
-        store.genesis_time
-        + (spec.get_current_slot(store) + 1) * spec.config.SLOT_DURATION_MS // 1000
-    )
-    on_tick_and_append_step(spec, store, next_slot_time, test_steps)
+    next_slot = spec.get_current_slot(store) + 1
+    next_slot_time_ms = spec.compute_time_at_slot_ms(test_data.anchor_state, next_slot)
+    on_tick_and_append_step(spec, store, next_slot_time_ms, test_steps)
     output_store_checks(spec, store, test_steps, with_viable_for_head_weights=True)
 
     yield "steps", test_steps

--- a/tests/generators/compliance_runners/fork_choice/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/test_run.py
@@ -70,8 +70,8 @@ def run_test(test_info):
     store = spec.get_forkchoice_store(anchor_state, anchor_block)
     for step in steps:
         if "tick" in step:
-            time = step["tick"]
-            spec.on_tick(store, time)
+            time_ms = spec.seconds_to_milliseconds(step["tick"])
+            spec.on_tick(store, time_ms)
         elif "block" in step:
             block_id = step["block"]
             valid = step.get("valid", True)
@@ -111,7 +111,7 @@ def run_test(test_info):
             for check, value in checks.items():
                 if check == "time":
                     expected_time = value
-                    assert store.time == expected_time
+                    assert store.time_ms == spec.seconds_to_milliseconds(expected_time)
                 elif check == "head":
                     assert str(spec.get_head(store)) == value["root"]
                 elif check == "proposer_boost_root":


### PR DESCRIPTION
Now that the slot time is defined in milliseconds (`SLOT_DURATION_MS`), there's a bit of awkwardness around time fields in `Store` which are defined in seconds. This PR converts `Store.time` -> `Store.time_ms` and `Store.genesis_time` to `Store.genesis_time_ms`.