### PR TITLE
Skip fork and coverage flags for framework-only tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ COV_REPORT_DIR = $(PYSPEC_DIR)/.htmlcov
 #
 # Filtering
 test: MAYBE_TEST := $(if $(k),-k "$(k)")
-test: MAYBE_FORK := $(if $(fork),--fork=$(fork))
+test: MAYBE_FORK := $(if $(filter fw,$(component)),,$(if $(fork),--fork=$(fork)))
 test: PRESET := $(if $(filter fw,$(component)),,$(if $(preset),--preset=$(preset),))
 # Disable parallelism when running a specific test. Makes debugging difficult (print doesn't work).
 test: MAYBE_PARALLEL := $(if $(k),,-n logical --dist=worksteal)
@@ -215,7 +215,7 @@ test: COVERAGE_PRESETS := $(if $(preset),$(preset),$(if $(filter true,$(reftests
 test: COV_SCOPE_SINGLE := $(foreach P,$(COVERAGE_PRESETS), --cov=eth_consensus_specs.$(fork).$P)
 test: COV_SCOPE_ALL := $(foreach P,$(COVERAGE_PRESETS),$(foreach S,$(ALL_EXECUTABLE_SPEC_NAMES), --cov=eth_consensus_specs.$S.$P))
 test: COV_SCOPE := $(if $(filter true,$(coverage)),$(if $(fork),$(COV_SCOPE_SINGLE),$(COV_SCOPE_ALL)))
-test: COVERAGE := $(if $(filter true,$(coverage)),--coverage $(COV_SCOPE) --cov-report="html:$(COV_REPORT_DIR)" --cov-report="json:$(COV_REPORT_DIR)/coverage.json" --cov-branch --no-cov-on-fail)
+test: COVERAGE := $(if $(filter fw,$(component)),,$(if $(filter true,$(coverage)),--coverage $(COV_SCOPE) --cov-report="html:$(COV_REPORT_DIR)" --cov-report="json:$(COV_REPORT_DIR)/coverage.json" --cov-branch --no-cov-on-fail))
 test: _pyspec
 	@mkdir -p $(TEST_REPORT_DIR)
 	@$(UV_RUN) pytest \


### PR DESCRIPTION
## Description

Avoid passing pyspec-only `--fork` and coverage flags when `make test` runs in
`component=fw` mode. Framework-only runs do not load the pyspec `conftest.py`,
so the current command can fail with unrecognized arguments or collect coverage
for the wrong scope.

## Checklist

- [ ] Update documentation (if applicable)
- [x] Run `make test component=fw fork=deneb coverage=true k=test_manifest_decorator_basic`
- [ ] Run `make lint`
- [ ] Run full `make test`

## Relations

- Related to #5015