### PR TITLE
Fix comptest generator after delayed payload processing change

### DIFF
--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
@@ -1,5 +1,8 @@
 import random
 
+from eth_consensus_specs.test.helpers.fork_choice import (
+    get_genesis_forkchoice_store_and_block,
+)
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
     transition_to,
@@ -204,7 +207,7 @@ def _generate_filter_block_tree(
 
 def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTestData, object):
     anchor_state = state
-    anchor_block = spec.BeaconBlock(state_root=anchor_state.hash_tree_root())
+    _, anchor_block = get_genesis_forkchoice_store_and_block(spec, anchor_state)
 
     if debug:
         print("\nseed:", seed)

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -3,6 +3,9 @@ import random
 from eth_consensus_specs.test.helpers.attester_slashings import (
     get_valid_attester_slashing_by_indices,
 )
+from eth_consensus_specs.test.helpers.fork_choice import (
+    get_genesis_forkchoice_store_and_block,
+)
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
     transition_to,
@@ -645,7 +648,7 @@ def gen_block_tree_test_data(
     sm_links = [SmLink(l) for l in sm_links]
 
     anchor_state = state
-    anchor_block = spec.BeaconBlock(state_root=anchor_state.hash_tree_root())
+    _, anchor_block = get_genesis_forkchoice_store_and_block(spec, anchor_state)
 
     # Find a reachable solution trying with different seeds if needed
     # sm_links constraints may not have a solution because of the randomization affecting validator partitions


### PR DESCRIPTION
The PR fixes a problem with the comptests generator, which was building anchor block incorrectly in case of `gloas`.

Related to #5094
