### PR TITLE
Improve comptests fork choice generator

### DIFF
--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
@@ -265,16 +265,10 @@ def _debug_run_sanity_checks(
         run_on_block(spec, store, signed_block, valid=True)
 
         for attestation in signed_block.message.body.attestations:
-            try:
-                run_on_attestation(spec, store, attestation, is_from_block=True, valid=True)
-            except AssertionError:
-                pass
+            run_on_attestation(spec, store, attestation, is_from_block=True, valid=True)
 
         for attester_slashing in signed_block.message.body.attester_slashings:
-            try:
-                run_on_attester_slashing(spec, store, attester_slashing, valid=True)
-            except AssertionError:
-                pass
+            run_on_attester_slashing(spec, store, attester_slashing, valid=True)
 
         if is_post_gloas(spec):
             state = store.block_states[signed_block.message.hash_tree_root()]

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
@@ -101,7 +101,7 @@ def _generate_filter_block_tree(
             if _should_justify_epoch(parents, current_justifications, previous_justifications, b)
         ]
 
-        common_prefix_len = min(JUSTIFYING_SLOT, spec.SLOTS_PER_EPOCH - len(current_blocks))
+        common_prefix_len = common_prefix_len = min(JUSTIFYING_SLOT, spec.SLOTS_PER_EPOCH - len(current_blocks))
         threshold_slot = spec.compute_start_slot_at_epoch(epoch) + common_prefix_len
 
         # Build the chain up to but excluding a block that will justify current checkpoint
@@ -137,14 +137,23 @@ def _generate_filter_block_tree(
         # if that needed. Considering that most of attestations were already included into the common chain prefix,
         # we assume it is possible
         empty_slot_count = spec.SLOTS_PER_EPOCH - common_prefix_len - len(current_blocks)
-        block_distribution = current_blocks.copy() + [-1 for _ in range(0, empty_slot_count)]
+        prefix_window_len = JUSTIFYING_SLOT - common_prefix_len
+        suffix_window_len = spec.SLOTS_PER_EPOCH - JUSTIFYING_SLOT
 
-        # Randomly distribute blocks across slots
-        rnd.shuffle(block_distribution)
+        remaining_items = [b for b in current_blocks if b not in justifying_blocks]
+        remaining_items = remaining_items + [-1 for _ in range(0, empty_slot_count)]
+        rnd.shuffle(remaining_items)
 
-        # Move all blocks that require to justify current epoch to the end to increase the chance of justification
-        block_distribution = [b for b in block_distribution if b not in justifying_blocks]
-        block_distribution = block_distribution + justifying_blocks
+        suffix_extra_count = suffix_window_len - len(justifying_blocks)
+        suffix_items = justifying_blocks.copy() + remaining_items[:suffix_extra_count]
+        prefix_items = remaining_items[suffix_extra_count:]
+
+        assert len(prefix_items) == prefix_window_len
+        assert len(suffix_items) == suffix_window_len
+
+        rnd.shuffle(prefix_items)
+        rnd.shuffle(suffix_items)
+        block_distribution = prefix_items + suffix_items
 
         for index, block in enumerate(block_distribution):
             slot = threshold_slot + index
@@ -332,7 +341,7 @@ def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTest
         post_block_tips[target_block].beacon_state.latest_block_header
     )
 
-    if debug:
+    if True:
         _debug_run_sanity_checks(
             spec, anchor_state, anchor_block, signed_blocks, model_params, target_block_root
         )

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
@@ -2,7 +2,12 @@ import random
 
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
+    run_on_block,
+    run_on_attestation,
+    run_on_attester_slashing,
+    run_on_payload_attestation_message,
 )
+from eth_consensus_specs.test.helpers.forks import is_post_gloas
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
     transition_to,
@@ -14,6 +19,7 @@ from .helpers import (
     attest_to_slot,
     BranchTip,
     FCTestData,
+    payload_attestation_to_messages,
     produce_block,
     ProtocolMessage,
 )
@@ -205,6 +211,51 @@ def _generate_filter_block_tree(
     return signed_blocks, block_tips
 
 
+def _debug_run_sanity_checks(spec, anchor_state, anchor_block, signed_blocks, model_params, target_block_root):
+    store = spec.get_forkchoice_store(anchor_state, anchor_block)
+
+    def debug_add_block(signed_block):
+        run_on_block(spec, store, signed_block, valid=True)
+
+        for attestation in signed_block.message.body.attestations:
+            try:
+                run_on_attestation(spec, store, attestation, is_from_block=True, valid=True)
+            except AssertionError:
+                pass
+
+        for attester_slashing in signed_block.message.body.attester_slashings:
+            try:
+                run_on_attester_slashing(spec, store, attester_slashing, valid=True)
+            except AssertionError:
+                pass
+
+        if is_post_gloas(spec):
+            state = store.block_states[signed_block.message.hash_tree_root()]
+            for payload_attestation in signed_block.message.body.payload_attestations:
+                for ptc_message in payload_attestation_to_messages(spec, state, payload_attestation):
+                    run_on_payload_attestation_message(
+                        spec, store, ptc_message, is_from_block=True, valid=True
+                    )
+
+    for signed_block in signed_blocks:
+        block_time = (
+            anchor_state.genesis_time
+            + signed_block.message.slot * spec.config.SLOT_DURATION_MS // 1000
+        )
+        if block_time > store.time:
+            spec.on_tick(store, block_time)
+        debug_add_block(signed_block)
+
+    current_epoch_slot = spec.compute_start_slot_at_epoch(model_params["current_epoch"])
+    current_epoch_time = (
+        anchor_state.genesis_time + current_epoch_slot * spec.config.SLOT_DURATION_MS // 1000
+    )
+    if current_epoch_time > store.time:
+        spec.on_tick(store, current_epoch_time)
+
+    run_sanity_checks(spec, store, model_params, target_block_root)
+
+
 def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTestData, object):
     anchor_state = state
     _, anchor_block = get_genesis_forkchoice_store_and_block(spec, anchor_state)
@@ -280,6 +331,11 @@ def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTest
     target_block_root = spec.hash_tree_root(
         post_block_tips[target_block].beacon_state.latest_block_header
     )
+
+    if debug:
+        _debug_run_sanity_checks(
+            spec, anchor_state, anchor_block, signed_blocks, model_params, target_block_root
+        )
 
     return test_data, target_block_root
 

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
@@ -5,7 +5,11 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     run_on_block,
     run_on_attestation,
     run_on_attester_slashing,
+    run_on_execution_payload_envelope,
     run_on_payload_attestation_message,
