### PR TITLE
Rename `on_execution_payload` to `on_execution_payload_envelope`

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -42,7 +42,7 @@
 - [Handlers](#handlers)
   - [Modified `on_block`](#modified-on_block)
   - [Modified `is_data_available`](#modified-is_data_available)
-  - [New `on_execution_payload`](#new-on_execution_payload)
+  - [New `on_execution_payload_envelope`](#new-on_execution_payload_envelope)
   - [New `on_payload_attestation_message`](#new-on_payload_attestation_message)
 
 <!-- mdformat-toc end -->
@@ -812,15 +812,17 @@ def is_data_available(beacon_block_root: Root) -> bool:
     )
 ```
 
-### New `on_execution_payload`
+### New `on_execution_payload_envelope`
 
-The handler `on_execution_payload` is called when the node receives a
+The handler `on_execution_payload_envelope` is called when the node receives a
 `SignedExecutionPayloadEnvelope` to sync.
 
 ```python
-def on_execution_payload(store: Store, signed_envelope: SignedExecutionPayloadEnvelope) -> None:
+def on_execution_payload_envelope(
+    store: Store, signed_envelope: SignedExecutionPayloadEnvelope
+) -> None:
     """
-    Run ``on_execution_payload`` upon receiving a new execution payload.
+    Run ``on_execution_payload_envelope`` upon receiving a new execution payload envelope.
     """
     envelope = signed_envelope.message
     # The corresponding beacon block root needs to be known

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -23,7 +23,7 @@
   - [New `get_proposer_inclusion_list_cutoff_ms`](#new-get_proposer_inclusion_list_cutoff_ms)
 - [Handlers](#handlers)
   - [New `on_inclusion_list`](#new-on_inclusion_list)
-  - [Modified `on_execution_payload`](#modified-on_execution_payload)
+  - [Modified `on_execution_payload_envelope`](#modified-on_execution_payload_envelope)
 
 <!-- mdformat-toc end -->
 
@@ -285,12 +285,14 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     process_inclusion_list(get_inclusion_list_store(), inclusion_list, is_before_view_freeze_cutoff)
 ```
 
-### Modified `on_execution_payload`
+### Modified `on_execution_payload_envelope`
 
 ```python
-def on_execution_payload(store: Store, signed_envelope: SignedExecutionPayloadEnvelope) -> None:
+def on_execution_payload_envelope(
+    store: Store, signed_envelope: SignedExecutionPayloadEnvelope
+) -> None:
     """
-    Run ``on_execution_payload`` upon receiving a new execution payload.
+    Run ``on_execution_payload_envelope`` upon receiving a new execution payload envelope.
     """
     envelope = signed_envelope.message
     # The corresponding beacon block root needs to be known

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_execution_payload_envelope.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_execution_payload_envelope.py
@@ -23,7 +23,7 @@ from eth_consensus_specs.test.helpers.state import (
 
 @with_gloas_and_later
 @spec_state_test
-def test_on_execution_payload(spec, state):
+def test_on_execution_payload_envelope(spec, state):
     test_steps = []
 
     # Initialization

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -400,10 +400,10 @@ def add_block(
 def run_on_execution_payload(spec, store, signed_envelope, valid=True):
     """Process execution payload envelope through the fork choice store."""
     if not valid:
-        expect_assertion_error(lambda: spec.on_execution_payload(store, signed_envelope))
+        expect_assertion_error(lambda: spec.on_execution_payload_envelope(store, signed_envelope))
         return
 
-    spec.on_execution_payload(store, signed_envelope)
+    spec.on_execution_payload_envelope(store, signed_envelope)
 
     # Verify the envelope was processed, block should now have FULL state
     envelope_root = signed_envelope.message.beacon_block_root

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -397,7 +397,7 @@ def add_block(
     return store.block_states[signed_block.message.hash_tree_root()]
 
 
-def run_on_execution_payload(spec, store, signed_envelope, valid=True):
+def run_on_execution_payload_envelope(spec, store, signed_envelope, valid=True):
     """Process execution payload envelope through the fork choice store."""
     if not valid:
         expect_assertion_error(lambda: spec.on_execution_payload_envelope(store, signed_envelope))
@@ -419,11 +419,11 @@ def add_execution_payload(spec, store, signed_envelope, test_steps, valid=True):
     yield file_name, signed_envelope
 
     if not valid:
-        run_on_execution_payload(spec, store, signed_envelope, valid=False)
+        run_on_execution_payload_envelope(spec, store, signed_envelope, valid=False)
         test_steps.append({"execution_payload": file_name, "valid": False})
         return
 
-    run_on_execution_payload(spec, store, signed_envelope, valid=True)
+    run_on_execution_payload_envelope(spec, store, signed_envelope, valid=True)
     test_steps.append({"execution_payload": file_name, "valid": True})
     output_store_checks(spec, store, test_steps)
 

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -16,7 +16,7 @@ components of the fork choice.
     - [`on_merge_block` execution step](#on_merge_block-execution-step)
     - [`on_attester_slashing` execution step](#on_attester_slashing-execution-step)
     - [`on_payload_info` execution step](#on_payload_info-execution-step)
-    - [`on_execution_payload` execution step](#on_execution_payload-execution-step)
+    - [`on_execution_payload_envelope` execution step](#on_execution_payload_envelope-execution-step)
     - [Checks step](#checks-step)
   - [`attestation_<32-byte-root>.ssz_snappy`](#attestation_32-byte-rootssz_snappy)
   - [`block_<32-byte-root>.ssz_snappy`](#block_32-byte-rootssz_snappy)
@@ -182,15 +182,15 @@ the corresponding `on_block` execution step.
 *Note*: Status of the same payload may be updated for several times throughout
 the test.
 
-#### `on_execution_payload` execution step
+#### `on_execution_payload_envelope` execution step
 
 The parameter that is required for executing
-`on_execution_payload(store, signed_execution_payload_envelope)`.
+`on_execution_payload_envelope(store, signed_execution_payload_envelope)`.
 
 ```yaml
 {
     execution_payload: string  -- the name of the `execution_payload_envelope_<32-byte-root>.ssz_snappy` file.
-                                  To execute `on_execution_payload(store, signed_envelope)` with the given envelope.
+                                  To execute `on_execution_payload_envelope(store, signed_envelope)` with the given envelope.
     valid: bool                -- optional, default to `true`.
                                   If it's `false`, this execution step is expected to be invalid.
 }
@@ -300,8 +300,8 @@ Each file is an SSZ-snappy encoded `SignedExecutionPayloadEnvelope`.
        `len(block.message.body.attestations) > 0`, execute each attestation with
        `on_attestation(store, attestation)` after executing
        `on_block(store, block)`.
-     - For the `on_execution_payload` execution step: look up the corresponding
-       `execution_payload_envelope_<root>.ssz_snappy` file and execute
-       `on_execution_payload(store, signed_envelope)`.
+     - For the `on_execution_payload_envelope` execution step: look up the
+       corresponding `execution_payload_envelope_<root>.ssz_snappy` file and
+       execute `on_execution_payload_envelope(store, signed_envelope)`.
    - For each `checks` step, the assertions on the current store must be
      satisfied.

--- a/tests/generators/compliance_runners/fork_choice/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/test_run.py
@@ -122,9 +122,11 @@ def run_test(test_info):
             valid = step.get("valid", True)
             signed_envelope = envelopes[envelope_id]
             if valid:
-                spec.on_execution_payload(store, signed_envelope)
+                spec.on_execution_payload_envelope(store, signed_envelope)
             else:
-                expect_assertion_error(lambda: spec.on_execution_payload(store, signed_envelope))
+                expect_assertion_error(
+                    lambda: spec.on_execution_payload_envelope(store, signed_envelope)
+                )
         elif "checks" in step:
             checks = step["checks"]
             for check, value in checks.items():


### PR DESCRIPTION
This function processes the _envelope_, and the execution payload is just a part of that.

cc @nflaig