### PR TITLE
Fix website syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ tests/core/pyspec/eth_consensus_specs/test_results.xml
 # TOC tool outputs temporary files
 *.tmp
 
+# website
+docs/
+site/
+
 # docker test results
 testResults
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ markdown_extensions:
   - pymdownx.highlight:
       use_pygments: true
       noclasses: true
-      pygments_style: monokai
+      pygments_style: default
       linenums: true
       anchor_linenums: true
   - mdx_truly_sane_lists:
@@ -35,8 +35,6 @@ plugins:
   - gen-files:
       scripts:
         - scripts/gen_spec_indices.py
-extra_css:
-  - stylesheets/extra.css
 extra:
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
In #5144 I accidentally broken syntax highlighting on the website.

<img width="1920" height="1105" alt="image" src="https://github.com/user-attachments/assets/9ebb5515-c0a7-4791-bab3-7f26a74e12ed" />

I had removed the file used in the config here:

https://github.com/ethereum/consensus-specs/blob/3171cfbe020b334e100978251ec0f867d8044de4/mkdocs.yml#L38-L39

With this PR, the website now looks like:

<img width="1262" height="764" alt="image" src="https://github.com/user-attachments/assets/86bfc3c1-eda4-489c-9e1b-f4b1b2c89943" />

I've also checked dark-mode & it looks great too.

PS: I added back the gitignore stuff, as these show up as untracked when running the local web server.