### PR TITLE
Treat genesis block as empty payload parent

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -143,6 +143,7 @@ Gloas is a consensus-layer upgrade containing a number of features. Including:
 | `BUILDER_INDEX_SELF_BUILD`              | `BuilderIndex(UINT64_MAX)` | Value which indicates the proposer built the payload |
 | `BUILDER_PAYMENT_THRESHOLD_NUMERATOR`   | `uint64(6)`                |                                                      |
 | `BUILDER_PAYMENT_THRESHOLD_DENOMINATOR` | `uint64(10)`               |                                                      |
+| `EMPTY_BLOCK_HASH`                      | `Hash32()`                 |                                                      |
 
 ### Withdrawal prefixes
 
@@ -999,7 +1000,9 @@ def process_parent_execution_payload(state: BeaconState, block: BeaconBlock) -> 
     requests = block.body.parent_execution_requests
 
     # True if this block built on the parent's full payload
-    is_parent_block_full = bid.parent_block_hash == parent_bid.block_hash
+    is_parent_block_full = (
+        parent_bid.block_hash != EMPTY_BLOCK_HASH and bid.parent_block_hash == parent_bid.block_hash
+    )
 
     if not is_parent_block_full:
         # Parent was EMPTY -- no execution requests expected
@@ -1196,7 +1199,10 @@ def process_withdrawals(
 ) -> None:
     # [New in Gloas:EIP7732]
     # Return early if the parent block is empty
-    if state.latest_block_hash != state.latest_execution_payload_bid.block_hash:
+    if (
+        state.latest_block_hash == EMPTY_BLOCK_HASH
+        or state.latest_block_hash != state.latest_execution_payload_bid.block_hash
+    ):
         return
 
     # Get expected withdrawals

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -143,7 +143,6 @@ Gloas is a consensus-layer upgrade containing a number of features. Including:
 | `BUILDER_INDEX_SELF_BUILD`              | `BuilderIndex(UINT64_MAX)` | Value which indicates the proposer built the payload |
 | `BUILDER_PAYMENT_THRESHOLD_NUMERATOR`   | `uint64(6)`                |                                                      |
 | `BUILDER_PAYMENT_THRESHOLD_DENOMINATOR` | `uint64(10)`               |                                                      |
-| `EMPTY_BLOCK_HASH`                      | `Hash32()`                 |                                                      |
 
 ### Withdrawal prefixes
 
@@ -999,7 +998,7 @@ def process_parent_execution_payload(state: BeaconState, block: BeaconBlock) -> 
     parent_bid = state.latest_execution_payload_bid
     requests = block.body.parent_execution_requests
 
-    is_genesis_block = parent_bid.block_hash == EMPTY_BLOCK_HASH
+    is_genesis_block = parent_bid.block_hash == Hash32()
     is_parent_block_empty = bid.parent_block_hash != parent_bid.block_hash
     if is_genesis_block or is_parent_block_empty:
         # Parent was EMPTY -- no execution requests expected
@@ -1196,7 +1195,7 @@ def process_withdrawals(
 ) -> None:
     # [New in Gloas:EIP7732]
     # Return early if the parent block is empty
-    is_genesis_block = state.latest_block_hash == EMPTY_BLOCK_HASH
+    is_genesis_block = state.latest_block_hash == Hash32()
     is_parent_block_empty = state.latest_block_hash != state.latest_execution_payload_bid.block_hash
     if is_genesis_block or is_parent_block_empty:
         return

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -999,12 +999,9 @@ def process_parent_execution_payload(state: BeaconState, block: BeaconBlock) -> 
     parent_bid = state.latest_execution_payload_bid
     requests = block.body.parent_execution_requests
 
-    # True if this block built on the parent's full payload
-    is_parent_block_full = (
-        parent_bid.block_hash != EMPTY_BLOCK_HASH and bid.parent_block_hash == parent_bid.block_hash
-    )
-
-    if not is_parent_block_full:
+    is_genesis_block = parent_bid.block_hash == EMPTY_BLOCK_HASH
+    is_parent_block_empty = bid.parent_block_hash != parent_bid.block_hash
+    if is_genesis_block or is_parent_block_empty:
         # Parent was EMPTY -- no execution requests expected
         assert requests == ExecutionRequests()
         return
