### PR TITLE
Swap latest_block_hash / latest_execution_payload_bid

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -357,7 +357,7 @@ class BeaconState(Container):
     # [Modified in Gloas:EIP7732]
     # Removed `latest_execution_payload_header`
     # [New in Gloas:EIP7732]
-    latest_execution_payload_bid: ExecutionPayloadBid
+    latest_block_hash: Hash32
     next_withdrawal_index: WithdrawalIndex
     next_withdrawal_validator_index: ValidatorIndex
     historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
@@ -382,7 +382,7 @@ class BeaconState(Container):
     # [New in Gloas:EIP7732]
     builder_pending_withdrawals: List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
     # [New in Gloas:EIP7732]
-    latest_block_hash: Hash32
+    latest_execution_payload_bid: ExecutionPayloadBid
     # [New in Gloas:EIP7732]
     payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
     # [New in Gloas:EIP7732]

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -155,9 +155,7 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         # [Modified in Gloas:EIP7732]
         # Removed `latest_execution_payload_header`
         # [New in Gloas:EIP7732]
-        latest_execution_payload_bid=ExecutionPayloadBid(
-            block_hash=pre.latest_execution_payload_header.block_hash,
-        ),
+        latest_block_hash=pre.latest_execution_payload_header.block_hash,
         next_withdrawal_index=pre.next_withdrawal_index,
         next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
         historical_summaries=pre.historical_summaries,
@@ -182,7 +180,9 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         # [New in Gloas:EIP7732]
         builder_pending_withdrawals=[],
         # [New in Gloas:EIP7732]
-        latest_block_hash=pre.latest_execution_payload_header.block_hash,
+        latest_execution_payload_bid=ExecutionPayloadBid(
+            block_hash=pre.latest_execution_payload_header.block_hash,
+        ),
         # [New in Gloas:EIP7732]
         payload_expected_withdrawals=[],
         # [New in Gloas:EIP7732]

--- a/specs/heze/beacon-chain.md
+++ b/specs/heze/beacon-chain.md
@@ -128,8 +128,7 @@ class BeaconState(Container):
     inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
-    # [Modified in Heze:EIP7805]
-    latest_execution_payload_bid: ExecutionPayloadBid
+    latest_block_hash: Hash32
     next_withdrawal_index: WithdrawalIndex
     next_withdrawal_validator_index: ValidatorIndex
     historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
@@ -148,7 +147,8 @@ class BeaconState(Container):
     execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
     builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
     builder_pending_withdrawals: List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
-    latest_block_hash: Hash32
+    # [Modified in Heze:EIP7805]
+    latest_execution_payload_bid: ExecutionPayloadBid
     payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
     ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
 ```

--- a/specs/heze/fork.md
+++ b/specs/heze/fork.md
@@ -81,8 +81,7 @@ def upgrade_to_heze(pre: gloas.BeaconState) -> BeaconState:
         inactivity_scores=pre.inactivity_scores,
         current_sync_committee=pre.current_sync_committee,
         next_sync_committee=pre.next_sync_committee,
-        # [Modified in Heze:EIP7805]
-        latest_execution_payload_bid=latest_execution_payload_bid,
+        latest_block_hash=pre.latest_block_hash,
         next_withdrawal_index=pre.next_withdrawal_index,
         next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
         historical_summaries=pre.historical_summaries,
@@ -101,7 +100,8 @@ def upgrade_to_heze(pre: gloas.BeaconState) -> BeaconState:
         execution_payload_availability=pre.execution_payload_availability,
         builder_pending_payments=pre.builder_pending_payments,
         builder_pending_withdrawals=pre.builder_pending_withdrawals,
-        latest_block_hash=pre.latest_block_hash,
+        # [Modified in Heze:EIP7805]
+        latest_execution_payload_bid=latest_execution_payload_bid,
         payload_expected_withdrawals=pre.payload_expected_withdrawals,
         ptc_window=pre.ptc_window,
     )


### PR DESCRIPTION
To reduce generalized index churn, preserve the gindex representing the latest execution data (latest_execution_payload_header before Gloas / latest_block_hash after Gloas). The latest_execution_payload_bid has nothing to do with the latest execution data, it represents a potential future payload that may or may not arrive. Different semantics.
