### PR TITLE
Add run-tests skill

### DIFF
--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: run-tests
+description: >-
+  Run tests and generate reference tests. Use when the user asks to run tests,
+  verify changes, check a fix, or regenerate reference tests.
+compatibility: Requires make and uv
+---
+
+# Running tests
+
+All testing is done with `make test`. Do not use `pytest` directly. When
+possible, testing should be targeted to areas affected by the change rather than
+running the full suite. When fixing issues, the targeted set should be run once
+to collect failures, then individual failing tests should be re-run to verify
+fixes rather than re-running the whole filtered set after each edit.
+
+## Filter by name
+
+Tests can be filtered by name via the `k=<string>` flag. This value is passed
+directly to pytest with `-k` and therefore supports its features, such as
+boolean operators (`and`, `or`, `not`). For example,
+`make test k="gossip and valid"` is valid.
+
+## Filter by fork
+
+Tests can be limited to a single fork via the `fork=<fork>` flag. It is not
+currently possible to specify multiple forks with the flag. The available forks
+are the names of all directories in `./specs/` (except for `_features`) and all
+directories in `./specs/_features/`.
+
+## Filter by preset
+
+Tests can be run against a preset via the `preset=<preset>` flag. There are
+three presets: general, minimal, and mainnet. By default, `make test` only runs
+minimal tests. The general tests cover things like BLS, KZG, and SSZ tests. The
+minimal tests are fast to execute but do not cover the full range of possible
+situations. The mainnet tests are very slow and should only be run in targeted
+commands. Note that there are some tests which are only executed under a single
+preset.
+
+## Filter by component
+
+Tests can be scoped to a component via the `component=<comp>` flag. Three values
+are accepted: `all` (the default), `pyspec`, and `fw` (short for framework). The
+`pyspec` value runs only the spec tests under `./tests/core/pyspec`, while `fw`
+runs only the tests under `./tests/infra`. Some flags (`fork`, `preset`, etc)
+are ignored with `component=fw` since those tests do not depend on the spec.
+
+## Generate reference tests
+
+Reference tests can be generated for clients to ensure compliance with the
+specifications. Enable reference tests outputs with the `reftests=true` flag.
+These are written to `./reftests` at the project root; this directory is
+automatically created. Unlike `make test`, `reftests=true` runs all presets
+(general, minimal, mainnet) by default; this can be overridden by using the
+`preset=<preset>` flag. The framework deletes individual test case directories
+before regenerating them, so targeted reruns will update existing reference
+tests. If a test case function was deleted, `make test reftests=true` will not
+delete its previously generated reference test.
+
+## Track code coverage
+
+Code coverage tracking can be enabled with the `coverage=true` flag. The results
+are available as HTML for humans at `./tests/core/pyspec/.htmlcov/index.html`
+and as JSON for robots at `./tests/core/pyspec/.htmlcov/coverage.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,6 @@
 - [Important commands](#important-commands)
   - [Linting](#linting)
   - [Running tests](#running-tests)
-  - [Generating reference tests](#generating-reference-tests)
   - [Cleaning](#cleaning)
 - [Writing tests](#writing-tests)
   - [Reference tests vs unittests](#reference-tests-vs-unittests)
@@ -274,72 +273,7 @@ the project standards.
 
 ### Running tests
 
-```bash
-# Run all minimal preset tests (~30 minutes)
-make test
-
-# Run all mainnet preset tests (~5 hours)
-make test preset=mainnet
-
-# Run tests for a specific fork
-make test fork=deneb
-
-# Run tests matching a pattern (partial match)
-make test k=deposit  # Runs all tests with "deposit" in the name
-
-# Combine options
-make test preset=mainnet fork=deneb k=test_verify_kzg_proof
-```
-
-When testing, focus on what might have been impacted by the changes. Running the
-full test suite is slow, so target testing to relevant areas. For example, a bug
-fix in Electra deposit handling should be tested with deposit tests for Electra
-and any later forks. This may require multiple commands with different
-`fork=<fork>` options, as there is currently no single command to run tests for
-a given fork and all subsequent forks.
-
-Use `preset=minimal` (the default) while developing and iterating on changes.
-Once everything works, run the same targeted tests with `preset=mainnet` as a
-final sanity check before committing.
-
-### Generating reference tests
-
-```bash
-# Generate all reference tests (runs both presets by default)
-make test reftests=true
-
-# AI agents should use verbose mode (default view uses dynamic tables)
-make test reftests=true verbose=true
-
-# Generate tests for a specific fork
-make test reftests=true fork=electra verbose=true
-
-# Generate tests matching a pattern (omit the "test_" prefix)
-make test reftests=true k=verify_kzg_proof verbose=true
-
-# Combine options
-make test reftests=true preset=mainnet fork=deneb k=verify_kzg_proof verbose=true
-```
-
-Reference tests are written to the `../consensus-spec-tests` directory, which is
-created automatically.
-
-If a full suite of tests has been generated and an issue is identified, there is
-no need to regenerate everything. Only the affected test cases need to be
-regenerated; the framework will delete the individual test case directories
-before regenerating them.
-
-Note that if a test case is removed from the framework,
-`make test reftests=true` will not delete previously generated reference tests
-for that case. The corresponding directories must be deleted manually, or the
-entire `../consensus-spec-tests` directory can be removed if regenerating
-everything is acceptable.
-
-To see available runners:
-
-```bash
-find tests/generators/runners -maxdepth 1 -type f -name '*.py' ! -name '__init__.py' -exec basename {} .py \;
-```
+See [`.claude/skills/run-tests/SKILL.md`](.claude/skills/run-tests/SKILL.md).
 
 ### Cleaning
 

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ serve_docs: _pyspec _copy_docs
 
 LINT_DIFF_BEFORE := .lint_diff_before
 LINT_DIFF_AFTER := .lint_diff_after
-MARKDOWN_FILES := $(shell find $(CURDIR) -name '*.md' -not -path '$(CURDIR)/.*')
+MARKDOWN_FILES := $(shell find $(CURDIR) -name '*.md' -not -path '$(CURDIR)/.git/*' -not -path '$(CURDIR)/.venv/*')
 MYPY_PACKAGE_BASE := $(subst /,.,$(PYSPEC_DIR:$(CURDIR)/%=%))
 MYPY_SCOPE := $(foreach S,$(ALL_EXECUTABLE_SPEC_NAMES), -p $(MYPY_PACKAGE_BASE).eth_consensus_specs.$S)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ test = [
 ]
 lint = [
   "codespell==2.4.2",
+  "mdformat-frontmatter==2.0.10",
   "mdformat-gfm-alerts==2.0.0",
   "mdformat-gfm==1.0.0",
   "mdformat-ruff==0.1.3",

--- a/uv.lock
+++ b/uv.lock
@@ -471,6 +471,7 @@ generator = [
 lint = [
     { name = "codespell" },
     { name = "mdformat" },
+    { name = "mdformat-frontmatter" },
     { name = "mdformat-gfm" },
     { name = "mdformat-gfm-alerts" },
     { name = "mdformat-ruff" },
@@ -504,6 +505,7 @@ requires-dist = [
     { name = "lru-dict", specifier = "==1.4.1" },
     { name = "marko", specifier = "==2.2.2" },
     { name = "mdformat", marker = "extra == 'lint'", specifier = "==1.0.0" },
+    { name = "mdformat-frontmatter", marker = "extra == 'lint'", specifier = "==2.0.10" },
     { name = "mdformat-gfm", marker = "extra == 'lint'", specifier = "==1.0.0" },
     { name = "mdformat-gfm-alerts", marker = "extra == 'lint'", specifier = "==2.0.0" },
     { name = "mdformat-ruff", marker = "extra == 'lint'", specifier = "==0.1.3" },
@@ -918,6 +920,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/05/32b5e14b192b0a8a309f32232c580aefedd9d06017cb8fe8fce34bec654c/mdformat-1.0.0.tar.gz", hash = "sha256:4954045fcae797c29f86d4ad879e43bb151fa55dbaf74ac6eaeacf1d45bb3928", size = 56953, upload-time = "2025-10-16T12:05:03.695Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/9a/8fe71b95985ca7a4001effbcc58e5a07a1f2a2884203f74dcf48a3b08315/mdformat-1.0.0-py3-none-any.whl", hash = "sha256:bca015d65a1d063a02e885a91daee303057bc7829c2cd37b2075a50dbb65944b", size = 53288, upload-time = "2025-10-16T12:05:02.607Z" },
+]
+
+[[package]]
+name = "mdformat-frontmatter"
+version = "2.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "ruamel-yaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/94/ccb15e0535f35c21b2b533cafb232f11ac0e7046dd122029b7ec0513c82e/mdformat_frontmatter-2.0.10.tar.gz", hash = "sha256:decefcb4beb66cf111f17e8c0d82e60b208104c7922ec09564d05365db551bd8", size = 3958, upload-time = "2026-01-19T23:42:23.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/40/e61f8ed549bed3159a9677eadb89849ccca6de30eb90bf61e1b6026df96d/mdformat_frontmatter-2.0.10-py3-none-any.whl", hash = "sha256:c99f7c52de0403e39f48b6a1c2bb79a4c8ce69304a799ff0e403e3957aa3669b", size = 4636, upload-time = "2026-01-19T23:42:22.341Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a new agent skill which defines instructions on how to run tests. This is our repository's first agent skill. I am unsure of a standard (non-claude) way of doing this. If there's a way which works with claude & codex, I would prefer that.