### PR TITLE
Add sliced test generation for comptests

### DIFF
--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -90,7 +90,7 @@ jobs:
 
           # Forks
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            forks='["altair","bellatrix","capella","deneb","electra","fulu","gloas"]'
+            forks='["fulu","gloas"]'
           else
             selected=()
             [[ "${{ inputs.altair }}" == "true" ]] && selected+=("altair")

--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -1,5 +1,8 @@
 name: Compliance Tests
 
+env:
+  COMPTEST_SLICING_CONFIG: '{"tiny":1,"small":4,"standard":4}'
+
 on:
   workflow_dispatch:
     inputs:
@@ -65,6 +68,7 @@ jobs:
       presets: ${{ steps.config.outputs.presets }}
       forks: ${{ steps.config.outputs.forks }}
       configs: ${{ steps.config.outputs.configs }}
+      generate_matrix: ${{ steps.config.outputs.generate_matrix }}
       seed: ${{ steps.config.outputs.seed }}
     steps:
       - name: Resolve configuration
@@ -138,6 +142,36 @@ jobs:
           fi
           echo "seed=$seed" >> "$GITHUB_OUTPUT"
 
+          # Generation matrix
+          generate_matrix=$(
+            jq -cn \
+              --argjson presets "$presets" \
+              --argjson forks "$forks" \
+              --argjson configs "$configs" \
+              --argjson slices '${{ env.COMPTEST_SLICING_CONFIG }}' \
+              '
+              [
+                $presets[] as $preset
+                | $forks[] as $fork
+                | $configs[] as $config
+                | (($slices[$config] // 1) | tonumber) as $slice_count
+                | if $slice_count < 1 then
+                    error("Invalid slice count for config \($config): \($slice_count)")
+                  else
+                    range(0; $slice_count) as $slice_index
+                    | {
+                        preset: $preset,
+                        fork: $fork,
+                        config: $config,
+                        slice_index: $slice_index,
+                        slice_count: $slice_count
+                      }
+                  end
+              ]
+              '
+          )
+          echo "generate_matrix=$generate_matrix" >> "$GITHUB_OUTPUT"
+
           # Summary
           echo "Configuration:"
           echo "  repo:    $repo"
@@ -146,6 +180,8 @@ jobs:
           echo "  forks:   $forks"
           echo "  configs: $configs"
           echo "  seed:    $seed"
+          echo "  slicing_config: ${{ env.COMPTEST_SLICING_CONFIG }}"
+          echo "  generate_matrix: $generate_matrix"
 
   generate:
     needs: config
@@ -153,9 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        preset: ${{ fromJson(needs.config.outputs.presets) }}
-        fork: ${{ fromJson(needs.config.outputs.forks) }}
-        config: ${{ fromJson(needs.config.outputs.configs) }}
+        include: ${{ fromJson(needs.config.outputs.generate_matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -174,18 +208,27 @@ jobs:
           enable-cache: true
 
       - name: Generate compliance tests
-        run: >
-          make comptests
-          fc_gen_config=${{ matrix.config }}
-          preset=${{ matrix.preset }}
-          fork=${{ matrix.fork }}
-          comptests_dir=./compliance-spec-tests/${{ matrix.config }}
-          seed=${{ needs.config.outputs.seed }}
+        run: |
+          extra_args=()
+          if [[ "${{ matrix.slice_count }}" -gt 1 ]]; then
+            extra_args+=(
+              "group_slice_index=${{ matrix.slice_index }}"
+              "group_slice_count=${{ matrix.slice_count }}"
+            )
+          fi
+
+          make comptests \
+            fc_gen_config=${{ matrix.config }} \
+            preset=${{ matrix.preset }} \
+            fork=${{ matrix.fork }} \
+            comptests_dir=./compliance-spec-tests/${{ matrix.config }} \
+            seed=${{ needs.config.outputs.seed }} \
+            "${extra_args[@]}"
 
       - name: Upload compliance tests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: comptests-${{ matrix.config }}-${{ matrix.preset }}-${{ matrix.fork }}
+          name: comptests-${{ matrix.config }}-${{ matrix.preset }}-${{ matrix.fork }}-slice${{ matrix.slice_index }}of${{ matrix.slice_count }}
           path: compliance-spec-tests/${{ matrix.config }}
           if-no-files-found: ignore
 

--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -1,8 +1,5 @@
 name: Compliance Tests
 
-env:
-  COMPTEST_SLICING_CONFIG: '{"tiny":1,"small":4,"standard":4}'
-
 on:
   workflow_dispatch:
     inputs:
@@ -62,6 +59,8 @@ on:
 jobs:
   config:
     runs-on: ubuntu-latest
+    env:
+      COMPTEST_SLICING_CONFIG: '{"tiny":1,"small":4,"standard":4}'
     outputs:
       repo: ${{ steps.config.outputs.repo }}
       ref: ${{ steps.config.outputs.ref }}

--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -65,11 +65,9 @@ jobs:
     outputs:
       repo: ${{ steps.config.outputs.repo }}
       ref: ${{ steps.config.outputs.ref }}
-      presets: ${{ steps.config.outputs.presets }}
-      forks: ${{ steps.config.outputs.forks }}
       configs: ${{ steps.config.outputs.configs }}
-      generate_matrix: ${{ steps.config.outputs.generate_matrix }}
       seed: ${{ steps.config.outputs.seed }}
+      matrix: ${{ steps.config.outputs.matrix }}
     steps:
       - name: Resolve configuration
         id: config
@@ -111,7 +109,7 @@ jobs:
           fi
           echo "forks=$forks" >> "$GITHUB_OUTPUT"
 
-          # Generator configs
+          # Configs
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             configs='["tiny"]'
           else
@@ -142,8 +140,8 @@ jobs:
           fi
           echo "seed=$seed" >> "$GITHUB_OUTPUT"
 
-          # Generation matrix
-          generate_matrix=$(
+          # Matrix
+          matrix=$(
             jq -cn \
               --argjson presets "$presets" \
               --argjson forks "$forks" \
@@ -170,7 +168,7 @@ jobs:
               ]
               '
           )
-          echo "generate_matrix=$generate_matrix" >> "$GITHUB_OUTPUT"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
           # Summary
           echo "Configuration:"
@@ -180,16 +178,17 @@ jobs:
           echo "  forks:   $forks"
           echo "  configs: $configs"
           echo "  seed:    $seed"
-          echo "  slicing_config: ${{ env.COMPTEST_SLICING_CONFIG }}"
-          echo "  generate_matrix: $generate_matrix"
+          echo "  matrix:  $matrix"
+          echo "  slicing: ${{ env.COMPTEST_SLICING_CONFIG }}"
 
   generate:
     needs: config
+    name: generate (${{ matrix.fork }}, ${{ matrix.config }}, ${{ matrix.slice_index }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.config.outputs.generate_matrix) }}
+        include: ${{ fromJson(needs.config.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -228,7 +227,7 @@ jobs:
       - name: Upload compliance tests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: comptests-${{ matrix.config }}-${{ matrix.preset }}-${{ matrix.fork }}-slice${{ matrix.slice_index }}of${{ matrix.slice_count }}
+          name: comptests-${{ matrix.config }}-${{ matrix.preset }}-${{ matrix.fork }}-${{ matrix.slice_index }}
           path: compliance-spec-tests/${{ matrix.config }}
           if-no-files-found: ignore
 

--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -111,7 +111,7 @@ jobs:
 
           # Configs
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            configs='["tiny"]'
+            configs='["small"]'
           else
             selected=()
             [[ "${{ inputs.tiny }}" == "true" ]] && selected+=("tiny")

--- a/Makefile
+++ b/Makefile
@@ -120,12 +120,15 @@ help-verbose:
 	@echo "    comptests_dir=<dir>    Output directory for generated compliance tests"
 	@echo "    threads=N              Number of threads to use"
 	@echo "    seed=N                 Override test seeds (fuzzing mode)"
+	@echo "    group_slice_index=N    0-based shard index for deterministic test-group slicing"
+	@echo "    group_slice_count=N    Number of deterministic test-group slices"
 	@echo ""
 	@echo "  Examples:"
 	@echo "    make comptests"
 	@echo "    make comptests fc_gen_config=standard"
 	@echo "    make comptests comptests_dir=./compliance-spec-tests/tests"
 	@echo "    make comptests fc_gen_config=standard fork=deneb preset=mainnet threads=8"
+	@echo "    make comptests fc_gen_config=tiny fork=gloas group_slice_index=0 group_slice_count=4"
 	@echo ""
 	@echo "$(BOLD)DOCUMENTATION$(NORM)"
 	@echo "$(BOLD)--------------------------------------------------------------------------------$(NORM)"
@@ -301,6 +304,8 @@ comptests: MAYBE_THREADS := $(if $(threads),--threads=$(threads),--fc-gen-multi-
 comptests: MAYBE_FORKS := $(if $(fork),--forks $(subst ${COMMA}, ,$(fork)))
 comptests: MAYBE_PRESETS := $(if $(preset),--presets $(subst ${COMMA}, ,$(preset)))
 comptests: MAYBE_SEED := $(if $(seed),--fc-gen-seed $(seed))
+comptests: MAYBE_GROUP_SLICE_INDEX := $(if $(group_slice_index),--group-slice-index $(group_slice_index))
+comptests: MAYBE_GROUP_SLICE_COUNT := $(if $(group_slice_count),--group-slice-count $(group_slice_count))
 comptests: _pyspec
 	@$(UV_RUN) python -m tests.generators.compliance_runners.fork_choice.test_gen \
 		--output-dir=$(COMPTESTS_DIR) \
@@ -308,7 +313,9 @@ comptests: _pyspec
 		$(MAYBE_THREADS) \
 		$(MAYBE_FORKS) \
 		$(MAYBE_PRESETS) \
-		$(MAYBE_SEED)
+		$(MAYBE_SEED) \
+		$(MAYBE_GROUP_SLICE_INDEX) \
+		$(MAYBE_GROUP_SLICE_COUNT)
 
 ###############################################################################
 # Cleaning

--- a/tests/generators/compliance_runners/gen_base/args.py
+++ b/tests/generators/compliance_runners/gen_base/args.py
@@ -64,6 +64,22 @@ def create_arg_parser() -> argparse.ArgumentParser:
         default=os.cpu_count(),
         help="Generate tests with N threads. Defaults to core count.",
     )
+    parser.add_argument(
+        "--group-slice-index",
+        dest="group_slice_index",
+        type=int,
+        default=None,
+        required=False,
+        help="Select the 0-based slice index of test groups to generate.",
+    )
+    parser.add_argument(
+        "--group-slice-count",
+        dest="group_slice_count",
+        type=int,
+        default=None,
+        required=False,
+        help="Split test groups into this many deterministic slices.",
+    )
     return parser
 
 

--- a/tests/generators/compliance_runners/gen_base/gen_runner.py
+++ b/tests/generators/compliance_runners/gen_base/gen_runner.py
@@ -18,7 +18,7 @@ from eth_consensus_specs.test.exceptions import SkippedTest
 from tests.infra.dumper import Dumper
 
 from .args import parse_arguments
-from .gen_typing import TestCaseResult, TestGroup
+from .gen_typing import TestCase, TestCaseResult, TestGroup
 from .utils import install_sigint_handler, time_since
 
 
@@ -114,6 +114,61 @@ def execute_test_group(
         dump_test_case_result(test_case_result, dumper)
 
 
+def validate_group_slice_args(args) -> None:
+    """Validate deterministic group slicing arguments."""
+    slice_index = args.group_slice_index
+    slice_count = args.group_slice_count
+    if slice_index is None and slice_count is None:
+        return
+    if slice_index is None or slice_count is None:
+        raise ValueError("Both --group-slice-index and --group-slice-count must be specified")
+    if slice_count <= 0:
+        raise ValueError("--group-slice-count must be a positive integer")
+    if slice_index < 0 or slice_index >= slice_count:
+        raise ValueError("--group-slice-index must be in [0, --group-slice-count)")
+
+
+def is_selected_test_case(test_case: TestCase, args) -> bool:
+    """Return whether a test case matches the requested filters."""
+    if len(args.runners) != 0 and test_case.runner_name not in args.runners:
+        return False
+    if len(args.presets) != 0 and test_case.preset_name not in args.presets:
+        return False
+    if len(args.forks) != 0 and test_case.fork_name not in args.forks:
+        return False
+    if len(args.cases) != 0 and not any(s in test_case.case_name for s in args.cases):
+        return False
+    return True
+
+
+def select_generator_groups(
+    input_test_groups: Iterable[TestGroup], args
+) -> tuple[int, list[TestGroup]]:
+    """Filter generator groups for execution."""
+    total_found = 0
+    selected_test_groups = []
+    for test_group in input_test_groups:
+        selected_group_cases = []
+        for test_case in test_group.test_cases:
+            total_found += 1
+            if is_selected_test_case(test_case, args):
+                selected_group_cases.append(test_case)
+
+        if selected_group_cases:
+            selected_test_groups.append(test_group)
+
+    return total_found, selected_test_groups
+
+
+def slice_generator_groups(selected_test_groups: list[TestGroup], args) -> list[TestGroup]:
+    """Apply deterministic slicing to already-filtered generator groups."""
+    return [
+        test_group
+        for group_index, test_group in enumerate(selected_test_groups)
+        if group_index % args.group_slice_count == args.group_slice_index
+    ]
+
+
 def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
     start_time = time.time()
     if args is None:
@@ -129,27 +184,13 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
 
     # Gracefully handle Ctrl+C
     install_sigint_handler(console)
+    validate_group_slice_args(args)
 
-    total_found = 0
-    selected_test_groups = []
-    for test_group in input_test_groups:
-        selected_group_cases = []
-        for test_case in test_group.test_cases:
-            total_found += 1
-            # Check if the test case should be filtered out
-            if len(args.runners) != 0 and test_case.runner_name not in args.runners:
-                continue
-            if len(args.presets) != 0 and test_case.preset_name not in args.presets:
-                continue
-            if len(args.forks) != 0 and test_case.fork_name not in args.forks:
-                continue
-            if len(args.cases) != 0 and not any(s in test_case.case_name for s in args.cases):
-                continue
-
-            selected_group_cases.append(test_case)
-
-        if selected_group_cases:
-            selected_test_groups.append(test_group)
+    total_found, selected_test_groups = select_generator_groups(
+        input_test_groups, args
+    )
+    if args.group_slice_count is not None:
+        selected_test_groups = slice_generator_groups(selected_test_groups, args)
 
     selected_test_cases = []
     for test_group in selected_test_groups:
@@ -167,6 +208,12 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
         return
 
     debug_print(f"Generating tests into {args.output_dir}")
+    if args.group_slice_count is not None:
+        debug_print(
+            f"Selecting deterministic group slice "
+            f"{args.group_slice_index + 1}/{args.group_slice_count} "
+            f"({len(selected_test_groups)} groups)"
+        )
     tests_prefix = get_shared_prefix(selected_test_cases)
 
     def worker_function(data):

--- a/tests/generators/compliance_runners/gen_base/gen_runner.py
+++ b/tests/generators/compliance_runners/gen_base/gen_runner.py
@@ -186,9 +186,7 @@ def run_generator_groups(input_test_groups: Iterable[TestGroup], args=None):
     install_sigint_handler(console)
     validate_group_slice_args(args)
 
-    total_found, selected_test_groups = select_generator_groups(
-        input_test_groups, args
-    )
+    total_found, selected_test_groups = select_generator_groups(input_test_groups, args)
     if args.group_slice_count is not None:
         selected_test_groups = slice_generator_groups(selected_test_groups, args)
 


### PR DESCRIPTION
Comptests test generation for `gloas` is slow, so [comptests.yml](https://github.com/ethereum/consensus-specs/blob/master/.github/workflows/comptests.yml) workflow being canceled by timeout.
This PR adds slicing CLI options, so that one can slice test generation plan into smaller parts.
It also modifies the comptests workflow, so that it cuts `small` (and `standard`) test gen configs into smaller pieces (4 by now).

Since `gloas` fork choice comptests generation is broken now, the PR has draft status.
- [x] resolve `gloas` comptests problems.

