### PR TITLE
Faster comptests generation by re-using common test data

### DIFF
--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 
+from eth_consensus_specs.test.context import spec_test
 from eth_consensus_specs.test.helpers.attestations import (
     get_valid_attestation,
 )
@@ -387,10 +388,11 @@ def _add_block(spec, store, signed_block, test_steps):
                 pass
 
 
+@spec_test
 @filter_out_duplicate_messages
-def yield_fork_choice_test_events(
-    spec, store, test_data: FCTestData, test_events: list, debug: bool
-):
+def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list, debug: bool):
+    store = spec.get_forkchoice_store(test_data.anchor_state, test_data.anchor_block)
+
     # Yield meta
     for k, v in test_data.meta.items():
         yield k, "meta", v

--- a/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
@@ -9,6 +9,7 @@ from ruamel.yaml import YAML
 from eth_consensus_specs.test.context import (
     spec_state_test,
     with_altair_and_later,
+
 )
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_attestation_file_name,
@@ -18,7 +19,12 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     output_store_checks,
 )
 from eth_consensus_specs.utils import bls
-from tests.generators.compliance_runners.gen_base.gen_typing import TestCase
+from tests.generators.compliance_runners.gen_base.gen_typing import (
+    TestCase,
+    TestCasePart,
+    TestCaseResult,
+    TestGroup,
+)
 
 from .block_cover import gen_block_cover_test_data
 from .block_tree import gen_block_tree_test_data
@@ -82,18 +88,56 @@ class PlainFCTestCase(TestCase):
             handler_name=kwds["handler_name"],
             suite_name=kwds["suite_name"],
             case_name=kwds["case_name"],
-            case_fn=self.mutation_case_fn,
         )
         self.test_dna = test_dna
         self.bls_active = bls_active
         self.debug = debug
 
-    def mutation_case_fn(self):
-        test_kind = self.test_dna.kind
-        phase, preset = self.fork_name, self.preset_name
-        bls_active, debug = self.bls_active, self.debug
-        solution, seed = self.test_dna.solution, self.test_dna.variation_seed
-        mut_seed = self.test_dna.mutation_seed
+
+@dataclass(init=False)
+class MutationGroupTestGroup(TestGroup):
+    mutation_group: MutationGroup
+    fork_name: str
+    preset_name: str
+    bls_active: bool
+    debug: bool
+
+    def __init__(self, mutation_group, fork_name, preset_name, bls_active=False, debug=False):
+        test_cases = [
+            PlainFCTestCase(
+                test_dna=test_dna,
+                bls_active=bls_active,
+                debug=debug,
+                fork_name=fork_name,
+                preset_name=preset_name,
+                runner_name=GENERATOR_NAME,
+                handler_name=mutation_group.test_name,
+                suite_name=SUITE_NAME,
+                case_name=case_name,
+            )
+            for case_name, test_dna in enumerate_test_dnas(mutation_group)
+        ]
+        super().__init__(
+            group_name=(
+                f"{preset_name}::{fork_name}::{GENERATOR_NAME}::"
+                f"{mutation_group.test_name}::{mutation_group.solution_index}::"
+                f"{mutation_group.test_dna_base.variation_seed}"
+            ),
+            test_cases=test_cases,
+            group_fn=self.execute_group,
+        )
+        self.mutation_group = mutation_group
+        self.fork_name = fork_name
+        self.preset_name = preset_name
+        self.bls_active = bls_active
+        self.debug = debug
+
+    def run_case_fn(self, test_case: PlainFCTestCase):
+        test_kind = test_case.test_dna.kind
+        phase, preset = test_case.fork_name, test_case.preset_name
+        bls_active, debug = test_case.bls_active, test_case.debug
+        solution, seed = test_case.test_dna.solution, test_case.test_dna.variation_seed
+        mut_seed = test_case.test_dna.mutation_seed
         return yield_mutation_test_case(
             phase=phase,
             preset=preset,
@@ -104,6 +148,26 @@ class PlainFCTestCase(TestCase):
             test_kind=test_kind,
             solution=solution,
         )
