### PR TITLE
Use `engine_getPayloadV6`

### DIFF
--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -114,7 +114,7 @@ to include. They produce a `SignedExecutionPayloadBid` as follows.
     come from the same `state` and `store` by the method described in this and
     the previous point.
 03. Construct an execution payload. This can be performed with an external
-    execution engine via a call to `engine_getPayloadV5`.
+    execution engine via a call to `engine_getPayloadV6`.
 04. Set `bid.block_hash` to be the block hash of the constructed payload, that
     is `payload.block_hash`.
 05. Set `bid.prev_randao` to be the previous RANDAO of the constructed payload,
@@ -136,10 +136,10 @@ to include. They produce a `SignedExecutionPayloadBid` as follows.
     execution-layer payment. Bids with non-zero `execution_payment` **MUST NOT**
     be broadcast to the `execution_payload_bid` gossip topic.
 12. Set `bid.blob_kzg_commitments` to be the `blobsbundle.commitments` field
-    returned by `engine_getPayloadV5`.
+    returned by `engine_getPayloadV6`.
 13. Set `bid.execution_requests_root` to `hash_tree_root(execution_requests)`,
     where `execution_requests` is the `ExecutionRequests` field returned by
-    `engine_getPayloadV5`.
+    `engine_getPayloadV6`.
 
 After building the `bid`, the builder obtains a `signature` of the bid by using:
 


### PR DESCRIPTION
Update builder specs to use the updated `engine_getPayloadV6` introduced in EIP-7928.