### PR TITLE
Add compliance testing support for Gloas

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/attestations.py
@@ -6,6 +6,7 @@ from eth_consensus_specs.test.helpers.forks import (
     is_post_altair,
     is_post_deneb,
     is_post_electra,
+    is_post_gloas,
 )
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
@@ -101,6 +102,7 @@ def get_valid_attestation(
     state,
     slot=None,
     index=None,
+    payload_index=None,
     filter_participant_set=None,
     beacon_block_root=None,
     signed=False,
@@ -119,6 +121,8 @@ def get_valid_attestation(
     attestation_data = build_attestation_data(
         spec, state, slot=slot, index=index, beacon_block_root=beacon_block_root
     )
+    if is_post_gloas(spec) and payload_index is not None:
+        attestation_data.index = payload_index
 
     attestation = spec.Attestation(data=attestation_data)
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -298,6 +298,10 @@ def get_sidecar_file_name(sidecar: DataColumnSidecar) -> str:
     return f"column_{encode_hex(sidecar.hash_tree_root())}"
 
 
+def get_payload_attestation_message_file_name(ptc_message):
+    return f"payload_attestation_{encode_hex(ptc_message.hash_tree_root())}"
+
+
 def on_tick_and_append_step(spec, store, time, test_steps):
     assert time >= store.time
     spec.on_tick(store, time)
@@ -393,6 +397,24 @@ def add_block(
     # An on_block step implies receiving block's attester slashings
     for attester_slashing in signed_block.message.body.attester_slashings:
         run_on_attester_slashing(spec, store, attester_slashing, valid=True)
+    
+    if is_post_gloas(spec):
+        # An on_block step implies receiving block's payload attestations (post GLOAS)
+        state = store.block_states[signed_block.message.hash_tree_root()]
+        for payload_attestation in signed_block.message.body.payload_attestations:
+            slot = payload_attestation.data.slot
+            ptc = spec.get_ptc(state, slot)
+            bits = payload_attestation.aggregation_bits
+            attesting_indices = [index for i, index in enumerate(ptc) if bits[i]]
+            for validator_index in attesting_indices:
+                ptc_message = spec.PayloadAttestationMessage(
+                    validator_index=validator_index,
+                    data=payload_attestation.data,
+                    signature=spec.BLSSignature()
+                )
+                run_on_payload_attestation_message(
+                    spec, store, ptc_message, is_from_block=True, valid=True
+                )
 
     block_root = signed_block.message.hash_tree_root()
     assert store.blocks[block_root] == signed_block.message
@@ -458,6 +480,27 @@ def add_attester_slashing(spec, store, attester_slashing, test_steps, valid=True
 
     run_on_attester_slashing(spec, store, attester_slashing)
     test_steps.append({"attester_slashing": slashing_file_name})
+
+
+def run_on_payload_attestation_message(spec, store, ptc_message, is_from_block=False, valid=True):
+    if not valid:
+        expect_assertion_error(lambda: spec.on_payload_attestation_message(store, ptc_message, is_from_block=is_from_block))
+        return
+    
+    spec.on_payload_attestation_message(store, ptc_message, is_from_block=is_from_block)
+
+
+def add_payload_attestation_message(spec, store, ptc_message, test_steps, valid=True):
+    ptc_file_name = get_payload_attestation_message_file_name(ptc_message)
+    yield ptc_file_name, ptc_message
+    
+    if not valid:
+        expect_assertion_error(lambda: spec.on_payload_attestation_message(store, ptc_message))
+        test_steps.append({"payload_attestation": ptc_file_name, "valid": False})
+        return
+
+    run_on_payload_attestation_message(spec, store, ptc_message)
+    test_steps.append({"payload_attestation": ptc_file_name})
 
 
 def _get_head_root(spec, store):

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -397,7 +397,7 @@ def add_block(
     # An on_block step implies receiving block's attester slashings
     for attester_slashing in signed_block.message.body.attester_slashings:
         run_on_attester_slashing(spec, store, attester_slashing, valid=True)
-    
+
     if is_post_gloas(spec):
         # An on_block step implies receiving block's payload attestations (post GLOAS)
         state = store.block_states[signed_block.message.hash_tree_root()]
@@ -410,7 +410,7 @@ def add_block(
                 ptc_message = spec.PayloadAttestationMessage(
                     validator_index=validator_index,
                     data=payload_attestation.data,
-                    signature=spec.BLSSignature()
+                    signature=spec.BLSSignature(),
                 )
                 run_on_payload_attestation_message(
                     spec, store, ptc_message, is_from_block=True, valid=True
@@ -484,16 +484,20 @@ def add_attester_slashing(spec, store, attester_slashing, test_steps, valid=True
 
 def run_on_payload_attestation_message(spec, store, ptc_message, is_from_block=False, valid=True):
     if not valid:
-        expect_assertion_error(lambda: spec.on_payload_attestation_message(store, ptc_message, is_from_block=is_from_block))
+        expect_assertion_error(
+            lambda: spec.on_payload_attestation_message(
+                store, ptc_message, is_from_block=is_from_block
+            )
+        )
         return
-    
+
     spec.on_payload_attestation_message(store, ptc_message, is_from_block=is_from_block)
 
 
 def add_payload_attestation_message(spec, store, ptc_message, test_steps, valid=True):
     ptc_file_name = get_payload_attestation_message_file_name(ptc_message)
     yield ptc_file_name, ptc_message
-    
+
     if not valid:
         expect_assertion_error(lambda: spec.on_payload_attestation_message(store, ptc_message))
         test_steps.append({"payload_attestation": ptc_file_name, "valid": False})

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -17,10 +17,12 @@ components of the fork choice.
     - [`on_attester_slashing` execution step](#on_attester_slashing-execution-step)
     - [`on_payload_info` execution step](#on_payload_info-execution-step)
     - [`on_execution_payload_envelope` execution step](#on_execution_payload_envelope-execution-step)
+    - [`on_payload_attestation` execution step](#on_payload_attestation-execution-step)
     - [Checks step](#checks-step)
   - [`attestation_<32-byte-root>.ssz_snappy`](#attestation_32-byte-rootssz_snappy)
   - [`block_<32-byte-root>.ssz_snappy`](#block_32-byte-rootssz_snappy)
   - [`execution_payload_envelope_<32-byte-root>.ssz_snappy`](#execution_payload_envelope_32-byte-rootssz_snappy)
+  - [`payload_attestation_<32-byte-root>.ssz_snappy`](#payload_attestation_32-byte-rootssz_snappy)
 - [Condition](#condition)
 
 <!-- mdformat-toc end -->
@@ -200,6 +202,26 @@ The file is located in the same folder (see below).
 
 After this step, the `store` object may have been updated.
 
+#### `on_payload_attestation` execution step
+
+The parameter that is required for executing
+`on_payload_attestation_message(store, ptc_message)`.
+
+```yaml
+{
+    payload_attestation: string  -- the name of the `payload_attestation_<32-byte-root>.ssz_snappy` file.
+                                   To execute `on_payload_attestation_message(store, ptc_message)` with the given message.
+    valid: bool                  -- optional, default to `true`.
+                                   If it's `false`, this execution step is expected to be invalid.
+}
+```
+
+The file is located in the same folder (see below).
+
+This execution step is available for Gloas and later forks.
+
+After this step, the `store` object may have been updated.
+
 #### Checks step
 
 The checks to verify the current status of `store`.
@@ -285,6 +307,13 @@ Each file is an SSZ-snappy encoded `SignedBeaconBlock`.
 
 Each file is an SSZ-snappy encoded `SignedExecutionPayloadEnvelope`.
 
+### `payload_attestation_<32-byte-root>.ssz_snappy`
+
+`<32-byte-root>` is the hash tree root of the given payload attestation
+message.
+
+Each file is an SSZ-snappy encoded `PayloadAttestationMessage`.
+
 ## Condition
 
 1. Deserialize `anchor_state.ssz_snappy` and `anchor_block.ssz_snappy` to
@@ -297,8 +326,17 @@ Each file is an SSZ-snappy encoded `SignedExecutionPayloadEnvelope`.
        `len(block.message.body.attestations) > 0`, execute each attestation with
        `on_attestation(store, attestation)` after executing
        `on_block(store, block)`.
+       For Gloas and later forks, if
+       `len(block.message.body.payload_attestations) > 0`, expand each
+       `PayloadAttestation` into its constituent `PayloadAttestationMessage`
+       values and execute each one with
+       `on_payload_attestation_message(store, ptc_message, is_from_block=True)`
+       after executing `on_block(store, block)`.
      - For the `on_execution_payload_envelope` execution step: look up the
        corresponding `execution_payload_envelope_<root>.ssz_snappy` file and
        execute `on_execution_payload_envelope(store, signed_envelope)`.
+     - For the `on_payload_attestation` execution step: look up the
+       corresponding `payload_attestation_<root>.ssz_snappy` file and execute
+       `on_payload_attestation_message(store, ptc_message)`.
    - For each `checks` step, the assertions on the current store must be
      satisfied.

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -309,8 +309,7 @@ Each file is an SSZ-snappy encoded `SignedExecutionPayloadEnvelope`.
 
 ### `payload_attestation_<32-byte-root>.ssz_snappy`
 
-`<32-byte-root>` is the hash tree root of the given payload attestation
-message.
+`<32-byte-root>` is the hash tree root of the given payload attestation message.
 
 Each file is an SSZ-snappy encoded `PayloadAttestationMessage`.
 
@@ -325,8 +324,7 @@ Each file is an SSZ-snappy encoded `PayloadAttestationMessage`.
      - For the `on_block` execution step: if
        `len(block.message.body.attestations) > 0`, execute each attestation with
        `on_attestation(store, attestation)` after executing
-       `on_block(store, block)`.
-       For Gloas and later forks, if
+       `on_block(store, block)`. For Gloas and later forks, if
        `len(block.message.body.payload_attestations) > 0`, expand each
        `PayloadAttestation` into its constituent `PayloadAttestationMessage`
        values and execute each one with

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
@@ -102,7 +102,7 @@ def _generate_filter_block_tree(
         while state.slot < threshold_slot:
             # Do not include attestations into blocks
             if state.slot < spec.compute_start_slot_at_epoch(epoch):
-                new_block, state, _, _ = produce_block(spec, state, [])
+                new_block, state, _, _, _ = produce_block(spec, state, [])
                 signed_blocks.append(new_block)
             else:
                 # Prevent previous epoch from being accidentally justified
@@ -111,7 +111,7 @@ def _generate_filter_block_tree(
                     a for a in attestations if epoch == spec.compute_epoch_at_slot(a.data.slot)
                 ]
                 other_attestations = [a for a in attestations if a not in curr_epoch_attestations]
-                new_block, state, curr_epoch_attestations, _ = produce_block(
+                new_block, state, curr_epoch_attestations, _, _ = produce_block(
                     spec, state, curr_epoch_attestations
                 )
                 attestations = other_attestations + curr_epoch_attestations
@@ -163,7 +163,7 @@ def _generate_filter_block_tree(
                     block_attestations = block_attestations + current_epoch_attestations
 
                 # Propose block
-                new_block, state, _, _ = produce_block(spec, state, block_attestations)
+                new_block, state, _, _, _ = produce_block(spec, state, block_attestations)
                 signed_blocks.append(new_block)
 
             # Attest

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -4,7 +4,7 @@ from eth_consensus_specs.test.helpers.attester_slashings import (
     get_valid_attester_slashing_by_indices,
 )
 from eth_consensus_specs.test.helpers.execution_payload import (
-    build_signed_execution_payload_envelope
+    build_signed_execution_payload_envelope,
 )
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
@@ -502,18 +502,27 @@ def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
             slot=attested_slot,
             payload_present=rnd.choice([True, False]),
         )
-        messages.append(spec.PayloadAttestationMessage(
-            validator_index=validator_index,
-            data=data,
-            signature=spec.BLSSignature(),
-        ))
+        messages.append(
+            spec.PayloadAttestationMessage(
+                validator_index=validator_index,
+                data=data,
+                signature=spec.BLSSignature(),
+            )
+        )
 
     return messages
 
 
-def _disseminate(rnd, message, off_chain_list, in_block_list,
-                 off_chain_rate, on_chain_rate,
-                 with_invalid_messages, spoil_fn=None):
+def _disseminate(
+    rnd,
+    message,
+    off_chain_list,
+    in_block_list,
+    off_chain_rate,
+    on_chain_rate,
+    with_invalid_messages,
+    spoil_fn=None,
+):
     """
     Randomly assigns a protocol message to off-chain, on-chain, or both dissemination paths.
     Optionally spoils the message to make it invalid (off-chain only path).
@@ -591,12 +600,12 @@ def _generate_block_tree(
                     in_block_attestations,
                     in_block_attester_slashings,
                     in_block_pa_messages,
-                ) = (
-                    produce_block(
-                        spec, parent_state, in_block_attestations,
-                        in_block_attester_slashings,
-                        in_block_pa_messages
-                    )
+                ) = produce_block(
+                    spec,
+                    parent_state,
+                    in_block_attestations,
+                    in_block_attester_slashings,
+                    in_block_pa_messages,
                 )
 
                 # Valid block
@@ -611,7 +620,9 @@ def _generate_block_tree(
 
                 if is_post_gloas(spec):
                     # Builder reveals execution payload
-                    envelope = build_signed_execution_payload_envelope(spec, post_state, block_root, signed_block)
+                    envelope = build_signed_execution_payload_envelope(
+                        spec, post_state, block_root, signed_block
+                    )
 
                 # Next block
             block_index += 1
@@ -641,21 +652,34 @@ def _generate_block_tree(
 
             # Sample on chain and off chain attestations
             for a in attestations_in_slot:
-                _disseminate(rnd, a, out_of_block_attestation_messages, in_block_attestations,
-                             OFF_CHAIN_ATTESTATION_RATE, ON_CHAIN_ATTESTATION_RATE,
-                             with_invalid_messages,
-                             spoil_fn=lambda msg: _spoil_attestation(spec, rnd, msg))
+                _disseminate(
+                    rnd,
+                    a,
+                    out_of_block_attestation_messages,
+                    in_block_attestations,
+                    OFF_CHAIN_ATTESTATION_RATE,
+                    ON_CHAIN_ATTESTATION_RATE,
+                    with_invalid_messages,
+                    spoil_fn=lambda msg: _spoil_attestation(spec, rnd, msg),
+                )
 
         if is_post_gloas(spec) and envelope is not None:
             signed_envelope_messages.append(ProtocolMessage(envelope, True))
 
             if is_post_gloas(spec):
                 for ptc_message in _get_random_payload_attestation_messages(spec, post_state, rnd):
-                    _disseminate(rnd, ptc_message, out_of_block_pa_messages, in_block_pa_messages,
-                                 OFF_CHAIN_ATTESTATION_RATE, ON_CHAIN_ATTESTATION_RATE,
-                                 with_invalid_messages,
-                                 spoil_fn=lambda msg: _spoil_payload_attestation_message(spec, rnd, post_state, msg))
-
+                    _disseminate(
+                        rnd,
+                        ptc_message,
+                        out_of_block_pa_messages,
+                        in_block_pa_messages,
+                        OFF_CHAIN_ATTESTATION_RATE,
+                        ON_CHAIN_ATTESTATION_RATE,
+                        with_invalid_messages,
+                        spoil_fn=lambda msg: _spoil_payload_attestation_message(
+                            spec, rnd, post_state, msg
+                        ),
+                    )
 
         # Create attester slashing
         if with_attester_slashings and attester_slashings_count < MAX_ATTESTER_SLASHINGS:
@@ -666,11 +690,16 @@ def _generate_block_tree(
                     spec, state, indices, slot=current_slot, signed_1=True, signed_2=True
                 )
 
-                _disseminate(rnd, attester_slashing,
-                             out_of_block_attester_slashing_messages, in_block_attester_slashings,
-                             OFF_CHAIN_SLASHING_RATE, ON_CHAIN_SLASHING_RATE,
-                             with_invalid_messages,
-                             spoil_fn=lambda msg: _spoil_attester_slashing(spec, rnd, msg))
+                _disseminate(
+                    rnd,
+                    attester_slashing,
+                    out_of_block_attester_slashing_messages,
+                    in_block_attester_slashings,
+                    OFF_CHAIN_SLASHING_RATE,
+                    ON_CHAIN_SLASHING_RATE,
+                    with_invalid_messages,
+                    spoil_fn=lambda msg: _spoil_attester_slashing(spec, rnd, msg),
+                )
 
                 attester_slashings_count += 1
 

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -53,6 +53,7 @@ ON_CHAIN_SLASHING_RATE = 33
 
 INVALID_MESSAGES_RATE = 5
 EXECUTION_PAYLOAD_SEND_RATE = 65
+PAYLOAD_ATTESTATION_SEND_RATE = 65
 
 
 class SmLink(tuple):
@@ -681,7 +682,12 @@ def _generate_block_tree(
                 )
 
         if is_post_gloas(spec):
-            if valid_block_was_produced:
+            if valid_block_was_produced and rnd.randint(0, 99) < PAYLOAD_ATTESTATION_SEND_RATE:
+                # TODO: Consider explicit payload-attestation cases without a
+                # newly produced block in this iteration, e.g. delayed votes
+                # for an older known block root or invalid votes for an unknown
+                # root. Those should stay out of the orderly base scenario
+                # unless `with_invalid_messages` is enabled.
                 for ptc_message in _get_random_payload_attestation_messages(
                     spec, post_state, rnd
                 ):

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -52,6 +52,7 @@ OFF_CHAIN_SLASHING_RATE = 33
 ON_CHAIN_SLASHING_RATE = 33
 
 INVALID_MESSAGES_RATE = 5
+EXECUTION_PAYLOAD_SEND_RATE = 65
 
 
 class SmLink(tuple):
@@ -473,6 +474,10 @@ def _spoil_payload_attestation_message(spec, rnd: random.Random, state, ptc_mess
     ptc_message.validator_index = (ptc_message.validator_index + 1) % len(state.validators)
 
 
+def _spoil_execution_payload_envelope(spec, rnd: random.Random, signed_envelope):
+    signed_envelope.message.payload.parent_hash = spec.Hash32(rnd.randbytes(32))
+
+
 def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
     """Build random PayloadAttestationMessage objects with diverse PTC vote values."""
     attested_slot = state.latest_block_header.slot
@@ -568,6 +573,7 @@ def _generate_block_tree(
 
     while block_index < len(block_parents):
         envelope = None
+        valid_block_was_produced = False
         # Propose a block if slot shouldn't be empty
         if rnd.randint(1, 100) > EMPTY_SLOTS_RATE:
             # Advance parent state to the current slot
@@ -612,6 +618,7 @@ def _generate_block_tree(
                 # Valid block
                 signed_block_messages.append(ProtocolMessage(signed_block, True))
                 post_states.append(post_state)
+                valid_block_was_produced = True
 
                 # Update tips
                 block_tree_tips.discard(parent_index)
@@ -619,14 +626,23 @@ def _generate_block_tree(
 
                 block_root = signed_block.message.hash_tree_root()
 
-                if is_post_gloas(spec):
-                    # Builder reveals execution payload
-                    envelope = build_signed_execution_payload_envelope(
-                        spec, post_state, block_root, signed_block
-                    )
-
                 # Next block
             block_index += 1
+
+        if is_post_gloas(spec) and valid_block_was_produced:
+            # Builder reveals execution payload
+            envelope = build_signed_execution_payload_envelope(
+                spec, post_state, block_root, signed_block
+            )
+            if rnd.randint(0, 99) < EXECUTION_PAYLOAD_SEND_RATE:
+                # TODO: Consider an explicit invalid case for an execution payload
+                # targeting an unknown beacon block root. That should stay out of
+                # the orderly base scenario unless `with_invalid_messages` is enabled.
+                valid = True
+                if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+                    _spoil_execution_payload_envelope(spec, rnd, envelope)
+                    valid = False
+                signed_envelope_messages.append(ProtocolMessage(envelope, valid))
 
         # Attest to randomly selected tips
         def split_list(lst, n):
@@ -664,11 +680,11 @@ def _generate_block_tree(
                     spoil_fn=lambda msg: _spoil_attestation(spec, rnd, msg),
                 )
 
-        if is_post_gloas(spec) and envelope is not None:
-            signed_envelope_messages.append(ProtocolMessage(envelope, True))
-
-            if is_post_gloas(spec):
-                for ptc_message in _get_random_payload_attestation_messages(spec, post_state, rnd):
+        if is_post_gloas(spec):
+            if valid_block_was_produced:
+                for ptc_message in _get_random_payload_attestation_messages(
+                    spec, post_state, rnd
+                ):
                     _disseminate(
                         rnd,
                         ptc_message,

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -3,9 +3,13 @@ import random
 from eth_consensus_specs.test.helpers.attester_slashings import (
     get_valid_attester_slashing_by_indices,
 )
+from eth_consensus_specs.test.helpers.execution_payload import (
+    build_signed_execution_payload_envelope
+)
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
+from eth_consensus_specs.test.helpers.forks import is_post_gloas
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
     transition_to,
@@ -465,7 +469,7 @@ def _generate_block_tree(
     block_parents,
     with_attester_slashings,
     with_invalid_messages,
-) -> ([], [], []):
+) -> ([], [], [], []):
     in_block_attestations = anchor_tip.attestations.copy()
     post_states = [anchor_tip.beacon_state.copy()]
     current_slot = anchor_tip.beacon_state.slot
@@ -476,8 +480,10 @@ def _generate_block_tree(
     out_of_block_attestation_messages = []
     out_of_block_attester_slashing_messages = []
     signed_block_messages = []
+    signed_envelope_messages = []
 
     while block_index < len(block_parents):
+        envelope = None
         # Propose a block if slot shouldn't be empty
         if rnd.randint(1, 100) > EMPTY_SLOTS_RATE:
             # Advance parent state to the current slot
@@ -518,6 +524,12 @@ def _generate_block_tree(
                 # Update tips
                 block_tree_tips.discard(parent_index)
                 block_tree_tips.add(block_index)
+
+                block_root = signed_block.message.hash_tree_root()
+
+                if is_post_gloas(spec):
+                    # Builder reveals execution payload
+                    envelope = build_signed_execution_payload_envelope(spec, post_state, block_root, signed_block)
 
                 # Next block
             block_index += 1
@@ -560,6 +572,9 @@ def _generate_block_tree(
                 else:
                     out_of_block_attestation_messages.append(ProtocolMessage(a, True))
                     in_block_attestations.insert(0, a)
+
+        if is_post_gloas(spec) and envelope is not None:
+            signed_envelope_messages.append(ProtocolMessage(envelope, True))
 
         # Create attester slashing
         if with_attester_slashings and attester_slashings_count < MAX_ATTESTER_SLASHINGS:
@@ -631,6 +646,7 @@ def _generate_block_tree(
         sorted(
             out_of_block_attester_slashing_messages, key=lambda a: a.payload.attestation_1.data.slot
         ),
+        sorted(signed_envelope_messages, key=lambda e: e.payload.message.payload.slot_number),
     )
 
 
@@ -680,7 +696,7 @@ def gen_block_tree_test_data(
         seed = new_seed
 
     # Block tree model
-    block_tree, attestation_messages, attester_slashing_messages = _generate_block_tree(
+    block_tree, attestation_messages, attester_slashing_messages, envelopes = _generate_block_tree(
         spec, highest_tip, rnd, debug, block_parents, with_attester_slashings, with_invalid_messages
     )
 
@@ -706,4 +722,5 @@ def gen_block_tree_test_data(
         signed_block_messages,
         attestation_messages,
         attester_slashing_messages,
+        envelopes,
     )

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -680,7 +680,10 @@ def _generate_block_tree(
                         att_payload_index_invalid = True
                     else:
                         payload_index = 0
-                elif attesting_block_index != new_block_index and attesting_block_index in payload_known_block_indices:
+                elif (
+                    attesting_block_index != new_block_index
+                    and attesting_block_index in payload_known_block_indices
+                ):
                     if rnd.randint(0, 99) < GLOAS_FULL_ATTESTATION_RATE:
                         payload_index = 1
                     else:
@@ -718,9 +721,7 @@ def _generate_block_tree(
                 # for an older known block root or invalid votes for an unknown
                 # root. Those should stay out of the orderly base scenario
                 # unless `with_invalid_messages` is enabled.
-                for ptc_message in _get_random_payload_attestation_messages(
-                    spec, post_state, rnd
-                ):
+                for ptc_message in _get_random_payload_attestation_messages(spec, post_state, rnd):
                     _disseminate(
                         rnd,
                         ptc_message,

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -474,7 +474,7 @@ def _spoil_payload_attestation_message(spec, rnd: random.Random, state, ptc_mess
 
 
 def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
-    """Build random PayloadAttestationMessage objects with diverse payload_present values."""
+    """Build random PayloadAttestationMessage objects with diverse PTC vote values."""
     attested_slot = state.latest_block_header.slot
     if attested_slot != state.slot or attested_slot == 0:
         return []
@@ -501,6 +501,7 @@ def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
             beacon_block_root=beacon_block_root,
             slot=attested_slot,
             payload_present=rnd.choice([True, False]),
+            blob_data_available=rnd.choice([True, False]),
         )
         messages.append(
             spec.PayloadAttestationMessage(

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -54,6 +54,7 @@ ON_CHAIN_SLASHING_RATE = 33
 INVALID_MESSAGES_RATE = 5
 EXECUTION_PAYLOAD_SEND_RATE = 65
 PAYLOAD_ATTESTATION_SEND_RATE = 65
+GLOAS_FULL_ATTESTATION_RATE = 50
 
 
 class SmLink(tuple):
@@ -571,10 +572,13 @@ def _generate_block_tree(
     signed_block_messages = []
     signed_envelope_messages = []
     in_block_pa_messages = []
+    payload_known_block_indices = set()
 
     while block_index < len(block_parents):
         envelope = None
         valid_block_was_produced = False
+        new_block_index = None
+        valid_execution_payload_sent = False
         # Propose a block if slot shouldn't be empty
         if rnd.randint(1, 100) > EMPTY_SLOTS_RATE:
             # Advance parent state to the current slot
@@ -620,6 +624,7 @@ def _generate_block_tree(
                 signed_block_messages.append(ProtocolMessage(signed_block, True))
                 post_states.append(post_state)
                 valid_block_was_produced = True
+                new_block_index = block_index
 
                 # Update tips
                 block_tree_tips.discard(parent_index)
@@ -644,6 +649,9 @@ def _generate_block_tree(
                     _spoil_execution_payload_envelope(spec, rnd, envelope)
                     valid = False
                 signed_envelope_messages.append(ProtocolMessage(envelope, valid))
+                valid_execution_payload_sent = valid
+                if valid:
+                    payload_known_block_indices.add(new_block_index)
 
         # Attest to randomly selected tips
         def split_list(lst, n):
@@ -661,25 +669,47 @@ def _generate_block_tree(
             transition_to(spec, attesting_state, current_slot)
 
             # Attest to the block
+            payload_index = None
+            att_payload_index_invalid = False
+            if is_post_gloas(spec):
+                if valid_execution_payload_sent and attesting_block_index == new_block_index:
+                    if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+                        # payload_index=1 for a same-slot block is GLOAS-invalid:
+                        # spec requires data.index==0 when block_slot==attestation.data.slot
+                        payload_index = 1
+                        att_payload_index_invalid = True
+                    else:
+                        payload_index = 0
+                elif attesting_block_index != new_block_index and attesting_block_index in payload_known_block_indices:
+                    if rnd.randint(0, 99) < GLOAS_FULL_ATTESTATION_RATE:
+                        payload_index = 1
+                    else:
+                        payload_index = 0
             attestations_in_slot = attest_to_slot(
                 spec,
                 attesting_state,
                 attesting_state.slot,
                 lambda comm: [i for i in comm if i in attesters[index]],
+                payload_index=payload_index,
             )
 
             # Sample on chain and off chain attestations
             for a in attestations_in_slot:
-                _disseminate(
-                    rnd,
-                    a,
-                    out_of_block_attestation_messages,
-                    in_block_attestations,
-                    OFF_CHAIN_ATTESTATION_RATE,
-                    ON_CHAIN_ATTESTATION_RATE,
-                    with_invalid_messages,
-                    spoil_fn=lambda msg: _spoil_attestation(spec, rnd, msg),
-                )
+                if att_payload_index_invalid:
+                    # Already known invalid due to GLOAS payload_index constraint;
+                    # skip _disseminate to avoid it being marked valid=True
+                    out_of_block_attestation_messages.append(ProtocolMessage(a, False))
+                else:
+                    _disseminate(
+                        rnd,
+                        a,
+                        out_of_block_attestation_messages,
+                        in_block_attestations,
+                        OFF_CHAIN_ATTESTATION_RATE,
+                        ON_CHAIN_ATTESTATION_RATE,
+                        with_invalid_messages,
+                        spoil_fn=lambda msg: _spoil_attestation(spec, rnd, msg),
+                    )
 
         if is_post_gloas(spec):
             if valid_block_was_produced and rnd.randint(0, 99) < PAYLOAD_ATTESTATION_SEND_RATE:

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -10,6 +10,9 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
 from eth_consensus_specs.test.helpers.forks import is_post_gloas
+from eth_consensus_specs.test.helpers.keys import (
+    privkeys,
+)
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
     transition_to,
@@ -363,7 +366,7 @@ def _generate_sm_link_tree(
                 while spec.get_beacon_proposer_index(state) not in advanced_branch_tip.participants:
                     next_slot(spec, state)
 
-                tip_block, _, _, _ = produce_block(spec, state, [])
+                tip_block, _, _, _, _ = produce_block(spec, state, [])
                 new_signed_blocks.append(tip_block)
 
                 assert state.current_justified_checkpoint.epoch == sm_link.target, (
@@ -461,6 +464,75 @@ def _spoil_attestation(spec, rnd: random.Random, attestation):
     attestation.data.target.epoch = spec.GENESIS_EPOCH
 
 
+def _spoil_payload_attestation_message(spec, rnd: random.Random, state, ptc_message):
+    ptc = spec.get_ptc(state, ptc_message.data.slot)
+    for validator_index in range(len(state.validators)):
+        if validator_index not in ptc:
+            ptc_message.validator_index = validator_index
+            return
+    ptc_message.validator_index = (ptc_message.validator_index + 1) % len(state.validators)
+
+
+def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
+    """Build random PayloadAttestationMessage objects with diverse payload_present values."""
+    attested_slot = state.latest_block_header.slot
+    if attested_slot != state.slot or attested_slot == 0:
+        return []
+
+    parent_header = state.latest_block_header.copy()
+    if parent_header.state_root == spec.Root():
+        parent_header.state_root = spec.hash_tree_root(state)
+    beacon_block_root = spec.hash_tree_root(parent_header)
+
+    ptc = spec.get_ptc(state, attested_slot)
+    if len(ptc) == 0:
+        return []
+
+    num_attesters = rnd.randint(len(ptc) // 2, len(ptc))
+    attesting_indices = rnd.sample(list(ptc), num_attesters) if num_attesters > 0 else []
+    if not attesting_indices:
+        return []
+
+    messages = []
+    for validator_index in attesting_indices:
+        if validator_index >= len(privkeys):
+            continue
+        data = spec.PayloadAttestationData(
+            beacon_block_root=beacon_block_root,
+            slot=attested_slot,
+            payload_present=rnd.choice([True, False]),
+        )
+        messages.append(spec.PayloadAttestationMessage(
+            validator_index=validator_index,
+            data=data,
+            signature=spec.BLSSignature(),
+        ))
+
+    return messages
+
+
+def _disseminate(rnd, message, off_chain_list, in_block_list,
+                 off_chain_rate, on_chain_rate,
+                 with_invalid_messages, spoil_fn=None):
+    """
+    Randomly assigns a protocol message to off-chain, on-chain, or both dissemination paths.
+    Optionally spoils the message to make it invalid (off-chain only path).
+    """
+    choice = rnd.randint(0, 99)
+    if choice < off_chain_rate:
+        if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+            if spoil_fn:
+                spoil_fn(message)
+            off_chain_list.append(ProtocolMessage(message, False))
+        else:
+            off_chain_list.append(ProtocolMessage(message, True))
+    elif choice < off_chain_rate + on_chain_rate:
+        in_block_list.append(message)
+    else:
+        off_chain_list.append(ProtocolMessage(message, True))
+        in_block_list.append(message)
+
+
 def _generate_block_tree(
     spec,
     anchor_tip: BranchTip,
@@ -469,7 +541,7 @@ def _generate_block_tree(
     block_parents,
     with_attester_slashings,
     with_invalid_messages,
-) -> ([], [], [], []):
+) -> ([], [], [], [], []):
     in_block_attestations = anchor_tip.attestations.copy()
     post_states = [anchor_tip.beacon_state.copy()]
     current_slot = anchor_tip.beacon_state.slot
@@ -478,9 +550,11 @@ def _generate_block_tree(
     in_block_attester_slashings = []
     attester_slashings_count = 0
     out_of_block_attestation_messages = []
+    out_of_block_pa_messages = []
     out_of_block_attester_slashing_messages = []
     signed_block_messages = []
     signed_envelope_messages = []
+    in_block_pa_messages = []
 
     while block_index < len(block_parents):
         envelope = None
@@ -505,15 +579,23 @@ def _generate_block_tree(
             ):
                 # Do not include attestations and slashings into invalid block
                 # as clients may opt in to process or not process attestations contained by invalid block
-                signed_block, _, _, _ = produce_block(spec, parent_state, [], [])
+                signed_block, _, _, _, _ = produce_block(spec, parent_state, [], [], [])
                 _spoil_block(spec, rnd, signed_block)
                 signed_block_messages.append(ProtocolMessage(signed_block, False))
                 # Append the parent state as the post state as if the block were not applied
                 post_states.append(parent_state)
             else:
-                signed_block, post_state, in_block_attestations, in_block_attester_slashings = (
+                (
+                    signed_block,
+                    post_state,
+                    in_block_attestations,
+                    in_block_attester_slashings,
+                    in_block_pa_messages,
+                ) = (
                     produce_block(
-                        spec, parent_state, in_block_attestations, in_block_attester_slashings
+                        spec, parent_state, in_block_attestations,
+                        in_block_attester_slashings,
+                        in_block_pa_messages
                     )
                 )
 
@@ -559,22 +641,21 @@ def _generate_block_tree(
 
             # Sample on chain and off chain attestations
             for a in attestations_in_slot:
-                choice = rnd.randint(0, 99)
-                if choice < OFF_CHAIN_ATTESTATION_RATE:
-                    if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
-                        _spoil_attestation(spec, rnd, a)
-                        attestation_message = ProtocolMessage(a, False)
-                    else:
-                        attestation_message = ProtocolMessage(a, True)
-                    out_of_block_attestation_messages.append(attestation_message)
-                elif choice < OFF_CHAIN_ATTESTATION_RATE + ON_CHAIN_ATTESTATION_RATE:
-                    in_block_attestations.insert(0, a)
-                else:
-                    out_of_block_attestation_messages.append(ProtocolMessage(a, True))
-                    in_block_attestations.insert(0, a)
+                _disseminate(rnd, a, out_of_block_attestation_messages, in_block_attestations,
+                             OFF_CHAIN_ATTESTATION_RATE, ON_CHAIN_ATTESTATION_RATE,
+                             with_invalid_messages,
+                             spoil_fn=lambda msg: _spoil_attestation(spec, rnd, msg))
 
         if is_post_gloas(spec) and envelope is not None:
             signed_envelope_messages.append(ProtocolMessage(envelope, True))
+
+            if is_post_gloas(spec):
+                for ptc_message in _get_random_payload_attestation_messages(spec, post_state, rnd):
+                    _disseminate(rnd, ptc_message, out_of_block_pa_messages, in_block_pa_messages,
+                                 OFF_CHAIN_ATTESTATION_RATE, ON_CHAIN_ATTESTATION_RATE,
+                                 with_invalid_messages,
+                                 spoil_fn=lambda msg: _spoil_payload_attestation_message(spec, rnd, post_state, msg))
+
 
         # Create attester slashing
         if with_attester_slashings and attester_slashings_count < MAX_ATTESTER_SLASHINGS:
@@ -585,21 +666,11 @@ def _generate_block_tree(
                     spec, state, indices, slot=current_slot, signed_1=True, signed_2=True
                 )
 
-                choice = rnd.randint(0, 99)
-                if choice < OFF_CHAIN_SLASHING_RATE:
-                    if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
-                        _spoil_attester_slashing(spec, rnd, attester_slashing)
-                        attester_slashing_message = ProtocolMessage(attester_slashing, False)
-                    else:
-                        attester_slashing_message = ProtocolMessage(attester_slashing, True)
-                    out_of_block_attester_slashing_messages.append(attester_slashing_message)
-                elif choice < OFF_CHAIN_SLASHING_RATE + ON_CHAIN_SLASHING_RATE:
-                    in_block_attester_slashings.append(attester_slashing)
-                else:
-                    out_of_block_attester_slashing_messages.append(
-                        ProtocolMessage(attester_slashing, True)
-                    )
-                    in_block_attester_slashings.append(attester_slashing)
+                _disseminate(rnd, attester_slashing,
+                             out_of_block_attester_slashing_messages, in_block_attester_slashings,
+                             OFF_CHAIN_SLASHING_RATE, ON_CHAIN_SLASHING_RATE,
+                             with_invalid_messages,
+                             spoil_fn=lambda msg: _spoil_attester_slashing(spec, rnd, msg))
 
                 attester_slashings_count += 1
 
@@ -632,6 +703,13 @@ def _generate_block_tree(
             "valid =",
             len([a for a in out_of_block_attestation_messages if a.valid]),
         )
+        print("on_payload_attestation_message:")
+        print("              ", "count =", len(out_of_block_pa_messages))
+        print(
+            "              ",
+            "valid =",
+            len([a for a in out_of_block_pa_messages if a.valid]),
+        )
         print("on_attester_slashing:")
         print("              ", "count =", len(out_of_block_attester_slashing_messages))
         print(
@@ -647,6 +725,7 @@ def _generate_block_tree(
             out_of_block_attester_slashing_messages, key=lambda a: a.payload.attestation_1.data.slot
         ),
         sorted(signed_envelope_messages, key=lambda e: e.payload.message.payload.slot_number),
+        sorted(out_of_block_pa_messages, key=lambda a: a.payload.data.slot),
     )
 
 
@@ -696,7 +775,13 @@ def gen_block_tree_test_data(
         seed = new_seed
 
     # Block tree model
-    block_tree, attestation_messages, attester_slashing_messages, envelopes = _generate_block_tree(
+    (
+        block_tree,
+        attestation_messages,
+        attester_slashing_messages,
+        envelopes,
+        payload_attestation_messages,
+    ) = _generate_block_tree(
         spec, highest_tip, rnd, debug, block_parents, with_attester_slashings, with_invalid_messages
     )
 
@@ -723,4 +808,5 @@ def gen_block_tree_test_data(
         attestation_messages,
         attester_slashing_messages,
         envelopes,
+        payload_attestation_messages,
     )

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -12,8 +12,10 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     add_attestation,
     add_attester_slashing,
     add_block,
+    add_execution_payload,
     get_attestation_file_name,
     get_attester_slashing_file_name,
+    get_execution_payload_envelope_file_name,
     get_block_file_name,
     on_tick_and_append_step,
     output_store_checks,
@@ -43,6 +45,7 @@ class FCTestData:
     blocks: list[ProtocolMessage]
     atts: list[ProtocolMessage] = field(default_factory=list)
     slashings: list[ProtocolMessage] = field(default_factory=list)
+    envelopes: list[ProtocolMessage] = field(default_factory=list)
     store_final_time: int = 0
 
 
@@ -315,6 +318,8 @@ def make_events(spec, test_data: FCTestData) -> list[tuple[int, object, bool]]:
             return data.data.slot + 1
         elif event_kind == "attester_slashing":
             return max(data.attestation_1.data.slot, data.attestation_1.data.slot) + 1
+        elif event_kind == "execution_payload":
+            return data.message.payload.slot_number
         else:
             assert False
 
@@ -322,6 +327,7 @@ def make_events(spec, test_data: FCTestData) -> list[tuple[int, object, bool]]:
         [("attestation", m.payload, m.valid) for m in test_data.atts]
         + [("attester_slashing", m.payload, m.valid) for m in test_data.slashings]
         + [("block", m.payload, m.valid) for m in test_data.blocks]
+        + [("execution_payload", m.payload, m.valid) for m in test_data.envelopes]
     )
 
     for event in sorted(messages, key=get_seffective_slot):
@@ -413,6 +419,10 @@ def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list
         attester_slashing = message.payload
         yield get_attester_slashing_file_name(attester_slashing), attester_slashing.encode_bytes()
 
+    for message in test_data.envelopes:
+        envelope = message.payload
+        yield get_execution_payload_envelope_file_name(envelope), envelope.encode_bytes()
+
     test_steps = []
 
     def try_add_mesage(runner, message):
@@ -458,6 +468,11 @@ def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list
             yield from add_attester_slashing(
                 spec, store, attester_slashing, test_steps, valid=valid
             )
+            output_store_checks(spec, store, test_steps)
+        elif event_kind == "execution_payload":
+            _, signed_envelope, valid = event
+            assert valid # invalid not supported yet
+            yield from add_execution_payload(spec, store, signed_envelope, test_steps, valid=valid)
             output_store_checks(spec, store, test_steps)
         else:
             raise ValueError("Unknown event " + str(event_kind))

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -232,7 +232,9 @@ def produce_block(
     )
 
 
-def attest_to_slot(spec, state, slot_to_attest, participants_filter=None) -> []:
+def attest_to_slot(
+    spec, state, slot_to_attest, participants_filter=None, payload_index=None
+) -> []:
     """
     Creates attestation is a slot respecting participating validators.
     :return: produced attestations
@@ -257,6 +259,7 @@ def attest_to_slot(spec, state, slot_to_attest, participants_filter=None) -> []:
                 state,
                 slot_to_attest,
                 index=index,
+                payload_index=payload_index,
                 signed=True,
                 filter_participant_set=participants_filter,
             )

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -24,6 +24,7 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     run_on_attestation,
     run_on_attester_slashing,
     run_on_block,
+    run_on_execution_payload_envelope,
     run_on_payload_attestation_message,
 )
 from eth_consensus_specs.test.helpers.forks import is_post_gloas
@@ -577,7 +578,8 @@ def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list
             output_store_checks(spec, store, test_steps)
         elif event_kind == "execution_payload":
             _, signed_envelope, valid = event
-            assert valid  # invalid not supported yet
+            if valid is None:
+                valid = try_add_mesage(run_on_execution_payload_envelope, signed_envelope)
             yield from add_execution_payload(spec, store, signed_envelope, test_steps, valid=valid)
             output_store_checks(spec, store, test_steps)
         elif event_kind == "payload_attestation":

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -232,9 +232,7 @@ def produce_block(
     )
 
 
-def attest_to_slot(
-    spec, state, slot_to_attest, participants_filter=None, payload_index=None
-) -> []:
+def attest_to_slot(spec, state, slot_to_attest, participants_filter=None, payload_index=None) -> []:
     """
     Creates attestation is a slot respecting participating validators.
     :return: produced attestations

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -13,15 +13,22 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     add_attester_slashing,
     add_block,
     add_execution_payload,
+    add_payload_attestation_message,
     get_attestation_file_name,
     get_attester_slashing_file_name,
-    get_execution_payload_envelope_file_name,
     get_block_file_name,
+    get_execution_payload_envelope_file_name,
+    get_payload_attestation_message_file_name,
     on_tick_and_append_step,
     output_store_checks,
     run_on_attestation,
     run_on_attester_slashing,
     run_on_block,
+    run_on_payload_attestation_message,
+)
+from eth_consensus_specs.test.helpers.forks import is_post_gloas
+from eth_consensus_specs.test.helpers.keys import (
+    privkeys,
 )
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
@@ -46,6 +53,7 @@ class FCTestData:
     atts: list[ProtocolMessage] = field(default_factory=list)
     slashings: list[ProtocolMessage] = field(default_factory=list)
     envelopes: list[ProtocolMessage] = field(default_factory=list)
+    payload_atts: list[ProtocolMessage] = field(default_factory=list)
     store_final_time: int = 0
 
 
@@ -63,6 +71,58 @@ class BranchTip:
             self.participants.copy(),
             self.eventually_justified_checkpoint,
         )
+
+
+def payload_attestation_to_messages(spec, state, payload_attestation, signed=False):
+    ptc = spec.get_ptc(state, payload_attestation.data.slot)
+    bits = payload_attestation.aggregation_bits
+    attesting_indices = [index for i, index in enumerate(ptc) if bits[i]]
+    messages = []
+    for validator_index in attesting_indices:
+        if validator_index >= len(privkeys):
+            continue
+        ptc_message = spec.PayloadAttestationMessage(
+            validator_index=validator_index,
+            data=payload_attestation.data,
+            signature=spec.BLSSignature(),
+        )
+        if signed:
+            ptc_message.signature = spec.get_payload_attestation_message_signature(
+                state, ptc_message, privkeys[validator_index]
+            )
+        messages.append(ptc_message)
+    return messages
+
+
+def messages_to_payload_attestations(spec, state, messages):
+    """Aggregates a list of PayloadAttestationMessage objects into PayloadAttestation objects,
+    one per distinct PayloadAttestationData."""
+    if not messages:
+        return []
+
+    # Group messages by data
+    groups = {}
+    for m in messages:
+        key = m.data.hash_tree_root()
+        if key not in groups:
+            groups[key] = (m.data, [])
+        groups[key][1].append(m.validator_index)
+
+    result = []
+    for data, attesting_indices in groups.values():
+        ptc = spec.get_ptc(state, data.slot)
+        index_set = set(attesting_indices)
+        aggregation_bits = spec.Bitvector[spec.PTC_SIZE]()
+        for i, validator_index in enumerate(ptc):
+            if validator_index in index_set:
+                aggregation_bits[i] = True
+        result.append(spec.PayloadAttestation(
+            aggregation_bits=aggregation_bits,
+            data=data,
+            signature=spec.BLSSignature(),
+        ))
+
+    return result
 
 
 def _get_eligible_attestations(spec, state, attestations) -> []:
@@ -87,10 +147,11 @@ def _compute_pseudo_randao_reveal(spec, proposer_index, epoch):
     return spec.BLSSignature(randao_reveal_bytes)
 
 
-def produce_block(spec, state, attestations, attester_slashings=[]):
+def produce_block(spec, state, attestations, attester_slashings=[], payload_attestation_messages=[]):
     """
     Produces a block including as many attestations as it is possible.
-    :return: Signed block, the post block state and attestations that were not included into the block.
+    Accepts PayloadAttestationMessage objects and aggregates them into PayloadAttestation for on-chain inclusion.
+    :return: Signed block, the post block state, and operations not included into the block.
     """
 
     # Filter out too old attestastions (TODO relax condition for Deneb)
@@ -114,6 +175,15 @@ def produce_block(spec, state, attestations, attester_slashings=[]):
     for s in attester_slashings_in_block:
         block.body.attester_slashings.append(s)
 
+    if is_post_gloas(spec):
+        # Aggregate eligible payload attestation messages into PayloadAttestations for on-chain inclusion
+        eligible_pa_messages = [
+            m for m in payload_attestation_messages
+            if m.data.beacon_block_root == block.parent_root and m.data.slot + 1 == block.slot
+        ]
+        for pa in messages_to_payload_attestations(spec, state, eligible_pa_messages):
+            block.body.payload_attestations.append(pa)
+
     # Run state transition and sign off on a block
     post_state = state.copy()
 
@@ -128,18 +198,30 @@ def produce_block(spec, state, attestations, attester_slashings=[]):
 
     # Filter out operations only if the block is valid
     not_included_attestations = attestations
+    not_included_pa_messages = payload_attestation_messages
     not_included_attester_slashings = attester_slashings
     if valid:
         not_included_attestations = [a for a in attestations if a not in attestation_in_block]
         not_included_attester_slashings = [
             s for s in attester_slashings if s not in attester_slashings_in_block
         ]
+        if is_post_gloas(spec):
+            included_pa_indices = set(m.validator_index for m in eligible_pa_messages)
+            not_included_pa_messages = [
+                m for m in payload_attestation_messages if m.validator_index not in included_pa_indices
+            ]
 
     # Return a pre state if the block is invalid
     if not valid:
         post_state = state
 
-    return signed_block, post_state, not_included_attestations, not_included_attester_slashings
+    return (
+        signed_block,
+        post_state,
+        not_included_attestations,
+        not_included_attester_slashings,
+        not_included_pa_messages,
+    )
 
 
 def attest_to_slot(spec, state, slot_to_attest, participants_filter=None) -> []:
@@ -217,7 +299,7 @@ def advance_branch_to_next_epoch(spec, branch_tip, enable_attesting=True):
         # Produce block if the proposer is among participanting validators
         proposer = spec.get_beacon_proposer_index(state)
         if state.slot > spec.GENESIS_SLOT and proposer in branch_tip.participants:
-            signed_block, state, attestations, _ = produce_block(spec, state, attestations)
+            signed_block, state, attestations, _, _ = produce_block(spec, state, attestations)
             signed_blocks.append(signed_block)
 
         if enable_attesting:
@@ -293,7 +375,8 @@ def advance_state_to_anchor_epoch(spec, state, anchor_epoch, debug) -> ([], Bran
 def make_events(spec, test_data: FCTestData) -> list[tuple[int, object, bool]]:
     """
     Makes test events from `test_data`'s blocks, attestations and slashings, sorted by an effective slot.
-    Each event is a triple ('tick'|'block'|'attestation'|'attester_slashing', message, valid).
+    Each event is a triple
+    ('tick'|'block'|'envelope'|'attestation'|'payload_attestation'|'attester_slashing', message, valid).
     """
     genesis_time = test_data.anchor_state.genesis_time
     test_events = []
@@ -320,6 +403,8 @@ def make_events(spec, test_data: FCTestData) -> list[tuple[int, object, bool]]:
             return max(data.attestation_1.data.slot, data.attestation_1.data.slot) + 1
         elif event_kind == "execution_payload":
             return data.message.payload.slot_number
+        elif event_kind == "payload_attestation":
+            return data.data.slot
         else:
             assert False
 
@@ -328,6 +413,7 @@ def make_events(spec, test_data: FCTestData) -> list[tuple[int, object, bool]]:
         + [("attester_slashing", m.payload, m.valid) for m in test_data.slashings]
         + [("block", m.payload, m.valid) for m in test_data.blocks]
         + [("execution_payload", m.payload, m.valid) for m in test_data.envelopes]
+        + [("payload_attestation", m.payload, m.valid) for m in test_data.payload_atts]
     )
 
     for event in sorted(messages, key=get_seffective_slot):
@@ -392,6 +478,15 @@ def _add_block(spec, store, signed_block, test_steps):
             except AssertionError:
                 # ignore possible faults, if the block is valid
                 pass
+        
+        if is_post_gloas(spec):
+            # An on_block step implies receiving block's payload attestations (post GLOAS)
+            st = store.block_states[signed_block.message.hash_tree_root()]
+            for payload_attestation in signed_block.message.body.payload_attestations:
+                for ptc_message in payload_attestation_to_messages(spec, st, payload_attestation):
+                    run_on_payload_attestation_message(
+                        spec, store, ptc_message, is_from_block=True, valid=True
+                    )
 
 
 @spec_test
@@ -422,6 +517,10 @@ def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list
     for message in test_data.envelopes:
         envelope = message.payload
         yield get_execution_payload_envelope_file_name(envelope), envelope.encode_bytes()
+
+    for message in test_data.payload_atts:
+        ptc_message = message.payload
+        yield get_payload_attestation_message_file_name(ptc_message), ptc_message.encode_bytes()
 
     test_steps = []
 
@@ -473,6 +572,14 @@ def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list
             _, signed_envelope, valid = event
             assert valid # invalid not supported yet
             yield from add_execution_payload(spec, store, signed_envelope, test_steps, valid=valid)
+            output_store_checks(spec, store, test_steps)
+        elif event_kind == "payload_attestation":
+            _, ptc_message, valid = event
+            if valid is None:
+                valid = try_add_mesage(run_on_payload_attestation_message, ptc_message)
+            yield from add_payload_attestation_message(
+                spec, store, ptc_message, test_steps, valid=valid
+            )
             output_store_checks(spec, store, test_steps)
         else:
             raise ValueError("Unknown event " + str(event_kind))

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -116,11 +116,13 @@ def messages_to_payload_attestations(spec, state, messages):
         for i, validator_index in enumerate(ptc):
             if validator_index in index_set:
                 aggregation_bits[i] = True
-        result.append(spec.PayloadAttestation(
-            aggregation_bits=aggregation_bits,
-            data=data,
-            signature=spec.BLSSignature(),
-        ))
+        result.append(
+            spec.PayloadAttestation(
+                aggregation_bits=aggregation_bits,
+                data=data,
+                signature=spec.BLSSignature(),
+            )
+        )
 
     return result
 
@@ -147,7 +149,9 @@ def _compute_pseudo_randao_reveal(spec, proposer_index, epoch):
     return spec.BLSSignature(randao_reveal_bytes)
 
 
-def produce_block(spec, state, attestations, attester_slashings=[], payload_attestation_messages=[]):
+def produce_block(
+    spec, state, attestations, attester_slashings=[], payload_attestation_messages=[]
+):
     """
     Produces a block including as many attestations as it is possible.
     Accepts PayloadAttestationMessage objects and aggregates them into PayloadAttestation for on-chain inclusion.
@@ -178,7 +182,8 @@ def produce_block(spec, state, attestations, attester_slashings=[], payload_atte
     if is_post_gloas(spec):
         # Aggregate eligible payload attestation messages into PayloadAttestations for on-chain inclusion
         eligible_pa_messages = [
-            m for m in payload_attestation_messages
+            m
+            for m in payload_attestation_messages
             if m.data.beacon_block_root == block.parent_root and m.data.slot + 1 == block.slot
         ]
         for pa in messages_to_payload_attestations(spec, state, eligible_pa_messages):
@@ -208,7 +213,9 @@ def produce_block(spec, state, attestations, attester_slashings=[], payload_atte
         if is_post_gloas(spec):
             included_pa_indices = set(m.validator_index for m in eligible_pa_messages)
             not_included_pa_messages = [
-                m for m in payload_attestation_messages if m.validator_index not in included_pa_indices
+                m
+                for m in payload_attestation_messages
+                if m.validator_index not in included_pa_indices
             ]
 
     # Return a pre state if the block is invalid
@@ -478,7 +485,7 @@ def _add_block(spec, store, signed_block, test_steps):
             except AssertionError:
                 # ignore possible faults, if the block is valid
                 pass
-        
+
         if is_post_gloas(spec):
             # An on_block step implies receiving block's payload attestations (post GLOAS)
             st = store.block_states[signed_block.message.hash_tree_root()]
@@ -570,7 +577,7 @@ def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list
             output_store_checks(spec, store, test_steps)
         elif event_kind == "execution_payload":
             _, signed_envelope, valid = event
-            assert valid # invalid not supported yet
+            assert valid  # invalid not supported yet
             yield from add_execution_payload(spec, store, signed_envelope, test_steps, valid=valid)
             output_store_checks(spec, store, test_steps)
         elif event_kind == "payload_attestation":

--- a/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
@@ -176,7 +176,7 @@ class MessageScheduler:
             applied_events.extend(self.purge_queue())
             self.process_block_messages(signed_block)
         return valid, applied_events
-    
+
     def process_payload(self, signed_payload) -> bool:
         try:
             self.spec.on_execution_payload_envelope(self.store, signed_payload)

--- a/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass, field
 from enum import Enum
 
+from .helpers import payload_attestation_to_messages
+
 
 class QueueItemKind(Enum):
     BLOCK = 0
     ATTESTATION = 1
     EXECUTION_PAYLOAD = 2
+    PAYLOAD_ATTESTATION = 3
 
 
 @dataclass(order=True, init=False)
@@ -29,12 +32,17 @@ class QueueItem:
             self.effective_slot = block.slot
             self.dependencies = [block.parent_root]
             self.is_from_block = False
-        else:
-            assert kind == QueueItemKind.EXECUTION_PAYLOAD
+        elif kind == QueueItemKind.EXECUTION_PAYLOAD:
             payload = message.message
             self.effective_slot = payload.payload.slot_number
             self.dependencies = [payload.beacon_block_root]
             self.is_from_block = False
+        else:
+            assert kind == QueueItemKind.PAYLOAD_ATTESTATION
+            data = message.data
+            self.effective_slot = data.slot
+            self.dependencies = [data.beacon_block_root]
+            self.is_from_block = is_from_block
 
 
 class MessageScheduler:
@@ -74,10 +82,15 @@ class MessageScheduler:
                     updated = True
                     applied_events.extend(events_)
                     assert ("block", item.message, True) in events_
-            else:
-                assert item.kind == QueueItemKind.EXECUTION_PAYLOAD
+            elif item.kind == QueueItemKind.EXECUTION_PAYLOAD:
                 if self.process_payload(item.message):
                     applied_events.append(("execution_payload", item.message, True))
+            else:
+                assert item.kind == QueueItemKind.PAYLOAD_ATTESTATION
+                if self.process_payload_attestation_message(
+                    item.message, is_from_block=item.is_from_block
+                ):
+                    applied_events.append(("payload_attestation", item.message, True))
         return updated, applied_events
 
     def purge_queue(self) -> list:
@@ -124,8 +137,25 @@ class MessageScheduler:
         except AssertionError:
             return False
 
+    def process_payload_attestation_message(self, ptc_message, is_from_block=False):
+        try:
+            self.spec.on_payload_attestation_message(self.store, ptc_message, is_from_block)
+            return True
+        except AssertionError:
+            item = QueueItem(ptc_message, QueueItemKind.PAYLOAD_ATTESTATION, is_from_block)
+            if self.is_early_message(item):
+                self.enque_message(item)
+            return False
+
     def process_block_messages(self, signed_block):
         block = signed_block.message
+        if hasattr(block.body, "payload_attestations"):
+            state = self.store.block_states[block.hash_tree_root()]
+            for payload_attestation in block.body.payload_attestations:
+                for ptc_message in payload_attestation_to_messages(
+                    self.spec, state, payload_attestation
+                ):
+                    self.process_payload_attestation_message(ptc_message, is_from_block=True)
         for attestation in block.body.attestations:
             self.process_attestation(attestation, is_from_block=True)
         for attester_slashing in block.body.attester_slashings:
@@ -156,4 +186,3 @@ class MessageScheduler:
             if self.is_early_message(item):
                 self.enque_message(item)
             return False
-

--- a/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
@@ -1,26 +1,39 @@
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class QueueItemKind(Enum):
+    BLOCK = 0
+    ATTESTATION = 1
+    EXECUTION_PAYLOAD = 2
 
 
 @dataclass(order=True, init=False)
 class QueueItem:
     effective_slot: int
-    is_attestation: bool
+    kind: QueueItemKind
     message: object = field(compare=False)
     dependencies: list = field(compare=False)
     is_from_block: bool = field(compare=False)
 
-    def __init__(self, message, is_attestation, is_from_block=False):
+    def __init__(self, message, kind: QueueItemKind, is_from_block=False):
         self.message = message
-        self.is_attestation = is_attestation
-        if is_attestation:
+        self.kind = kind
+        if kind == QueueItemKind.ATTESTATION:
             data = message.data
             self.effective_slot = data.slot + 1
             self.dependencies = [data.beacon_block_root, data.target.root]
             self.is_from_block = is_from_block
-        else:
+        elif kind == QueueItemKind.BLOCK:
             block = message.message
             self.effective_slot = block.slot
             self.dependencies = [block.parent_root]
+            self.is_from_block = False
+        else:
+            assert kind == QueueItemKind.EXECUTION_PAYLOAD
+            payload = message.message
+            self.effective_slot = payload.payload.slot_number
+            self.dependencies = [payload.beacon_block_root]
             self.is_from_block = False
 
 
@@ -52,15 +65,19 @@ class MessageScheduler:
         for item in self.drain_queue():
             if self.is_early_message(item):
                 self.enque_message(item)
-            elif item.is_attestation:
+            elif item.kind == QueueItemKind.ATTESTATION:
                 if self.process_attestation(item.message):
                     applied_events.append(("attestation", item.message, True))
-            else:
+            elif item.kind == QueueItemKind.BLOCK:
                 updated_, events_ = self.process_block(item.message, recovery=True)
                 if updated_:
                     updated = True
                     applied_events.extend(events_)
                     assert ("block", item.message, True) in events_
+            else:
+                assert item.kind == QueueItemKind.EXECUTION_PAYLOAD
+                if self.process_payload(item.message):
+                    applied_events.append(("execution_payload", item.message, True))
         return updated, applied_events
 
     def purge_queue(self) -> list:
@@ -95,7 +112,7 @@ class MessageScheduler:
             self.spec.on_attestation(self.store, attestation, is_from_block)
             return True
         except AssertionError:
-            item = QueueItem(attestation, True, is_from_block)
+            item = QueueItem(attestation, QueueItemKind.ATTESTATION, is_from_block)
             if self.is_early_message(item):
                 self.enque_message(item)
             return False
@@ -121,7 +138,7 @@ class MessageScheduler:
             valid = True
             applied_events.append(("block", signed_block, recovery))
         except AssertionError:
-            item = QueueItem(signed_block, False)
+            item = QueueItem(signed_block, QueueItemKind.BLOCK)
             if self.is_early_message(item):
                 self.enque_message(item)
             valid = False
@@ -129,3 +146,14 @@ class MessageScheduler:
             applied_events.extend(self.purge_queue())
             self.process_block_messages(signed_block)
         return valid, applied_events
+    
+    def process_payload(self, signed_payload) -> bool:
+        try:
+            self.spec.on_execution_payload_envelope(self.store, signed_payload)
+            return True
+        except AssertionError:
+            item = QueueItem(signed_payload, QueueItemKind.EXECUTION_PAYLOAD)
+            if self.is_early_message(item):
+                self.enque_message(item)
+            return False
+

--- a/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
@@ -16,6 +16,7 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     get_attester_slashing_file_name,
     get_block_file_name,
     get_execution_payload_envelope_file_name,
+    get_payload_attestation_message_file_name,
     on_tick_and_append_step,
     output_store_checks,
 )
@@ -256,6 +257,8 @@ def events_to_test_vector(events) -> list[Any]:
                 event_id = data
             elif event_kind == "execution_payload":
                 event_id = data
+            elif event_kind == "payload_attestation":
+                event_id = data
             else:
                 assert False, event_kind
             test_vector.append((current_time, (event_kind, event_id)))
@@ -299,6 +302,10 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
         envelope = message.payload
         yield get_execution_payload_envelope_file_name(envelope), envelope
 
+    for message in test_data.payload_atts:
+        ptc_message = message.payload
+        yield get_payload_attestation_message_file_name(ptc_message), ptc_message
+
     test_steps = []
     scheduler = MessageScheduler(spec, store)
 
@@ -328,6 +335,14 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
                             assert recovery
                             _payload_id = get_execution_payload_envelope_file_name(event_data)
                             test_steps.append({"execution_payload": _payload_id, "valid": True})
+                        elif event_kind == "payload_attestation":
+                            assert recovery
+                            _payload_attestation_id = get_payload_attestation_message_file_name(
+                                event_data
+                            )
+                            test_steps.append(
+                                {"payload_attestation": _payload_attestation_id, "valid": True}
+                            )
                         else:
                             assert False
                 else:
@@ -360,6 +375,18 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
                             else:
                                 assert False
                                 test_steps.append({"attestation": _attestation_id, "valid": True})
+                        elif event_kind == "execution_payload":
+                            assert recovery
+                            _payload_id = get_execution_payload_envelope_file_name(event_data)
+                            test_steps.append({"execution_payload": _payload_id, "valid": True})
+                        elif event_kind == "payload_attestation":
+                            _payload_attestation_id = get_payload_attestation_message_file_name(
+                                event_data
+                            )
+                            assert recovery
+                            test_steps.append(
+                                {"payload_attestation": _payload_attestation_id, "valid": True}
+                            )
                         else:
                             assert False
                 else:
@@ -389,6 +416,12 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
             envelope_id = get_execution_payload_envelope_file_name(envelope)
             valid = scheduler.process_payload(envelope)
             test_steps.append({"execution_payload": envelope_id, "valid": valid})
+            output_store_checks(spec, store, test_steps)
+        elif kind == "payload_attestation":
+            ptc_message = data
+            ptc_message_id = get_payload_attestation_message_file_name(ptc_message)
+            valid = scheduler.process_payload_attestation_message(ptc_message, is_from_block=False)
+            test_steps.append({"payload_attestation": ptc_message_id, "valid": valid})
             output_store_checks(spec, store, test_steps)
         else:
             raise ValueError(f"not implemented {kind}")

--- a/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
@@ -15,6 +15,7 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     get_attestation_file_name,
     get_attester_slashing_file_name,
     get_block_file_name,
+    get_execution_payload_envelope_file_name,
     on_tick_and_append_step,
     output_store_checks,
 )
@@ -253,6 +254,8 @@ def events_to_test_vector(events) -> list[Any]:
                 event_id = data
             elif event_kind == "attester_slashing":
                 event_id = data
+            elif event_kind == "execution_payload":
+                event_id = data
             else:
                 assert False, event_kind
             test_vector.append((current_time, (event_kind, event_id)))
@@ -292,6 +295,10 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
         attester_slashing = message.payload
         yield get_attester_slashing_file_name(attester_slashing), attester_slashing
 
+    for message in test_data.envelopes:
+        envelope = message.payload
+        yield get_execution_payload_envelope_file_name(envelope), envelope
+
     test_steps = []
     scheduler = MessageScheduler(spec, store)
 
@@ -317,6 +324,10 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
                             if _attestation_id not in test_data.atts:
                                 yield _attestation_id, event_data
                             test_steps.append({"attestation": _attestation_id, "valid": True})
+                        elif event_kind == "execution_payload":
+                            assert recovery
+                            _payload_id = get_execution_payload_envelope_file_name(event_data)
+                            test_steps.append({"execution_payload": _payload_id, "valid": True})
                         else:
                             assert False
                 else:
@@ -372,6 +383,12 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
             slashing_id = get_attester_slashing_file_name(attester_slashing)
             valid = scheduler.process_slashing(attester_slashing)
             test_steps.append({"attester_slashing": slashing_id, "valid": valid})
+            output_store_checks(spec, store, test_steps)
+        elif kind == "execution_payload":
+            envelope = data
+            envelope_id = get_execution_payload_envelope_file_name(envelope)
+            valid = scheduler.process_payload(envelope)
+            test_steps.append({"execution_payload": envelope_id, "valid": valid})
             output_store_checks(spec, store, test_steps)
         else:
             raise ValueError(f"not implemented {kind}")

--- a/tests/generators/compliance_runners/fork_choice/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/test_run.py
@@ -77,8 +77,8 @@ TestInfo = namedtuple(
 def run_test(test_info):
     preset, fork, test_dir = test_info
     spec = spec_targets[preset][fork]
-    _, anchor_block, anchor_state, blocks, atts, slashings, envelopes, payload_atts, steps = get_test_case(
-        spec, test_dir
+    _, anchor_block, anchor_state, blocks, atts, slashings, envelopes, payload_atts, steps = (
+        get_test_case(spec, test_dir)
     )
     store = spec.get_forkchoice_store(anchor_state, anchor_block)
     for step in steps:

--- a/tests/generators/compliance_runners/fork_choice/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/test_run.py
@@ -33,14 +33,6 @@ def get_test_case(spec, td):
     def get_prefix(p):
         return p[p.rindex("/") + 1 : p.rindex(".")]
 
-    envelope_files = glob(f"{td}/execution_payload_envelope_*.ssz_snappy")
-    envelopes = {}
-    if envelope_files:
-        envelopes = {
-            get_prefix(e): spec.SignedExecutionPayloadEnvelope.decode_bytes(read_ssz_snappy(e))
-            for e in envelope_files
-        }
-
     return (
         read_yaml(f"{td}/meta.yaml"),
         spec.BeaconBlock.decode_bytes(read_ssz_snappy(f"{td}/anchor_block.ssz_snappy")),
@@ -57,7 +49,10 @@ def get_test_case(spec, td):
             get_prefix(b): spec.AttesterSlashing.decode_bytes(read_ssz_snappy(b))
             for b in glob(f"{td}/attester_slashing_*.ssz_snappy")
         },
-        envelopes,
+        {
+            get_prefix(e): spec.SignedExecutionPayloadEnvelope.decode_bytes(read_ssz_snappy(e))
+            for e in glob(f"{td}/execution_payload_envelope_*.ssz_snappy")
+        },
         read_yaml(f"{td}/steps.yaml"),
     )
 

--- a/tests/generators/compliance_runners/fork_choice/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/test_run.py
@@ -11,8 +11,11 @@ from snappy import uncompress
 from tqdm import tqdm
 
 from eth_consensus_specs.test.context import expect_assertion_error
+from eth_consensus_specs.test.helpers.forks import is_post_gloas
 from eth_consensus_specs.test.helpers.specs import spec_targets
 from eth_consensus_specs.utils import bls
+
+from .instantiators.helpers import payload_attestation_to_messages
 
 bls.bls_active = False
 
@@ -53,6 +56,10 @@ def get_test_case(spec, td):
             get_prefix(e): spec.SignedExecutionPayloadEnvelope.decode_bytes(read_ssz_snappy(e))
             for e in glob(f"{td}/execution_payload_envelope_*.ssz_snappy")
         },
+        {
+            get_prefix(b): spec.PayloadAttestationMessage.decode_bytes(read_ssz_snappy(b))
+            for b in glob(f"{td}/payload_attestation_*.ssz_snappy")
+        },
         read_yaml(f"{td}/steps.yaml"),
     )
 
@@ -70,7 +77,7 @@ TestInfo = namedtuple(
 def run_test(test_info):
     preset, fork, test_dir = test_info
     spec = spec_targets[preset][fork]
-    meta, anchor_block, anchor_state, blocks, atts, slashings, envelopes, steps = get_test_case(
+    _, anchor_block, anchor_state, blocks, atts, slashings, envelopes, payload_atts, steps = get_test_case(
         spec, test_dir
     )
     store = spec.get_forkchoice_store(anchor_state, anchor_block)
@@ -94,6 +101,18 @@ def run_test(test_info):
                         spec.on_attester_slashing(store, block_att_slashing)
                     except AssertionError:
                         pass
+                if is_post_gloas(spec):
+                    state = store.block_states[signed_block.message.hash_tree_root()]
+                    for payload_attestation in signed_block.message.body.payload_attestations:
+                        for ptc_message in payload_attestation_to_messages(
+                            spec, state, payload_attestation
+                        ):
+                            try:
+                                spec.on_payload_attestation_message(
+                                    store, ptc_message, is_from_block=True
+                                )
+                            except AssertionError:
+                                pass
             else:
                 expect_assertion_error(lambda: spec.on_block(store, signed_block))
         elif "attestation" in step:
@@ -121,6 +140,18 @@ def run_test(test_info):
             else:
                 expect_assertion_error(
                     lambda: spec.on_execution_payload_envelope(store, signed_envelope)
+                )
+        elif "payload_attestation" in step:
+            ptc_message_id = step["payload_attestation"]
+            valid = step.get("valid", True)
+            ptc_message = payload_atts[ptc_message_id]
+            if valid:
+                spec.on_payload_attestation_message(store, ptc_message, is_from_block=False)
+            else:
+                expect_assertion_error(
+                    lambda: spec.on_payload_attestation_message(
+                        store, ptc_message, is_from_block=False
+                    )
                 )
         elif "checks" in step:
             checks = step["checks"]


### PR DESCRIPTION
The PR implement changes that add Gloas support to the Fork Choice compliance test generator (e.g. execution payload and payload attestation). The gloas test vectors can be generated by running `make comptests fork=gloas`.
Produced tests have been validated by running the tests against the specs (using the [test runner](https://github.com/ethereum/consensus-specs/blob/master/tests/generators/compliance_runners/fork_choice/test_run.py), which has been updated to support gloas features too) and by running tests against a [version](https://github.com/tbenr/teku/tree/gloas-forkchoice) of Teku.

The PR has a draft status, anticipated changes:
- [x] Update test generator to comply with upcoming #5094 PR
- [x] `on_payload_attestation_message` step is absent in [fork choice test format](https://github.com/ethereum/consensus-specs/tree/master/tests/formats/fork_choice#stepsyaml).
- [x] Improve test coverage, where possible and/or reasonable

Related to #5094