+
+    def execute_group(self) -> Iterable[TestCaseResult]:
+        for test_case in self.test_cases:
+            yield collect_test_case_result_from_iterator(test_case, self.run_case_fn(test_case))
+
+
+def collect_test_case_result_from_iterator(
+    test_case: TestCase,
+    parts_iter: Iterable[TestCasePart],
+) -> TestCaseResult:
+    meta: dict[str, Any] = {}
+    outputs: list[TestCasePart] = []
+
+    for name, kind, data in parts_iter:
+        if kind == "meta":
+            meta[name] = data
+        else:
+            outputs.append(TestCasePart((name, kind, data)))
+
+    return TestCaseResult(test_case=test_case, meta=meta, case_parts=outputs)
 
 
 def get_test_data(spec, state, test_kind, solution, debug, seed):
@@ -362,7 +426,7 @@ def enumerate_test_dnas(mutation_group: MutationGroup) -> Iterable[tuple[str, FC
         yield case_name, test_dna
 
 
-def enumerate_test_cases(config_path, forks, presets, debug, initial_seed: int = None):
+def enumerate_test_groups(config_path, forks, presets, debug, initial_seed: int = None):
     config_dir = path.dirname(config_path)
     test_gen_config = _load_yaml(config_path)
 
@@ -375,15 +439,10 @@ def enumerate_test_cases(config_path, forks, presets, debug, initial_seed: int =
         for fork_name in forks:
             for preset_name in presets:
                 for mutation_group in enumerate_mutation_groups(config_dir, test_name, params):
-                    for case_name, test_dna in enumerate_test_dnas(mutation_group):
-                        yield PlainFCTestCase(
-                            test_dna=test_dna,
-                            bls_active=BLS_ACTIVE,
-                            debug=debug,
-                            fork_name=fork_name,
-                            preset_name=preset_name,
-                            runner_name=GENERATOR_NAME,
-                            handler_name=test_name,
-                            suite_name=SUITE_NAME,
-                            case_name=case_name,
-                        )
+                    yield MutationGroupTestGroup(
+                        mutation_group=mutation_group,
+                        fork_name=fork_name,
+                        preset_name=preset_name,
+                        bls_active=BLS_ACTIVE,
+                        debug=debug,
+                    )

--- a/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
@@ -60,6 +60,14 @@ class FCTestDNA:
     mutation_seed: int | None
 
 
+@dataclass(eq=True, frozen=True)
+class MutationGroup:
+    test_name: str
+    solution_index: int
+    test_dna_base: FCTestDNA
+    nr_mutations: int
+
+
 @dataclass(init=False)
 class PlainFCTestCase(TestCase):
     test_dna: FCTestDNA
@@ -309,7 +317,7 @@ def _load_yaml(path: str):
         return yaml.load(f)
 
 
-def enumerate_test_dnas(config_dir, test_name, params) -> Iterable[tuple[str, FCTestData]]:
+def enumerate_mutation_groups(config_dir, test_name, params) -> Iterable[MutationGroup]:
     test_type = params["test_type"]
     instances_path = params["instances"]
     initial_seed = params["seed"]
@@ -329,10 +337,29 @@ def enumerate_test_dnas(config_dir, test_name, params) -> Iterable[tuple[str, FC
 
     for i, solution in enumerate(solutions):
         for seed in seeds:
-            for j in range(1 + nr_mutations):
-                test_dna = FCTestDNA(test_kind, solution, seed, None if j == 0 else seed + j - 1)
-                case_name = test_name + "_" + str(i) + "_" + str(seed) + "_" + str(j)
-                yield case_name, test_dna
+            yield MutationGroup(
+                test_name=test_name,
+                solution_index=i,
+                test_dna_base=FCTestDNA(test_kind, solution, seed, None),
+                nr_mutations=nr_mutations,
+            )
+
+
+def enumerate_test_dnas(mutation_group: MutationGroup) -> Iterable[tuple[str, FCTestDNA]]:
+    test_name = mutation_group.test_name
+    solution_index = mutation_group.solution_index
+    test_dna_base = mutation_group.test_dna_base
+    seed = test_dna_base.variation_seed
+
+    for j in range(1 + mutation_group.nr_mutations):
+        test_dna = FCTestDNA(
+            test_dna_base.kind,
+            test_dna_base.solution,
+            seed,
+            None if j == 0 else seed + j - 1,
+        )
+        case_name = test_name + "_" + str(solution_index) + "_" + str(seed) + "_" + str(j)
+        yield case_name, test_dna
 
 
 def enumerate_test_cases(config_path, forks, presets, debug, initial_seed: int = None):
@@ -347,15 +374,16 @@ def enumerate_test_cases(config_path, forks, presets, debug, initial_seed: int =
             print(test_name)
         for fork_name in forks:
             for preset_name in presets:
-                for case_name, test_dna in enumerate_test_dnas(config_dir, test_name, params):
-                    yield PlainFCTestCase(
-                        test_dna=test_dna,
-                        bls_active=BLS_ACTIVE,
-                        debug=debug,
-                        fork_name=fork_name,
-                        preset_name=preset_name,
-                        runner_name=GENERATOR_NAME,
-                        handler_name=test_name,
-                        suite_name=SUITE_NAME,
-                        case_name=case_name,
-                    )
+                for mutation_group in enumerate_mutation_groups(config_dir, test_name, params):
+                    for case_name, test_dna in enumerate_test_dnas(mutation_group):
+                        yield PlainFCTestCase(
+                            test_dna=test_dna,
+                            bls_active=BLS_ACTIVE,
+                            debug=debug,
+                            fork_name=fork_name,
+                            preset_name=preset_name,
+                            runner_name=GENERATOR_NAME,
+                            handler_name=test_name,
+                            suite_name=SUITE_NAME,
+                            case_name=case_name,
+                        )

--- a/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
@@ -8,8 +8,8 @@ from ruamel.yaml import YAML
 
 from eth_consensus_specs.test.context import (
     spec_state_test,
+    spec_test,
     with_altair_and_later,
-
 )
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_attestation_file_name,
@@ -132,26 +132,30 @@ class MutationGroupTestGroup(TestGroup):
         self.bls_active = bls_active
         self.debug = debug
 
-    def run_case_fn(self, test_case: PlainFCTestCase):
-        test_kind = test_case.test_dna.kind
-        phase, preset = test_case.fork_name, test_case.preset_name
-        bls_active, debug = test_case.bls_active, test_case.debug
-        solution, seed = test_case.test_dna.solution, test_case.test_dna.variation_seed
-        mut_seed = test_case.test_dna.mutation_seed
-        return yield_mutation_test_case(
-            phase=phase,
-            preset=preset,
+    def execute_group(self) -> Iterable[TestCaseResult]:
+        bls_active = self.bls_active
+        debug = self.debug
+
+        spec, test_data, events = make_test_context(
+            self.mutation_group.test_dna_base,
+            self.fork_name,
+            self.preset_name,
             bls_active=bls_active,
             debug=debug,
-            seed=seed,
-            mut_seed=mut_seed,
-            test_kind=test_kind,
-            solution=solution,
         )
 
-    def execute_group(self) -> Iterable[TestCaseResult]:
         for test_case in self.test_cases:
-            yield collect_test_case_result_from_iterator(test_case, self.run_case_fn(test_case))
+            mut_seed = test_case.test_dna.mutation_seed
+            if mut_seed is None:
+                parts_iter = yield_fork_choice_test_events(
+                    spec, test_data, events, debug, bls_active=bls_active
+                )
+            else:
+                parts_iter = yield_mutated_test_case_parts(
+                    spec, test_data, events, mut_seed, bls_active=bls_active
+                )
+
+            yield collect_test_case_result_from_iterator(test_case, parts_iter)
 
 
 def collect_test_case_result_from_iterator(
@@ -194,26 +198,45 @@ def get_test_data(spec, state, test_kind, solution, debug, seed):
     return test_data
 
 
-@with_altair_and_later
-@spec_state_test
-def yield_mutation_test_case(spec, state, test_kind, solution, debug, seed, mut_seed):
-    test_data = get_test_data(spec, state, test_kind, solution, debug, seed)
-    events = make_events(spec, test_data)
+def make_test_context(
+    test_dna_base: FCTestDNA,
+    fork_name: str,
+    preset_name: str,
+    bls_active: bool = False,
+    debug: bool = False,
+):
+    @with_altair_and_later
+    @spec_state_test
+    def get_spec_test_data_and_events(spec, state):
+        test_kind = test_dna_base.kind
+        solution = test_dna_base.solution
+        seed = test_dna_base.variation_seed
+        test_data = get_test_data(spec, state, test_kind, solution, debug, seed)
+        events = make_events(spec, test_data)
+        yield (spec, test_data, events)
+
+    ((spec, test_data, events),) = get_spec_test_data_and_events(
+        phase=fork_name,
+        preset=preset_name,
+        bls_active=bls_active,
+    )
+
+    return spec, test_data, events
+
+
+@spec_test
+def yield_mutated_test_case_parts(spec, test_data, events, mut_seed):
     store = spec.get_forkchoice_store(test_data.anchor_state, test_data.anchor_block)
 
-    if mut_seed is None:
-        return yield_fork_choice_test_events(spec, store, test_data, events, debug)
-    else:
-        test_vector = events_to_test_vector(events)
-        mops = MutationOps(store.time, spec.config.SLOT_DURATION_MS // 1000)
-        mutated_vector, mutations = mops.rand_mutations(test_vector, 4, random.Random(mut_seed))
+    test_vector = events_to_test_vector(events)
+    mops = MutationOps(store.time, spec.config.SLOT_DURATION_MS // 1000)
+    mutated_vector, mutations = mops.rand_mutations(test_vector, 4, random.Random(mut_seed))
 
-        test_data.meta["mut_seed"] = mut_seed
-        test_data.meta["mutations"] = mutations
+    test_data.meta["mut_seed"] = mut_seed
+    test_data.meta["mutations"] = mutations
 
-        mutated_events = convert_test_vector_to_events(mutated_vector)
-
-        return yield_test_parts(spec, store, test_data, mutated_events)
+    mutated_events = convert_test_vector_to_events(mutated_vector)
+    return yield_test_parts(spec, store, test_data, mutated_events)
 
 
 def events_to_test_vector(events) -> list[Any]:

--- a/tests/generators/compliance_runners/fork_choice/test_gen.py
+++ b/tests/generators/compliance_runners/fork_choice/test_gen.py
@@ -8,7 +8,7 @@ from tests.generators.compliance_runners.gen_base.args import create_arg_parser
 context.is_pytest = False
 context.is_generator = True
 
-from .instantiators.test_case import enumerate_test_cases, prepare_bls  # noqa: E402
+from .instantiators.test_case import enumerate_test_groups, prepare_bls  # noqa: E402
 
 default_forks = [ELECTRA]
 default_presets = [MINIMAL]
@@ -82,10 +82,10 @@ def main():
         raise ValueError("Neither neither fc-gen-config not fc-gen-config-path specified")
 
     prepare_bls()
-    test_cases = enumerate_test_cases(
+    test_groups = enumerate_test_groups(
         config_path, forks, presets, args.fc_gen_debug, args.fc_gen_seed
     )
-    gen_runner.run_generator(test_cases, args)
+    gen_runner.run_generator_groups(test_groups, args)
 
 
 if __name__ == "__main__":

--- a/tests/generators/compliance_runners/gen_base/gen_runner.py
+++ b/tests/generators/compliance_runners/gen_base/gen_runner.py
@@ -4,7 +4,6 @@ import threading
 import time
 import uuid
 from collections.abc import Iterable
-from typing import Any
 
 import psutil
 from pathos.multiprocessing import ProcessingPool as Pool
@@ -19,7 +18,7 @@ from eth_consensus_specs.test.exceptions import SkippedTest
 from tests.infra.dumper import Dumper
 
 from .args import parse_arguments
-from .gen_typing import TestCase, TestCasePart, TestCaseResult, TestGroup
+from .gen_typing import TestCaseResult, TestGroup
 from .utils import install_sigint_handler, time_since
 
 
@@ -81,24 +80,6 @@ def display_test_summary(
     console.print()
 
 
-def collect_test_case_result(test_case: TestCase) -> TestCaseResult:
-    """Execute a test case and collect its outputs in memory."""
-    meta: dict[str, Any] = {}
-    outputs: list[TestCasePart] = []
-
-    try:
-        for name, kind, data in test_case.case_fn():
-            if kind == "meta":
-                meta[name] = data
-            else:
-                outputs.append(TestCasePart((name, kind, data)))
-    except SkippedTest:
-        # Bail without writing any files
-        raise
-
-    return TestCaseResult(test_case=test_case, meta=meta, case_parts=outputs)
-
-
 def dump_test_case_result(test_case_result: TestCaseResult, dumper: Dumper) -> None:
     """Write a collected test case result to storage."""
     test_case = test_case_result.test_case
@@ -126,27 +107,11 @@ def dump_test_case_result(test_case_result: TestCaseResult, dumper: Dumper) -> N
 
 def execute_test_group(
     test_group: TestGroup,
-    selected_test_cases: list[TestCase],
     dumper: Dumper,
 ) -> None:
     """Execute a test group and write all of its selected test cases to storage."""
-    for test_case_result in test_group.group_fn(selected_test_cases):
+    for test_case_result in test_group.group_fn():
         dump_test_case_result(test_case_result, dumper)
-
-
-def execute_single_test_group(test_cases: list[TestCase]) -> Iterable[TestCaseResult]:
-    """Execute a trivial test group containing exactly one test case."""
-    assert len(test_cases) == 1
-    yield collect_test_case_result(test_cases[0])
-
-
-def wrap_test_case_in_group(test_case: TestCase) -> TestGroup:
-    """Wrap a test case in a single-case test group for compatibility."""
-    return TestGroup(
-        group_name=test_case.get_identifier(),
-        test_cases=[test_case],
-        group_fn=execute_single_test_group,
-    )
 
 
 def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
@@ -166,7 +131,6 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
     install_sigint_handler(console)
 
     total_found = 0
-    selected_test_cases = []
     selected_test_groups = []
     for test_group in input_test_groups:
         selected_group_cases = []
@@ -182,15 +146,19 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
             if len(args.cases) != 0 and not any(s in test_case.case_name for s in args.cases):
                 continue
 
+            selected_group_cases.append(test_case)
+
+        if selected_group_cases:
+            selected_test_groups.append(test_group)
+
+    selected_test_cases = []
+    for test_group in selected_test_groups:
+        for test_case in test_group.test_cases:
             # Set the output dir and add this to out list
             test_case.set_output_dir(args.output_dir)
             if test_case.dir.exists():
                 shutil.rmtree(test_case.dir)
-            selected_group_cases.append(test_case)
             selected_test_cases.append(test_case)
-
-        if selected_group_cases:
-            selected_test_groups.append((test_group, selected_group_cases))
 
     if len(selected_test_cases) == 0:
         # Show summary even when all tests are filtered out
@@ -203,7 +171,7 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
 
     def worker_function(data):
         """Execute a test group and update active tests."""
-        test_group, selected_group_cases, active_tests = data
+        test_group, active_tests = data
         key = (uuid.uuid4(), test_group.get_identifier())
         test_start = time.time()
         active_tests[key] = test_start
@@ -211,14 +179,14 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
         debug_print(f"Starting: {test_group.get_identifier()}")
 
         try:
-            execute_test_group(test_group, selected_group_cases, dumper)
+            execute_test_group(test_group, dumper)
             elapsed = time.time() - test_start
             debug_print(f"Generated: {test_group.get_identifier()} (took {elapsed:.2f}s)")
-            return ("generated", len(selected_group_cases))
+            return ("generated", len(test_group.test_cases))
         except SkippedTest:
             elapsed = time.time() - test_start
             debug_print(f"Skipped: {test_group.get_identifier()} (took {elapsed:.2f}s)")
-            return ("skipped", len(selected_group_cases))
+            return ("skipped", len(test_group.test_cases))
         finally:
             del active_tests[key]
 
@@ -298,7 +266,7 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
             active_tests = manager.dict()
             completed = manager.Value("i", 0)
             skipped = manager.Value("i", 0)
-            width = max([len(group.get_identifier()) for group, _ in selected_test_groups])
+            width = max([len(group.get_identifier()) for group in selected_test_groups])
 
             if not args.verbose:
                 display_thread = threading.Thread(
@@ -317,7 +285,7 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
                 status_thread.start()
 
             # Map each selected group to a worker
-            inputs = [(group, group_cases, active_tests) for group, group_cases in selected_test_groups]
+            inputs = [(group, active_tests) for group in selected_test_groups]
 
             if args.threads == 1:
                 for input in inputs:
@@ -360,7 +328,3 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
         debug_print(f"Completed generation of {tests_prefix} in {elapsed} seconds")
     except KeyboardInterrupt:
         return
-
-
-def run_generator(input_test_cases: Iterable[TestCase], args=None):
-    run_generator_groups((wrap_test_case_in_group(test_case) for test_case in input_test_cases), args)

--- a/tests/generators/compliance_runners/gen_base/gen_runner.py
+++ b/tests/generators/compliance_runners/gen_base/gen_runner.py
@@ -19,7 +19,7 @@ from eth_consensus_specs.test.exceptions import SkippedTest
 from tests.infra.dumper import Dumper
 
 from .args import parse_arguments
-from .gen_typing import TestCase
+from .gen_typing import TestCase, TestCasePart, TestCaseResult, TestGroup
 from .utils import install_sigint_handler, time_since
 
 
@@ -81,30 +81,36 @@ def display_test_summary(
     console.print()
 
 
-def execute_test(test_case: TestCase, dumper: Dumper):
-    """Execute a test and write the outputs to storage."""
+def collect_test_case_result(test_case: TestCase) -> TestCaseResult:
+    """Execute a test case and collect its outputs in memory."""
     meta: dict[str, Any] = {}
-    outputs: list[tuple[str, str, Any]] = []
+    outputs: list[TestCasePart] = []
 
     try:
         for name, kind, data in test_case.case_fn():
             if kind == "meta":
                 meta[name] = data
             else:
-                method = getattr(dumper, f"dump_{kind}", None)
-                if method is None:
-                    raise ValueError(f"Unknown kind {kind!r}")
-                outputs.append((name, kind, data))
+                outputs.append(TestCasePart((name, kind, data)))
     except SkippedTest:
         # Bail without writing any files
         raise
 
-    for name, kind, data in outputs:
-        method = getattr(dumper, f"dump_{kind}")
+    return TestCaseResult(test_case=test_case, meta=meta, case_parts=outputs)
+
+
+def dump_test_case_result(test_case_result: TestCaseResult, dumper: Dumper) -> None:
+    """Write a collected test case result to storage."""
+    test_case = test_case_result.test_case
+
+    for name, kind, data in test_case_result.case_parts:
+        method = getattr(dumper, f"dump_{kind}", None)
+        if method is None:
+            raise ValueError(f"Unknown kind {kind!r}")
         method(test_case.dir, name, data)
 
-    if meta:
-        dumper.dump_meta(test_case.dir, meta)
+    if test_case_result.meta:
+        dumper.dump_meta(test_case.dir, test_case_result.meta)
 
     # Always write manifest.yml for every test case
     manifest_data = {
@@ -118,7 +124,32 @@ def execute_test(test_case: TestCase, dumper: Dumper):
     dumper.dump_manifest(test_case.dir, manifest_data)
 
 
-def run_generator(input_test_cases: Iterable[TestCase], args=None):
+def execute_test_group(
+    test_group: TestGroup,
+    selected_test_cases: list[TestCase],
+    dumper: Dumper,
+) -> None:
+    """Execute a test group and write all of its selected test cases to storage."""
+    for test_case_result in test_group.group_fn(selected_test_cases):
+        dump_test_case_result(test_case_result, dumper)
+
+
+def execute_single_test_group(test_cases: list[TestCase]) -> Iterable[TestCaseResult]:
+    """Execute a trivial test group containing exactly one test case."""
+    assert len(test_cases) == 1
+    yield collect_test_case_result(test_cases[0])
+
+
+def wrap_test_case_in_group(test_case: TestCase) -> TestGroup:
+    """Wrap a test case in a single-case test group for compatibility."""
+    return TestGroup(
+        group_name=test_case.get_identifier(),
+        test_cases=[test_case],
+        group_fn=execute_single_test_group,
+    )
+
+
+def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
     start_time = time.time()
     if args is None:
         args = parse_arguments()
@@ -136,23 +167,30 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
 
     total_found = 0
     selected_test_cases = []
-    for test_case in input_test_cases:
-        total_found += 1
-        # Check if the test case should be filtered out
-        if len(args.runners) != 0 and test_case.runner_name not in args.runners:
-            continue
-        if len(args.presets) != 0 and test_case.preset_name not in args.presets:
-            continue
-        if len(args.forks) != 0 and test_case.fork_name not in args.forks:
-            continue
-        if len(args.cases) != 0 and not any(s in test_case.case_name for s in args.cases):
-            continue
+    selected_test_groups = []
+    for test_group in input_test_groups:
+        selected_group_cases = []
+        for test_case in test_group.test_cases:
+            total_found += 1
+            # Check if the test case should be filtered out
+            if len(args.runners) != 0 and test_case.runner_name not in args.runners:
+                continue
+            if len(args.presets) != 0 and test_case.preset_name not in args.presets:
+                continue
+            if len(args.forks) != 0 and test_case.fork_name not in args.forks:
+                continue
+            if len(args.cases) != 0 and not any(s in test_case.case_name for s in args.cases):
+                continue
 
-        # Set the output dir and add this to out list
-        test_case.set_output_dir(args.output_dir)
-        if test_case.dir.exists():
-            shutil.rmtree(test_case.dir)
-        selected_test_cases.append(test_case)
+            # Set the output dir and add this to out list
+            test_case.set_output_dir(args.output_dir)
+            if test_case.dir.exists():
+                shutil.rmtree(test_case.dir)
+            selected_group_cases.append(test_case)
+            selected_test_cases.append(test_case)
+
+        if selected_group_cases:
+            selected_test_groups.append((test_group, selected_group_cases))
 
     if len(selected_test_cases) == 0:
         # Show summary even when all tests are filtered out
@@ -164,23 +202,23 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
     tests_prefix = get_shared_prefix(selected_test_cases)
 
     def worker_function(data):
-        """Execute a test case and update active tests."""
-        test_case, active_tests = data
-        key = (uuid.uuid4(), test_case.get_identifier())
+        """Execute a test group and update active tests."""
+        test_group, selected_group_cases, active_tests = data
+        key = (uuid.uuid4(), test_group.get_identifier())
         test_start = time.time()
         active_tests[key] = test_start
 
-        debug_print(f"Starting: {test_case.get_identifier()}")
+        debug_print(f"Starting: {test_group.get_identifier()}")
 
         try:
-            execute_test(test_case, dumper)
+            execute_test_group(test_group, selected_group_cases, dumper)
             elapsed = time.time() - test_start
-            debug_print(f"Generated: {test_case.get_identifier()} (took {elapsed:.2f}s)")
-            return "generated"
+            debug_print(f"Generated: {test_group.get_identifier()} (took {elapsed:.2f}s)")
+            return ("generated", len(selected_group_cases))
         except SkippedTest:
             elapsed = time.time() - test_start
-            debug_print(f"Skipped: {test_case.get_identifier()} (took {elapsed:.2f}s)")
-            return "skipped"
+            debug_print(f"Skipped: {test_group.get_identifier()} (took {elapsed:.2f}s)")
+            return ("skipped", len(selected_group_cases))
         finally:
             del active_tests[key]
 
@@ -260,7 +298,7 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
             active_tests = manager.dict()
             completed = manager.Value("i", 0)
             skipped = manager.Value("i", 0)
-            width = max([len(t.get_identifier()) for t in selected_test_cases])
+            width = max([len(group.get_identifier()) for group, _ in selected_test_groups])
 
             if not args.verbose:
                 display_thread = threading.Thread(
@@ -278,23 +316,23 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
                 )
                 status_thread.start()
 
-            # Map each test case to a thread worker
-            inputs = [(t, active_tests) for t in selected_test_cases]
+            # Map each selected group to a worker
+            inputs = [(group, group_cases, active_tests) for group, group_cases in selected_test_groups]
 
             if args.threads == 1:
                 for input in inputs:
-                    result = worker_function(input)
+                    result, nr_cases = worker_function(input)
                     if result == "skipped":
-                        skipped.value += 1
-                    completed.value += 1
+                        skipped.value += nr_cases
+                    completed.value += nr_cases
             else:
                 # Restart workers periodically to prevent memory accumulation
                 pool = Pool(processes=args.threads, maxtasksperchild=100)
                 try:
-                    for result in pool.uimap(worker_function, inputs):
+                    for result, nr_cases in pool.uimap(worker_function, inputs):
                         if result == "skipped":
-                            skipped.value += 1
-                        completed.value += 1
+                            skipped.value += nr_cases
+                        completed.value += nr_cases
                 except KeyboardInterrupt:
                     # Terminate pool immediately on interrupt
                     pool.terminate()
@@ -322,3 +360,7 @@ def run_generator(input_test_cases: Iterable[TestCase], args=None):
         debug_print(f"Completed generation of {tests_prefix} in {elapsed} seconds")
     except KeyboardInterrupt:
         return
+
+
+def run_generator(input_test_cases: Iterable[TestCase], args=None):
+    run_generator_groups((wrap_test_case_in_group(test_case) for test_case in input_test_cases), args)

--- a/tests/generators/compliance_runners/gen_base/gen_typing.py
+++ b/tests/generators/compliance_runners/gen_base/gen_typing.py
@@ -26,7 +26,6 @@ class TestCase:
     handler_name: str
     suite_name: str
     case_name: str
-    case_fn: Callable[[], Iterable[TestCasePart]]
     dir: Path | None = None
 
     def get_identifier(self):
@@ -66,7 +65,7 @@ class TestCaseResult:
 class TestGroup:
     group_name: str
     test_cases: list[TestCase]
-    group_fn: Callable[[list[TestCase]], Iterable[TestCaseResult]]
+    group_fn: Callable[[], Iterable[TestCaseResult]]
 
     def get_identifier(self) -> str:
         """Return the human readable identifier for the group."""

--- a/tests/generators/compliance_runners/gen_base/gen_typing.py
+++ b/tests/generators/compliance_runners/gen_base/gen_typing.py
@@ -53,3 +53,21 @@ class TestCase:
             / self.suite_name
             / self.case_name
         )
+
+
+@dataclass
+class TestCaseResult:
+    test_case: TestCase
+    meta: dict[str, Any]
+    case_parts: list[TestCasePart]
+
+
+@dataclass
+class TestGroup:
+    group_name: str
+    test_cases: list[TestCase]
+    group_fn: Callable[[list[TestCase]], Iterable[TestCaseResult]]
+
+    def get_identifier(self) -> str:
+        """Return the human readable identifier for the group."""
+        return self.group_name


### PR DESCRIPTION
The PR implements a faster approach to generate comptests: mutation tests now re-use common test data.
Test generation is about 20% faster (`small` test suite takes 20% less time to generate, up to 33% saving on mutation heavy cases).

To implement the faster generator, `gen_runner` has been changed to support test groups (i.e. a group of tests is a scheduling unit). This well also help implementing "sliced" test generation (to address slow test generation for `gloas`).