### PR TITLE
Filter fork/transition tests by output fork

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/context.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/context.py
@@ -631,6 +631,7 @@ def with_phases(phases, other_phases=None):
                             accumulated.update(ret)
                     ret = accumulated if accumulated else None
                 else:
+                    ret = None
                     for fork_meta in fork_metas:
                         if fork_meta.post_fork_name not in DEFAULT_PYTEST_FORKS:
                             continue

--- a/tests/core/pyspec/eth_consensus_specs/test/context.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/context.py
@@ -524,7 +524,7 @@ def _get_preset_targets(kw):
     return spec_targets[preset_name]
 
 
-def _get_run_phases(phases, kw):
+def _get_run_phases(phases, kw, other_phases=None):
     """
     Return the fork names for the base `spec` in test cases
     """
@@ -538,6 +538,12 @@ def _get_run_phases(phases, kw):
     else:
         # If pytest `--fork` flag is set, filter out the rest of the forks
         run_phases = set(phases).intersection(DEFAULT_PYTEST_FORKS)
+        # Fork/transition tests run on the pre-fork but emit output under the
+        # post-fork (carried via `other_phases`). If the post-fork is selected
+        # but the pre-fork isn't, still run — the dump-level filter decides
+        # whether the resolved output fork is written.
+        if not run_phases and other_phases and set(other_phases).intersection(DEFAULT_PYTEST_FORKS):
+            run_phases = set(phases)
 
     return run_phases
 
@@ -553,7 +559,7 @@ def _get_available_phases(run_phases, other_phases):
 
 
 def _run_test_case_with_phases(fn, phases, other_phases, kw, args, is_fork_transition=False):
-    run_phases = _get_run_phases(phases, kw)
+    run_phases = _get_run_phases(phases, kw, other_phases=other_phases)
 
     if len(run_phases) == 0:
         if not is_fork_transition:
@@ -614,6 +620,8 @@ def with_phases(phases, other_phases=None):
                     # so that each fork transition produces a test vector.
                     accumulated = {}
                     for fork_meta in fork_metas:
+                        if fork_meta.post_fork_name not in DEFAULT_PYTEST_FORKS:
+                            continue
                         _phases = [fork_meta.pre_fork_name]
                         _other_phases = [fork_meta.post_fork_name]
                         ret = _run_test_case_with_phases(
@@ -624,6 +632,8 @@ def with_phases(phases, other_phases=None):
                     ret = accumulated if accumulated else None
                 else:
                     for fork_meta in fork_metas:
+                        if fork_meta.post_fork_name not in DEFAULT_PYTEST_FORKS:
+                            continue
                         _phases = [fork_meta.pre_fork_name]
                         _other_phases = [fork_meta.post_fork_name]
                         ret = _run_test_case_with_phases(

--- a/tests/infra/pytest_plugins/yield_generator.py
+++ b/tests/infra/pytest_plugins/yield_generator.py
@@ -336,6 +336,11 @@ class YieldGeneratorPlugin:
 
     def _dump_phase(self, manifest: Manifest, phase_result: list, fork_name: SpecForkName) -> None:
         """Write a single phase's test vector to disk."""
+        # Skip output whose resolved fork isn't in the selected --fork set.
+        # Fork/transition tests run on the pre-fork but emit under the post-fork;
+        # this keeps vectors under the directory matching the selected fork.
+        if fork_name not in context.DEFAULT_PYTEST_FORKS:
+            return
         manifest = manifest.with_defaults(Manifest(fork_name=fork_name))
         assert manifest.is_complete(), (
             f"Manifest must be complete to generate test vector for {manifest}"


### PR DESCRIPTION
I noticed this issue when dealing with FCR tests. When generating tests, we did not select the Gloas radio button, but it still output Gloas tests. I described the issue to Claude and asked it to fix it. To confirm the fix, I first generated Phase0 & Altair tests and moved them to a new directory. Then applied the fix from Claude and regenerated Altair tests. I then used Meld to check that the generated tests for Altair were the exact same.