### PR TITLE
Add on-demand PR test-vector workflow

### DIFF
--- a/.github/scripts/detect_affected_forks.py
+++ b/.github/scripts/detect_affected_forks.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Map a list of changed paths (one per line on stdin) to the set of forks
+whose reference test vectors should be regenerated.
+
+Used by .github/workflows/pr-vectors.yml to keep PR-triggered vector runs
+focused on the forks actually touched by the PR.
+
+Output: a single JSON array of fork names on stdout, e.g. ["gloas","heze"].
+If the PR touches build/runner/utility code that affects every fork, or if
+no recognizable spec/test paths changed, the script falls back to the full
+fork list so the maintainer always gets a safe-by-default run.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPECS_DIR = REPO_ROOT / "specs"
+
+
+def all_forks() -> list[str]:
+    return sorted(
+        p.name for p in SPECS_DIR.iterdir() if p.is_dir() and not p.name.startswith("_")
+    )
+
+
+GLOBAL_PREFIXES = (
+    "tests/generators/",
+    "tests/core/pyspec/eth_consensus_specs/utils/",
+    "tests/core/pyspec/eth_consensus_specs/config/",
+    "configs/",
+    "specs/_features/",
+)
+
+GLOBAL_FILES = {"Makefile", "pyproject.toml", "uv.lock"}
+
+
+def affected(paths: list[str], forks: list[str]) -> set[str]:
+    fork_set = set(forks)
+    hit: set[str] = set()
+    for raw in paths:
+        path = raw.strip()
+        if not path:
+            continue
+        if path in GLOBAL_FILES or path.startswith(GLOBAL_PREFIXES):
+            return fork_set
+        for fork in fork_set:
+            if (
+                path.startswith(f"specs/{fork}/")
+                or path.startswith(f"presets/mainnet/{fork}.")
+                or path.startswith(f"presets/minimal/{fork}.")
+                or path.startswith(f"tests/core/pyspec/eth_consensus_specs/{fork}/")
+                or path.startswith(f"tests/core/pyspec/eth_consensus_specs/test/{fork}/")
+            ):
+                hit.add(fork)
+                break
+    return hit
+
+
+def main() -> int:
+    forks = all_forks()
+    paths = sys.stdin.read().splitlines()
+    selected = affected(paths, forks)
+    if not selected:
+        selected = set(forks)
+    print(json.dumps(sorted(selected)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/pr-vectors.yml
+++ b/.github/workflows/pr-vectors.yml
@@ -1,0 +1,131 @@
+name: PR Vectors
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to generate vectors for (e.g. 5094)
+        required: true
+        type: string
+      presets:
+        description: Comma-separated presets (subset of general,minimal,mainnet)
+        default: mainnet,minimal
+        type: string
+      forks:
+        description: Comma-separated fork list, or "auto" to detect from changed paths
+        default: auto
+        type: string
+      k:
+        description: Optional pytest -k expression to narrow the generated set further
+        default: ""
+        type: string
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      repo: ${{ steps.resolve.outputs.repo }}
+      ref: ${{ steps.resolve.outputs.ref }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      presets: ${{ steps.resolve.outputs.presets }}
+      forks: ${{ steps.resolve.outputs.forks }}
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve PR head and matrix
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ inputs.pr }}
+          PRESETS_INPUT: ${{ inputs.presets }}
+          FORKS_INPUT: ${{ inputs.forks }}
+        run: |
+          set -euo pipefail
+
+          pr_json=$(gh pr view "$PR" --repo ${{ github.repository }} \
+            --json headRefName,headRepositoryOwner,headRepository,headRefOid)
+          head_owner=$(echo "$pr_json" | jq -r '.headRepositoryOwner.login')
+          head_repo_name=$(echo "$pr_json" | jq -r '.headRepository.name')
+          head_ref=$(echo "$pr_json" | jq -r '.headRefName')
+          head_sha=$(echo "$pr_json" | jq -r '.headRefOid')
+          head_repo="${head_owner}/${head_repo_name}"
+
+          presets_json=$(python3 -c "import json,sys,os; \
+            allowed={'general','minimal','mainnet'}; \
+            items=[s.strip() for s in os.environ['PRESETS_INPUT'].split(',') if s.strip()]; \
+            bad=[s for s in items if s not in allowed]; \
+            sys.exit(f'invalid preset(s): {bad}') if bad else print(json.dumps(items))")
+
+          if [[ "$FORKS_INPUT" == "auto" ]]; then
+            forks_json=$(gh pr diff "$PR" --repo ${{ github.repository }} --name-only \
+              | python3 .github/scripts/detect_affected_forks.py)
+          else
+            forks_json=$(python3 -c "import json,os; \
+              print(json.dumps(sorted(s.strip() for s in os.environ['FORKS_INPUT'].split(',') if s.strip())))")
+          fi
+
+          {
+            echo "repo=$head_repo"
+            echo "ref=$head_ref"
+            echo "sha=$head_sha"
+            echo "presets=$presets_json"
+            echo "forks=$forks_json"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## PR Vectors — resolution"
+            echo ""
+            echo "| Field   | Value |"
+            echo "| ------- | ----- |"
+            echo "| PR      | #$PR |"
+            echo "| Repo    | \`$head_repo\` |"
+            echo "| Ref     | \`$head_ref\` |"
+            echo "| SHA     | \`$head_sha\` |"
+            echo "| Presets | \`$presets_json\` |"
+            echo "| Forks   | \`$forks_json\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  generate:
+    needs: resolve
+    timeout-minutes: 720
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        preset: ${{ fromJson(needs.resolve.outputs.presets) }}
+        fork: ${{ fromJson(needs.resolve.outputs.forks) }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ needs.resolve.outputs.repo }}
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Setup python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Generate tests
+        env:
+          K: ${{ inputs.k }}
+        run: |
+          extra=""
+          if [[ -n "$K" ]]; then
+            extra="k=$K"
+          fi
+          make test component=pyspec verbose=true \
+            preset=${{ matrix.preset }} fork=${{ matrix.fork }} reftests=true $extra
+
+      - name: Upload reference tests
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: pr${{ inputs.pr }}-reftests-${{ matrix.preset }}-${{ matrix.fork }}
+          path: reftests/${{ matrix.preset }}
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- New `.github/workflows/pr-vectors.yml` workflow (manual `workflow_dispatch`) that takes a PR number and generates reference test vectors against that PR's head ref, on demand. Artifacts are uploaded as workflow run artifacts.
- New `.github/scripts/detect_affected_forks.py` helper that maps a PR's changed paths to the minimal fork set whose vectors should be regenerated, with a safe fallback to all forks when the change touches global build/runner/utility code.

## Motivation

Today the only way to obtain reference vectors for an in-flight spec PR is to wait for the nightly `tests.yml` run on `master` (post-merge) or to run `make test reftests=true` locally for hours. Meanwhile, client teams reviewing PRs like ethereum/consensus-specs#5094 (which restructures GLOAS/HEZE state-transition semantics across 24 files) want vectors *before* merge to validate their implementations against the proposal.

`tests.yml` already supports `repo` / `ref` `workflow_dispatch` inputs, but it always runs the full 9-fork × N-preset matrix (24h timeout). For a PR like #5094 that only touches a handful of forks, that's mostly wasted compute and slow feedback.

## How it works

```bash
# Generate vectors for PR #5094 with auto-detected forks (mainnet + minimal):
gh workflow run pr-vectors.yml -f pr=5094

# Override to a single fork/preset:
gh workflow run pr-vectors.yml -f pr=5094 -f forks=gloas -f presets=mainnet

# Narrow with a pytest -k expression:
gh workflow run pr-vectors.yml -f pr=5094 -f k=execution_payload
```

The `resolve` job calls `gh pr view` + `gh pr diff` to find the head repo, ref, SHA, and the changed-path-derived fork list. The `generate` job then fans out across `presets × forks`, runs `make test reftests=true`, and uploads `pr<N>-reftests-<preset>-<fork>` artifacts (90-day retention).

## Path → fork detection

| Pattern                                                                     | Effect                       |
|-----------------------------------------------------------------------------|------------------------------|
| `Makefile`, `pyproject.toml`, `uv.lock`, `configs/**`, `tests/generators/**`, `tests/core/pyspec/eth_consensus_specs/utils/**`, `tests/core/pyspec/eth_consensus_specs/config/**`, `specs/_features/**` | All forks (hard global)      |
| `specs/<fork>/**`, `presets/{mainnet,minimal}/<fork>.yaml`, `tests/core/pyspec/eth_consensus_specs/{<fork>,test/<fork>}/**` | Add `<fork>`                 |
| Other (incl. `pysetup/**`, `tests/.../test/helpers/**`, docs)              | No signal                    |
| Resulting set empty                                                         | Fall back to all forks       |

The fork list is read dynamically from `specs/` so newly added forks need no script change. PR #5094 resolves to `["bellatrix","capella","deneb","gloas","heze","phase0"]` instead of the full nine.

## Out of scope

- `tests.yml`, `release.yml`, and `checks.yml` are unchanged — nightly and release flows are unaffected.
- No automatic `pull_request` trigger and no comment-handler — manual `workflow_dispatch` only, which keeps fork-PR permissions trivial. These can be layered on later if maintainers want.

## Test plan

- [ ] Run `gh workflow run pr-vectors.yml -f pr=5094` and verify the `resolve` job summary shows `nflaig/consensus-specs@deferred-payload-processing` and the expected fork list.
- [ ] Verify the matrix expands to `presets={mainnet,minimal} × forks=auto-detected` and each cell produces a `pr5094-reftests-<preset>-<fork>` artifact.
- [ ] Run `gh workflow run pr-vectors.yml -f pr=<some-id> -f forks=gloas -f presets=mainnet` and verify a 1-cell run.
- [ ] Run on a PR touching only `tests/generators/**` and verify it fans out to all forks (hard-global rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)