+)
+from eth_consensus_specs.test.helpers.execution_payload import (
+    build_signed_execution_payload_envelope,
 )
 from eth_consensus_specs.test.helpers.forks import is_post_gloas
 from eth_consensus_specs.test.helpers.state import (
@@ -17,6 +21,7 @@ from eth_consensus_specs.utils import bls
 from .helpers import (
     advance_state_to_anchor_epoch,
     attest_to_slot,
+    build_random_payload_attestation_messages,
     BranchTip,
     FCTestData,
     payload_attestation_to_messages,
@@ -46,7 +51,7 @@ def _generate_filter_block_tree(
     current_justifications,
     rnd: random.Random,
     debug,
-) -> ([], []):
+) -> ([], [], [], []):
     JUSTIFYING_SLOT = 2 * spec.SLOTS_PER_EPOCH // 3 + 1
     JUSTIFYING_SLOT_COUNT = spec.SLOTS_PER_EPOCH - JUSTIFYING_SLOT
 
@@ -64,6 +69,8 @@ def _generate_filter_block_tree(
             for b in current_blocks
             if _should_justify_epoch(parents, current_justifications, previous_justifications, b)
         ]
+        current_justifying_blocks = [b for b in justifying_blocks if current_justifications[b]]
+        previous_only_justifying_blocks = [b for b in justifying_blocks if not current_justifications[b]]
 
         # There should be enough slots to propose all blocks that are required to justify the epoch
         assert len(justifying_blocks) <= JUSTIFYING_SLOT_COUNT, (
@@ -75,6 +82,8 @@ def _generate_filter_block_tree(
     )
 
     block_tips = [None for _ in range(0, len(block_epochs))]
+    model_blocks = [None for _ in range(0, len(block_epochs))]
+    model_post_states = [None for _ in range(0, len(block_epochs))]
     # Initialize with the anchor block
     block_tips[0] = anchor_tip
 
@@ -101,7 +110,7 @@ def _generate_filter_block_tree(
             if _should_justify_epoch(parents, current_justifications, previous_justifications, b)
         ]
 
-        common_prefix_len = common_prefix_len = min(JUSTIFYING_SLOT, spec.SLOTS_PER_EPOCH - len(current_blocks))
+        common_prefix_len = min(JUSTIFYING_SLOT, spec.SLOTS_PER_EPOCH - len(current_blocks))
         threshold_slot = spec.compute_start_slot_at_epoch(epoch) + common_prefix_len
 
         # Build the chain up to but excluding a block that will justify current checkpoint
@@ -145,14 +154,21 @@ def _generate_filter_block_tree(
         rnd.shuffle(remaining_items)
 
         suffix_extra_count = suffix_window_len - len(justifying_blocks)
-        suffix_items = justifying_blocks.copy() + remaining_items[:suffix_extra_count]
+        suffix_extras = remaining_items[:suffix_extra_count]
         prefix_items = remaining_items[suffix_extra_count:]
 
         assert len(prefix_items) == prefix_window_len
-        assert len(suffix_items) == suffix_window_len
+        assert len(suffix_extras) + len(previous_only_justifying_blocks) + len(
+            current_justifying_blocks
+        ) == suffix_window_len
 
         rnd.shuffle(prefix_items)
-        rnd.shuffle(suffix_items)
+        rnd.shuffle(suffix_extras)
+        rnd.shuffle(previous_only_justifying_blocks)
+        rnd.shuffle(current_justifying_blocks)
+        suffix_items = (
+            suffix_extras + previous_only_justifying_blocks + current_justifying_blocks
+        )
         block_distribution = prefix_items + suffix_items
 
         for index, block in enumerate(block_distribution):
@@ -180,6 +196,8 @@ def _generate_filter_block_tree(
                 # Propose block
                 new_block, state, _, _, _ = produce_block(spec, state, block_attestations)
                 signed_blocks.append(new_block)
+                model_blocks[block] = new_block
+                model_post_states[block] = state.copy()
 
             # Attest
             # TODO pick a random tip to make attestation with if the slot is empty
@@ -217,11 +235,26 @@ def _generate_filter_block_tree(
                     check_up_state.current_justified_checkpoint,
                 )
 
-    return signed_blocks, block_tips
+    return signed_blocks, block_tips, model_blocks, model_post_states
 
 
-def _debug_run_sanity_checks(spec, anchor_state, anchor_block, signed_blocks, model_params, target_block_root):
+def _debug_run_sanity_checks(
+    spec,
+    anchor_state,
+    anchor_block,
+    signed_blocks,
+    envelopes,
+    payload_attestations,
+    model_params,
+    target_block_root,
+):
     store = spec.get_forkchoice_store(anchor_state, anchor_block)
+    envelopes_by_block_root = {e.payload.message.beacon_block_root: e.payload for e in envelopes}
+    payload_attestations_by_block_root = {}
+    for ptc_message in payload_attestations:
+        payload_attestations_by_block_root.setdefault(ptc_message.data.beacon_block_root, []).append(
+            ptc_message
+        )
 
     def debug_add_block(signed_block):
         run_on_block(spec, store, signed_block, valid=True)
@@ -245,6 +278,15 @@ def _debug_run_sanity_checks(spec, anchor_state, anchor_block, signed_blocks, mo
                     run_on_payload_attestation_message(
                         spec, store, ptc_message, is_from_block=True, valid=True
                     )
+
+            envelope = envelopes_by_block_root.get(signed_block.message.hash_tree_root())
+            if envelope is not None:
+                run_on_execution_payload_envelope(spec, store, envelope, valid=True)
+
+            for ptc_message in payload_attestations_by_block_root.get(
+                signed_block.message.hash_tree_root(), []
+            ):
+                run_on_payload_attestation_message(spec, store, ptc_message, valid=True)
 
     for signed_block in signed_blocks:
         block_time = (
@@ -309,7 +351,7 @@ def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTest
             )
 
     rnd = random.Random(seed)
-    signed_blocks, post_block_tips = _generate_filter_block_tree(
+    signed_blocks, post_block_tips, model_blocks, model_post_states = _generate_filter_block_tree(
         spec,
         state,
         block_epochs,
@@ -328,6 +370,8 @@ def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTest
     }
 
     blocks = [ProtocolMessage(block) for block in signed_blocks]
+    envelopes = []
+    payload_attestations = []
 
     current_epoch_slot = spec.compute_start_slot_at_epoch(model_params["current_epoch"])
     current_epoch_time = (
@@ -340,10 +384,41 @@ def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTest
     target_block_root = spec.hash_tree_root(
         post_block_tips[target_block].beacon_state.latest_block_header
     )
+    if is_post_gloas(spec):
+        target_signed_block = model_blocks[target_block]
+        target_post_state = model_post_states[target_block]
+        if target_signed_block is not None and target_post_state is not None:
+            envelope_mode = rnd.choice(["none", "valid"])
+            if envelope_mode == "valid":
+                envelopes.append(
+                    ProtocolMessage(
+                        build_signed_execution_payload_envelope(
+                            spec, target_post_state, target_block_root, target_signed_block
+                        )
+                    )
+                )
+                for ptc_message in build_random_payload_attestation_messages(
+                    spec,
+                    target_post_state,
+                    target_block_root,
+                    target_signed_block.message.slot,
+                    rnd,
+                ):
+                    payload_attestations.append(ProtocolMessage(ptc_message))
 
-    if True:
+    test_data.envelopes = envelopes
+    test_data.payload_atts = payload_attestations
+
+    if debug:
         _debug_run_sanity_checks(
-            spec, anchor_state, anchor_block, signed_blocks, model_params, target_block_root
+            spec,
+            anchor_state,
+            anchor_block,
+            signed_blocks,
+            envelopes,
+            [m.payload for m in payload_attestations],
+            model_params,
+            target_block_root,
         )
 
     return test_data, target_block_root

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
@@ -49,9 +49,10 @@ def _generate_filter_block_tree(
     parents,
     previous_justifications,
     current_justifications,
+    target_block,
     rnd: random.Random,
     debug,
-) -> ([], [], [], []):
+) -> ([], [], object, object):
     JUSTIFYING_SLOT = 2 * spec.SLOTS_PER_EPOCH // 3 + 1
     JUSTIFYING_SLOT_COUNT = spec.SLOTS_PER_EPOCH - JUSTIFYING_SLOT
 
@@ -84,8 +85,8 @@ def _generate_filter_block_tree(
     )
 
     block_tips = [None for _ in range(0, len(block_epochs))]
-    model_blocks = [None for _ in range(0, len(block_epochs))]
-    model_post_states = [None for _ in range(0, len(block_epochs))]
+    target_signed_block = None
+    target_post_state = None
     # Initialize with the anchor block
     block_tips[0] = anchor_tip
 
@@ -199,8 +200,9 @@ def _generate_filter_block_tree(
                 # Propose block
                 new_block, state, _, _, _ = produce_block(spec, state, block_attestations)
                 signed_blocks.append(new_block)
-                model_blocks[block] = new_block
-                model_post_states[block] = state.copy()
+                if block == target_block and is_post_gloas(spec):
+                    target_signed_block = new_block
+                    target_post_state = state.copy()
 
             # Attest
             # TODO pick a random tip to make attestation with if the slot is empty
@@ -238,7 +240,7 @@ def _generate_filter_block_tree(
                     check_up_state.current_justified_checkpoint,
                 )
 
-    return signed_blocks, block_tips, model_blocks, model_post_states
+    return signed_blocks, block_tips, target_signed_block, target_post_state
 
 
 def _debug_run_sanity_checks(
@@ -356,15 +358,18 @@ def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTest
             )
 
     rnd = random.Random(seed)
-    signed_blocks, post_block_tips, model_blocks, model_post_states = _generate_filter_block_tree(
-        spec,
-        state,
-        block_epochs,
-        parents,
-        previous_justifications,
-        current_justifications,
-        rnd,
-        debug,
+    signed_blocks, post_block_tips, target_signed_block, target_post_state = (
+        _generate_filter_block_tree(
+            spec,
+            state,
+            block_epochs,
+            parents,
+            previous_justifications,
+            current_justifications,
+            target_block,
+            rnd,
+            debug,
+        )
     )
 
     # Meta data
@@ -390,8 +395,6 @@ def gen_block_cover_test_data(spec, state, model_params, debug, seed) -> (FCTest
         post_block_tips[target_block].beacon_state.latest_block_header
     )
     if is_post_gloas(spec):
-        target_signed_block = model_blocks[target_block]
-        target_post_state = model_post_states[target_block]
         if target_signed_block is not None and target_post_state is not None:
             envelope_mode = rnd.choice(["none", "valid"])
             if envelope_mode == "valid":

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_cover.py
@@ -1,15 +1,15 @@
 import random
 
-from eth_consensus_specs.test.helpers.fork_choice import (
-    get_genesis_forkchoice_store_and_block,
-    run_on_block,
-    run_on_attestation,
-    run_on_attester_slashing,
-    run_on_execution_payload_envelope,
-    run_on_payload_attestation_message,
-)
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_signed_execution_payload_envelope,
+)
+from eth_consensus_specs.test.helpers.fork_choice import (
+    get_genesis_forkchoice_store_and_block,
+    run_on_attestation,
+    run_on_attester_slashing,
+    run_on_block,
+    run_on_execution_payload_envelope,
+    run_on_payload_attestation_message,
 )
 from eth_consensus_specs.test.helpers.forks import is_post_gloas
 from eth_consensus_specs.test.helpers.state import (
@@ -21,8 +21,8 @@ from eth_consensus_specs.utils import bls
 from .helpers import (
     advance_state_to_anchor_epoch,
     attest_to_slot,
-    build_random_payload_attestation_messages,
     BranchTip,
+    build_random_payload_attestation_messages,
     FCTestData,
     payload_attestation_to_messages,
     produce_block,
@@ -70,7 +70,9 @@ def _generate_filter_block_tree(
             if _should_justify_epoch(parents, current_justifications, previous_justifications, b)
         ]
         current_justifying_blocks = [b for b in justifying_blocks if current_justifications[b]]
-        previous_only_justifying_blocks = [b for b in justifying_blocks if not current_justifications[b]]
+        previous_only_justifying_blocks = [
+            b for b in justifying_blocks if not current_justifications[b]
+        ]
 
         # There should be enough slots to propose all blocks that are required to justify the epoch
         assert len(justifying_blocks) <= JUSTIFYING_SLOT_COUNT, (
@@ -158,17 +160,18 @@ def _generate_filter_block_tree(
         prefix_items = remaining_items[suffix_extra_count:]
 
         assert len(prefix_items) == prefix_window_len
-        assert len(suffix_extras) + len(previous_only_justifying_blocks) + len(
-            current_justifying_blocks
-        ) == suffix_window_len
+        assert (
+            len(suffix_extras)
+            + len(previous_only_justifying_blocks)
+            + len(current_justifying_blocks)
+            == suffix_window_len
+        )
 
         rnd.shuffle(prefix_items)
         rnd.shuffle(suffix_extras)
         rnd.shuffle(previous_only_justifying_blocks)
         rnd.shuffle(current_justifying_blocks)
-        suffix_items = (
-            suffix_extras + previous_only_justifying_blocks + current_justifying_blocks
-        )
+        suffix_items = suffix_extras + previous_only_justifying_blocks + current_justifying_blocks
         block_distribution = prefix_items + suffix_items
 
         for index, block in enumerate(block_distribution):
@@ -252,9 +255,9 @@ def _debug_run_sanity_checks(
     envelopes_by_block_root = {e.payload.message.beacon_block_root: e.payload for e in envelopes}
     payload_attestations_by_block_root = {}
     for ptc_message in payload_attestations:
-        payload_attestations_by_block_root.setdefault(ptc_message.data.beacon_block_root, []).append(
-            ptc_message
-        )
+        payload_attestations_by_block_root.setdefault(
+            ptc_message.data.beacon_block_root, []
+        ).append(ptc_message)
 
     def debug_add_block(signed_block):
         run_on_block(spec, store, signed_block, valid=True)
@@ -274,7 +277,9 @@ def _debug_run_sanity_checks(
         if is_post_gloas(spec):
             state = store.block_states[signed_block.message.hash_tree_root()]
             for payload_attestation in signed_block.message.body.payload_attestations:
-                for ptc_message in payload_attestation_to_messages(spec, state, payload_attestation):
+                for ptc_message in payload_attestation_to_messages(
+                    spec, state, payload_attestation
+                ):
                     run_on_payload_attestation_message(
                         spec, store, ptc_message, is_from_block=True, valid=True
                     )

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -477,6 +477,43 @@ def _spoil_execution_payload_envelope(spec, rnd: random.Random, signed_envelope)
     signed_envelope.message.payload.parent_hash = spec.Hash32(rnd.randbytes(32))
 
 
+def _choose_payload_attestation_vote_count(spec, ptc, rnd: random.Random):
+    threshold = int(spec.PAYLOAD_TIMELY_THRESHOLD)
+    max_voters = len(ptc)
+    mode = rnd.choice(["none", "below_threshold", "edge", "above_threshold"])
+
+    if mode == "none":
+        return 0
+
+    if mode == "below_threshold":
+        max_count = min(max_voters, threshold)
+        return rnd.randint(0, max_count)
+
+    if mode == "edge":
+        candidates = [count for count in {threshold, threshold + 1} if 0 <= count <= max_voters]
+        return rnd.choice(candidates)
+
+    candidates = [count for count in range(threshold + 1, max_voters + 1)]
+    if candidates:
+        return rnd.choice(candidates)
+
+    return max_voters
+
+
+def _sample_payload_attestation_vote_values(mode, rnd: random.Random):
+    if mode == "all_true_true":
+        return True, True
+    if mode == "all_false_false":
+        return False, False
+    if mode == "mostly_true_true":
+        return (False, False) if _roll(rnd, 20) else (True, True)
+    if mode == "mostly_true_false":
+        return (False, True) if _roll(rnd, 20) else (True, False)
+    if mode == "mostly_false_true":
+        return (True, False) if _roll(rnd, 20) else (False, True)
+    return rnd.choice([True, False]), rnd.choice([True, False])
+
+
 def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
     """Build random PayloadAttestationMessage objects with diverse PTC vote values."""
     attested_slot = state.latest_block_header.slot
@@ -492,20 +529,34 @@ def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
     if len(ptc) == 0:
         return []
 
-    num_attesters = rnd.randint(len(ptc) // 2, len(ptc))
+    num_attesters = _choose_payload_attestation_vote_count(spec, ptc, rnd)
     attesting_indices = rnd.sample(list(ptc), num_attesters) if num_attesters > 0 else []
     if not attesting_indices:
         return []
+
+    vote_pattern_mode = rnd.choice(
+        [
+            "all_true_true",
+            "all_false_false",
+            "mostly_true_true",
+            "mostly_true_false",
+            "mostly_false_true",
+            "mixed",
+        ]
+    )
 
     messages = []
     for validator_index in attesting_indices:
         if validator_index >= len(privkeys):
             continue
+        payload_present, blob_data_available = _sample_payload_attestation_vote_values(
+            vote_pattern_mode, rnd
+        )
         data = spec.PayloadAttestationData(
             beacon_block_root=beacon_block_root,
             slot=attested_slot,
-            payload_present=rnd.choice([True, False]),
-            blob_data_available=rnd.choice([True, False]),
+            payload_present=payload_present,
+            blob_data_available=blob_data_available,
         )
         messages.append(
             spec.PayloadAttestationMessage(

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -633,6 +633,33 @@ class RuntimeState:
         self.payload_known_block_indices = set()
 
 
+def _get_state_block_root(spec, state):
+    block_header = state.latest_block_header.copy()
+    if block_header.state_root == spec.Bytes32():
+        block_header.state_root = spec.hash_tree_root(state)
+    return spec.hash_tree_root(block_header)
+
+
+def _debug_assert_block_tree_shape(spec, anchor_state, block_parents, signed_block_messages):
+    signed_blocks = [message.payload for message in signed_block_messages if message.valid]
+    assert len(signed_blocks) == len(block_parents) - 1, (
+        "Constructed block tree does not match the model size: "
+        f"expected {len(block_parents) - 1} blocks, got {len(signed_blocks)}"
+    )
+
+    block_roots = [_get_state_block_root(spec, anchor_state)]
+    block_roots.extend(block.message.hash_tree_root() for block in signed_blocks)
+
+    for block_index in range(1, len(block_parents)):
+        expected_parent_index = block_parents[block_index]
+        block = signed_blocks[block_index - 1]
+        expected_parent_root = block_roots[expected_parent_index]
+        assert block.message.parent_root == expected_parent_root, (
+            f"Block {block_index} has wrong parent root: "
+            f"expected parent index {expected_parent_index}"
+        )
+
+
 def _generate_block_tree(
     spec,
     anchor_tip: BranchTip,
@@ -919,6 +946,11 @@ def _generate_block_tree(
             "              ",
             "valid =",
             len([s for s in protocol.out_of_block_attester_slashing_messages if s.valid]),
+        )
+
+    if debug and not with_invalid_messages:
+        _debug_assert_block_tree_shape(
+            spec, anchor_tip.beacon_state, block_parents, protocol.signed_block_messages
         )
 
     return (

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -529,26 +529,108 @@ def _disseminate(
     in_block_list,
     off_chain_rate,
     on_chain_rate,
-    with_invalid_messages,
-    spoil_fn=None,
 ):
     """
-    Randomly assigns a protocol message to off-chain, on-chain, or both dissemination paths.
-    Optionally spoils the message to make it invalid (off-chain only path).
+    Randomly assigns a valid protocol message to off-chain, on-chain, or both
+    dissemination paths.
     """
     choice = rnd.randint(0, 99)
     if choice < off_chain_rate:
-        if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
-            if spoil_fn:
-                spoil_fn(message)
-            off_chain_list.append(ProtocolMessage(message, False))
-        else:
-            off_chain_list.append(ProtocolMessage(message, True))
+        off_chain_list.append(ProtocolMessage(message, True))
     elif choice < off_chain_rate + on_chain_rate:
         in_block_list.append(message)
     else:
         off_chain_list.append(ProtocolMessage(message, True))
         in_block_list.append(message)
+
+
+class ProtocolState:
+    def __init__(self, spec, anchor_tip: BranchTip):
+        self.spec = spec
+        self.in_block_attestations = anchor_tip.attestations.copy()
+        self.in_block_attester_slashings = []
+        self.in_block_pa_messages = []
+        self.out_of_block_attestation_messages = []
+        self.out_of_block_attester_slashing_messages = []
+        self.out_of_block_pa_messages = []
+        self.signed_block_messages = []
+        self.signed_envelope_messages = []
+
+    def add_signed_block(self, signed_block, valid: bool):
+        self.signed_block_messages.append(ProtocolMessage(signed_block, valid))
+
+    def add_signed_envelope(self, envelope, valid: bool):
+        self.signed_envelope_messages.append(ProtocolMessage(envelope, valid))
+
+    def add_invalid_off_chain_attestation(self, attestation):
+        self.out_of_block_attestation_messages.append(ProtocolMessage(attestation, False))
+
+    def add_invalid_off_chain_payload_attestation(self, ptc_message):
+        self.out_of_block_pa_messages.append(ProtocolMessage(ptc_message, False))
+
+    def add_invalid_off_chain_attester_slashing(self, attester_slashing):
+        self.out_of_block_attester_slashing_messages.append(ProtocolMessage(attester_slashing, False))
+
+    def maybe_invalidate_attestation(self, rnd, attestation, with_invalid_messages):
+        if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+            _spoil_attestation(self.spec, rnd, attestation)
+            self.add_invalid_off_chain_attestation(attestation)
+            return True
+        return False
+
+    def maybe_invalidate_payload_attestation(
+        self, rnd, state, ptc_message, with_invalid_messages
+    ):
+        if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+            _spoil_payload_attestation_message(self.spec, rnd, state, ptc_message)
+            self.add_invalid_off_chain_payload_attestation(ptc_message)
+            return True
+        return False
+
+    def maybe_invalidate_attester_slashing(self, rnd, attester_slashing, with_invalid_messages):
+        if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+            _spoil_attester_slashing(self.spec, rnd, attester_slashing)
+            self.add_invalid_off_chain_attester_slashing(attester_slashing)
+            return True
+        return False
+
+    def disseminate_attestation(self, rnd, attestation):
+        _disseminate(
+            rnd,
+            attestation,
+            self.out_of_block_attestation_messages,
+            self.in_block_attestations,
+            OFF_CHAIN_ATTESTATION_RATE,
+            ON_CHAIN_ATTESTATION_RATE,
+        )
+
+    def disseminate_payload_attestation(self, rnd, ptc_message):
+        _disseminate(
+            rnd,
+            ptc_message,
+            self.out_of_block_pa_messages,
+            self.in_block_pa_messages,
+            OFF_CHAIN_ATTESTATION_RATE,
+            ON_CHAIN_ATTESTATION_RATE,
+        )
+
+    def disseminate_attester_slashing(self, rnd, attester_slashing):
+        _disseminate(
+            rnd,
+            attester_slashing,
+            self.out_of_block_attester_slashing_messages,
+            self.in_block_attester_slashings,
+            OFF_CHAIN_SLASHING_RATE,
+            ON_CHAIN_SLASHING_RATE,
+        )
+
+
+class RuntimeState:
+    def __init__(self, anchor_tip: BranchTip):
+        self.current_slot = anchor_tip.beacon_state.slot
+        self.post_states = [anchor_tip.beacon_state.copy()]
+        self.block_tree_tips = {0}
+        self.payload_known_block_indices = set()
 
 
 def _generate_block_tree(
@@ -560,27 +642,26 @@ def _generate_block_tree(
     with_attester_slashings,
     with_invalid_messages,
 ) -> ([], [], [], [], []):
-    in_block_attestations = anchor_tip.attestations.copy()
-    post_states = [anchor_tip.beacon_state.copy()]
-    current_slot = anchor_tip.beacon_state.slot
-    block_index = 1
-    block_tree_tips = set([0])
-    in_block_attester_slashings = []
+    protocol = ProtocolState(spec, anchor_tip)
+    runtime = RuntimeState(anchor_tip)
     # Tracks every validator selected for a generated attester slashing in this
     # scenario, so later selections cannot target the same validator again.
     validators_to_be_slashed = set()
-    out_of_block_attestation_messages = []
-    out_of_block_pa_messages = []
-    out_of_block_attester_slashing_messages = []
-    signed_block_messages = []
-    signed_envelope_messages = []
-    in_block_pa_messages = []
-    payload_known_block_indices = set()
     slot_assignments = {}
+    state_cache_key = None
+    cached_state = None
+    block_edges = iter(enumerate(block_parents[1:], start=1))
 
     def get_state_by_block_index(index):
-        state = post_states[index].copy()
-        transition_to(spec, state, current_slot)
+        nonlocal state_cache_key, cached_state
+        cache_key = (index, runtime.current_slot)
+        if state_cache_key == cache_key:
+            return cached_state.copy()
+
+        state = runtime.post_states[index].copy()
+        transition_to(spec, state, runtime.current_slot)
+        state_cache_key = cache_key
+        cached_state = state
         return state
 
     def assign_voters_to_slots(epoch):
@@ -612,118 +693,119 @@ def _generate_block_tree(
             block_index_voters.setdefault(attesting_block_index, set()).add(validator_index)
         return block_index_voters
 
-    while block_index < len(block_parents):
-        epoch = spec.compute_epoch_at_slot(current_slot)
-        if current_slot not in slot_assignments:
+    def ensure_slot_assignments():
+        epoch = spec.compute_epoch_at_slot(runtime.current_slot)
+        if runtime.current_slot not in slot_assignments:
             assign_voters_to_slots(epoch)
 
-        envelope = None
-        valid_block_was_produced = False
-        new_block_index = None
-        valid_execution_payload_sent = False
-        # Propose a block if slot shouldn't be empty
-        if rnd.randint(1, 100) > EMPTY_SLOTS_RATE:
-            # Advance parent state to the current slot
-            parent_index = block_parents[block_index]
-            parent_state = get_state_by_block_index(parent_index)
+    def next_block_edge():
+        return next(block_edges, None)
 
-            # Filter out non-viable attestations
-            in_block_attestations = [
-                a
-                for a in in_block_attestations
-                if parent_state.slot <= a.data.slot + spec.SLOTS_PER_EPOCH
-            ]
+    def maybe_propose_block(block_edge):
+        if rnd.randint(1, 100) <= EMPTY_SLOTS_RATE:
+            return None, None, None
 
-            # Produce block
-            proposer = spec.get_beacon_proposer_index(parent_state)
-            if parent_state.validators[proposer].slashed or (
-                with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE
-            ):
-                # Do not include attestations and slashings into invalid block
-                # as clients may opt in to process or not process attestations contained by invalid block
-                signed_block, _, _, _, _ = produce_block(spec, parent_state, [], [], [])
-                _spoil_block(spec, rnd, signed_block)
-                signed_block_messages.append(ProtocolMessage(signed_block, False))
-                # Append the parent state as the post state as if the block were not applied
-                post_states.append(parent_state)
-            else:
-                (
-                    signed_block,
-                    post_state,
-                    in_block_attestations,
-                    in_block_attester_slashings,
-                    in_block_pa_messages,
-                ) = produce_block(
-                    spec,
-                    parent_state,
-                    in_block_attestations,
-                    in_block_attester_slashings,
-                    in_block_pa_messages,
-                )
+        block_index, parent_index = block_edge
+        parent_state = get_state_by_block_index(parent_index)
 
-                # Valid block
-                signed_block_messages.append(ProtocolMessage(signed_block, True))
-                post_states.append(post_state)
-                valid_block_was_produced = True
-                new_block_index = block_index
+        protocol.in_block_attestations = [
+            a
+            for a in protocol.in_block_attestations
+            if parent_state.slot <= a.data.slot + spec.SLOTS_PER_EPOCH
+        ]
 
-                # Update tips
-                block_tree_tips.discard(parent_index)
-                block_tree_tips.add(block_index)
+        proposer = spec.get_beacon_proposer_index(parent_state)
 
-                block_root = signed_block.message.hash_tree_root()
-
-                # Next block
-            block_index += 1
-
-        if is_post_gloas(spec) and valid_block_was_produced:
-            # Builder reveals execution payload
-            envelope = build_signed_execution_payload_envelope(
-                spec, post_state, block_root, signed_block
+        if parent_state.validators[proposer].slashed or (
+            with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE
+        ):
+            # Do not include attestations and slashings into invalid block
+            # as clients may opt in to process or not process attestations
+            # contained by invalid block.
+            signed_block, _, _, _, _ = produce_block(spec, parent_state, [], [], [])
+            _spoil_block(spec, rnd, signed_block)
+            protocol.add_signed_block(signed_block, False)
+            runtime.post_states.append(parent_state)
+            post_state = parent_state
+            new_block_index = None
+        else:
+            (
+                signed_block,
+                post_state,
+                protocol.in_block_attestations,
+                protocol.in_block_attester_slashings,
+                protocol.in_block_pa_messages,
+            ) = produce_block(
+                spec,
+                parent_state,
+                protocol.in_block_attestations,
+                protocol.in_block_attester_slashings,
+                protocol.in_block_pa_messages,
             )
-            if rnd.randint(0, 99) < EXECUTION_PAYLOAD_SEND_RATE:
-                # TODO: Consider an explicit invalid case for an execution payload
-                # targeting an unknown beacon block root. That should stay out of
-                # the orderly base scenario unless `with_invalid_messages` is enabled.
-                valid = True
-                if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
-                    _spoil_execution_payload_envelope(spec, rnd, envelope)
-                    valid = False
-                signed_envelope_messages.append(ProtocolMessage(envelope, valid))
-                valid_execution_payload_sent = valid
-                if valid:
-                    payload_known_block_indices.add(new_block_index)
 
-        # Assign each validator in the current slot's committees to a block tree tip.
-        attesting_committee = slot_assignments[current_slot]
+            protocol.add_signed_block(signed_block, True)
+            runtime.post_states.append(post_state)
+            new_block_index = block_index
+
+            runtime.block_tree_tips.discard(parent_index)
+            runtime.block_tree_tips.add(block_index)
+
+        return signed_block, post_state, new_block_index
+
+    def maybe_send_execution_payload(signed_block, post_state, new_block_index):
+        if not is_post_gloas(spec) or new_block_index is None:
+            return False
+
+        block_root = signed_block.message.hash_tree_root()
+        envelope = build_signed_execution_payload_envelope(spec, post_state, block_root, signed_block)
+        if rnd.randint(0, 99) >= EXECUTION_PAYLOAD_SEND_RATE:
+            return False
+
+        # TODO: Consider an explicit invalid case for an execution payload
+        # targeting an unknown beacon block root. That should stay out of
+        # the orderly base scenario unless `with_invalid_messages` is enabled.
+        valid = True
+        if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+            _spoil_execution_payload_envelope(spec, rnd, envelope)
+            valid = False
+        protocol.add_signed_envelope(envelope, valid)
+        if valid:
+            runtime.payload_known_block_indices.add(new_block_index)
+        return valid
+
+    def get_attestation_payload_index(attesting_block_index, new_block_index, valid_execution_payload_sent):
+        payload_index = None
+        att_payload_index_invalid = False
+        if is_post_gloas(spec):
+            if valid_execution_payload_sent and attesting_block_index == new_block_index:
+                if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+                    # payload_index=1 for a same-slot block is GLOAS-invalid:
+                    # spec requires data.index==0 when block_slot==attestation.data.slot
+                    payload_index = 1
+                    att_payload_index_invalid = True
+                else:
+                    payload_index = 0
+            elif (
+                attesting_block_index != new_block_index
+                and attesting_block_index in runtime.payload_known_block_indices
+            ):
+                if rnd.randint(0, 99) < GLOAS_FULL_ATTESTATION_RATE:
+                    payload_index = 1
+                else:
+                    payload_index = 0
+        return payload_index, att_payload_index_invalid
+
+    def make_slot_attestations(new_block_index, valid_execution_payload_sent):
+        attesting_committee = slot_assignments[runtime.current_slot]
         block_index_voters = assign_committee_votes(
-            attesting_committee, block_tree_tips, block_parents
+            attesting_committee, runtime.block_tree_tips, block_parents
         )
 
         for attesting_block_index, attesters in block_index_voters.items():
-            # Advance the state to the current slot
             attesting_state = get_state_by_block_index(attesting_block_index)
-
-            # Attest to the block
-            payload_index = None
-            att_payload_index_invalid = False
-            if is_post_gloas(spec):
-                if valid_execution_payload_sent and attesting_block_index == new_block_index:
-                    if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
-                        # payload_index=1 for a same-slot block is GLOAS-invalid:
-                        # spec requires data.index==0 when block_slot==attestation.data.slot
-                        payload_index = 1
-                        att_payload_index_invalid = True
-                    else:
-                        payload_index = 0
-                elif (
-                    attesting_block_index != new_block_index
-                    and attesting_block_index in payload_known_block_indices
-                ):
-                    if rnd.randint(0, 99) < GLOAS_FULL_ATTESTATION_RATE:
-                        payload_index = 1
-                    else:
-                        payload_index = 0
+            payload_index, att_payload_index_invalid = get_attestation_payload_index(
+                attesting_block_index, new_block_index, valid_execution_payload_sent
+            )
             attestations_in_slot = attest_to_slot(
                 spec,
                 attesting_state,
@@ -732,127 +814,122 @@ def _generate_block_tree(
                 payload_index=payload_index,
             )
 
-            # Sample on chain and off chain attestations
-            for a in attestations_in_slot:
+            for attestation in attestations_in_slot:
                 if att_payload_index_invalid:
-                    # Already known invalid due to GLOAS payload_index constraint;
-                    # skip _disseminate to avoid it being marked valid=True
-                    out_of_block_attestation_messages.append(ProtocolMessage(a, False))
-                else:
-                    _disseminate(
-                        rnd,
-                        a,
-                        out_of_block_attestation_messages,
-                        in_block_attestations,
-                        OFF_CHAIN_ATTESTATION_RATE,
-                        ON_CHAIN_ATTESTATION_RATE,
-                        with_invalid_messages,
-                        spoil_fn=lambda msg: _spoil_attestation(spec, rnd, msg),
-                    )
+                    protocol.add_invalid_off_chain_attestation(attestation)
+                elif not protocol.maybe_invalidate_attestation(
+                    rnd, attestation, with_invalid_messages
+                ):
+                    protocol.disseminate_attestation(rnd, attestation)
 
-        if is_post_gloas(spec):
-            if valid_block_was_produced and rnd.randint(0, 99) < PAYLOAD_ATTESTATION_SEND_RATE:
-                # TODO: Consider explicit payload-attestation cases without a
-                # newly produced block in this iteration, e.g. delayed votes
-                # for an older known block root or invalid votes for an unknown
-                # root. Those should stay out of the orderly base scenario
-                # unless `with_invalid_messages` is enabled.
-                for ptc_message in _get_random_payload_attestation_messages(spec, post_state, rnd):
-                    _disseminate(
-                        rnd,
-                        ptc_message,
-                        out_of_block_pa_messages,
-                        in_block_pa_messages,
-                        OFF_CHAIN_ATTESTATION_RATE,
-                        ON_CHAIN_ATTESTATION_RATE,
-                        with_invalid_messages,
-                        spoil_fn=lambda msg: _spoil_payload_attestation_message(
-                            spec, rnd, post_state, msg
-                        ),
-                    )
+    def maybe_send_payload_attestations(post_state, new_block_index):
+        if not is_post_gloas(spec) or new_block_index is None:
+            return
+        if rnd.randint(0, 99) >= PAYLOAD_ATTESTATION_SEND_RATE:
+            return
 
-        # Create attester slashing
-        if with_attester_slashings and len(validators_to_be_slashed) < MAX_ATTESTER_SLASHINGS:
-            if rnd.randint(0, 99) < ATTESTER_SLASHINGS_RATE:
-                state = get_state_by_block_index(-1)
+        # TODO: Consider explicit payload-attestation cases without a
+        # newly produced block in this iteration, e.g. delayed votes
+        # for an older known block root or invalid votes for an unknown
+        # root. Those should stay out of the orderly base scenario
+        # unless `with_invalid_messages` is enabled.
+        for ptc_message in _get_random_payload_attestation_messages(spec, post_state, rnd):
+            if not protocol.maybe_invalidate_payload_attestation(
+                rnd, post_state, ptc_message, with_invalid_messages
+            ):
+                protocol.disseminate_payload_attestation(rnd, ptc_message)
 
-                assert len(validators_to_be_slashed) < len(state.validators)
-                while True:
-                    validator_to_slash = rnd.randint(0, len(state.validators) - 1)
-                    # avoid slashing a validator who might be slashed already
-                    if validator_to_slash not in validators_to_be_slashed:
-                        break
+    def maybe_create_attester_slashing():
+        if not with_attester_slashings or len(validators_to_be_slashed) >= MAX_ATTESTER_SLASHINGS:
+            return
+        if rnd.randint(0, 99) >= ATTESTER_SLASHINGS_RATE:
+            return
 
-                indices = [validator_to_slash]
-                attester_slashing = get_valid_attester_slashing_by_indices(
-                    spec, state, indices, slot=current_slot, signed_1=True, signed_2=True
-                )
+        state = get_state_by_block_index(-1)
 
-                _disseminate(
-                    rnd,
-                    attester_slashing,
-                    out_of_block_attester_slashing_messages,
-                    in_block_attester_slashings,
-                    OFF_CHAIN_SLASHING_RATE,
-                    ON_CHAIN_SLASHING_RATE,
-                    with_invalid_messages,
-                    spoil_fn=lambda msg: _spoil_attester_slashing(spec, rnd, msg),
-                )
+        assert len(validators_to_be_slashed) < len(state.validators)
+        while True:
+            validator_to_slash = rnd.randint(0, len(state.validators) - 1)
+            # avoid slashing a validator who might be slashed already
+            if validator_to_slash not in validators_to_be_slashed:
+                break
 
-                validators_to_be_slashed.update(indices)
+        indices = [validator_to_slash]
+        attester_slashing = get_valid_attester_slashing_by_indices(
+            spec, state, indices, slot=runtime.current_slot, signed_1=True, signed_2=True
+        )
 
-        # Next slot
-        current_slot += 1
+        if not protocol.maybe_invalidate_attester_slashing(
+            rnd, attester_slashing, with_invalid_messages
+        ):
+            protocol.disseminate_attester_slashing(rnd, attester_slashing)
+
+        validators_to_be_slashed.update(indices)
+
+    block_edge = next_block_edge()
+    while block_edge is not None:
+        ensure_slot_assignments()
+        signed_block, post_state, new_block_index = maybe_propose_block(block_edge)
+        if signed_block is not None:
+            block_edge = next_block_edge()
+        valid_execution_payload_sent = maybe_send_execution_payload(signed_block, post_state, new_block_index)
+        make_slot_attestations(new_block_index, valid_execution_payload_sent)
+        maybe_send_payload_attestations(post_state, new_block_index)
+        maybe_create_attester_slashing()
+        runtime.current_slot += 1
 
     if debug:
         print("\nblock_tree:")
         print(
             "blocks:       ",
-            print_block_tree(spec, post_states[0], [b.payload for b in signed_block_messages]),
+            print_block_tree(
+                spec, runtime.post_states[0], [b.payload for b in protocol.signed_block_messages]
+            ),
         )
         print(
             "              ",
             "state.current_justified_checkpoint:",
             "(epoch="
-            + str(post_states[len(post_states) - 1].current_justified_checkpoint.epoch)
+            + str(runtime.post_states[len(runtime.post_states) - 1].current_justified_checkpoint.epoch)
             + ", root="
-            + str(post_states[len(post_states) - 1].current_justified_checkpoint.root)[:6]
+            + str(runtime.post_states[len(runtime.post_states) - 1].current_justified_checkpoint.root)[:6]
             + ")",
         )
 
         print("on_block:")
-        print("              ", "count =", len(signed_block_messages))
-        print("              ", "valid =", len([b for b in signed_block_messages if b.valid]))
+        print("              ", "count =", len(protocol.signed_block_messages))
+        print("              ", "valid =", len([b for b in protocol.signed_block_messages if b.valid]))
         print("on_attestation:")
-        print("              ", "count =", len(out_of_block_attestation_messages))
+        print("              ", "count =", len(protocol.out_of_block_attestation_messages))
         print(
             "              ",
             "valid =",
-            len([a for a in out_of_block_attestation_messages if a.valid]),
+            len([a for a in protocol.out_of_block_attestation_messages if a.valid]),
         )
         print("on_payload_attestation_message:")
-        print("              ", "count =", len(out_of_block_pa_messages))
+        print("              ", "count =", len(protocol.out_of_block_pa_messages))
         print(
             "              ",
             "valid =",
-            len([a for a in out_of_block_pa_messages if a.valid]),
+            len([a for a in protocol.out_of_block_pa_messages if a.valid]),
         )
         print("on_attester_slashing:")
-        print("              ", "count =", len(out_of_block_attester_slashing_messages))
+        print("              ", "count =", len(protocol.out_of_block_attester_slashing_messages))
         print(
             "              ",
             "valid =",
-            len([s for s in out_of_block_attester_slashing_messages if s.valid]),
+            len([s for s in protocol.out_of_block_attester_slashing_messages if s.valid]),
         )
 
     return (
-        sorted(signed_block_messages, key=lambda b: b.payload.message.slot),
-        sorted(out_of_block_attestation_messages, key=lambda a: a.payload.data.slot),
+        sorted(protocol.signed_block_messages, key=lambda b: b.payload.message.slot),
+        sorted(protocol.out_of_block_attestation_messages, key=lambda a: a.payload.data.slot),
         sorted(
-            out_of_block_attester_slashing_messages, key=lambda a: a.payload.attestation_1.data.slot
+            protocol.out_of_block_attester_slashing_messages,
+            key=lambda a: a.payload.attestation_1.data.slot,
         ),
-        sorted(signed_envelope_messages, key=lambda e: e.payload.message.payload.slot_number),
-        sorted(out_of_block_pa_messages, key=lambda a: a.payload.data.slot),
+        sorted(protocol.signed_envelope_messages, key=lambda e: e.payload.message.payload.slot_number),
+        sorted(protocol.out_of_block_pa_messages, key=lambda a: a.payload.data.slot),
     )
 
 

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -45,6 +45,7 @@ MAX_TIPS_TO_ATTEST = 2
 
 OFF_CHAIN_ATTESTATION_RATE = 10
 ON_CHAIN_ATTESTATION_RATE = 20
+ATTEST_TO_PARENT_RATE = 10
 
 MAX_ATTESTER_SLASHINGS = 8
 ATTESTER_SLASHINGS_RATE = 8
@@ -575,8 +576,47 @@ def _generate_block_tree(
     signed_envelope_messages = []
     in_block_pa_messages = []
     payload_known_block_indices = set()
+    slot_assignments = {}
+
+    def get_state_by_block_index(index):
+        state = post_states[index].copy()
+        transition_to(spec, state, current_slot)
+        return state
+
+    def assign_voters_to_slots(epoch):
+        epoch_start_slot = spec.compute_start_slot_at_epoch(epoch)
+        epoch_state = get_state_by_block_index(-1)
+        committee_count_per_slot = spec.get_committee_count_per_slot(epoch_state, epoch)
+        for slot in range(epoch_start_slot, epoch_start_slot + spec.SLOTS_PER_EPOCH):
+            assignments = []
+            for index in range(committee_count_per_slot):
+                committee = spec.get_beacon_committee(
+                    epoch_state,
+                    spec.Slot(slot),
+                    spec.CommitteeIndex(index),
+                )
+                assignments.extend(committee)
+            slot_assignments[slot] = assignments
+
+    def choose_attested_block_index(tips, block_parents):
+        attesting_block_index = rnd.choice(tips)
+        while attesting_block_index != 0 and rnd.randint(0, 99) < ATTEST_TO_PARENT_RATE:
+            attesting_block_index = block_parents[attesting_block_index]
+        return attesting_block_index
+
+    def assign_committee_votes(attesting_committee, block_tree_tips, block_parents):
+        tips = sorted(block_tree_tips)
+        block_index_voters = {}
+        for validator_index in attesting_committee:
+            attesting_block_index = choose_attested_block_index(tips, block_parents)
+            block_index_voters.setdefault(attesting_block_index, set()).add(validator_index)
+        return block_index_voters
 
     while block_index < len(block_parents):
+        epoch = spec.compute_epoch_at_slot(current_slot)
+        if current_slot not in slot_assignments:
+            assign_voters_to_slots(epoch)
+
         envelope = None
         valid_block_was_produced = False
         new_block_index = None
@@ -585,8 +625,7 @@ def _generate_block_tree(
         if rnd.randint(1, 100) > EMPTY_SLOTS_RATE:
             # Advance parent state to the current slot
             parent_index = block_parents[block_index]
-            parent_state = post_states[parent_index].copy()
-            transition_to(spec, parent_state, current_slot)
+            parent_state = get_state_by_block_index(parent_index)
 
             # Filter out non-viable attestations
             in_block_attestations = [
@@ -655,20 +694,15 @@ def _generate_block_tree(
                 if valid:
                     payload_known_block_indices.add(new_block_index)
 
-        # Attest to randomly selected tips
-        def split_list(lst, n):
-            k, m = divmod(len(lst), n)
-            return [lst[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] for i in range(n)]
-
-        attesting_tips = rnd.sample(
-            sorted(block_tree_tips), min(len(block_tree_tips), MAX_TIPS_TO_ATTEST)
+        # Assign each validator in the current slot's committees to a block tree tip.
+        attesting_committee = slot_assignments[current_slot]
+        block_index_voters = assign_committee_votes(
+            attesting_committee, block_tree_tips, block_parents
         )
-        validator_count = len(post_states[attesting_tips[0]].validators)
-        attesters = split_list([i for i in range(validator_count)], len(attesting_tips))
-        for index, attesting_block_index in enumerate(attesting_tips):
+
+        for attesting_block_index, attesters in block_index_voters.items():
             # Advance the state to the current slot
-            attesting_state = post_states[attesting_block_index]
-            transition_to(spec, attesting_state, current_slot)
+            attesting_state = get_state_by_block_index(attesting_block_index)
 
             # Attest to the block
             payload_index = None
@@ -694,7 +728,7 @@ def _generate_block_tree(
                 spec,
                 attesting_state,
                 attesting_state.slot,
-                lambda comm: [i for i in comm if i in attesters[index]],
+                lambda comm: set(comm) & attesters,
                 payload_index=payload_index,
             )
 
@@ -740,7 +774,7 @@ def _generate_block_tree(
         # Create attester slashing
         if with_attester_slashings and len(validators_to_be_slashed) < MAX_ATTESTER_SLASHINGS:
             if rnd.randint(0, 99) < ATTESTER_SLASHINGS_RATE:
-                state = post_states[attesting_tips[0]]
+                state = get_state_by_block_index(-1)
 
                 assert len(validators_to_be_slashed) < len(state.validators)
                 while True:

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -660,6 +660,48 @@ def _debug_assert_block_tree_shape(spec, anchor_state, block_parents, signed_blo
         )
 
 
+def _debug_print_block_tree(spec, runtime, protocol):
+    print("\nblock_tree:")
+    print(
+        "blocks:       ",
+        print_block_tree(spec, runtime.post_states[0], [b.payload for b in protocol.signed_block_messages]),
+    )
+    print(
+        "              ",
+        "state.current_justified_checkpoint:",
+        "(epoch="
+        + str(runtime.post_states[len(runtime.post_states) - 1].current_justified_checkpoint.epoch)
+        + ", root="
+        + str(runtime.post_states[len(runtime.post_states) - 1].current_justified_checkpoint.root)[:6]
+        + ")",
+    )
+
+    print("on_block:")
+    print("              ", "count =", len(protocol.signed_block_messages))
+    print("              ", "valid =", len([b for b in protocol.signed_block_messages if b.valid]))
+    print("on_attestation:")
+    print("              ", "count =", len(protocol.out_of_block_attestation_messages))
+    print(
+        "              ",
+        "valid =",
+        len([a for a in protocol.out_of_block_attestation_messages if a.valid]),
+    )
+    print("on_payload_attestation_message:")
+    print("              ", "count =", len(protocol.out_of_block_pa_messages))
+    print(
+        "              ",
+        "valid =",
+        len([a for a in protocol.out_of_block_pa_messages if a.valid]),
+    )
+    print("on_attester_slashing:")
+    print("              ", "count =", len(protocol.out_of_block_attester_slashing_messages))
+    print(
+        "              ",
+        "valid =",
+        len([s for s in protocol.out_of_block_attester_slashing_messages if s.valid]),
+    )
+
+
 def _generate_block_tree(
     spec,
     anchor_tip: BranchTip,
@@ -906,47 +948,7 @@ def _generate_block_tree(
         runtime.current_slot += 1
 
     if debug:
-        print("\nblock_tree:")
-        print(
-            "blocks:       ",
-            print_block_tree(
-                spec, runtime.post_states[0], [b.payload for b in protocol.signed_block_messages]
-            ),
-        )
-        print(
-            "              ",
-            "state.current_justified_checkpoint:",
-            "(epoch="
-            + str(runtime.post_states[len(runtime.post_states) - 1].current_justified_checkpoint.epoch)
-            + ", root="
-            + str(runtime.post_states[len(runtime.post_states) - 1].current_justified_checkpoint.root)[:6]
-            + ")",
-        )
-
-        print("on_block:")
-        print("              ", "count =", len(protocol.signed_block_messages))
-        print("              ", "valid =", len([b for b in protocol.signed_block_messages if b.valid]))
-        print("on_attestation:")
-        print("              ", "count =", len(protocol.out_of_block_attestation_messages))
-        print(
-            "              ",
-            "valid =",
-            len([a for a in protocol.out_of_block_attestation_messages if a.valid]),
-        )
-        print("on_payload_attestation_message:")
-        print("              ", "count =", len(protocol.out_of_block_pa_messages))
-        print(
-            "              ",
-            "valid =",
-            len([a for a in protocol.out_of_block_pa_messages if a.valid]),
-        )
-        print("on_attester_slashing:")
-        print("              ", "count =", len(protocol.out_of_block_attester_slashing_messages))
-        print(
-            "              ",
-            "valid =",
-            len([s for s in protocol.out_of_block_attester_slashing_messages if s.valid]),
-        )
+        _debug_print_block_tree(spec, runtime, protocol)
 
     if debug and not with_invalid_messages:
         _debug_assert_block_tree_shape(

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -431,11 +431,7 @@ def _generate_sm_link_tree(
                     # Attesting indexes from not yet included attestations
                     for a in new_branch_tip.attestations:
                         if a.data.target.epoch == current_epoch:
-                            attesters.update(
-                                spec.get_attesting_indices(
-                                    current_epoch_state, a.data, a.aggregation_bits
-                                )
-                            )
+                            attesters.update(spec.get_attesting_indices(current_epoch_state, a))
                     unexpected_attesters = attesters.difference(branch_tip.participants)
                     assert len(unexpected_attesters) == 0, (
                         "Unexpected attester: "
@@ -632,6 +628,67 @@ class RuntimeState:
         self.block_tree_tips = {0}
         self.payload_known_block_indices = set()
 
+    def append_post_state(self, post_state):
+        self.post_states.append(post_state)
+
+    def apply_new_block(self, parent_index, block_index, post_state):
+        self.append_post_state(post_state)
+        self.block_tree_tips.discard(parent_index)
+        self.block_tree_tips.add(block_index)
+
+
+class StateCache:
+    def __init__(self, spec, runtime: RuntimeState):
+        self.spec = spec
+        self.runtime = runtime
+        self.cache_key = None
+        self.cached_state = None
+
+    def get_state_by_block_index(self, index):
+        cache_key = (index, self.runtime.current_slot)
+        if self.cache_key == cache_key:
+            return self.cached_state.copy()
+
+        state = self.runtime.post_states[index].copy()
+        transition_to(self.spec, state, self.runtime.current_slot)
+        self.cache_key = cache_key
+        self.cached_state = state
+        return state
+
+
+class CommitteeAssignments:
+    def __init__(self, spec, get_state_by_block_index):
+        self.spec = spec
+        self.get_state_by_block_index = get_state_by_block_index
+        self.slot_assignments = {}
+
+    def assign_voters_to_slots(self, epoch):
+        epoch_start_slot = self.spec.compute_start_slot_at_epoch(epoch)
+        epoch_state = self.get_state_by_block_index(-1)
+        committee_count_per_slot = self.spec.get_committee_count_per_slot(epoch_state, epoch)
+        for slot in range(epoch_start_slot, epoch_start_slot + self.spec.SLOTS_PER_EPOCH):
+            assignments = []
+            for index in range(committee_count_per_slot):
+                committee = self.spec.get_beacon_committee(
+                    epoch_state,
+                    self.spec.Slot(slot),
+                    self.spec.CommitteeIndex(index),
+                )
+                assignments.extend(committee)
+            self.slot_assignments[slot] = assignments
+
+    def ensure_slot_assignments(self, slot):
+        epoch = self.spec.compute_epoch_at_slot(slot)
+        if slot not in self.slot_assignments:
+            self.assign_voters_to_slots(epoch)
+
+    def get_attesting_committee(self, slot):
+        return self.slot_assignments[slot]
+
+
+def _roll(rnd, rate):
+    return rnd.randint(0, 99) < rate
+
 
 def _get_state_block_root(spec, state):
     block_header = state.latest_block_header.copy()
@@ -702,6 +759,20 @@ def _debug_print_block_tree(spec, runtime, protocol):
     )
 
 
+def _debug_run_block_tree_checks(
+    spec, debug, with_invalid_messages, anchor_tip, block_parents, runtime, protocol
+):
+    if not debug:
+        return
+
+    _debug_print_block_tree(spec, runtime, protocol)
+
+    if not with_invalid_messages:
+        _debug_assert_block_tree_shape(
+            spec, anchor_tip.beacon_state, block_parents, protocol.signed_block_messages
+        )
+
+
 def _generate_block_tree(
     spec,
     anchor_tip: BranchTip,
@@ -716,41 +787,13 @@ def _generate_block_tree(
     # Tracks every validator selected for a generated attester slashing in this
     # scenario, so later selections cannot target the same validator again.
     validators_to_be_slashed = set()
-    slot_assignments = {}
-    state_cache_key = None
-    cached_state = None
     block_edges = iter(enumerate(block_parents[1:], start=1))
-
-    def get_state_by_block_index(index):
-        nonlocal state_cache_key, cached_state
-        cache_key = (index, runtime.current_slot)
-        if state_cache_key == cache_key:
-            return cached_state.copy()
-
-        state = runtime.post_states[index].copy()
-        transition_to(spec, state, runtime.current_slot)
-        state_cache_key = cache_key
-        cached_state = state
-        return state
-
-    def assign_voters_to_slots(epoch):
-        epoch_start_slot = spec.compute_start_slot_at_epoch(epoch)
-        epoch_state = get_state_by_block_index(-1)
-        committee_count_per_slot = spec.get_committee_count_per_slot(epoch_state, epoch)
-        for slot in range(epoch_start_slot, epoch_start_slot + spec.SLOTS_PER_EPOCH):
-            assignments = []
-            for index in range(committee_count_per_slot):
-                committee = spec.get_beacon_committee(
-                    epoch_state,
-                    spec.Slot(slot),
-                    spec.CommitteeIndex(index),
-                )
-                assignments.extend(committee)
-            slot_assignments[slot] = assignments
+    state_cache = StateCache(spec, runtime)
+    committee_assignments = CommitteeAssignments(spec, state_cache.get_state_by_block_index)
 
     def choose_attested_block_index(tips, block_parents):
         attesting_block_index = rnd.choice(tips)
-        while attesting_block_index != 0 and rnd.randint(0, 99) < ATTEST_TO_PARENT_RATE:
+        while attesting_block_index != 0 and _roll(rnd, ATTEST_TO_PARENT_RATE):
             attesting_block_index = block_parents[attesting_block_index]
         return attesting_block_index
 
@@ -762,20 +805,44 @@ def _generate_block_tree(
             block_index_voters.setdefault(attesting_block_index, set()).add(validator_index)
         return block_index_voters
 
-    def ensure_slot_assignments():
-        epoch = spec.compute_epoch_at_slot(runtime.current_slot)
-        if runtime.current_slot not in slot_assignments:
-            assign_voters_to_slots(epoch)
-
     def next_block_edge():
         return next(block_edges, None)
 
+    def produce_invalid_block(parent_state):
+        # Do not include attestations and slashings into invalid block
+        # as clients may opt in to process or not process attestations
+        # contained by invalid block.
+        signed_block, _, _, _, _ = produce_block(spec, parent_state, [], [], [])
+        _spoil_block(spec, rnd, signed_block)
+        protocol.add_signed_block(signed_block, False)
+        runtime.append_post_state(parent_state)
+        return signed_block, parent_state, None
+
+    def produce_valid_block(parent_state, parent_index, block_index):
+        (
+            signed_block,
+            post_state,
+            protocol.in_block_attestations,
+            protocol.in_block_attester_slashings,
+            protocol.in_block_pa_messages,
+        ) = produce_block(
+            spec,
+            parent_state,
+            protocol.in_block_attestations,
+            protocol.in_block_attester_slashings,
+            protocol.in_block_pa_messages,
+        )
+
+        protocol.add_signed_block(signed_block, True)
+        runtime.apply_new_block(parent_index, block_index, post_state)
+        return signed_block, post_state, block_index
+
     def maybe_propose_block(block_edge):
-        if rnd.randint(1, 100) <= EMPTY_SLOTS_RATE:
+        if _roll(rnd, EMPTY_SLOTS_RATE):
             return None, None, None
 
         block_index, parent_index = block_edge
-        parent_state = get_state_by_block_index(parent_index)
+        parent_state = state_cache.get_state_by_block_index(parent_index)
 
         protocol.in_block_attestations = [
             a
@@ -786,38 +853,13 @@ def _generate_block_tree(
         proposer = spec.get_beacon_proposer_index(parent_state)
 
         if parent_state.validators[proposer].slashed or (
-            with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE
+            with_invalid_messages and _roll(rnd, INVALID_MESSAGES_RATE)
         ):
-            # Do not include attestations and slashings into invalid block
-            # as clients may opt in to process or not process attestations
-            # contained by invalid block.
-            signed_block, _, _, _, _ = produce_block(spec, parent_state, [], [], [])
-            _spoil_block(spec, rnd, signed_block)
-            protocol.add_signed_block(signed_block, False)
-            runtime.post_states.append(parent_state)
-            post_state = parent_state
-            new_block_index = None
+            signed_block, post_state, new_block_index = produce_invalid_block(parent_state)
         else:
-            (
-                signed_block,
-                post_state,
-                protocol.in_block_attestations,
-                protocol.in_block_attester_slashings,
-                protocol.in_block_pa_messages,
-            ) = produce_block(
-                spec,
-                parent_state,
-                protocol.in_block_attestations,
-                protocol.in_block_attester_slashings,
-                protocol.in_block_pa_messages,
+            signed_block, post_state, new_block_index = produce_valid_block(
+                parent_state, parent_index, block_index
             )
-
-            protocol.add_signed_block(signed_block, True)
-            runtime.post_states.append(post_state)
-            new_block_index = block_index
-
-            runtime.block_tree_tips.discard(parent_index)
-            runtime.block_tree_tips.add(block_index)
 
         return signed_block, post_state, new_block_index
 
@@ -827,14 +869,14 @@ def _generate_block_tree(
 
         block_root = signed_block.message.hash_tree_root()
         envelope = build_signed_execution_payload_envelope(spec, post_state, block_root, signed_block)
-        if rnd.randint(0, 99) >= EXECUTION_PAYLOAD_SEND_RATE:
+        if not _roll(rnd, EXECUTION_PAYLOAD_SEND_RATE):
             return False
 
         # TODO: Consider an explicit invalid case for an execution payload
         # targeting an unknown beacon block root. That should stay out of
         # the orderly base scenario unless `with_invalid_messages` is enabled.
         valid = True
-        if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+        if with_invalid_messages and _roll(rnd, INVALID_MESSAGES_RATE):
             _spoil_execution_payload_envelope(spec, rnd, envelope)
             valid = False
         protocol.add_signed_envelope(envelope, valid)
@@ -847,7 +889,7 @@ def _generate_block_tree(
         att_payload_index_invalid = False
         if is_post_gloas(spec):
             if valid_execution_payload_sent and attesting_block_index == new_block_index:
-                if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
+                if with_invalid_messages and _roll(rnd, INVALID_MESSAGES_RATE):
                     # payload_index=1 for a same-slot block is GLOAS-invalid:
                     # spec requires data.index==0 when block_slot==attestation.data.slot
                     payload_index = 1
@@ -858,20 +900,20 @@ def _generate_block_tree(
                 attesting_block_index != new_block_index
                 and attesting_block_index in runtime.payload_known_block_indices
             ):
-                if rnd.randint(0, 99) < GLOAS_FULL_ATTESTATION_RATE:
+                if _roll(rnd, GLOAS_FULL_ATTESTATION_RATE):
                     payload_index = 1
                 else:
                     payload_index = 0
         return payload_index, att_payload_index_invalid
 
     def make_slot_attestations(new_block_index, valid_execution_payload_sent):
-        attesting_committee = slot_assignments[runtime.current_slot]
+        attesting_committee = committee_assignments.get_attesting_committee(runtime.current_slot)
         block_index_voters = assign_committee_votes(
             attesting_committee, runtime.block_tree_tips, block_parents
         )
 
         for attesting_block_index, attesters in block_index_voters.items():
-            attesting_state = get_state_by_block_index(attesting_block_index)
+            attesting_state = state_cache.get_state_by_block_index(attesting_block_index)
             payload_index, att_payload_index_invalid = get_attestation_payload_index(
                 attesting_block_index, new_block_index, valid_execution_payload_sent
             )
@@ -894,7 +936,7 @@ def _generate_block_tree(
     def maybe_send_payload_attestations(post_state, new_block_index):
         if not is_post_gloas(spec) or new_block_index is None:
             return
-        if rnd.randint(0, 99) >= PAYLOAD_ATTESTATION_SEND_RATE:
+        if not _roll(rnd, PAYLOAD_ATTESTATION_SEND_RATE):
             return
 
         # TODO: Consider explicit payload-attestation cases without a
@@ -911,10 +953,10 @@ def _generate_block_tree(
     def maybe_create_attester_slashing():
         if not with_attester_slashings or len(validators_to_be_slashed) >= MAX_ATTESTER_SLASHINGS:
             return
-        if rnd.randint(0, 99) >= ATTESTER_SLASHINGS_RATE:
+        if not _roll(rnd, ATTESTER_SLASHINGS_RATE):
             return
 
-        state = get_state_by_block_index(-1)
+        state = state_cache.get_state_by_block_index(-1)
 
         assert len(validators_to_be_slashed) < len(state.validators)
         while True:
@@ -937,7 +979,7 @@ def _generate_block_tree(
 
     block_edge = next_block_edge()
     while block_edge is not None:
-        ensure_slot_assignments()
+        committee_assignments.ensure_slot_assignments(runtime.current_slot)
         signed_block, post_state, new_block_index = maybe_propose_block(block_edge)
         if signed_block is not None:
             block_edge = next_block_edge()
@@ -947,13 +989,9 @@ def _generate_block_tree(
         maybe_create_attester_slashing()
         runtime.current_slot += 1
 
-    if debug:
-        _debug_print_block_tree(spec, runtime, protocol)
-
-    if debug and not with_invalid_messages:
-        _debug_assert_block_tree_shape(
-            spec, anchor_tip.beacon_state, block_parents, protocol.signed_block_messages
-        )
+    _debug_run_block_tree_checks(
+        spec, debug, with_invalid_messages, anchor_tip, block_parents, runtime, protocol
+    )
 
     return (
         sorted(protocol.signed_block_messages, key=lambda b: b.payload.message.slot),

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -28,6 +28,7 @@ from .helpers import (
     BranchTip,
     build_random_payload_attestation_messages,
     FCTestData,
+    is_attestation_eligible_for_block,
     produce_block,
     ProtocolMessage,
 )
@@ -859,7 +860,7 @@ def _generate_block_tree(
         protocol.in_block_attestations = [
             a
             for a in protocol.in_block_attestations
-            if parent_state.slot <= a.data.slot + spec.SLOTS_PER_EPOCH
+            if is_attestation_eligible_for_block(spec, parent_state, a)
         ]
 
         proposer = spec.get_beacon_proposer_index(parent_state)

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -44,6 +44,8 @@ MAX_TIPS_TO_ATTEST = 2
 OFF_CHAIN_ATTESTATION_RATE = 10
 ON_CHAIN_ATTESTATION_RATE = 20
 ATTEST_TO_PARENT_RATE = 10
+IGNORE_IN_BLOCK_ATTESTATION_RATE = 5
+COPY_IN_BLOCK_ATTESTATION_RATE = 10
 
 MAX_ATTESTER_SLASHINGS = 8
 ATTESTER_SLASHINGS_RATE = 8
@@ -779,6 +781,33 @@ def _generate_block_tree(
     def next_block_edge():
         return next(block_edges, None)
 
+    def _subtract_items_once(source_items, items_to_remove):
+        remaining_items = list(source_items)
+        for item in items_to_remove:
+            if item in remaining_items:
+                remaining_items.remove(item)
+        return remaining_items
+
+    def choose_block_attestation_pool():
+        # Model three in-block attestation behaviors:
+        # ignore: never offered for inclusion and kept in the pool,
+        # move: offered for inclusion and removed if included,
+        # copy: offered for inclusion and kept in the pool even if included.
+        candidate_attestations = []
+        ignored_attestations = []
+        copied_candidate_attestations = []
+
+        for attestation in protocol.in_block_attestations:
+            if _roll(rnd, IGNORE_IN_BLOCK_ATTESTATION_RATE):
+                ignored_attestations.append(attestation)
+                continue
+
+            candidate_attestations.append(attestation)
+            if _roll(rnd, COPY_IN_BLOCK_ATTESTATION_RATE):
+                copied_candidate_attestations.append(attestation)
+
+        return candidate_attestations, ignored_attestations, copied_candidate_attestations
+
     def produce_invalid_block(parent_state):
         # Do not include attestations and slashings into invalid block
         # as clients may opt in to process or not process attestations
@@ -791,17 +820,29 @@ def _generate_block_tree(
 
     def produce_valid_block(parent_state, parent_index, block_index):
         (
+            candidate_attestations,
+            ignored_attestations,
+            copied_candidate_attestations,
+        ) = choose_block_attestation_pool()
+        (
             signed_block,
             post_state,
-            protocol.in_block_attestations,
+            not_included_attestations,
             protocol.in_block_attester_slashings,
             protocol.in_block_pa_messages,
         ) = produce_block(
             spec,
             parent_state,
-            protocol.in_block_attestations,
+            candidate_attestations,
             protocol.in_block_attester_slashings,
             protocol.in_block_pa_messages,
+        )
+
+        copied_included_attestations = _subtract_items_once(
+            copied_candidate_attestations, not_included_attestations
+        )
+        protocol.in_block_attestations = (
+            ignored_attestations + not_included_attestations + copied_included_attestations
         )
 
         protocol.add_signed_block(signed_block, True)

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -10,9 +10,6 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
 from eth_consensus_specs.test.helpers.forks import is_post_gloas
-from eth_consensus_specs.test.helpers.keys import (
-    privkeys,
-)
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
     transition_to,
@@ -28,6 +25,7 @@ from .helpers import (
     advance_branch_to_next_epoch,
     advance_state_to_anchor_epoch,
     attest_to_slot,
+    build_random_payload_attestation_messages,
     BranchTip,
     FCTestData,
     produce_block,
@@ -477,43 +475,6 @@ def _spoil_execution_payload_envelope(spec, rnd: random.Random, signed_envelope)
     signed_envelope.message.payload.parent_hash = spec.Hash32(rnd.randbytes(32))
 
 
-def _choose_payload_attestation_vote_count(spec, ptc, rnd: random.Random):
-    threshold = int(spec.PAYLOAD_TIMELY_THRESHOLD)
-    max_voters = len(ptc)
-    mode = rnd.choice(["none", "below_threshold", "edge", "above_threshold"])
-
-    if mode == "none":
-        return 0
-
-    if mode == "below_threshold":
-        max_count = min(max_voters, threshold)
-        return rnd.randint(0, max_count)
-
-    if mode == "edge":
-        candidates = [count for count in {threshold, threshold + 1} if 0 <= count <= max_voters]
-        return rnd.choice(candidates)
-
-    candidates = [count for count in range(threshold + 1, max_voters + 1)]
-    if candidates:
-        return rnd.choice(candidates)
-
-    return max_voters
-
-
-def _sample_payload_attestation_vote_values(mode, rnd: random.Random):
-    if mode == "all_true_true":
-        return True, True
-    if mode == "all_false_false":
-        return False, False
-    if mode == "mostly_true_true":
-        return (False, False) if _roll(rnd, 20) else (True, True)
-    if mode == "mostly_true_false":
-        return (False, True) if _roll(rnd, 20) else (True, False)
-    if mode == "mostly_false_true":
-        return (True, False) if _roll(rnd, 20) else (False, True)
-    return rnd.choice([True, False]), rnd.choice([True, False])
-
-
 def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
     """Build random PayloadAttestationMessage objects with diverse PTC vote values."""
     attested_slot = state.latest_block_header.slot
@@ -524,49 +485,7 @@ def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
     if parent_header.state_root == spec.Root():
         parent_header.state_root = spec.hash_tree_root(state)
     beacon_block_root = spec.hash_tree_root(parent_header)
-
-    ptc = spec.get_ptc(state, attested_slot)
-    if len(ptc) == 0:
-        return []
-
-    num_attesters = _choose_payload_attestation_vote_count(spec, ptc, rnd)
-    attesting_indices = rnd.sample(list(ptc), num_attesters) if num_attesters > 0 else []
-    if not attesting_indices:
-        return []
-
-    vote_pattern_mode = rnd.choice(
-        [
-            "all_true_true",
-            "all_false_false",
-            "mostly_true_true",
-            "mostly_true_false",
-            "mostly_false_true",
-            "mixed",
-        ]
-    )
-
-    messages = []
-    for validator_index in attesting_indices:
-        if validator_index >= len(privkeys):
-            continue
-        payload_present, blob_data_available = _sample_payload_attestation_vote_values(
-            vote_pattern_mode, rnd
-        )
-        data = spec.PayloadAttestationData(
-            beacon_block_root=beacon_block_root,
-            slot=attested_slot,
-            payload_present=payload_present,
-            blob_data_available=blob_data_available,
-        )
-        messages.append(
-            spec.PayloadAttestationMessage(
-                validator_index=validator_index,
-                data=data,
-                signature=spec.BLSSignature(),
-            )
-        )
-
-    return messages
+    return build_random_payload_attestation_messages(spec, state, beacon_block_root, attested_slot, rnd)
 
 
 def _disseminate(

--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -25,8 +25,8 @@ from .helpers import (
     advance_branch_to_next_epoch,
     advance_state_to_anchor_epoch,
     attest_to_slot,
-    build_random_payload_attestation_messages,
     BranchTip,
+    build_random_payload_attestation_messages,
     FCTestData,
     produce_block,
     ProtocolMessage,
@@ -485,7 +485,9 @@ def _get_random_payload_attestation_messages(spec, state, rnd: random.Random):
     if parent_header.state_root == spec.Root():
         parent_header.state_root = spec.hash_tree_root(state)
     beacon_block_root = spec.hash_tree_root(parent_header)
-    return build_random_payload_attestation_messages(spec, state, beacon_block_root, attested_slot, rnd)
+    return build_random_payload_attestation_messages(
+        spec, state, beacon_block_root, attested_slot, rnd
+    )
 
 
 def _disseminate(
@@ -535,7 +537,9 @@ class ProtocolState:
         self.out_of_block_pa_messages.append(ProtocolMessage(ptc_message, False))
 
     def add_invalid_off_chain_attester_slashing(self, attester_slashing):
-        self.out_of_block_attester_slashing_messages.append(ProtocolMessage(attester_slashing, False))
+        self.out_of_block_attester_slashing_messages.append(
+            ProtocolMessage(attester_slashing, False)
+        )
 
     def maybe_invalidate_attestation(self, rnd, attestation, with_invalid_messages):
         if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
@@ -544,9 +548,7 @@ class ProtocolState:
             return True
         return False
 
-    def maybe_invalidate_payload_attestation(
-        self, rnd, state, ptc_message, with_invalid_messages
-    ):
+    def maybe_invalidate_payload_attestation(self, rnd, state, ptc_message, with_invalid_messages):
         if with_invalid_messages and rnd.randint(0, 99) < INVALID_MESSAGES_RATE:
             _spoil_payload_attestation_message(self.spec, rnd, state, ptc_message)
             self.add_invalid_off_chain_payload_attestation(ptc_message)
@@ -691,7 +693,9 @@ def _debug_print_block_tree(spec, runtime, protocol):
     print("\nblock_tree:")
     print(
         "blocks:       ",
-        print_block_tree(spec, runtime.post_states[0], [b.payload for b in protocol.signed_block_messages]),
+        print_block_tree(
+            spec, runtime.post_states[0], [b.payload for b in protocol.signed_block_messages]
+        ),
     )
     print(
         "              ",
@@ -699,7 +703,9 @@ def _debug_print_block_tree(spec, runtime, protocol):
         "(epoch="
         + str(runtime.post_states[len(runtime.post_states) - 1].current_justified_checkpoint.epoch)
         + ", root="
-        + str(runtime.post_states[len(runtime.post_states) - 1].current_justified_checkpoint.root)[:6]
+        + str(runtime.post_states[len(runtime.post_states) - 1].current_justified_checkpoint.root)[
+            :6
+        ]
         + ")",
     )
 
@@ -729,18 +735,13 @@ def _debug_print_block_tree(spec, runtime, protocol):
     )
 
 
-def _debug_run_block_tree_checks(
-    spec, debug, with_invalid_messages, anchor_tip, block_parents, runtime, protocol
-):
-    if not debug:
-        return
-
-    _debug_print_block_tree(spec, runtime, protocol)
-
-    if not with_invalid_messages:
-        _debug_assert_block_tree_shape(
-            spec, anchor_tip.beacon_state, block_parents, protocol.signed_block_messages
-        )
+def _debug_run_block_tree_checks(spec, anchor_tip, block_parents, protocol):
+    assert all(message.valid for message in protocol.signed_block_messages), (
+        "Unexpected invalid block in base block-tree scenario"
+    )
+    _debug_assert_block_tree_shape(
+        spec, anchor_tip.beacon_state, block_parents, protocol.signed_block_messages
+    )
 
 
 def _generate_block_tree(
@@ -838,7 +839,9 @@ def _generate_block_tree(
             return False
 
         block_root = signed_block.message.hash_tree_root()
-        envelope = build_signed_execution_payload_envelope(spec, post_state, block_root, signed_block)
+        envelope = build_signed_execution_payload_envelope(
+            spec, post_state, block_root, signed_block
+        )
         if not _roll(rnd, EXECUTION_PAYLOAD_SEND_RATE):
             return False
 
@@ -854,7 +857,9 @@ def _generate_block_tree(
             runtime.payload_known_block_indices.add(new_block_index)
         return valid
 
-    def get_attestation_payload_index(attesting_block_index, new_block_index, valid_execution_payload_sent):
+    def get_attestation_payload_index(
+        attesting_block_index, new_block_index, valid_execution_payload_sent
+    ):
         payload_index = None
         att_payload_index_invalid = False
         if is_post_gloas(spec):
@@ -953,15 +958,19 @@ def _generate_block_tree(
         signed_block, post_state, new_block_index = maybe_propose_block(block_edge)
         if signed_block is not None:
             block_edge = next_block_edge()
-        valid_execution_payload_sent = maybe_send_execution_payload(signed_block, post_state, new_block_index)
+        valid_execution_payload_sent = maybe_send_execution_payload(
+            signed_block, post_state, new_block_index
+        )
         make_slot_attestations(new_block_index, valid_execution_payload_sent)
         maybe_send_payload_attestations(post_state, new_block_index)
         maybe_create_attester_slashing()
         runtime.current_slot += 1
 
-    _debug_run_block_tree_checks(
-        spec, debug, with_invalid_messages, anchor_tip, block_parents, runtime, protocol
-    )
+    if debug:
+        _debug_print_block_tree(spec, runtime, protocol)
+
+        if not with_invalid_messages and not with_attester_slashings:
+            _debug_run_block_tree_checks(spec, anchor_tip, block_parents, protocol)
 
     return (
         sorted(protocol.signed_block_messages, key=lambda b: b.payload.message.slot),
@@ -970,7 +979,9 @@ def _generate_block_tree(
             protocol.out_of_block_attester_slashing_messages,
             key=lambda a: a.payload.attestation_1.data.slot,
         ),
-        sorted(protocol.signed_envelope_messages, key=lambda e: e.payload.message.payload.slot_number),
+        sorted(
+            protocol.signed_envelope_messages, key=lambda e: e.payload.message.payload.slot_number
+        ),
         sorted(protocol.out_of_block_pa_messages, key=lambda a: a.payload.data.slot),
     )
 

--- a/tests/generators/compliance_runners/fork_choice/instantiators/debug_helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/debug_helpers.py
@@ -8,7 +8,7 @@ def attesters_in_block(spec, epoch_state, signed_block, target_epoch):
     attesters = set()
     for a in block.body.attestations:
         if a.data.target.epoch == target_epoch:
-            attesters.update(spec.get_attesting_indices(epoch_state, a.data, a.aggregation_bits))
+            attesters.update(spec.get_attesting_indices(epoch_state, a))
     return attesters
 
 

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -28,7 +28,10 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     run_on_execution_payload_envelope,
     run_on_payload_attestation_message,
 )
-from eth_consensus_specs.test.helpers.forks import is_post_gloas
+from eth_consensus_specs.test.helpers.forks import (
+    is_post_deneb,
+    is_post_gloas,
+)
 from eth_consensus_specs.test.helpers.keys import (
     privkeys,
 )
@@ -218,6 +221,15 @@ def messages_to_payload_attestations(spec, state, messages):
     return result
 
 
+def is_attestation_eligible_for_block(spec, state, attestation) -> bool:
+    if is_post_deneb(spec):
+        return spec.compute_epoch_at_slot(attestation.data.slot) + 1 >= spec.compute_epoch_at_slot(
+            state.slot
+        )
+
+    return state.slot <= attestation.data.slot + spec.SLOTS_PER_EPOCH
+
+
 def _get_eligible_attestations(spec, state, attestations) -> []:
     def _get_voting_source(target: spec.Checkpoint) -> spec.Checkpoint:
         if target.epoch == spec.get_current_epoch(state):
@@ -228,7 +240,7 @@ def _get_eligible_attestations(spec, state, attestations) -> []:
     return [
         a
         for a in attestations
-        if state.slot <= a.data.slot + spec.SLOTS_PER_EPOCH
+        if is_attestation_eligible_for_block(spec, state, a)
         and a.data.source == _get_voting_source(a.data.target)
     ]
 
@@ -249,7 +261,7 @@ def produce_block(
     :return: Signed block, the post block state, and operations not included into the block.
     """
 
-    # Filter out too old attestastions (TODO relax condition for Deneb)
+    # Filter out too old attestations.
     eligible_attestations = _get_eligible_attestations(spec, state, attestations)
 
     # Create a block with attestations

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -109,7 +109,7 @@ def choose_payload_attestation_vote_count(spec, ptc, rnd: random.Random):
         return rnd.randint(0, max_count)
 
     if mode == "edge":
-        candidates = [count for count in {threshold, threshold + 1} if 0 <= count <= max_voters]
+        candidates = [count for count in (threshold, threshold + 1) if 0 <= count <= max_voters]
         return rnd.choice(candidates)
 
     candidates = [count for count in range(threshold + 1, max_voters + 1)]

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -1,3 +1,4 @@
+import random
 from dataclasses import dataclass, field
 
 from eth_consensus_specs.test.context import spec_test
@@ -92,6 +93,95 @@ def payload_attestation_to_messages(spec, state, payload_attestation, signed=Fal
                 state, ptc_message, privkeys[validator_index]
             )
         messages.append(ptc_message)
+    return messages
+
+
+def choose_payload_attestation_vote_count(spec, ptc, rnd: random.Random):
+    threshold = int(spec.PAYLOAD_TIMELY_THRESHOLD)
+    max_voters = len(ptc)
+    mode = rnd.choice(["none", "below_threshold", "edge", "above_threshold"])
+
+    if mode == "none":
+        return 0
+
+    if mode == "below_threshold":
+        max_count = min(max_voters, threshold)
+        return rnd.randint(0, max_count)
+
+    if mode == "edge":
+        candidates = [count for count in {threshold, threshold + 1} if 0 <= count <= max_voters]
+        return rnd.choice(candidates)
+
+    candidates = [count for count in range(threshold + 1, max_voters + 1)]
+    if candidates:
+        return rnd.choice(candidates)
+
+    return max_voters
+
+
+def choose_payload_attestation_vote_pattern_mode(ptc, rnd: random.Random):
+    return rnd.choice(
+        [
+            "all_true_true",
+            "all_false_false",
+            "mostly_true_true",
+            "mostly_true_false",
+            "mostly_false_true",
+            "mixed",
+        ]
+    )
+
+
+def sample_payload_attestation_vote_values(mode, rnd: random.Random):
+    if mode == "all_true_true":
+        return True, True
+    if mode == "all_false_false":
+        return False, False
+    if mode == "mostly_true_true":
+        return (False, False) if rnd.randint(0, 99) < 20 else (True, True)
+    if mode == "mostly_true_false":
+        return (False, True) if rnd.randint(0, 99) < 20 else (True, False)
+    if mode == "mostly_false_true":
+        return (True, False) if rnd.randint(0, 99) < 20 else (False, True)
+    return rnd.choice([True, False]), rnd.choice([True, False])
+
+
+def build_random_payload_attestation_messages(
+    spec, state, beacon_block_root, slot, rnd: random.Random
+):
+    ptc = spec.get_ptc(state, slot)
+    if len(ptc) == 0:
+        return []
+
+    num_attesters = choose_payload_attestation_vote_count(spec, ptc, rnd)
+    attesting_indices = rnd.sample(list(ptc), num_attesters) if num_attesters > 0 else []
+    if not attesting_indices:
+        return []
+
+    vote_pattern_mode = choose_payload_attestation_vote_pattern_mode(ptc, rnd)
+    messages = []
+    for validator_index in attesting_indices:
+        if validator_index >= len(privkeys):
+            continue
+
+        payload_present, blob_data_available = sample_payload_attestation_vote_values(
+            vote_pattern_mode, rnd
+        )
+        ptc_message = spec.PayloadAttestationMessage(
+            validator_index=validator_index,
+            data=spec.PayloadAttestationData(
+                beacon_block_root=beacon_block_root,
+                slot=slot,
+                payload_present=payload_present,
+                blob_data_available=blob_data_available,
+            ),
+            signature=spec.BLSSignature(),
+        )
+        ptc_message.signature = spec.get_payload_attestation_message_signature(
+            state, ptc_message, privkeys[validator_index]
+        )
+        messages.append(ptc_message)
+
     return messages
 
 

--- a/tests/generators/compliance_runners/fork_choice/instantiators/mutation_operators.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/mutation_operators.py
@@ -90,9 +90,32 @@ class MutationOps:
             shifts.append(rnd.randint(1, max(1, last_time)))
         return tuple(shifts)
 
+    def rand_event_index(self, tv, rnd: random.Random) -> int:
+        # Bias mutations toward later events to preserve more of the early
+        # scenario setup and reduce accidental truncation.
+        return rnd.choices(range(len(tv)), weights=range(1, len(tv) + 1), k=1)[0]
+
+    def rand_operator_kind(self, event_kind: str, rnd: random.Random) -> str:
+        if event_kind == "block":
+            choices = ["shift", "late_arrival", "multi_route"]
+            weights = [5, 1, 3]
+        elif event_kind in ("attestation", "payload_attestation"):
+            choices = ["shift", "late_arrival", "multi_route"]
+            weights = [2, 3, 4]
+        elif event_kind == "execution_payload":
+            choices = ["shift", "late_arrival", "multi_route"]
+            weights = [2, 4, 3]
+        else:
+            assert event_kind == "attester_slashing"
+            choices = ["shift", "late_arrival", "multi_route"]
+            weights = [4, 3, 1]
+
+        return rnd.choices(choices, weights=weights, k=1)[0]
+
     def rand_mutation(self, tv, rnd: random.Random):
-        idx = rnd.choice(range(len(tv)))
-        op_kind = rnd.choice(["shift", "late_arrival", "multi_route"])
+        idx = self.rand_event_index(tv, rnd)
+        event_kind = tv[idx][1][0]
+        op_kind = self.rand_operator_kind(event_kind, rnd)
         if op_kind == "shift":
             evt_time = int(tv[idx][0])
             params = idx, self.rand_shift(evt_time, rnd)

--- a/tests/generators/compliance_runners/fork_choice/instantiators/mutation_operators.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/mutation_operators.py
@@ -21,61 +21,29 @@ def mut_shift(tv, rnd: random.Random):
     return mut_shift_(tv, idx, time_shift)
 
 
-def mut_drop_(tv, idx):
-    return tv[:idx] + tv[idx + 1 :]
+def mut_late_arrival_(tv, idx, new_time):
+    _, event = tv[idx]
+    return sorted(tv[:idx] + tv[idx + 1 :] + [(new_time, event)], key=lambda x: x[0])
 
 
-def mut_drop(tv, rnd: random.Random):
-    idx = rnd.choice(range(len(tv)))
-    return mut_drop_(tv, idx)
-
-
-def mut_dup_(tv, idx, shift):
-    return mut_shift_(tv + [tv[idx]], len(tv), shift)
-
-
-def mutate_test_vector(rnd, initial_tv, cnt, debug=False):
-    tv_ = initial_tv
-    for i in range(cnt):
-        coin = rnd.randint(0, 1)
-        if coin:
-            if debug:
-                print("  mutating initial tv")
-            tv__ = initial_tv
-        else:
-            if debug:
-                print("  mutating tv_")
-            tv__ = tv_
-        tv = tv__
-        op_kind = rnd.randint(0, 2)
-        if op_kind == 0:
-            idx = rnd.choice(range(len(tv)))
-            if debug:
-                print(f"  dropping {idx}")
-            tv_ = mut_drop_(tv, idx)
-        elif op_kind == 1:
-            idx = rnd.choice(range(len(tv)))
-            idx_time = tv[idx][0]
-            dir = rnd.randint(0, 1)
-            if idx_time == 0 or dir:
-                time_shift = rnd.randint(0, 6) * 3
-            else:
-                time_shift = -rnd.randint(0, idx_time // 3) * 3
-            if debug:
-                print(f"  shifting {idx} by {time_shift}")
-            tv_ = mut_shift_(tv, idx, time_shift)
-        elif op_kind == 2:
-            idx = rnd.choice(range(len(tv)))
-            shift = rnd.randint(0, 5) * 3
-            if debug:
-                print(f"  dupping {idx} and shifting by {shift}")
-            tv_ = mut_dup_(tv, idx, shift)
-        else:
-            assert False
-        yield tv_
+def mut_multi_route_(tv, idx, shifts):
+    base_time, event = tv[idx]
+    duplicates = [(base_time + delta, event) for delta in shifts if base_time + delta >= 0]
+    return sorted(tv + duplicates, key=lambda x: x[0])
 
 
 class MutationOps:
+    """
+    Random mutations for fork-choice event vectors.
+
+    The active mutation set is:
+    - ``shift``: move one event earlier or later in time
+    - ``late_arrival``: remove an event from its original position and reinsert it
+      near the tail of the test vector
+    - ``multi_route``: keep the original event and add one or more shifted copies,
+      modeling delivery through multiple routes
+    """
+
     def __init__(self, start_time, seconds_per_slot, shift_bounds=(-2, 4)):
         self.start_time = int(start_time)
         self.seconds_per_slot = int(seconds_per_slot)
@@ -84,19 +52,19 @@ class MutationOps:
     def apply_shift(self, tv, idx, delta):
         return mut_shift_(tv, idx, delta)
 
-    def apply_drop(self, tv, idx):
-        return mut_drop_(tv, idx)
+    def apply_late_arrival(self, tv, idx, new_time):
+        return mut_late_arrival_(tv, idx, new_time)
 
-    def apply_dup_shift(self, tv, idx, delta):
-        return mut_dup_(tv, idx, delta)
+    def apply_multi_route(self, tv, idx, deltas):
+        return mut_multi_route_(tv, idx, deltas)
 
     def apply_mutation(self, tv, op_kind, *params):
         if op_kind == "shift":
             return self.apply_shift(tv, *params)
-        elif op_kind == "dup_shift":
-            return self.apply_dup_shift(tv, *params)
-        elif op_kind == "drop":
-            return self.apply_drop(tv, *params)
+        elif op_kind == "late_arrival":
+            return self.apply_late_arrival(tv, *params)
+        elif op_kind == "multi_route":
+            return self.apply_multi_route(tv, *params)
         else:
             assert False
 
@@ -110,14 +78,31 @@ class MutationOps:
         else:
             return rnd.randint(1, max_shift)
 
+    def rand_late_arrival_time(self, tv, rnd: random.Random) -> int:
+        last_time = max(int(time) for time, _ in tv)
+        extra_slots = rnd.randint(1, 3)
+        return last_time + extra_slots * self.seconds_per_slot
+
+    def rand_multi_route_shifts(self, time: int, rnd: random.Random) -> tuple[int, ...]:
+        shifts = [self.rand_shift(time, rnd)]
+        if rnd.randint(0, 1) == 1:
+            last_time = abs(self.shift_bounds[1]) * self.seconds_per_slot
+            shifts.append(rnd.randint(1, max(1, last_time)))
+        return tuple(shifts)
+
     def rand_mutation(self, tv, rnd: random.Random):
         idx = rnd.choice(range(len(tv)))
-        op_kind = rnd.choice(["shift", "drop", "dup_shift"])
-        if op_kind == "shift" or op_kind == "dup_shift":
+        op_kind = rnd.choice(["shift", "late_arrival", "multi_route"])
+        if op_kind == "shift":
             evt_time = int(tv[idx][0])
             params = idx, self.rand_shift(evt_time, rnd)
+        elif op_kind == "late_arrival":
+            params = idx, self.rand_late_arrival_time(tv, rnd)
+        elif op_kind == "multi_route":
+            evt_time = int(tv[idx][0])
+            params = idx, self.rand_multi_route_shifts(evt_time, rnd)
         else:
-            params = (idx,)
+            assert False
         return op_kind, *params
 
     def rand_mutations(self, tv, num, rnd: random.Random):

--- a/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
@@ -395,9 +395,6 @@ def yield_test_parts(spec, store, test_data: FCTestData, events):
             else:
                 assert False
                 test_steps.append({"block": block_id, "valid": valid})
-            block_root = block.message.hash_tree_root()
-            assert valid == (block_root in store.blocks)
-
             output_store_checks(spec, store, test_steps)
         elif kind == "attestation":
             attestation = data

--- a/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/test_case.py
@@ -454,6 +454,10 @@ def _load_yaml(path: str):
         return yaml.load(f)
 
 
+def derive_effective_seed(seed: int, solution_index: int) -> int:
+    return random.Random(f"{seed}:{solution_index}").randint(0, 1_000_000_000)
+
+
 def enumerate_mutation_groups(config_dir, test_name, params) -> Iterable[MutationGroup]:
     test_type = params["test_type"]
     instances_path = params["instances"]
@@ -474,10 +478,11 @@ def enumerate_mutation_groups(config_dir, test_name, params) -> Iterable[Mutatio
 
     for i, solution in enumerate(solutions):
         for seed in seeds:
+            effective_seed = derive_effective_seed(seed, i)
             yield MutationGroup(
                 test_name=test_name,
                 solution_index=i,
-                test_dna_base=FCTestDNA(test_kind, solution, seed, None),
+                test_dna_base=FCTestDNA(test_kind, solution, effective_seed, None),
                 nr_mutations=nr_mutations,
             )
 


### PR DESCRIPTION
The PR adds various improvements to the comptests Fork Choice [generator](https://github.com/ethereum/consensus-specs/tree/master/tests/generators/compliance_runners/fork_choice):
- randomization improvements for `block_tree` and `block_cover` tests
- implemented more consistency checks for `block_tree` and `block_cover` tests
- gloas support for `block_cover` tests
- more robust seed generation scheme
- refactoring of the `block_tree` main generation loop
Updated:
- better randomization of in-block attestations for `block_tree` (`ignore|copy|move`)
- relaxed attestation inclusion criterion for deneb+
- mutation operator improvements (very `late_arrival` instead of `drop`, weighted operator sampling based on message kinds).

Related to #5107