### PR TITLE
Fix some syntax warnings

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/utils/bls.py
+++ b/tests/core/pyspec/eth_consensus_specs/utils/bls.py
@@ -147,8 +147,7 @@ def Verify(PK, message, signature):
             result = bls.Verify(PK, message, signature)
     except Exception:
         result = False
-    finally:
-        return result
+    return result
 
 
 @only_with_bls(alt_return=True)
@@ -160,8 +159,7 @@ def AggregateVerify(pubkeys, messages, signature):
             result = bls.AggregateVerify(list(pubkeys), list(messages), signature)
     except Exception:
         result = False
-    finally:
-        return result
+    return result
 
 
 @only_with_bls(alt_return=True)
@@ -173,8 +171,7 @@ def FastAggregateVerify(pubkeys, message, signature):
             result = bls.FastAggregateVerify(list(pubkeys), message, signature)
     except Exception:
         result = False
-    finally:
-        return result
+    return result
 
 
 @only_with_bls(alt_return=STUB_SIGNATURE)


### PR DESCRIPTION
When reviewing a test issue, I noticed these warnings:

```
/home/runner/work/consensus-specs/consensus-specs/tests/core/pyspec/eth_consensus_specs/utils/bls.py:151: SyntaxWarning: 'return' in a 'finally' block
  return result
/home/runner/work/consensus-specs/consensus-specs/tests/core/pyspec/eth_consensus_specs/utils/bls.py:164: SyntaxWarning: 'return' in a 'finally' block
  return result
/home/runner/work/consensus-specs/consensus-specs/tests/core/pyspec/eth_consensus_specs/utils/bls.py:177: SyntaxWarning: 'return' in a 'finally' block
  return result
```