### PR TITLE
Guard `get_parent_payload_status` at fork boundary

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -276,7 +276,7 @@ def get_parent_payload_status(store: Store, block: BeaconBlock) -> PayloadStatus
     parent = store.blocks[block.parent_root]
     parent_state = store.block_states[block.parent_root]
     # pre-Gloas parent has no bid field hence, treat as PENDING
-    if parent_state.fork.current_version != GLOAS_FORK_VERSION:
+    if parent_state.fork.current_version < GLOAS_FORK_VERSION:
         return PAYLOAD_STATUS_PENDING
 
     parent_block_hash = block.body.signed_execution_payload_bid.message.parent_block_hash

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -274,6 +274,11 @@ def is_payload_data_available(store: Store, root: Root) -> bool:
 ```python
 def get_parent_payload_status(store: Store, block: BeaconBlock) -> PayloadStatus:
     parent = store.blocks[block.parent_root]
+    parent_state = store.block_states[block.parent_root]
+    # pre-Gloas parent has no bid field hence, treat as PENDING
+    if parent_state.fork.current_version != GLOAS_FORK_VERSION:
+        return PAYLOAD_STATUS_PENDING
+
     parent_block_hash = block.body.signed_execution_payload_bid.message.parent_block_hash
     message_block_hash = parent.body.signed_execution_payload_bid.message.block_hash
     return PAYLOAD_STATUS_FULL if parent_block_hash == message_block_hash else PAYLOAD_STATUS_EMPTY


### PR DESCRIPTION
`get_parent_payload_status` (and therefore `is_parent_node_full`) was unconditionally accessing the Gloas-only field `parent.body.signed_execution_payload_bid` even for pre-Gloas blocks.

This PR adds a guard that checks `parent_state.fork.current_version` and treats any pre-Gloas parent as `PAYLOAD_STATUS_PENDING`(matching the behavior Lighthouse already implements).

No changes were needed to `on_block` or `is_parent_node_full`.

All Gloas tests pass with`make test fork=gloas`.

Fixes #5096 
