### PR TITLE
Align `should_extend_payload` with Gloas

### DIFF
--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -221,10 +221,11 @@ not satisfy the inclusion list constraints.
 
 ```python
 def should_extend_payload(store: Store, root: Root) -> bool:
+    if not is_payload_verified(store, root):
+        return False
     # [New in Heze:EIP7805]
     if not is_payload_inclusion_list_satisfied(store, root):
         return False
-
     proposer_root = store.proposer_boost_root
     return (
         (is_payload_timely(store, root) and is_payload_data_available(store, root))


### PR DESCRIPTION
This PR aligns Heze's `should_extend_payload`` to Gloas.