@@ -1199,10 +1196,9 @@ def process_withdrawals(
 ) -> None:
     # [New in Gloas:EIP7732]
     # Return early if the parent block is empty
-    if (
-        state.latest_block_hash == EMPTY_BLOCK_HASH
-        or state.latest_block_hash != state.latest_execution_payload_bid.block_hash
-    ):
+    is_genesis_block = state.latest_block_hash == EMPTY_BLOCK_HASH
+    is_parent_block_empty = state.latest_block_hash != state.latest_execution_payload_bid.block_hash
+    if is_genesis_block or is_parent_block_empty:
         return
 
     # Get expected withdrawals

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -291,6 +291,11 @@ def get_parent_payload_status(store: Store, block: BeaconBlock) -> PayloadStatus
     parent = store.blocks[block.parent_root]
     parent_block_hash = block.body.signed_execution_payload_bid.message.parent_block_hash
     message_block_hash = parent.body.signed_execution_payload_bid.message.block_hash
+
+    # Check for uninitialized genesis block hash
+    if message_block_hash == EMPTY_BLOCK_HASH:
+        return PAYLOAD_STATUS_EMPTY
+
     return PAYLOAD_STATUS_FULL if parent_block_hash == message_block_hash else PAYLOAD_STATUS_EMPTY
 ```
 

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -293,7 +293,7 @@ def get_parent_payload_status(store: Store, block: BeaconBlock) -> PayloadStatus
     message_block_hash = parent.body.signed_execution_payload_bid.message.block_hash
 
     # Check for uninitialized genesis block hash
-    if message_block_hash == EMPTY_BLOCK_HASH:
+    if message_block_hash == Hash32():
         return PAYLOAD_STATUS_EMPTY
 
     return PAYLOAD_STATUS_FULL if parent_block_hash == message_block_hash else PAYLOAD_STATUS_EMPTY

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
@@ -96,3 +96,24 @@ def test_process_parent_execution_payload__empty_parent_requires_empty_requests(
 
     spec.process_slots(state, block.slot)
     yield from run_parent_execution_payload_processing(spec, state, block, valid=False)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_parent_execution_payload_genesis(spec, state):
+    """
+    Verify that process_parent_execution_payload does not update
+    latest_block_hash when both hashes are EMPTY_BLOCK_HASH.
+    """
+    state.latest_block_hash = spec.EMPTY_BLOCK_HASH
+    state.latest_execution_payload_bid.block_hash = spec.EMPTY_BLOCK_HASH
+
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.signed_execution_payload_bid.message.parent_block_hash = spec.EMPTY_BLOCK_HASH
+
+    pre_latest_block_hash = state.latest_block_hash
+
+    spec.process_slots(state, block.slot)
+    yield from run_parent_execution_payload_processing(spec, state, block)
+
+    assert state.latest_block_hash == pre_latest_block_hash

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
@@ -103,13 +103,13 @@ def test_process_parent_execution_payload__empty_parent_requires_empty_requests(
 def test_process_parent_execution_payload_genesis(spec, state):
     """
     Verify that process_parent_execution_payload does not update
-    latest_block_hash when both hashes are EMPTY_BLOCK_HASH.
+    latest_block_hash when both hashes are Hash32().
     """
-    state.latest_block_hash = spec.EMPTY_BLOCK_HASH
-    state.latest_execution_payload_bid.block_hash = spec.EMPTY_BLOCK_HASH
+    state.latest_block_hash = spec.Hash32()
+    state.latest_execution_payload_bid.block_hash = spec.Hash32()
 
     block = build_empty_block_for_next_slot(spec, state)
-    block.body.signed_execution_payload_bid.message.parent_block_hash = spec.EMPTY_BLOCK_HASH
+    block.body.signed_execution_payload_bid.message.parent_block_hash = spec.Hash32()
 
     pre_latest_block_hash = state.latest_block_hash
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_withdrawals.py
@@ -1118,10 +1118,10 @@ def test_full_builder_payload_reserves_sweep_slot(spec, state):
 def test_zero_hash_genesis_skips_withdrawals(spec, state):
     """
     Verify that process_withdrawals does not advance withdrawal indices
-    when both hashes are EMPTY_BLOCK_HASH.
+    when both hashes are Hash32().
     """
-    state.latest_block_hash = spec.EMPTY_BLOCK_HASH
-    state.latest_execution_payload_bid.block_hash = spec.EMPTY_BLOCK_HASH
+    state.latest_block_hash = spec.Hash32()
+    state.latest_execution_payload_bid.block_hash = spec.Hash32()
 
     pre_state = state.copy()
     yield from run_gloas_withdrawals_processing(spec, state)

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_withdrawals.py
@@ -1115,6 +1115,27 @@ def test_full_builder_payload_reserves_sweep_slot(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
+def test_zero_hash_genesis_skips_withdrawals(spec, state):
+    """
+    Verify that process_withdrawals does not advance withdrawal indices
+    when both hashes are EMPTY_BLOCK_HASH.
+    """
+    state.latest_block_hash = spec.EMPTY_BLOCK_HASH
+    state.latest_execution_payload_bid.block_hash = spec.EMPTY_BLOCK_HASH
+
+    pre_state = state.copy()
+    yield from run_gloas_withdrawals_processing(spec, state)
+
+    assert_process_withdrawals(
+        spec,
+        state,
+        pre_state,
+        all_state_unchanged=True,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
 def test_single_builder_sweep_withdrawal(spec, state):
     """
     Test processing a single builder sweep withdrawal.

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_get_parent_payload_status.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_get_parent_payload_status.py
@@ -1,0 +1,50 @@
+from eth_consensus_specs.test.context import (
+    spec_state_test,
+    with_gloas_and_later,
+)
+from eth_consensus_specs.test.helpers.block import (
+    build_empty_block_for_next_slot,
+)
+from eth_consensus_specs.test.helpers.fork_choice import (
+    get_anchor_root,
+    get_genesis_forkchoice_store_and_block,
+    on_tick_and_append_step,
+    tick_and_add_block,
+)
+from eth_consensus_specs.test.helpers.state import (
+    state_transition_and_sign_block,
+)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_get_parent_payload_status__genesis_empty_block_hash(spec, state):
+    """
+    Verify that get_parent_payload_status returns EMPTY when the parent
+    block's bid has EMPTY_BLOCK_HASH.
+    """
+    test_steps = []
+
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    anchor_root = get_anchor_root(spec, state)
+
+    store.blocks[
+        anchor_root
+    ].body.signed_execution_payload_bid.message.block_hash = spec.EMPTY_BLOCK_HASH
+
+    yield "anchor_state", state
+    yield "anchor_block", anchor_block
+
+    current_time = state.slot * (spec.config.SLOT_DURATION_MS // 1000) + store.genesis_time
+    on_tick_and_append_step(spec, store, current_time, test_steps)
+
+    # Add a block on top of genesis
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.signed_execution_payload_bid.message.parent_block_hash = spec.EMPTY_BLOCK_HASH
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    yield from tick_and_add_block(spec, store, signed_block, test_steps)
+
+    # Parent payload status should be EMPTY
+    assert spec.get_parent_payload_status(store, signed_block.message) == spec.PAYLOAD_STATUS_EMPTY
+
+    yield "steps", test_steps

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_get_parent_payload_status.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_get_parent_payload_status.py
@@ -21,7 +21,7 @@ from eth_consensus_specs.test.helpers.state import (
 def test_get_parent_payload_status__genesis_empty_block_hash(spec, state):
     """
     Verify that get_parent_payload_status returns EMPTY when the parent
-    block's bid has EMPTY_BLOCK_HASH.
+    block's bid has Hash32().
     """
     test_steps = []
 
@@ -30,7 +30,7 @@ def test_get_parent_payload_status__genesis_empty_block_hash(spec, state):
 
     store.blocks[
         anchor_root
-    ].body.signed_execution_payload_bid.message.block_hash = spec.EMPTY_BLOCK_HASH
+    ].body.signed_execution_payload_bid.message.block_hash = spec.Hash32()
 
     yield "anchor_state", state
     yield "anchor_block", anchor_block
@@ -40,7 +40,7 @@ def test_get_parent_payload_status__genesis_empty_block_hash(spec, state):
 
     # Add a block on top of genesis
     block = build_empty_block_for_next_slot(spec, state)
-    block.body.signed_execution_payload_bid.message.parent_block_hash = spec.EMPTY_BLOCK_HASH
+    block.body.signed_execution_payload_bid.message.parent_block_hash = spec.Hash32()
     signed_block = state_transition_and_sign_block(spec, state, block)
     yield from tick_and_add_block(spec, store, signed_block, test_steps)
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_get_parent_payload_status.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_get_parent_payload_status.py
@@ -28,9 +28,7 @@ def test_get_parent_payload_status__genesis_empty_block_hash(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     anchor_root = get_anchor_root(spec, state)
 
-    store.blocks[
-        anchor_root
-    ].body.signed_execution_payload_bid.message.block_hash = spec.Hash32()
+    store.blocks[anchor_root].body.signed_execution_payload_bid.message.block_hash = spec.Hash32()
 
     yield "anchor_state", state
     yield "anchor_block", anchor_block

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -198,10 +198,10 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 
     if is_post_gloas(spec):
         # Initialize the latest_execution_payload_bid (match fork upgrade in fork.md).
-        # Genesis payload is EMPTY: ``latest_block_hash`` is set to EMPTY_BLOCK_HASH while
+        # Genesis payload is EMPTY: ``latest_block_hash`` is set to Hash32() while
         # ``bid.block_hash`` is set to the eth1 block hash, so the parent of any
         # first post-genesis block is (correctly) treated as empty.
-        state.latest_block_hash = spec.EMPTY_BLOCK_HASH
+        state.latest_block_hash = spec.Hash32()
         empty_requests_root = spec.hash_tree_root(spec.ExecutionRequests())
         state.latest_execution_payload_bid = spec.ExecutionPayloadBid(
             block_hash=spec.Hash32(eth1_block_hash),

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -198,7 +198,7 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 
     if is_post_gloas(spec):
         # Initialize the latest_execution_payload_bid (match fork upgrade in fork.md).
-        # Genesis payload is EMPTY: ``latest_block_hash`` is set to Hash32() while
+        # Genesis payload is EMPTY: ``latest_block_hash`` stays at default zero while
         # ``bid.block_hash`` is set to the eth1 block hash, so the parent of any
         # first post-genesis block is (correctly) treated as empty.
         state.latest_block_hash = spec.Hash32()

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -198,9 +198,10 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 
     if is_post_gloas(spec):
         # Initialize the latest_execution_payload_bid (match fork upgrade in fork.md).
-        # Genesis payload is EMPTY: ``latest_block_hash`` stays at default zero while
+        # Genesis payload is EMPTY: ``latest_block_hash`` is set to EMPTY_BLOCK_HASH while
         # ``bid.block_hash`` is set to the eth1 block hash, so the parent of any
         # first post-genesis block is (correctly) treated as empty.
+        state.latest_block_hash = spec.EMPTY_BLOCK_HASH
         empty_requests_root = spec.hash_tree_root(spec.ExecutionRequests())
         state.latest_execution_payload_bid = spec.ExecutionPayloadBid(
             block_hash=spec.Hash32(eth1_block_hash),


### PR DESCRIPTION
# Description

At Gloas genesis, `latest_block_hash` and `latest_execution_payload_bid.block_hash` are both `Hash32()`. This makes the genesis block appear full even though no execution payload was delivered, forcing clients to add custom genesis checks to avoid incorrect behavior.

This PR adds an empty check to both so clients don't need to figure out custom handling for this case.

## Changes

- Check for uninitialized `Hash32()` in `process_parent_execution_payload`
- Check for uninitialized `Hash32()` in `process_withdrawals`

## Related

- Closes #5043
- #4598
