### PR TITLE
Make test archives deterministic

### DIFF
--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -206,7 +206,17 @@ jobs:
           merge-multiple: true
 
       - name: Archive compliance tests
-        run: tar -czvf ${{ matrix.config }}.tar.gz tests
+        run: |
+          tar --sort=name \
+              --owner=0 \
+              --group=0 \
+              --numeric-owner \
+              --mtime='@0' \
+              --format=gnu \
+              --use-compress-program='gzip --no-name' \
+              --create \
+              --file=${{ matrix.config }}.tar.gz \
+              tests
 
       - name: Upload ${{ matrix.config }}.tar.gz
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,17 @@ jobs:
           merge-multiple: true
 
       - name: Archive reference tests
-        run: tar -czvf ${{ matrix.preset }}.tar.gz tests/${{ matrix.preset }}
+        run: |
+          tar --sort=name \
+              --owner=0 \
+              --group=0 \
+              --numeric-owner \
+              --mtime='@0' \
+              --format=gnu \
+              --use-compress-program='gzip --no-name' \
+              --create \
+              --file=${{ matrix.preset }}.tar.gz \
+              tests/${{ matrix.preset }}
 
       - name: Upload to release
         run: gh release upload "${{ needs.setup.outputs.tag }}" ${{ matrix.preset }}.tar.gz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,7 +185,17 @@ jobs:
           merge-multiple: true
 
       - name: Archive reference tests
-        run: tar -czvf ${{ matrix.preset }}.tar.gz tests/${{ matrix.preset }}
+        run: |
+          tar --sort=name \
+              --owner=0 \
+              --group=0 \
+              --numeric-owner \
+              --mtime='@0' \
+              --format=gnu \
+              --use-compress-program='gzip --no-name' \
+              --create \
+              --file=${{ matrix.preset }}.tar.gz \
+              tests/${{ matrix.preset }}
 
       - name: Upload ${{ matrix.preset }}.tar.gz
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
As mentioned in the following link, I noticed that archives were not deterministic because of timestamps. I launched the same action twice and the SHAs of the results were different but the contents were exactly the same. This PR solves this by sorting files & stripping metadata when archiving.

* https://github.com/ethereum/consensus-specs/pull/5119#issuecomment-4263694142