### PR TITLE
Add more test action inputs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,42 @@ on:
         description: Generate mainnet preset
         default: false
         type: boolean
+      phase0:
+        description: Generate phase0 tests
+        default: true
+        type: boolean
+      altair:
+        description: Generate altair tests
+        default: true
+        type: boolean
+      bellatrix:
+        description: Generate bellatrix tests
+        default: true
+        type: boolean
+      capella:
+        description: Generate capella tests
+        default: true
+        type: boolean
+      deneb:
+        description: Generate deneb tests
+        default: true
+        type: boolean
+      electra:
+        description: Generate electra tests
+        default: true
+        type: boolean
+      fulu:
+        description: Generate fulu tests
+        default: true
+        type: boolean
+      gloas:
+        description: Generate gloas tests
+        default: true
+        type: boolean
+      heze:
+        description: Generate heze tests
+        default: true
+        type: boolean
   schedule:
     - cron: "0 0 * * *"
 
@@ -26,8 +62,9 @@ jobs:
   config:
     runs-on: ubuntu-latest
     outputs:
-      presets: ${{ steps.config.outputs.presets }}
       ref: ${{ steps.config.outputs.ref }}
+      presets: ${{ steps.config.outputs.presets }}
+      forks: ${{ steps.config.outputs.forks }}
     steps:
       - name: Resolve configuration
         id: config
@@ -57,10 +94,36 @@ jobs:
           fi
           echo "presets=$presets" >> "$GITHUB_OUTPUT"
 
+          # Forks
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            forks='["phase0","altair","bellatrix","capella","deneb","electra","fulu","gloas","heze"]'
+          else
+            selected=()
+            [[ "${{ inputs.phase0 }}" == "true" ]] && selected+=("phase0")
+            [[ "${{ inputs.altair }}" == "true" ]] && selected+=("altair")
+            [[ "${{ inputs.bellatrix }}" == "true" ]] && selected+=("bellatrix")
+            [[ "${{ inputs.capella }}" == "true" ]] && selected+=("capella")
+            [[ "${{ inputs.deneb }}" == "true" ]] && selected+=("deneb")
+            [[ "${{ inputs.electra }}" == "true" ]] && selected+=("electra")
+            [[ "${{ inputs.fulu }}" == "true" ]] && selected+=("fulu")
+            [[ "${{ inputs.gloas }}" == "true" ]] && selected+=("gloas")
+            [[ "${{ inputs.heze }}" == "true" ]] && selected+=("heze")
+
+            if [[ ${#selected[@]} -eq 0 ]]; then
+              echo "No forks selected." >&2
+              exit 1
+            fi
+
+            json=$(printf '"%s",' "${selected[@]}")
+            forks="[${json%,}]"
+          fi
+          echo "forks=$forks" >> "$GITHUB_OUTPUT"
+
           # Summary
           echo "Configuration:"
           echo "  ref:     ${ref:-master}"
           echo "  presets: $presets"
+          echo "  forks:   $forks"
 
   generate:
     needs: config
@@ -70,16 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         preset: ${{ fromJson(needs.config.outputs.presets) }}
-        fork:
-          - phase0
-          - altair
-          - bellatrix
-          - capella
-          - deneb
-          - electra
-          - fulu
-          - gloas
-          - heze
+        fork: ${{ fromJson(needs.config.outputs.forks) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: Tests
 on:
   workflow_dispatch:
     inputs:
+      repo:
+        description: Repository (e.g., ethereum/consensus-specs)
+        type: string
       ref:
         description: Commit, branch, or tag
         default: master
@@ -62,6 +65,7 @@ jobs:
   config:
     runs-on: ubuntu-latest
     outputs:
+      repo: ${{ steps.config.outputs.repo }}
       ref: ${{ steps.config.outputs.ref }}
       presets: ${{ steps.config.outputs.presets }}
       forks: ${{ steps.config.outputs.forks }}
@@ -69,6 +73,10 @@ jobs:
       - name: Resolve configuration
         id: config
         run: |
+          # Repo
+          repo="${{ inputs.repo || github.repository }}"
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+
           # Ref
           ref="${{ inputs.ref }}"
           if [[ -n "$ref" ]]; then
@@ -121,6 +129,7 @@ jobs:
 
           # Summary
           echo "Configuration:"
+          echo "  repo:    $repo"
           echo "  ref:     ${ref:-master}"
           echo "  presets: $presets"
           echo "  forks:   $forks"
@@ -138,6 +147,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ needs.config.outputs.repo }}
           ref: ${{ needs.config.outputs.ref }}
 
       - name: Setup python


### PR DESCRIPTION
This PR adds back the `repo` input and adds toggles for each fork. So this will allow developers to generate tests for a specific preset/fork, for whichever repo. I looked into adding a test name filter, but there were non-trivial issues. If you ran the action with a test name filter which exists in fork A but not fork B, the action would fail with fork B. Also, it was non-trivial to prevent command injection via the test name filter. For these reasons, I decided not include that just yet. Regarding the `repo` input, we removed it #5091 but this was a mistake. There have already been several instances where I've wanted to generate tests for someone else's fork.