### PR TITLE
Mark Fulu as deployed on mainnet

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/constants.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/constants.py
@@ -23,7 +23,7 @@ EIP8025 = SpecForkName("eip8025")
 #
 
 # The forks that are deployed on Mainnet
-MAINNET_FORKS = (PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA)
+MAINNET_FORKS = (PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA, FULU)
 LATEST_FORK = MAINNET_FORKS[-1]
 # The forks that pytest can run with.
 # Note: when adding a new fork here, all tests from previous forks with decorator `with_X_and_later`
@@ -31,16 +31,15 @@ LATEST_FORK = MAINNET_FORKS[-1]
 ALL_PHASES = (
     # Formal forks
     *MAINNET_FORKS,
-    FULU,
     GLOAS,
     HEZE,
     # Experimental patches
     EIP8025,
 )
 # The forks that have light client specs
-LIGHT_CLIENT_TESTING_FORKS = [item for item in MAINNET_FORKS if item != PHASE0] + [FULU]
+LIGHT_CLIENT_TESTING_FORKS = [item for item in MAINNET_FORKS if item != PHASE0]
 # The forks that output to the test vectors.
-TESTGEN_FORKS = (*MAINNET_FORKS, FULU, GLOAS, HEZE)
+TESTGEN_FORKS = (*MAINNET_FORKS, GLOAS, HEZE)
 # Forks allowed in the test runner `--fork` flag, to fail fast in case of typos
 ALLOWED_TEST_RUNNER_FORKS = ALL_PHASES
 


### PR DESCRIPTION
Update test generation to treat Fulu as a fork launched on mainnet. No semantic change, Fulu tests were generated as an extra afterthought, now they are treated as every other mainnet fork.
