### PR TITLE
Define deprecated containers

### DIFF
--- a/pysetup/helpers.py
+++ b/pysetup/helpers.py
@@ -92,6 +92,13 @@ def objects_to_spec(
     )
     functions = {k: v for k, v in functions.items() if k not in deprecate_functions}
     functions_spec = "\n\n\n".join(functions.values())
+    # Remove deprecated containers
+    deprecate_containers = reduce(
+        lambda obj, builder: obj.union(builder.deprecate_containers()), builders, set()
+    )
+    ordered_class_objects = {
+        k: v for k, v in ordered_class_objects.items() if k not in deprecate_containers
+    }
     ordered_class_objects_spec = "\n\n\n".join(ordered_class_objects.values())
 
     # Access global dict of config vars for runtime configurables

--- a/pysetup/spec_builders/altair.py
+++ b/pysetup/spec_builders/altair.py
@@ -51,6 +51,14 @@ def compute_merkle_proof(object: SSZObject,
         return functions
 
     @classmethod
+    def deprecate_containers(cls) -> set[str]:
+        return set(
+            [
+                "PendingAttestation",
+            ]
+        )
+
+    @classmethod
     def deprecate_functions(cls) -> set[str]:
         return set(
             [

--- a/pysetup/spec_builders/base.py
+++ b/pysetup/spec_builders/base.py
@@ -63,5 +63,9 @@ class BaseSpecBuilder(ABC):
         return set()
 
     @classmethod
+    def deprecate_containers(cls) -> set[str]:
+        return set()
+
+    @classmethod
     def deprecate_functions(cls) -> set[str]:
         return set()

--- a/pysetup/spec_builders/capella.py
+++ b/pysetup/spec_builders/capella.py
@@ -18,6 +18,14 @@ from eth_consensus_specs.bellatrix import {preset_name} as bellatrix
         }
 
     @classmethod
+    def deprecate_containers(cls) -> set[str]:
+        return set(
+            [
+                "HistoricalBatch",
+            ]
+        )
+
+    @classmethod
     def deprecate_functions(cls) -> set[str]:
         return set(
             [

--- a/pysetup/spec_builders/gloas.py
+++ b/pysetup/spec_builders/gloas.py
@@ -29,6 +29,23 @@ from eth_consensus_specs.fulu import {preset_name} as fulu
         )
 
     @classmethod
+    def deprecate_containers(cls) -> set[str]:
+        return set(
+            [
+                "ExecutionPayloadHeader",
+                # Temporarily deprecate light-client containers
+                # See: https://github.com/ethereum/consensus-specs/pull/5142
+                "ExecutionBranch",
+                "LightClientBootstrap",
+                "LightClientFinalityUpdate",
+                "LightClientHeader",
+                "LightClientOptimisticUpdate",
+                "LightClientStore",
+                "LightClientUpdate",
+            ]
+        )
+
+    @classmethod
     def deprecate_functions(cls) -> set[str]:
         return set(
             [
@@ -37,6 +54,45 @@ from eth_consensus_specs.fulu import {preset_name} as fulu
                 "process_execution_payload",
                 "retrieve_column_sidecars",
                 "upgrade_to_fulu",
+                # Temporarily deprecate light-client functions
+                # See: https://github.com/ethereum/consensus-specs/pull/5142
+                "apply_light_client_update",
+                "block_to_light_client_header",
+                "create_light_client_bootstrap",
+                "create_light_client_finality_update",
+                "create_light_client_optimistic_update",
+                "create_light_client_update",
+                "get_lc_execution_root",
+                "get_safety_threshold",
+                "initialize_light_client_store",
+                "is_better_update",
+                "is_finality_update",
+                "is_next_sync_committee_known",
+                "is_sync_committee_update",
+                "is_valid_light_client_header",
+                "process_light_client_finality_update",
+                "process_light_client_optimistic_update",
+                "process_light_client_store_force_update",
+                "process_light_client_update",
+                "upgrade_lc_bootstrap_to_capella",
+                "upgrade_lc_bootstrap_to_deneb",
+                "upgrade_lc_bootstrap_to_electra",
+                "upgrade_lc_finality_update_to_capella",
+                "upgrade_lc_finality_update_to_deneb",
+                "upgrade_lc_finality_update_to_electra",
+                "upgrade_lc_header_to_capella",
+                "upgrade_lc_header_to_deneb",
+                "upgrade_lc_header_to_electra",
+                "upgrade_lc_optimistic_update_to_capella",
+                "upgrade_lc_optimistic_update_to_deneb",
+                "upgrade_lc_optimistic_update_to_electra",
+                "upgrade_lc_store_to_capella",
+                "upgrade_lc_store_to_deneb",
+                "upgrade_lc_store_to_electra",
+                "upgrade_lc_update_to_capella",
+                "upgrade_lc_update_to_deneb",
+                "upgrade_lc_update_to_electra",
+                "validate_light_client_update",
             ]
         )
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload.py
@@ -18,33 +18,6 @@ from eth_consensus_specs.utils.ssz.ssz_impl import hash_tree_root
 
 
 def get_execution_payload_header(spec, state, execution_payload):
-    if is_post_gloas(spec):
-        # For Gloas, create a standard ExecutionPayloadHeader
-        payload_header = spec.ExecutionPayloadHeader(
-            parent_hash=execution_payload.parent_hash,
-            fee_recipient=execution_payload.fee_recipient,
-            state_root=execution_payload.state_root,
-            receipts_root=execution_payload.receipts_root,
-            logs_bloom=execution_payload.logs_bloom,
-            prev_randao=execution_payload.prev_randao,
-            block_number=execution_payload.block_number,
-            gas_limit=execution_payload.gas_limit,
-            gas_used=execution_payload.gas_used,
-            timestamp=execution_payload.timestamp,
-            extra_data=execution_payload.extra_data,
-            base_fee_per_gas=execution_payload.base_fee_per_gas,
-            block_hash=execution_payload.block_hash,
-            transactions_root=execution_payload.transactions.hash_tree_root(),
-        )
-        # Add version-specific fields
-        if hasattr(execution_payload, "withdrawals"):
-            payload_header.withdrawals_root = execution_payload.withdrawals.hash_tree_root()
-        if hasattr(execution_payload, "blob_gas_used"):
-            payload_header.blob_gas_used = execution_payload.blob_gas_used
-        if hasattr(execution_payload, "excess_blob_gas"):
-            payload_header.excess_blob_gas = execution_payload.excess_blob_gas
-        return payload_header
-
     payload_header = spec.ExecutionPayloadHeader(
         parent_hash=execution_payload.parent_hash,
         fee_recipient=execution_payload.fee_recipient,
@@ -253,6 +226,8 @@ def get_consolidation_request_rlp_bytes(consolidation_request):
 
 
 def compute_el_block_hash_with_new_fields(spec, payload, parent_beacon_block_root, requests_hash):
+    if is_post_gloas(spec):
+        return spec.Hash32()
     if payload == spec.ExecutionPayload():
         return spec.Hash32()
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -71,35 +71,9 @@ def build_mock_validator(spec, i: int, balance: int):
     return validator
 
 
-def get_post_gloas_genesis_execution_payload_header(spec, slot, eth1_block_hash):
-    # For Gloas, use the standard ExecutionPayloadHeader from the parent fork
-    payload_header = spec.ExecutionPayloadHeader(
-        parent_hash=b"\x30" * 32,
-        fee_recipient=b"\x42" * 20,
-        state_root=b"\x20" * 32,
-        receipts_root=b"\x20" * 32,
-        logs_bloom=b"\x35" * spec.BYTES_PER_LOGS_BLOOM,
-        prev_randao=eth1_block_hash,
-        block_number=0,
-        gas_limit=30000000,
-        gas_used=0,
-        timestamp=0,
-        extra_data=b"",
-        base_fee_per_gas=1000000000,
-        block_hash=eth1_block_hash,
-        transactions_root=spec.Root(b"\x56" * 32),
-        withdrawals_root=spec.Root(b"\x56" * 32),
-        blob_gas_used=0,
-        excess_blob_gas=0,
-    )
-    return payload_header
-
-
 def get_sample_genesis_execution_payload_header(spec, slot, eth1_block_hash=None):
     if eth1_block_hash is None:
         eth1_block_hash = b"\x55" * 32
-    if is_post_gloas(spec):
-        return get_post_gloas_genesis_execution_payload_header(spec, slot, eth1_block_hash)
     payload_header = spec.ExecutionPayloadHeader(
         parent_hash=b"\x30" * 32,
         fee_recipient=b"\x42" * 20,


### PR DESCRIPTION
On discord, @StefanBratanov asked if we could disable SSZ tests for `ExecutionPayloadHeader` in Gloas. Since this container is no longer used, I thought it would be reasonable to mark it as deprecated which removes it from the generated executable specifications for Gloas and prevents reference tests for it be made. One issue I ran into when making this change is that the latest light client specs still use `ExecutionPayloadHeader`. I have chatted a little with @etan-status about this & he's going to look into paths forward. In order to deprecate `ExecutionPayloadHeader`, we must temporarily deprecate all light client containers & functions, otherwise there would be python errors. I'm unsure if we should merge this, as I don't really like the idea of temporarily marking all of those as deprecated. But also don't like the idea of modifying the automated test runners to prevent tests be generated for a single container.

<img width="631" height="332" alt="image" src="https://github.com/user-attachments/assets/191ba2f0-6398-42bd-8170-ae6cc8b0035a" />