### PR TITLE
Support optional execution and proof engines in optimistic sync

### DIFF
--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -174,7 +174,7 @@ To optimistically import a block:
     (e.g., `TERMINAL_BLOCK_HASH`) MUST prevent an optimistic import.
 - The parent of the block MUST NOT have an `INVALIDATED` execution payload.
 
-*[New in EIP-8025]* When the consensus engine is not configured with an
+*[New in EIP8025]* When the consensus engine is not configured with an
 `ExecutionEngine`, the
 [`verify_and_notify_new_payload`](../specs/bellatrix/beacon-chain.md#verify_and_notify_new_payload)
 call is not performed; the block is treated as if the execution engine had
@@ -198,7 +198,7 @@ transitions:
 - `NOT_VALIDATED` -> `VALID`
 - `NOT_VALIDATED` -> `INVALIDATED`
 
-*[New in EIP-8025]* In addition to the `ExecutionEngine` signal, the
+*[New in EIP8025]* In addition to the `ExecutionEngine` signal, the
 `ProofEngine` provides a parallel source of `VALID` signals. When the
 `ProofEngine` returns `VALID` for a `SignedExecutionProof` whose
 `public_input.new_payload_request_root` matches a block's `NewPayloadRequest`

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -202,8 +202,8 @@ transitions:
 `ProofEngine` provides a parallel source of `VALID` signals. When the
 `ProofEngine` returns `VALID` for a `SignedExecutionProof` whose
 `public_input.new_payload_request_root` matches a block's `NewPayloadRequest`
-(i.e. equals `hash_tree_root(new_payload_request)` for the corresponding
-block, as verified via
+(i.e. equals `hash_tree_root(new_payload_request)` for the corresponding block,
+as verified via
 [`process_execution_proof`](../specs/_features/eip8025/beacon-chain.md#new-process_execution_proof)),
 the consensus engine MUST transition the corresponding block from
 `NOT_VALIDATED` -> `VALID` in the same manner as an `ExecutionEngine` `VALID`

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -174,6 +174,18 @@ To optimistically import a block:
     (e.g., `TERMINAL_BLOCK_HASH`) MUST prevent an optimistic import.
 - The parent of the block MUST NOT have an `INVALIDATED` execution payload.
 
+*[New in EIP-8025]* When the consensus engine is not configured with an
+`ExecutionEngine`, the
+[`verify_and_notify_new_payload`](../specs/bellatrix/beacon-chain.md#verify_and_notify_new_payload)
+call is not performed; the block is treated as if the execution engine had
+returned `NOT_VALIDATED` for the purposes of optimistic import. Identically,
+when the consensus engine is not configured with a `ProofEngine`, the
+proof-engine signal is treated as `NOT_VALIDATED` for all blocks. A node
+configured with neither engine has no mechanism to transition any block out of
+`NOT_VALIDATED`; such nodes remain in the optimistic state defined below for
+all execution-enabled blocks and MUST signal `optimistic` to their consumers
+per the rules in [Fork Choice](#fork-choice).
+
 In addition to this change in validation, the consensus engine MUST track which
 blocks returned `NOT_VALIDATED` and which returned `VALID` for subsequent
 processing.
@@ -189,6 +201,22 @@ transitions:
 
 - `NOT_VALIDATED` -> `VALID`
 - `NOT_VALIDATED` -> `INVALIDATED`
+
+*[New in EIP-8025]* In addition to the `ExecutionEngine` signal, the
+`ProofEngine` provides a parallel source of `VALID` signals. When the
+`ProofEngine` returns `VALID` for a `SignedExecutionProof` whose
+`public_input.new_payload_request_root` matches a block's `NewPayloadRequest`
+(i.e. equals `hash_tree_root(new_payload_request)` for the corresponding
+block, as verified via
+[`process_execution_proof`](../specs/_features/eip8025/beacon-chain.md#new-process_execution_proof)),
+the consensus engine MUST transition the corresponding block from
+`NOT_VALIDATED` -> `VALID` in the same manner as an `ExecutionEngine` `VALID`
+response. A block is considered `VALID` when *at least one* signal source
+(`ExecutionEngine` or `ProofEngine`) has returned `VALID`; it remains
+`NOT_VALIDATED` when both sources are either absent or pending. The
+`ProofEngine` is not a source of `INVALIDATED` transitions: a non-`VALID`
+proof-engine response is handled at gossip-validation and does not constitute
+evidence that the execution payload itself is invalid.
 
 When a block transitions from `NOT_VALIDATED` -> `VALID`, all *ancestors* of the
 block MUST also transition from `NOT_VALIDATED` -> `VALID`. Such a block and any

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -180,11 +180,7 @@ To optimistically import a block:
 call is not performed; the block is treated as if the execution engine had
 returned `NOT_VALIDATED` for the purposes of optimistic import. Identically,
 when the consensus engine is not configured with a `ProofEngine`, the
-proof-engine signal is treated as `NOT_VALIDATED` for all blocks. A node
-configured with neither engine has no mechanism to transition any block out of
-`NOT_VALIDATED`; such nodes remain in the optimistic state defined below for
-all execution-enabled blocks and MUST signal `optimistic` to their consumers
-per the rules in [Fork Choice](#fork-choice).
+proof-engine signal is treated as `NOT_VALIDATED` for all blocks.
 
 In addition to this change in validation, the consensus engine MUST track which
 blocks returned `NOT_VALIDATED` and which returned `VALID` for subsequent


### PR DESCRIPTION
## Summary

Alternative direction to #5151 for the optional-engine aspect of EIP-8025. A single-file prose addition to `sync/optimistic.md` that handles engine-absence and `ProofEngine`-as-fork-choice-signal entirely via existing optimistic-sync semantics, with no function-signature changes, no modification to `beacon-chain.md` pseudocode, and no new `validator.md`.

## Two rules added to `sync/optimistic.md`

1. **Engine absence → `NOT_VALIDATED`.** If a consensus engine is not configured with an `ExecutionEngine` (or `ProofEngine`), the corresponding signal is treated as `NOT_VALIDATED` for optimistic-import purposes. A block is non-optimistic only after at least one signal source returns `VALID`.

2. **`ProofEngine` as parallel `VALID` signal source.** When the `ProofEngine` returns `VALID` for a `SignedExecutionProof` whose `public_input.new_payload_request_root` matches a block's `NewPayloadRequest`, the consensus engine transitions the block from `NOT_VALIDATED` → `VALID`, parallel to the existing `ExecutionEngine` `VALID` transition. The `ProofEngine` is not a source of `INVALIDATED` transitions — a non-`VALID` proof response is handled at gossip-validation and does not constitute evidence that the execution payload itself is invalid.

## Why this direction

- **Keeps `ExecutionEngine` and `ProofEngine` strictly disjoint at the function level.** No coupling inside `verify_and_notify_new_payload`, contra @mkalinin's earlier sketch in frisitano/consensus-specs#3. Two orthogonal validity sources stay orthogonal.
- **No `Optional[]` cascade through the fork hierarchy.** `process_execution_payload`'s signature is unchanged. Every call site in tests and helpers is unaffected.
- **`sync/optimistic.md` is the idiomatic home.** The file is already the spec authority on `NOT_VALIDATED` semantics and signal-driven state transitions. Adding a second signal source (PE) and an engine-absence rule fits the existing pattern.
- **Existing optimistic-sync attestation rules already cover honest-validator behaviour.** A block in `NOT_VALIDATED` state by the attestation deadline is not attestable — this rule is already in place, so no bespoke `validator.md` is needed.

## Relationship to #5151

File-level compatible (no overlap). Architecturally alternative:

- #5151 removes the EE assert in `process_execution_payload` and adds a new `validator.md` with a SHOULD-rule on attestation.
- This PR keeps the EE assert, keeps the `beacon-chain.md` pseudocode as-is, and adds no new validator file. The semantic work happens in `optimistic.md` prose.

If this direction is preferred, #5151 could be reduced in scope to just `*Note*` wording fixes (if any) or closed in favour of this PR.

## Prior discussion

frisitano/consensus-specs#3 contained the original review thread on the pre-#5055 version. Key comments there:

- [@frisitano on line 120](https://github.com/frisitano/consensus-specs/pull/3#discussion_r2478088614): wording on "accepts execution payloads" should acknowledge `NOT_VALIDATED` / optimistic import semantics.
- [@frisitano on line 76 of validator.md](https://github.com/frisitano/consensus-specs/pull/3#discussion_r...): observed overlap between the proposed validator rule and existing Optimistic Sync attestation rules.
- [@mkalinin on line 155](https://github.com/frisitano/consensus-specs/pull/3#discussion_r2485104497): proposed keeping the assert and coupling EE + PE inside `verify_and_notify_new_payload`, routing through Optimistic Sync. This PR takes the Optimistic Sync direction but without the EE/PE coupling.

## Test plan

- [ ] Rendered markdown reads correctly on GitHub (ToC, anchor to `process_execution_proof` in `beacon-chain.md`).
- [ ] Reviewer alignment with @barnabasbusa, @mkalinin on which architectural direction to take (this PR's optimistic-sync-only approach vs #5151's `beacon-chain.md` + `validator.md` approach).
- [ ] Confirm no interaction with existing optimistic-sync conformance tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)