### PR TITLE
Deprecate functions for previous upgrades

### DIFF
--- a/pysetup/spec_builders/bellatrix.py
+++ b/pysetup/spec_builders/bellatrix.py
@@ -55,3 +55,12 @@ class NoopExecutionEngine(ExecutionEngine):
 
 
 EXECUTION_ENGINE = NoopExecutionEngine()"""
+
+    @classmethod
+    def deprecate_functions(cls) -> set[str]:
+        return set(
+            [
+                "translate_participation",
+                "upgrade_to_altair",
+            ]
+        )

--- a/pysetup/spec_builders/capella.py
+++ b/pysetup/spec_builders/capella.py
@@ -26,6 +26,7 @@ from eth_consensus_specs.bellatrix import {preset_name} as bellatrix
                 "is_merge_transition_block",
                 "is_merge_transition_complete",
                 "process_historical_roots_update",
+                "upgrade_to_bellatrix",
                 "validate_merge_block",
             ]
         )

--- a/pysetup/spec_builders/deneb.py
+++ b/pysetup/spec_builders/deneb.py
@@ -78,6 +78,20 @@ class NoopExecutionEngine(ExecutionEngine):
 EXECUTION_ENGINE = NoopExecutionEngine()"""
 
     @classmethod
+    def deprecate_functions(cls) -> set[str]:
+        return set(
+            [
+                "upgrade_lc_bootstrap_to_capella",
+                "upgrade_lc_finality_update_to_capella",
+                "upgrade_lc_header_to_capella",
+                "upgrade_lc_optimistic_update_to_capella",
+                "upgrade_lc_store_to_capella",
+                "upgrade_lc_update_to_capella",
+                "upgrade_to_capella",
+            ]
+        )
+
+    @classmethod
     def hardcoded_func_dep_presets(cls, spec_object) -> dict[str, str]:
         return {
             "KZG_COMMITMENT_INCLUSION_PROOF_DEPTH": spec_object.preset_vars[

--- a/pysetup/spec_builders/electra.py
+++ b/pysetup/spec_builders/electra.py
@@ -25,6 +25,13 @@ from eth_consensus_specs.utils.ssz.ssz_impl import ssz_serialize, ssz_deserializ
         return set(
             [
                 "get_validator_activation_churn_limit",
+                "upgrade_lc_bootstrap_to_deneb",
+                "upgrade_lc_finality_update_to_deneb",
+                "upgrade_lc_header_to_deneb",
+                "upgrade_lc_optimistic_update_to_deneb",
+                "upgrade_lc_store_to_deneb",
+                "upgrade_lc_update_to_deneb",
+                "upgrade_to_deneb",
             ]
         )
 

--- a/pysetup/spec_builders/fulu.py
+++ b/pysetup/spec_builders/fulu.py
@@ -41,6 +41,21 @@ class CosetEvals(list):
 """
 
     @classmethod
+    def deprecate_functions(cls) -> set[str]:
+        return set(
+            [
+                "normalize_merkle_branch",
+                "upgrade_lc_bootstrap_to_electra",
+                "upgrade_lc_finality_update_to_electra",
+                "upgrade_lc_header_to_electra",
+                "upgrade_lc_optimistic_update_to_electra",
+                "upgrade_lc_store_to_electra",
+                "upgrade_lc_update_to_electra",
+                "upgrade_to_electra",
+            ]
+        )
+
+    @classmethod
     def sundry_functions(cls) -> str:
         return """
 def retrieve_column_sidecars(beacon_block_root: Root) -> Sequence[DataColumnSidecar]:

--- a/pysetup/spec_builders/gloas.py
+++ b/pysetup/spec_builders/gloas.py
@@ -33,8 +33,10 @@ from eth_consensus_specs.fulu import {preset_name} as fulu
         return set(
             [
                 "compute_proposer_index",
+                "initialize_proposer_lookahead",
                 "process_execution_payload",
                 "retrieve_column_sidecars",
+                "upgrade_to_fulu",
             ]
         )
 

--- a/pysetup/spec_builders/heze.py
+++ b/pysetup/spec_builders/heze.py
@@ -65,3 +65,13 @@ class NoopExecutionEngine(ExecutionEngine):
 
 
 EXECUTION_ENGINE = NoopExecutionEngine()"""
+
+    @classmethod
+    def deprecate_functions(cls) -> set[str]:
+        return set(
+            [
+                "initialize_ptc_window",
+                "onboard_builders_from_pending_deposits",
+                "upgrade_to_gloas",
+            ]
+        )

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/epoch_processing/test_process_proposer_lookahead.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/epoch_processing/test_process_proposer_lookahead.py
@@ -23,13 +23,6 @@ def test_proposer_lookahead_in_state_matches_computed_lookahead(spec, state):
         == initial_lookahead[spec.SLOTS_PER_EPOCH :]
     )
 
-    # run_epoch_processing_with does not increment the slot
-    state.slot += 1
-
-    # Verify lookahead in state matches the computed lookahead
-    computed_lookahead = spec.initialize_proposer_lookahead(state)
-    assert state.proposer_lookahead == computed_lookahead
-
 
 @with_fulu_and_later
 @spec_state_test

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_payload_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_payload_attestation.py
@@ -11,6 +11,7 @@ from eth_consensus_specs.test.context import (
     with_presets,
 )
 from eth_consensus_specs.test.helpers.constants import MINIMAL
+from eth_consensus_specs.test.helpers.gloas.state import compute_ptc_window
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import next_epoch
 from eth_consensus_specs.utils.ssz.ssz_typing import Bitvector
@@ -384,7 +385,7 @@ def test_process_payload_attestation_sampling_not_capped(spec, state):
     for validator in state.validators:
         validator.effective_balance = low_balance
     # Direct balance mutations bypass epoch processing, so refresh the cached current-epoch PTC.
-    state.ptc_window = spec.initialize_ptc_window(state)
+    state.ptc_window = compute_ptc_window(spec, state)
 
     chosen_slot = None
     chosen_index = None

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_payload_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_payload_attestation.py
@@ -11,7 +11,7 @@ from eth_consensus_specs.test.context import (
     with_presets,
 )
 from eth_consensus_specs.test.helpers.constants import MINIMAL
-from eth_consensus_specs.test.helpers.gloas.state import compute_ptc_window
+from eth_consensus_specs.test.helpers.gloas.state import initialize_ptc_window
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import next_epoch
 from eth_consensus_specs.utils.ssz.ssz_typing import Bitvector
@@ -385,7 +385,7 @@ def test_process_payload_attestation_sampling_not_capped(spec, state):
     for validator in state.validators:
         validator.effective_balance = low_balance
     # Direct balance mutations bypass epoch processing, so refresh the cached current-epoch PTC.
-    state.ptc_window = compute_ptc_window(spec, state)
+    state.ptc_window = initialize_ptc_window(spec, state)
 
     chosen_slot = None
     chosen_index = None

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fulu/state.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fulu/state.py
@@ -1,0 +1,6 @@
+def compute_proposer_lookahead(spec, state):
+    current_epoch = spec.get_current_epoch(state)
+    lookahead = []
+    for i in range(spec.MIN_SEED_LOOKAHEAD + 1):
+        lookahead.extend(spec.get_beacon_proposer_indices(state, spec.Epoch(current_epoch + i)))
+    return lookahead

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fulu/state.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fulu/state.py
@@ -1,4 +1,4 @@
-def compute_proposer_lookahead(spec, state):
+def initialize_proposer_lookahead(spec, state):
     current_epoch = spec.get_current_epoch(state)
     lookahead = []
     for i in range(spec.MIN_SEED_LOOKAHEAD + 1):

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -18,10 +18,10 @@ from eth_consensus_specs.test.helpers.forks import (
     is_post_gloas,
 )
 from eth_consensus_specs.test.helpers.fulu.state import (
-    compute_proposer_lookahead,
+    initialize_proposer_lookahead,
 )
 from eth_consensus_specs.test.helpers.gloas.state import (
-    compute_ptc_window,
+    initialize_ptc_window,
 )
 from eth_consensus_specs.test.helpers.keys import builder_pubkeys, pubkeys
 
@@ -254,10 +254,10 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
             spec.BuilderPendingPayment() for _ in range(2 * spec.SLOTS_PER_EPOCH)
         ]
         state.builder_pending_withdrawals = []
-        state.ptc_window = compute_ptc_window(spec, state)
+        state.ptc_window = initialize_ptc_window(spec, state)
 
     if is_post_fulu(spec):
         # Initialize proposer lookahead list
-        state.proposer_lookahead = compute_proposer_lookahead(spec, state)
+        state.proposer_lookahead = initialize_proposer_lookahead(spec, state)
 
     return state

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -17,6 +17,12 @@ from eth_consensus_specs.test.helpers.forks import (
     is_post_fulu,
     is_post_gloas,
 )
+from eth_consensus_specs.test.helpers.fulu.state import (
+    compute_proposer_lookahead,
+)
+from eth_consensus_specs.test.helpers.gloas.state import (
+    compute_ptc_window,
+)
 from eth_consensus_specs.test.helpers.keys import builder_pubkeys, pubkeys
 
 
@@ -248,10 +254,10 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
             spec.BuilderPendingPayment() for _ in range(2 * spec.SLOTS_PER_EPOCH)
         ]
         state.builder_pending_withdrawals = []
-        state.ptc_window = spec.initialize_ptc_window(state)
+        state.ptc_window = compute_ptc_window(spec, state)
 
     if is_post_fulu(spec):
         # Initialize proposer lookahead list
-        state.proposer_lookahead = spec.initialize_proposer_lookahead(state)
+        state.proposer_lookahead = compute_proposer_lookahead(spec, state)
 
     return state

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/state.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/state.py
@@ -1,0 +1,16 @@
+def compute_ptc_window(spec, state):
+    empty_previous_epoch = [
+        spec.Vector[spec.ValidatorIndex, spec.PTC_SIZE](
+            [spec.ValidatorIndex(0) for _ in range(spec.PTC_SIZE)]
+        )
+        for _ in range(spec.SLOTS_PER_EPOCH)
+    ]
+    ptcs = []
+    current_epoch = spec.get_current_epoch(state)
+    for e in range(1 + spec.MIN_SEED_LOOKAHEAD):
+        epoch = spec.Epoch(current_epoch + e)
+        start_slot = spec.compute_start_slot_at_epoch(epoch)
+        ptcs += [
+            spec.compute_ptc(state, spec.Slot(start_slot + i)) for i in range(spec.SLOTS_PER_EPOCH)
+        ]
+    return empty_previous_epoch + ptcs

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/state.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/state.py
@@ -1,4 +1,4 @@
-def compute_ptc_window(spec, state):
+def initialize_ptc_window(spec, state):
     empty_previous_epoch = [
         spec.Vector[spec.ValidatorIndex, spec.PTC_SIZE](
             [spec.ValidatorIndex(0) for _ in range(spec.PTC_SIZE)]


### PR DESCRIPTION
These functions are no longer required after the upgrade.