### PR TITLE
Speed up fork choice tests

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -460,12 +460,19 @@ def add_attester_slashing(spec, store, attester_slashing, test_steps, valid=True
     test_steps.append({"attester_slashing": slashing_file_name})
 
 
-def get_formatted_head_output(spec, store):
+def _get_head_root(spec, store):
     head = spec.get_head(store)
     if is_post_gloas(spec):
         head_root = head.root
     else:
         head_root = head
+    return head_root
+
+
+def get_formatted_head_output(spec, store, head_root=None):
+    if head_root is None:
+        head_root = _get_head_root(spec, store)
+
     slot = store.blocks[head_root].slot
     return {
         "slot": int(slot),
@@ -483,10 +490,13 @@ def output_head_check(spec, store, test_steps):
     )
 
 
-def get_basic_store_checks(spec, store):
+def get_basic_store_checks(spec, store, head_root=None):
+    if head_root is None:
+        head_root = _get_head_root(spec, store)
+
     return {
         "time": int(store.time),
-        "head": get_formatted_head_output(spec, store),
+        "head": get_formatted_head_output(spec, store, head_root),
         "justified_checkpoint": {
             "epoch": int(store.justified_checkpoint.epoch),
             "root": encode_hex(store.justified_checkpoint.root),
@@ -500,11 +510,12 @@ def get_basic_store_checks(spec, store):
 
 
 def output_store_checks(spec, store, test_steps, with_viable_for_head_weights=False):
-    checks = get_basic_store_checks(spec, store)
-
     if is_post_gloas(spec):
         head = spec.get_head(store)
+        checks = get_basic_store_checks(spec, store, head.root)
         checks["head_payload_status"] = int(head.payload_status)
+    else:
+        checks = get_basic_store_checks(spec, store)
 
     if with_viable_for_head_weights and not is_post_gloas(spec):
         filtered_block_roots = spec.get_filtered_block_tree(store).keys()

--- a/tests/generators/compliance_runners/fork_choice/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/test_run.py
@@ -129,12 +129,21 @@ def run_test(test_info):
                 )
         elif "checks" in step:
             checks = step["checks"]
+
+            cached_head = None
+
+            def get_head():
+                nonlocal cached_head
+                if cached_head is None:
+                    cached_head = spec.get_head(store)
+                return cached_head
+
             for check, value in checks.items():
                 if check == "time":
                     expected_time = value
                     assert store.time == expected_time
                 elif check == "head":
-                    head = spec.get_head(store)
+                    head = get_head()
                     head_root = head.root if hasattr(head, "root") else head
                     assert store.blocks[head_root].slot == value["slot"]
                     assert str(head_root) == value["root"]
@@ -164,7 +173,7 @@ def run_test(test_info):
                     expected = {kv["root"]: kv["weight"] for kv in value}
                     assert expected == viable_for_head_roots_and_weights
                 elif check == "head_payload_status":
-                    head = spec.get_head(store)
+                    head = get_head()
                     assert head.payload_status == value
                 else:
                     assert False


### PR DESCRIPTION
In case of `gloas`, `output_store_checks()` calls `get_head()` twice (and additional time to record `head_payload_status`). Since `get_head()` is quite slow in `gloas` this leads to excessively slow Fork Choice comptests generation.

The PR removes the extra `get_head()` call, thus reducing test generation time by 40%. It should benefit `fork_choice` reftests for `gloas` too.