### PR TITLE
Remove `PartialDataColumnHeader`

### DIFF
--- a/pysetup/spec_builders/gloas.py
+++ b/pysetup/spec_builders/gloas.py
@@ -54,8 +54,8 @@ from eth_consensus_specs.fulu import {preset_name} as fulu
                 "initialize_proposer_lookahead",
                 "process_execution_payload",
                 "retrieve_column_sidecars",
-                "verify_partial_data_column_header_inclusion_proof",
                 "upgrade_to_fulu",
+                "verify_partial_data_column_header_inclusion_proof",
                 # Temporarily deprecate light-client functions
                 # See: https://github.com/ethereum/consensus-specs/pull/5142
                 "apply_light_client_update",

--- a/pysetup/spec_builders/gloas.py
+++ b/pysetup/spec_builders/gloas.py
@@ -33,6 +33,7 @@ from eth_consensus_specs.fulu import {preset_name} as fulu
         return set(
             [
                 "ExecutionPayloadHeader",
+                "PartialDataColumnHeader",
                 # Temporarily deprecate light-client containers
                 # See: https://github.com/ethereum/consensus-specs/pull/5142
                 "ExecutionBranch",
@@ -53,6 +54,7 @@ from eth_consensus_specs.fulu import {preset_name} as fulu
                 "initialize_proposer_lookahead",
                 "process_execution_payload",
                 "retrieve_column_sidecars",
+                "verify_partial_data_column_header_inclusion_proof",
                 "upgrade_to_fulu",
                 # Temporarily deprecate light-client functions
                 # See: https://github.com/ethereum/consensus-specs/pull/5142

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -9,7 +9,9 @@
   - [Configuration](#configuration)
   - [Containers](#containers)
     - [Modified `DataColumnSidecar`](#modified-datacolumnsidecar)
-    - [Modified `PartialDataColumnHeader`](#modified-partialdatacolumnheader)
+    - [Removed `PartialDataColumnHeader`](#removed-partialdatacolumnheader)
+    - [Modified `PartialDataColumnSidecar`](#modified-partialdatacolumnsidecar)
+    - [New `PartialDataColumnGroupID`](#new-partialdatacolumngroupid)
     - [New `ProposerPreferences`](#new-proposerpreferences)
     - [New `SignedProposerPreferences`](#new-signedproposerpreferences)
   - [Helpers](#helpers)
@@ -82,20 +84,30 @@ class DataColumnSidecar(Container):
     beacon_block_root: Root
 ```
 
-#### Modified `PartialDataColumnHeader`
+#### Removed `PartialDataColumnHeader`
 
-*Note*: These are the same changes as the changes for `DataColumnSidecar` above.
+Just as the DataColumnSidecar removes the `kzg_commitments`, so too are the
+commitments unnecessary in the PartialDataColumnHeader. Without the KZG
+commitments, there is no value in this header. It is removed.
+
+#### Modified `PartialDataColumnSidecar`
 
 ```python
-class PartialDataColumnHeader(Container):
-    kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+class PartialDataColumnSidecar(Container):
+    cells_present_bitmap: Bitlist[MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    partial_column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     # [Modified in Gloas:EIP7732]
-    # Removed `signed_block_header`
-    # [Modified in Gloas:EIP7732]
-    # Removed `kzg_commitments_inclusion_proof`
-    # [New in Gloas:EIP7732]
+    # removed `header`
+```
+
+#### New `PartialDataColumnGroupID`
+
+*[New in Gloas:EIP7732]*
+
+```python
+class PartialDataColumnGroupID(Container):
     slot: Slot
-    # [New in Gloas:EIP7732]
     beacon_block_root: Root
 ```
 
@@ -468,22 +480,43 @@ the sidecar.
 
 *[Modified in Gloas:EIP7732]*
 
-*Note*: These are the same changes as the changes in validation rules for full
-messages on `data_column_sidecar_{subnet_id}` as defined above.
+*Group ID*: The Partial Message Group ID is the SSZ encoded
+`PartialDataColumnGroupID` prefixed with the version byte `0x01`.
+Implementations MUST ignore unknown versions.
 
 **Added in Gloas:**
 
-- _[IGNORE]_ The header's `beacon_block_root` has been seen via a valid signed
-  execution payload bid. A client MAY queue the sidecar for processing once the
-  block is retrieved.
-- _[REJECT]_ The header's `slot` matches the slot of the block with root
-  `beacon_block_root`.
-- _[REJECT]_ The hash of the header's `kzg_commitments` matches the
-  `blob_kzg_commitments_root` in the corresponding builder's bid for
-  `header.beacon_block_root`.
+*Note*: The added rules are similar to the changes in validation rules for full
+messages on `data_column_sidecar_{subnet_id}` as defined above.
+
+- _[IGNORE]_ A valid block for the Group ID's `slot` has been seen (via gossip
+  or non-gossip sources). If not yet seen, a client MUST queue the sidecar for
+  deferred validation and possible processing once the block is received or
+  retrieved.
+- _[REJECT]_ The Group ID's `slot` matches the slot of the block with root
+  `beacon_block_root`. The `beacon_block_root` is also identified by the Group
+  ID.
+
+**Modified in Gloas:**
+
+*Note*: These modifications only replace the mention of the header with the bid,
+as the bid contains the KZG commitments.
+
+- _[REJECT]_ The cells present bitmap length is equal to the number of KZG
+  commitments in the bid.
+- _[REJECT]_ The sidecar's cell and proof data is valid as verified by
+  `verify_partial_data_column_sidecar_kzg_proofs(sidecar, bid.kzg_commitments, column_index)`.
 
 **Removed from Fulu:**
 
+Rules related to the `PartialDataColumnHeader` are removed as that header is
+removed.
+
+- _[REJECT]_ If a valid header was previously received, the received header MUST
+  equal the previously valid header.
+- _[REJECT]_ The hash of the block header in `signed_block_header` MUST be the
+  same one identified by the partial message's group id.
+- _[REJECT]_ The header's `kzg_commitments` list is non-empty.
 - _[IGNORE]_ The header is not from a future slot (with a
   `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) -- i.e. validate that
   `block_header.slot <= current_slot` (a client MAY queue future headers for
@@ -511,6 +544,12 @@ messages on `data_column_sidecar_{subnet_id}` as defined above.
   cannot immediately be verified against the expected shuffling, the header MAY
   be queued for later processing while proposers for the block's branch are
   calculated -- in such a case _do not_ `REJECT`, instead `IGNORE` this message.
+- _[IGNORE]_ If the received partial message contains only cell and proof data,
+  the node has seen a valid corresponding `PartialDataColumnHeader`.
+- _[IGNORE]_ The corresponding header is not from a future slot. See related
+  header check above for more details.
+- _[IGNORE]_ The corresponding header is from a slot greater than the latest
+  finalized slot. See related header check above for more details.
 
 ##### Attestation subnets
 

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -9,7 +9,6 @@
   - [Configuration](#configuration)
   - [Containers](#containers)
     - [Modified `DataColumnSidecar`](#modified-datacolumnsidecar)
-    - [Removed `PartialDataColumnHeader`](#removed-partialdatacolumnheader)
     - [Modified `PartialDataColumnSidecar`](#modified-partialdatacolumnsidecar)
     - [New `PartialDataColumnGroupID`](#new-partialdatacolumngroupid)
     - [New `ProposerPreferences`](#new-proposerpreferences)
@@ -83,12 +82,6 @@ class DataColumnSidecar(Container):
     # [New in Gloas:EIP7732]
     beacon_block_root: Root
 ```
-
-#### Removed `PartialDataColumnHeader`
-
-Just as the DataColumnSidecar removes the `kzg_commitments`, so too are the
-commitments unnecessary in the PartialDataColumnHeader. Without the KZG
-commitments, there is no value in this header. It is removed.
 
 #### Modified `PartialDataColumnSidecar`
 

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -91,12 +91,10 @@ class PartialDataColumnSidecar(Container):
     partial_column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     # [Modified in Gloas:EIP7732]
-    # removed `header`
+    # Removed `header`
 ```
 
 #### New `PartialDataColumnGroupID`
-
-*[New in Gloas:EIP7732]*
 
 ```python
 class PartialDataColumnGroupID(Container):
@@ -473,7 +471,7 @@ the sidecar.
 
 *[Modified in Gloas:EIP7732]*
 
-*Group ID*: The Partial Message Group ID is the SSZ encoded
+*Note*: The Partial Message Group ID is the SSZ encoded
 `PartialDataColumnGroupID` prefixed with the version byte `0x01`.
 Implementations MUST ignore unknown versions.
 
@@ -496,14 +494,11 @@ messages on `data_column_sidecar_{subnet_id}` as defined above.
 as the bid contains the KZG commitments.
 
 - _[REJECT]_ The cells present bitmap length is equal to the number of KZG
-  commitments in the bid.
+  commitments in `bid.blob_kzg_commitments`.
 - _[REJECT]_ The sidecar's cell and proof data is valid as verified by
-  `verify_partial_data_column_sidecar_kzg_proofs(sidecar, bid.kzg_commitments, column_index)`.
+  `verify_partial_data_column_sidecar_kzg_proofs(sidecar, bid.blob_kzg_commitments, column_index)`.
 
 **Removed from Fulu:**
-
-Rules related to the `PartialDataColumnHeader` are removed as that header is
-removed.
 
 - _[REJECT]_ If a valid header was previously received, the received header MUST
   equal the previously valid header.


### PR DESCRIPTION
Extends the specification from #4558 to support Gloas. The changes are analogous to the changes to full data column sidecars.