### PR TITLE
Make `ExecutionEngine` highly recommended but optional

### DIFF
--- a/specs/_features/eip8025/beacon-chain.md
+++ b/specs/_features/eip8025/beacon-chain.md
@@ -110,9 +110,14 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 *Note*: `process_execution_payload` is modified in EIP-8025 to treat both
 `ExecutionEngine` and `ProofEngine` as fire-and-forget notifications rather
-than gating consensus. Running an execution engine is **highly recommended**
-for defense-in-depth, but is no longer mandatory — consensus correctness is
-established via the proof engine path.
+than gating consensus. The consensus state transition no longer verifies
+execution validity; it becomes an out-of-band concern handled asynchronously
+by (a) a locally-run execution engine and/or (b) gossiped execution proofs
+validated via `process_execution_proof` (see
+[p2p-interface.md](./p2p-interface.md)). Running an execution engine is
+**highly recommended** for defense-in-depth, but is no longer mandatory. A
+node doing neither accepts execution payloads without execution-validity
+verification.
 
 ```python
 def process_execution_payload(
@@ -143,9 +148,10 @@ def process_execution_payload(
     # [Modified in EIP8025]
     # Notify ExecutionEngine of the new execution payload. Running an execution
     # engine is highly recommended for defense-in-depth but is no longer
-    # mandatory -- consensus correctness is not gated on the execution
-    # engine's response. Clients that run an execution engine SHOULD still
-    # verify payloads locally.
+    # mandatory -- consensus is not gated on the execution engine's response.
+    # Execution validity becomes an out-of-band concern: it is verified by
+    # the locally-run execution engine (if present) and/or by asynchronously
+    # gossiped execution proofs processed via `process_execution_proof`.
     execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(
             execution_payload=payload,

--- a/specs/_features/eip8025/beacon-chain.md
+++ b/specs/_features/eip8025/beacon-chain.md
@@ -108,8 +108,11 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 ##### Modified `process_execution_payload`
 
-*Note*: `process_execution_payload` is modified in EIP-8025 to require both
-`ExecutionEngine` and `ProofEngine` for validation.
+*Note*: `process_execution_payload` is modified in EIP-8025 to treat both
+`ExecutionEngine` and `ProofEngine` as fire-and-forget notifications rather
+than gating consensus. Running an execution engine is **highly recommended**
+for defense-in-depth, but is no longer mandatory — consensus correctness is
+established via the proof engine path.
 
 ```python
 def process_execution_payload(
@@ -137,8 +140,13 @@ def process_execution_payload(
         kzg_commitment_to_versioned_hash(commitment) for commitment in body.blob_kzg_commitments
     ]
 
-    # Verify the execution payload is valid via ExecutionEngine
-    assert execution_engine.verify_and_notify_new_payload(
+    # [Modified in EIP8025]
+    # Notify ExecutionEngine of the new execution payload. Running an execution
+    # engine is highly recommended for defense-in-depth but is no longer
+    # mandatory -- consensus correctness is not gated on the execution
+    # engine's response. Clients that run an execution engine SHOULD still
+    # verify payloads locally.
+    execution_engine.verify_and_notify_new_payload(
         NewPayloadRequest(
             execution_payload=payload,
             versioned_hashes=versioned_hashes,

--- a/specs/_features/eip8025/beacon-chain.md
+++ b/specs/_features/eip8025/beacon-chain.md
@@ -109,15 +109,14 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 ##### Modified `process_execution_payload`
 
 *Note*: `process_execution_payload` is modified in EIP-8025 to treat both
-`ExecutionEngine` and `ProofEngine` as fire-and-forget notifications rather
-than gating consensus. The consensus state transition no longer verifies
-execution validity; it becomes an out-of-band concern handled asynchronously
-by (a) a locally-run execution engine and/or (b) gossiped execution proofs
-validated via `process_execution_proof` (see
-[p2p-interface.md](./p2p-interface.md)). Running an execution engine is
-**highly recommended** for defense-in-depth, but is no longer mandatory. A
-node doing neither accepts execution payloads without execution-validity
-verification.
+`ExecutionEngine` and `ProofEngine` as fire-and-forget notifications rather than
+gating consensus. The consensus state transition no longer verifies execution
+validity; it becomes an out-of-band concern handled asynchronously by (a) a
+locally-run execution engine and/or (b) gossiped execution proofs validated via
+`process_execution_proof` (see [p2p-interface.md](./p2p-interface.md)). Running
+an execution engine is **highly recommended** for defense-in-depth, but is no
+longer mandatory. A node doing neither accepts execution payloads without
+execution-validity verification.
 
 ```python
 def process_execution_payload(

--- a/specs/_features/eip8025/validator.md
+++ b/specs/_features/eip8025/validator.md
@@ -1,0 +1,74 @@
+# EIP-8025 -- Honest Validator
+
+*Note*: This document is a work-in-progress for researchers and implementers.
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
+
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Beacon chain responsibilities](#beacon-chain-responsibilities)
+  - [Attestation execution-validity gating](#attestation-execution-validity-gating)
+
+<!-- mdformat-toc end -->
+
+## Introduction
+
+This document represents the changes to be made in the code of an "honest
+validator" to implement EIP-8025.
+
+## Prerequisites
+
+This document is an extension of the
+[Fulu -- Honest Validator](../../fulu/validator.md) guide. All behaviors and
+definitions defined in this document, and documents it extends, carry over
+unless explicitly noted or overridden.
+
+All terminology, constants, functions, and protocol mechanics defined in
+[EIP-8025 -- The Beacon Chain](./beacon-chain.md),
+[EIP-8025 -- Proof Engine](./proof-engine.md), and
+[EIP-8025 -- Honest Prover](./prover.md) are requisite for this document and
+used throughout.
+
+## Beacon chain responsibilities
+
+### Attestation execution-validity gating
+
+*[New in EIP8025]*
+
+With `process_execution_payload` no longer gating consensus on execution
+validity, an honest validator SHOULD NOT attest to a block whose
+`execution_payload` has not been independently validated. Specifically, a
+validator SHOULD withhold its attestation for a block until at least one of
+the following conditions holds by the attestation deadline:
+
+1. A locally-run `ExecutionEngine` has returned `VALID` for the block's
+   corresponding `NewPayloadRequest` (i.e.
+   `execution_engine.verify_and_notify_new_payload(new_payload_request)`
+   returned `True`).
+2. A `SignedExecutionProof` has been received on the `execution_proof`
+   gossip topic for the block, and:
+   - `proof.public_input.new_payload_request_root` equals
+     `hash_tree_root(new_payload_request)` for the block's
+     `NewPayloadRequest`, and
+   - `proof_engine.verify_execution_proof(proof)` returned `True` (i.e. the
+     proof passed `process_execution_proof`).
+
+If neither signal is available by the attestation deadline, the validator
+SHOULD withhold its attestation for that block. This restores a
+defense-in-depth penalty signal against attesting to blocks with invalid
+execution payloads after the removal of the consensus-level assert on the
+execution engine: validators that opt out of both running a local execution
+engine and subscribing to execution proofs will miss attestations for blocks
+whose validity they cannot independently establish, and will therefore
+incur the standard missed-attestation penalty.
+
+*Note*: This guidance applies only to validators performing attestation
+duties. Follower or non-attesting nodes MAY accept blocks through
+state-transition without any execution-validity signal; they do not put
+network safety at risk by doing so.
+
+*Note*: Validators running a local execution engine are unaffected in
+practice — condition (1) will be satisfied via the existing
+`verify_and_notify_new_payload` call in `process_execution_payload`. This
+rule only changes behavior for validators that have opted out of running an
+execution engine.

--- a/specs/_features/eip8025/validator.md
+++ b/specs/_features/eip8025/validator.md
@@ -38,37 +38,36 @@ used throughout.
 With `process_execution_payload` no longer gating consensus on execution
 validity, an honest validator SHOULD NOT attest to a block whose
 `execution_payload` has not been independently validated. Specifically, a
-validator SHOULD withhold its attestation for a block until at least one of
-the following conditions holds by the attestation deadline:
+validator SHOULD withhold its attestation for a block until at least one of the
+following conditions holds by the attestation deadline:
 
 1. A locally-run `ExecutionEngine` has returned `VALID` for the block's
    corresponding `NewPayloadRequest` (i.e.
    `execution_engine.verify_and_notify_new_payload(new_payload_request)`
    returned `True`).
-2. A `SignedExecutionProof` has been received on the `execution_proof`
-   gossip topic for the block, and:
+2. A `SignedExecutionProof` has been received on the `execution_proof` gossip
+   topic for the block, and:
    - `proof.public_input.new_payload_request_root` equals
-     `hash_tree_root(new_payload_request)` for the block's
-     `NewPayloadRequest`, and
+     `hash_tree_root(new_payload_request)` for the block's `NewPayloadRequest`,
+     and
    - `proof_engine.verify_execution_proof(proof)` returned `True` (i.e. the
      proof passed `process_execution_proof`).
 
-If neither signal is available by the attestation deadline, the validator
-SHOULD withhold its attestation for that block. This restores a
-defense-in-depth penalty signal against attesting to blocks with invalid
-execution payloads after the removal of the consensus-level assert on the
-execution engine: validators that opt out of both running a local execution
-engine and subscribing to execution proofs will miss attestations for blocks
-whose validity they cannot independently establish, and will therefore
-incur the standard missed-attestation penalty.
+If neither signal is available by the attestation deadline, the validator SHOULD
+withhold its attestation for that block. This restores a defense-in-depth
+penalty signal against attesting to blocks with invalid execution payloads after
+the removal of the consensus-level assert on the execution engine: validators
+that opt out of both running a local execution engine and subscribing to
+execution proofs will miss attestations for blocks whose validity they cannot
+independently establish, and will therefore incur the standard
+missed-attestation penalty.
 
-*Note*: This guidance applies only to validators performing attestation
-duties. Follower or non-attesting nodes MAY accept blocks through
-state-transition without any execution-validity signal; they do not put
-network safety at risk by doing so.
+*Note*: This guidance applies only to validators performing attestation duties.
+Follower or non-attesting nodes MAY accept blocks through state-transition
+without any execution-validity signal; they do not put network safety at risk by
+doing so.
 
-*Note*: Validators running a local execution engine are unaffected in
-practice — condition (1) will be satisfied via the existing
-`verify_and_notify_new_payload` call in `process_execution_payload`. This
-rule only changes behavior for validators that have opted out of running an
-execution engine.
+*Note*: Validators running a local execution engine are unaffected in practice —
+condition (1) will be satisfied via the existing `verify_and_notify_new_payload`
+call in `process_execution_payload`. This rule only changes behavior for
+validators that have opted out of running an execution engine.


### PR DESCRIPTION
## Summary

This PR extends the fire-and-forget pattern used for the `ProofEngine` (introduced in #5055) to the `ExecutionEngine` in EIP-8025, while adding a validator-level rule that preserves the missed-attestation penalty signal for validators that opt out of running a local EL.

This was originally opened as frisitano/consensus-specs#3 against the `feat/eip8025-refactor` branch. Since #5055 is now merged upstream, this PR re-targets `ethereum/consensus-specs:master`. See the original thread for prior review discussion from @frisitano and @mkalinin — summarized in the "Prior review" section below.

## Proposal

Two changes:

1. **Drop the `assert` on `execution_engine.verify_and_notify_new_payload`** in `process_execution_payload`, matching the fire-and-forget `ProofEngine` treatment. A node that chooses not to run a local execution engine (e.g. a stateless client consuming proofs) should not be forced to by the consensus spec.
2. **Add an attestation execution-validity gating rule to a new `validator.md`** (SHOULD-level): a validator SHOULD NOT attest to a block whose `execution_payload` has not been independently validated — either by a local EL returning `VALID`, or by a verified `SignedExecutionProof` whose `public_input.new_payload_request_root` matches the block's `NewPayloadRequest`, received by the attestation deadline. If neither signal is available, the validator SHOULD withhold attestation.

## Why both changes are needed

Removing the consensus-level `assert` alone would be unsafe during the optional-proof phase:

- `proof_engine.notify_new_payload` is fire-and-forget; it performs no verification.
- `process_execution_proof` (which does verify proofs) is only invoked via `execution_proof` gossip validation — it is **not** part of block state-transition.
- Proofs are explicitly optional, arrive asynchronously, and may not be available before the 4-second attestation deadline.
- Without a gating rule, validators with no EL and no proof-in-hand would still happily attest to invalid blocks, and there would be no missed-attestation penalty to self-correct the behavior.

Change (2) restores the penalty signal. Validators that opt out of the EL and also fail to receive a valid proof in time simply miss their attestation and pay the standard inactivity penalty — making the opt-out economically self-regulating rather than a silent safety risk.

## What changed

- `specs/_features/eip8025/beacon-chain.md`
  - Removed `assert` wrapper on `execution_engine.verify_and_notify_new_payload(...)`.
  - Updated the `*Note*` above `process_execution_payload` to describe both engines as fire-and-forget notifications and to be explicit that execution-validity verification becomes out-of-band.
  - Updated the inline comment next to the EL call to match.
- `specs/_features/eip8025/validator.md` *(new file)*
  - New section **Attestation execution-validity gating** under *Beacon chain responsibilities* encoding the SHOULD-rule described above, plus non-normative notes clarifying (a) follower/non-attesting nodes are unaffected and (b) validators running an EL see no behavioral change in practice.

## Why "highly recommended" rather than "removed"

Running an execution engine remains the right default for defense-in-depth: independent check against proof-engine bugs/malicious provers, needed for local block building and fast attesting, useful fallback while proof availability/latency matures. Validators who want to opt out now pay the cost of either running a proof subscription or missing attestations — which seems like the right incentive shape for an optional-proof phase.

## Prior review on frisitano/consensus-specs#3

Not repeated here verbatim — please read the linked thread for full context — but the main discussion points were:

- @frisitano ([comment](https://github.com/frisitano/consensus-specs/pull/3#discussion_r2478088614)): wording tightening — "accepts execution payloads" should acknowledge `NOT_VALIDATED` / optimistic import semantics.
- @frisitano ([comment](https://github.com/frisitano/consensus-specs/pull/3#discussion_r2478090108)): alternative approach — instead of removing the assert, modify `verify_and_notify_new_payload` to return `NOT_VALIDATED` when no EL is configured.
- @mkalinin ([comment](https://github.com/frisitano/consensus-specs/pull/3#discussion_r2485060793)): SHOULD NOT → MUST NOT, on the grounds that SHOULD leaves clients technically spec-compliant if they attest without either signal.
- @mkalinin ([comment](https://github.com/frisitano/consensus-specs/pull/3#discussion_r2485104497)): proposed alternative architecture — keep the assertion, change `verify_and_notify_new_payload` to return `True` only when EL returned `VALID` **or** a `VALID` proof has been received from p2p; let Optimistic Sync handle the pending-proof state (analogous to how `SYNCING`/`ACCEPTED` is handled today).

Happy to iterate on these in this PR.

## Open questions for discussion

- Do we want to go further and rename/repoint the call to a pure `execution_engine.notify_new_payload` (returning `None`) to match the proof engine signature exactly? That is more invasive since `verify_and_notify_new_payload` is defined up the fork hierarchy (Bellatrix onwards), so I kept this PR to the minimal semantic change.
- Should the SHOULD-rule be strengthened to a MUST during the transitional phase (per @mkalinin's suggestion), or is SHOULD the right level given it's guidance for *honest* validators and we cannot punish deviation on-chain?
- Any need for a fork-choice-level rule in addition to the attestation rule, or is the attestation penalty signal sufficient?
- @mkalinin's "keep the assert, route through Optimistic Sync" approach vs. the approach taken here — worth comparing explicitly.

## Test plan

- [ ] Rendered markdown reads correctly on GitHub (ToC, section anchors).
- [ ] Spec builder still parses `eip8025/beacon-chain.md` (verified locally — Python blocks AST-parse cleanly; only change is `assert` removal).
- [ ] Review of the new `validator.md` section for correctness of the proof-matching condition (`public_input.new_payload_request_root` against `hash_tree_root(new_payload_request)`).
- [ ] Discussion with reviewers on SHOULD vs MUST level and on any interaction with fork choice.