### PR TITLE
Bump EIP-8025 `MAX_PROOF_SIZE` to 400 KiB

### DIFF
--- a/specs/_features/eip8025/beacon-chain.md
+++ b/specs/_features/eip8025/beacon-chain.md
@@ -48,7 +48,7 @@ imports proof types from [proof-engine.md](./proof-engine.md).
 
 | Name             | Value                |
 | ---------------- | -------------------- |
-| `MAX_PROOF_SIZE` | `307200` (= 300 KiB) |
+| `MAX_PROOF_SIZE` | `409600` (= 400 KiB) |
 
 ### Domains
 


### PR DESCRIPTION
## Summary

Bump `MAX_PROOF_SIZE` in the EIP-8025 constants table from `307200` (300 KiB) to `409600` (400 KiB).

## Motivation

Observed proof sizes from the zkboost integration are consistently **343,580 bytes** (~335 KiB) — above the current spec ceiling of 300 KiB, and below 400 KiB. The reference data is from a Kurtosis devnet run on 2026-04-02 with the `reth-zisk` prover variant, which produced 249 / 249 proofs at exactly 343,580 bytes; no proof in the captured window came in under 300 KiB.

The reference client implementation ([`eth-act/lighthouse`](https://github.com/eth-act/lighthouse)) already sizes both its proof-data type (`consensus/types/src/execution/eip8025.rs:19` — `MaxProofSize = U100 * U4096 = 409600`) and its RPC `RpcLimits` (`beacon_node/lighthouse_network/src/rpc/protocol.rs:130-134`) off 400 KiB. The 100 KiB drift between spec and reference impl is a hard-fork-level interop hazard for a constant that should be straightforward to settle: a 350 KiB proof would be valid under lighthouse's gossip + req/resp limits and rejected by any other client that adopts the spec value verbatim.

## Why up, not down

Lowering lighthouse to 300 KiB would invalidate every proof currently produced by the only integrated EIP-8025 prover (zkboost, with ere-server backed by Zisk). The 100 KiB headroom is consumed in practice; bumping the spec is the cheaper and more honest reconciliation.

## Scope of this change

- `specs/_features/eip8025/beacon-chain.md` — constants table only.
- The assembled pyspec under `tests/core/pyspec/eth_consensus_specs/eip8025/` is regenerated by `make _pyspec` to `MAX_PROOF_SIZE = 409600` automatically (gitignored, not committed).
- `pysetup/spec_builders/eip8025.py` — no change required; the constant flows from the markdown table.
- The byte budget propagates to gossip topic message-size limits, the req/resp `RpcLimits`, and the SSZ `ByteList[MAX_PROOF_SIZE]` type — all symbolic against `MAX_PROOF_SIZE`, so no further edits are needed.

## Validation

- [x] `make lint` — clean
- [x] Pyspec rebuild propagates the new value to mainnet + minimal
- [x] No prose anywhere quotes "300 KiB" outside the constants table