### PR TITLE
Pass `BeaconState` to `block_to_light_client_header`

### DIFF
--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -57,12 +57,12 @@ states and provide it to other clients.
 
 To form a `LightClientBootstrap`, the following objects are needed:
 
-- `state`: the post state of any post-Altair block
-- `block`: the corresponding block
+- `block`: any post-Altair block
+- `state`: the post state of `block`
 
 ```python
 def create_light_client_bootstrap(
-    state: BeaconState, block: SignedBeaconBlock
+    block: SignedBeaconBlock, state: BeaconState
 ) -> LightClientBootstrap:
     assert compute_epoch_at_slot(state.slot) >= ALTAIR_FORK_EPOCH
 
@@ -99,23 +99,23 @@ empty (no block proposed / orphaned).
 To form a `LightClientUpdate`, the following historical states and blocks are
 needed:
 
-- `state`: the post state of any block with a post-Altair parent block
-- `block`: the corresponding block
-- `attested_state`: the post state of `attested_block`
+- `block`: any block with a post-Altair parent block
+- `state`: the post state of `block`
 - `attested_block`: the block referred to by `block.parent_root`
-- `finalized_state`: the post state of `finalized_block`, if locally available
+- `attested_state`: the post state of `attested_block`
 - `finalized_block`: the block referred to by
   `attested_state.finalized_checkpoint.root`, if locally available (may be
   unavailable, e.g., when using checkpoint sync, or if it was pruned locally)
+- `finalized_state`: the post state of `finalized_block`, if locally available
 
 ```python
 def create_light_client_update(
-    state: BeaconState,
     block: SignedBeaconBlock,
-    attested_state: BeaconState,
+    state: BeaconState,
     attested_block: SignedBeaconBlock,
-    finalized_state: Optional[BeaconState],
+    attested_state: BeaconState,
     finalized_block: Optional[SignedBeaconBlock],
+    finalized_state: Optional[BeaconState],
 ) -> LightClientUpdate:
     assert compute_epoch_at_slot(attested_state.slot) >= ALTAIR_FORK_EPOCH
     assert (

--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -153,7 +153,13 @@ def create_light_client_update(
         )
 
     # Indicate finality whenever possible
-    if finalized_block is not None and finalized_state is not None:
+    if finalized_block is not None:
+        assert finalized_state is not None
+        assert finalized_state.slot == finalized_state.latest_block_header.slot
+        finalized_header = finalized_state.latest_block_header.copy()
+        finalized_header.state_root = hash_tree_root(finalized_state)
+        assert hash_tree_root(finalized_header) == hash_tree_root(finalized_block.message)
+
         if finalized_block.message.slot != GENESIS_SLOT:
             update.finalized_header = block_to_light_client_header(finalized_block, finalized_state)
             assert (
@@ -162,9 +168,12 @@ def create_light_client_update(
             )
         else:
             assert attested_state.finalized_checkpoint.root == Bytes32()
+
         update.finality_branch = FinalityBranch(
             compute_merkle_proof(attested_state, finalized_root_gindex_at_slot(attested_state.slot))
         )
+    else:
+        assert finalized_state is None
 
     update.sync_aggregate = block.message.body.sync_aggregate
     update.signature_slot = block.message.slot

--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -153,7 +153,7 @@ def create_light_client_update(
         )
 
     # Indicate finality whenever possible
-    if finalized_state is not None and finalized_block is not None:
+    if finalized_block is not None and finalized_state is not None:
         if finalized_block.message.slot != GENESIS_SLOT:
             update.finalized_header = block_to_light_client_header(finalized_block, finalized_state)
             assert (

--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -34,7 +34,9 @@ def compute_merkle_proof(object: SSZObject, index: GeneralizedIndex) -> Sequence
 ### `block_to_light_client_header`
 
 ```python
-def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
+def block_to_light_client_header(
+    block: SignedBeaconBlock, _state: BeaconState
+) -> LightClientHeader:
     return LightClientHeader(
         beacon=BeaconBlockHeader(
             slot=block.message.slot,
@@ -70,7 +72,7 @@ def create_light_client_bootstrap(
     assert hash_tree_root(header) == hash_tree_root(block.message)
 
     return LightClientBootstrap(
-        header=block_to_light_client_header(block),
+        header=block_to_light_client_header(block, state),
         current_sync_committee=state.current_sync_committee,
         current_sync_committee_branch=CurrentSyncCommitteeBranch(
             compute_merkle_proof(state, current_sync_committee_gindex_at_slot(state.slot))
@@ -101,6 +103,7 @@ needed:
 - `block`: the corresponding block
 - `attested_state`: the post state of `attested_block`
 - `attested_block`: the block referred to by `block.parent_root`
+- `finalized_state`: the post state of `finalized_block`, if locally available
 - `finalized_block`: the block referred to by
   `attested_state.finalized_checkpoint.root`, if locally available (may be
   unavailable, e.g., when using checkpoint sync, or if it was pruned locally)
@@ -111,6 +114,7 @@ def create_light_client_update(
     block: SignedBeaconBlock,
     attested_state: BeaconState,
     attested_block: SignedBeaconBlock,
+    finalized_state: Optional[BeaconState],
     finalized_block: Optional[SignedBeaconBlock],
 ) -> LightClientUpdate:
     assert compute_epoch_at_slot(attested_state.slot) >= ALTAIR_FORK_EPOCH
@@ -137,7 +141,7 @@ def create_light_client_update(
 
     update = LightClientUpdate()
 
-    update.attested_header = block_to_light_client_header(attested_block)
+    update.attested_header = block_to_light_client_header(attested_block, attested_state)
 
     # `next_sync_committee` is only useful if the message is signed by the current sync committee
     if update_attested_period == update_signature_period:
@@ -149,9 +153,9 @@ def create_light_client_update(
         )
 
     # Indicate finality whenever possible
-    if finalized_block is not None:
+    if finalized_state is not None and finalized_block is not None:
         if finalized_block.message.slot != GENESIS_SLOT:
-            update.finalized_header = block_to_light_client_header(finalized_block)
+            update.finalized_header = block_to_light_client_header(finalized_block, finalized_state)
             assert (
                 hash_tree_root(update.finalized_header.beacon)
                 == attested_state.finalized_checkpoint.root

--- a/specs/capella/light-client/full-node.md
+++ b/specs/capella/light-client/full-node.md
@@ -18,7 +18,9 @@ as part of the Capella upgrade.
 ### Modified `block_to_light_client_header`
 
 ```python
-def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
+def block_to_light_client_header(
+    block: SignedBeaconBlock, _state: BeaconState
+) -> LightClientHeader:
     epoch = compute_epoch_at_slot(block.message.slot)
 
     if epoch >= CAPELLA_FORK_EPOCH:

--- a/specs/deneb/light-client/full-node.md
+++ b/specs/deneb/light-client/full-node.md
@@ -17,7 +17,9 @@ Execution payload data is updated to account for the Deneb upgrade.
 ### Modified `block_to_light_client_header`
 
 ```python
-def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
+def block_to_light_client_header(
+    block: SignedBeaconBlock, _state: BeaconState
+) -> LightClientHeader:
     epoch = compute_epoch_at_slot(block.message.slot)
 
     if epoch >= CAPELLA_FORK_EPOCH:

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/light_client/test_sync.py
@@ -70,7 +70,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block
+        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -100,7 +100,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block
+        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -130,7 +130,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block
+        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -153,7 +153,14 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     update = yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block=None
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state=None,
+        finalized_block=None,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -177,7 +184,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     update = yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block
+        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -218,7 +225,14 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     update = yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block=None
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state=None,
+        finalized_block=None,
     )
     assert test.store.finalized_header.beacon.slot == store_state.slot
     assert test.store.next_sync_committee == store_state.next_sync_committee
@@ -241,7 +255,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     update = yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block
+        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
     )
     assert test.store.finalized_header.beacon.slot == store_state.slot
     assert test.store.next_sync_committee == store_state.next_sync_committee
@@ -276,7 +290,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block
+        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -315,7 +329,14 @@ def test_supply_sync_committee_from_past_update(spec, state):
 
     # Apply `LightClientUpdate` from the past, populating `store.next_sync_committee`
     yield from emit_update(
-        test, spec, past_state, block, attested_state, attested_block, finalized_block
+        test,
+        spec,
+        past_state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
     )
     assert test.store.finalized_header.beacon.slot == state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -350,7 +371,7 @@ def test_advance_finality_without_sync_committee(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block
+        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -371,7 +392,15 @@ def test_advance_finality_without_sync_committee(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, with_next=False
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        with_next=False,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert not spec.is_next_sync_committee_known(test.store)
@@ -390,7 +419,15 @@ def test_advance_finality_without_sync_committee(spec, state):
 
     # Apply `LightClientUpdate` without `finalized_header` nor `next_sync_committee`
     update = yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, None, with_next=False
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state=None,
+        finalized_block=None,
+        with_next=False,
     )
     assert test.store.finalized_header.beacon.slot == past_state.slot
     assert not spec.is_next_sync_committee_known(test.store)
@@ -399,7 +436,15 @@ def test_advance_finality_without_sync_committee(spec, state):
 
     # Apply `LightClientUpdate` with `finalized_header` but no `next_sync_committee`
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, with_next=False
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        with_next=False,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert not spec.is_next_sync_committee_known(test.store)
@@ -408,7 +453,7 @@ def test_advance_finality_without_sync_committee(spec, state):
 
     # Apply full `LightClientUpdate`, supplying `next_sync_committee`
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block
+        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -474,13 +519,20 @@ def test_light_client_sync_no_force_update(spec, state):
 
     # Create initial update to set up store state
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block
+        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
     )
     assert test.store.best_valid_update is None
 
     # Create a best_valid_update by emitting an update without a finalized_header
     update = yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block=None
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state=None,
+        finalized_block=None,
     )
     assert test.store.best_valid_update == update
 
@@ -514,7 +566,15 @@ def run_lc_sync_test_upgraded_store_with_legacy_data(spec, phases, state, fork):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/light_client/test_sync.py
@@ -70,7 +70,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
+        test, spec, block, state, attested_block, attested_state, finalized_block, finalized_state
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -100,7 +100,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
+        test, spec, block, state, attested_block, attested_state, finalized_block, finalized_state
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -130,7 +130,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
+        test, spec, block, state, attested_block, attested_state, finalized_block, finalized_state
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -155,12 +155,12 @@ def test_light_client_sync(spec, state):
     update = yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state=None,
+        attested_state,
         finalized_block=None,
+        finalized_state=None,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -184,7 +184,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     update = yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
+        test, spec, block, state, attested_block, attested_state, finalized_block, finalized_state
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -227,12 +227,12 @@ def test_light_client_sync(spec, state):
     update = yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state=None,
+        attested_state,
         finalized_block=None,
+        finalized_state=None,
     )
     assert test.store.finalized_header.beacon.slot == store_state.slot
     assert test.store.next_sync_committee == store_state.next_sync_committee
@@ -255,7 +255,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     update = yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
+        test, spec, block, state, attested_block, attested_state, finalized_block, finalized_state
     )
     assert test.store.finalized_header.beacon.slot == store_state.slot
     assert test.store.next_sync_committee == store_state.next_sync_committee
@@ -290,7 +290,7 @@ def test_light_client_sync(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
+        test, spec, block, state, attested_block, attested_state, finalized_block, finalized_state
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -331,12 +331,12 @@ def test_supply_sync_committee_from_past_update(spec, state):
     yield from emit_update(
         test,
         spec,
-        past_state,
         block,
-        attested_state,
+        past_state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
     )
     assert test.store.finalized_header.beacon.slot == state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -371,7 +371,7 @@ def test_advance_finality_without_sync_committee(spec, state):
     sync_aggregate, _ = get_sync_aggregate(spec, state)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
+        test, spec, block, state, attested_block, attested_state, finalized_block, finalized_state
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -394,12 +394,12 @@ def test_advance_finality_without_sync_committee(spec, state):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         with_next=False,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
@@ -421,12 +421,12 @@ def test_advance_finality_without_sync_committee(spec, state):
     update = yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state=None,
+        attested_state,
         finalized_block=None,
+        finalized_state=None,
         with_next=False,
     )
     assert test.store.finalized_header.beacon.slot == past_state.slot
@@ -438,12 +438,12 @@ def test_advance_finality_without_sync_committee(spec, state):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         with_next=False,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
@@ -453,7 +453,7 @@ def test_advance_finality_without_sync_committee(spec, state):
 
     # Apply full `LightClientUpdate`, supplying `next_sync_committee`
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
+        test, spec, block, state, attested_block, attested_state, finalized_block, finalized_state
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -519,7 +519,7 @@ def test_light_client_sync_no_force_update(spec, state):
 
     # Create initial update to set up store state
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_state, finalized_block
+        test, spec, block, state, attested_block, attested_state, finalized_block, finalized_state
     )
     assert test.store.best_valid_update is None
 
@@ -527,12 +527,12 @@ def test_light_client_sync_no_force_update(spec, state):
     update = yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state=None,
+        attested_state,
         finalized_block=None,
+        finalized_state=None,
     )
     assert test.store.best_valid_update == update
 
@@ -568,12 +568,12 @@ def run_lc_sync_test_upgraded_store_with_legacy_data(spec, phases, state, fork):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/light_client/test_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/light_client/test_sync.py
@@ -46,7 +46,7 @@ from eth_consensus_specs.test.helpers.state import (
 @with_presets([MINIMAL], reason="too slow")
 def test_light_client_sync(spec, state):
     # Start test
-    test = yield from setup_lc_sync_test(spec, state)
+    _, _, test = yield from setup_lc_sync_test(spec, state)
 
     # Initial `LightClientUpdate`, populating `store.next_sync_committee`
     # ```
@@ -324,7 +324,7 @@ def test_supply_sync_committee_from_past_update(spec, state):
     past_state = state.copy()
 
     # Start test
-    test = yield from setup_lc_sync_test(spec, state)
+    _, trusted_state, test = yield from setup_lc_sync_test(spec, state)
     assert not spec.is_next_sync_committee_known(test.store)
 
     # Apply `LightClientUpdate` from the past, populating `store.next_sync_committee`
@@ -338,10 +338,10 @@ def test_supply_sync_committee_from_past_update(spec, state):
         finalized_block,
         finalized_state,
     )
-    assert test.store.finalized_header.beacon.slot == state.slot
+    assert test.store.finalized_header.beacon.slot == trusted_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
     assert test.store.best_valid_update is None
-    assert test.store.optimistic_header.beacon.slot == state.slot
+    assert test.store.optimistic_header.beacon.slot == trusted_state.slot
 
     # Finish test
     yield from finish_lc_sync_test(test)
@@ -357,7 +357,7 @@ def test_supply_sync_committee_from_past_update(spec, state):
 @with_presets([MINIMAL], reason="too slow")
 def test_advance_finality_without_sync_committee(spec, state):
     # Start test
-    test = yield from setup_lc_sync_test(spec, state)
+    _, _, test = yield from setup_lc_sync_test(spec, state)
 
     # Initial `LightClientUpdate`, populating `store.next_sync_committee`
     next_slots(spec, state, spec.SLOTS_PER_EPOCH - 1)
@@ -504,7 +504,7 @@ def test_light_client_sync_no_force_update(spec, state):
     * advance to just before timeout threshold
     * verify force update does not occur
     """
-    test = yield from setup_lc_sync_test(spec, state)
+    _, _, test = yield from setup_lc_sync_test(spec, state)
 
     next_slots(spec, state, spec.SLOTS_PER_EPOCH - 1)
     finalized_block = state_transition_with_full_block(spec, state, True, True)
@@ -555,12 +555,11 @@ def test_light_client_sync_no_force_update(spec, state):
 
 def run_lc_sync_test_upgraded_store_with_legacy_data(spec, phases, state, fork):
     # Start test (Legacy bootstrap with an upgraded store)
-    test = yield from setup_lc_sync_test(spec, state, phases[fork], phases)
+    finalized_block, finalized_state, test = yield from setup_lc_sync_test(
+        spec, state, phases[fork], phases
+    )
 
     # Initial `LightClientUpdate` (check that the upgraded store can process it)
-    finalized_block = spec.SignedBeaconBlock()
-    finalized_block.message.state_root = state.hash_tree_root()
-    finalized_state = state.copy()
     attested_block = state_transition_with_full_block(spec, state, True, True)
     attested_state = state.copy()
     sync_aggregate, _ = get_sync_aggregate(spec, state)

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/light_client/test_update_ranking.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/light_client/test_update_ranking.py
@@ -19,11 +19,12 @@ from eth_consensus_specs.test.helpers.state import (
 def create_test_update(
     spec, test, with_next, with_finality, participation_rate, signature_slot=None
 ):
-    attested_state, attested_block, finalized_block = test
+    attested_state, attested_block, finalized_state, finalized_block = test
     return create_update(
         spec,
         attested_state,
         attested_block,
+        finalized_state,
         finalized_block,
         with_next,
         with_finality,
@@ -45,8 +46,10 @@ def test_update_ranking(spec, state):
         spec, state, spec.compute_start_slot_at_epoch(spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD - 3) - 1
     )
     sig_finalized_block = state_transition_with_full_block(spec, state, True, True)
+    sig_finalized_state = state.copy()
     _, _, state = next_slots_with_attestations(spec, state, spec.SLOTS_PER_EPOCH - 1, True, True)
     att_finalized_block = state_transition_with_full_block(spec, state, True, True)
+    att_finalized_state = state.copy()
     _, _, state = next_slots_with_attestations(
         spec, state, 2 * spec.SLOTS_PER_EPOCH - 2, True, True
     )
@@ -55,18 +58,20 @@ def test_update_ranking(spec, state):
     att_attested_block = state_transition_with_full_block(spec, state, True, True)
     att_attested_state = state.copy()
     fin_finalized_block = att_attested_block
+    fin_finalized_state = att_attested_state
     _, _, state = next_slots_with_attestations(
         spec, state, 2 * spec.SLOTS_PER_EPOCH - 1, True, True
     )
     fin_attested_block = state_transition_with_full_block(spec, state, True, True)
     fin_attested_state = state.copy()
     lat_finalized_block = fin_finalized_block
+    lat_finalized_state = fin_finalized_state
     lat_attested_block = state_transition_with_full_block(spec, state, True, True)
     lat_attested_state = state.copy()
-    sig = (sig_attested_state, sig_attested_block, sig_finalized_block)
-    att = (att_attested_state, att_attested_block, att_finalized_block)
-    fin = (fin_attested_state, fin_attested_block, fin_finalized_block)
-    lat = (lat_attested_state, lat_attested_block, lat_finalized_block)
+    sig = (sig_attested_state, sig_attested_block, sig_finalized_state, sig_finalized_block)
+    att = (att_attested_state, att_attested_block, att_finalized_state, att_finalized_block)
+    fin = (fin_attested_state, fin_attested_block, fin_finalized_state, fin_finalized_block)
+    lat = (lat_attested_state, lat_attested_block, lat_finalized_state, lat_finalized_block)
 
     # Create updates (in descending order of quality)
     updates = [

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/unittests/light_client/test_sync_protocol.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/unittests/light_client/test_sync_protocol.py
@@ -7,7 +7,6 @@ from eth_consensus_specs.test.context import (
     with_presets,
 )
 from eth_consensus_specs.test.helpers.attestations import (
-    next_epoch_with_attestations,
     state_transition_with_full_block,
 )
 from eth_consensus_specs.test.helpers.constants import MINIMAL
@@ -24,11 +23,13 @@ def setup_test(spec, state):
     trusted_block = spec.SignedBeaconBlock()
     trusted_block.message.state_root = state.hash_tree_root()
     trusted_block_root = trusted_block.message.hash_tree_root()
-    bootstrap = spec.create_light_client_bootstrap(state, trusted_block)
+    trusted_state = state.copy()
+
+    bootstrap = spec.create_light_client_bootstrap(trusted_block, trusted_state)
     store = spec.initialize_light_client_store(trusted_block_root, bootstrap)
     store.next_sync_committee = state.next_sync_committee
 
-    return (trusted_block, store)
+    return (trusted_block, trusted_state, store)
 
 
 @with_light_client
@@ -39,7 +40,7 @@ def setup_test(spec, state):
 )
 @spec_state_test_with_matching_config
 def test_process_light_client_update_not_timeout(spec, state):
-    genesis_block, store = setup_test(spec, state)
+    genesis_block, genesis_state, store = setup_test(spec, state)
 
     # Block at slot 1 doesn't increase sync committee period, so it won't force update store.finalized_header
     attested_block = state_transition_with_full_block(spec, state, False, False)
@@ -52,6 +53,7 @@ def test_process_light_client_update_not_timeout(spec, state):
         spec,
         attested_state=state,
         attested_block=attested_block,
+        finalized_state=genesis_state,
         finalized_block=genesis_block,
         with_next=False,
         with_finality=False,
@@ -77,7 +79,7 @@ def test_process_light_client_update_not_timeout(spec, state):
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_at_period_boundary(spec, state):
-    genesis_block, store = setup_test(spec, state)
+    genesis_block, genesis_state, store = setup_test(spec, state)
 
     # Forward to slot before next sync committee period so that next block is final one in period
     next_slots(spec, state, spec.UPDATE_TIMEOUT - 2)
@@ -92,6 +94,7 @@ def test_process_light_client_update_at_period_boundary(spec, state):
         spec,
         attested_state=state,
         attested_block=attested_block,
+        finalized_state=genesis_state,
         finalized_block=genesis_block,
         with_next=False,
         with_finality=False,
@@ -117,7 +120,7 @@ def test_process_light_client_update_at_period_boundary(spec, state):
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_timeout(spec, state):
-    genesis_block, store = setup_test(spec, state)
+    genesis_block, genesis_state, store = setup_test(spec, state)
 
     # Forward to next sync committee period
     next_slots(spec, state, spec.UPDATE_TIMEOUT)
@@ -132,6 +135,7 @@ def test_process_light_client_update_timeout(spec, state):
         spec,
         attested_state=state,
         attested_block=attested_block,
+        finalized_state=genesis_state,
         finalized_block=genesis_block,
         with_next=True,
         with_finality=False,
@@ -157,14 +161,15 @@ def test_process_light_client_update_timeout(spec, state):
 @spec_state_test_with_matching_config
 @with_presets([MINIMAL], reason="too slow")
 def test_process_light_client_update_finality_updated(spec, state):
-    _, store = setup_test(spec, state)
+    _, _, store = setup_test(spec, state)
 
     # Change finality
     blocks = []
+    states = []
     next_slots(spec, state, spec.SLOTS_PER_EPOCH * 2)
-    for epoch in range(3):
-        prev_state, new_blocks, state = next_epoch_with_attestations(spec, state, True, True)
-        blocks += new_blocks
+    for _ in range(3 * spec.SLOTS_PER_EPOCH):
+        blocks.append(state_transition_with_full_block(spec, state, True, True))
+        states.append(state.copy())
     # Ensure that finality checkpoint has changed
     assert state.finalized_checkpoint.epoch == 3
     # Ensure that it's same period
@@ -177,6 +182,7 @@ def test_process_light_client_update_finality_updated(spec, state):
 
     # Updated finality
     finalized_block = blocks[spec.SLOTS_PER_EPOCH - 1]
+    finalized_state = states[spec.SLOTS_PER_EPOCH - 1]
     assert finalized_block.message.slot == spec.compute_start_slot_at_epoch(
         state.finalized_checkpoint.epoch
     )
@@ -186,6 +192,7 @@ def test_process_light_client_update_finality_updated(spec, state):
         spec,
         attested_state=state,
         attested_block=attested_block,
+        finalized_state=finalized_state,
         finalized_block=finalized_block,
         with_next=False,
         with_finality=True,

--- a/tests/core/pyspec/eth_consensus_specs/test/bellatrix/light_client/test_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/bellatrix/light_client/test_sync.py
@@ -23,7 +23,7 @@ from eth_consensus_specs.test.helpers.light_client_sync import (
 @spec_test
 @with_config_overrides(
     {
-        "CAPELLA_FORK_EPOCH": 3,  # Test setup advances to epoch 2
+        "CAPELLA_FORK_EPOCH": 5,  # Test setup advances to epoch 4
     },
 )
 @with_state
@@ -37,8 +37,8 @@ def test_capella_fork(spec, phases, state):
 @spec_test
 @with_config_overrides(
     {
-        "CAPELLA_FORK_EPOCH": 3,  # Test setup advances to epoch 2
-        "DENEB_FORK_EPOCH": 4,
+        "CAPELLA_FORK_EPOCH": 5,  # Test setup advances to epoch 4
+        "DENEB_FORK_EPOCH": 6,
     },
 )
 @with_state
@@ -52,9 +52,9 @@ def test_capella_deneb_fork(spec, phases, state):
 @spec_test
 @with_config_overrides(
     {
-        "CAPELLA_FORK_EPOCH": 3,  # Test setup advances to epoch 2
-        "DENEB_FORK_EPOCH": 4,
-        "ELECTRA_FORK_EPOCH": 5,
+        "CAPELLA_FORK_EPOCH": 5,  # Test setup advances to epoch 4
+        "DENEB_FORK_EPOCH": 6,
+        "ELECTRA_FORK_EPOCH": 7,
     },
 )
 @with_state

--- a/tests/core/pyspec/eth_consensus_specs/test/capella/light_client/test_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/capella/light_client/test_sync.py
@@ -22,7 +22,7 @@ from eth_consensus_specs.test.helpers.light_client_sync import (
 @spec_test
 @with_config_overrides(
     {
-        "DENEB_FORK_EPOCH": 3,  # Test setup advances to epoch 2
+        "DENEB_FORK_EPOCH": 5,  # Test setup advances to epoch 4
     },
 )
 @with_state
@@ -36,8 +36,8 @@ def test_deneb_fork(spec, phases, state):
 @spec_test
 @with_config_overrides(
     {
-        "DENEB_FORK_EPOCH": 3,  # Test setup advances to epoch 2
-        "ELECTRA_FORK_EPOCH": 4,
+        "DENEB_FORK_EPOCH": 5,  # Test setup advances to epoch 4
+        "ELECTRA_FORK_EPOCH": 6,
     },
 )
 @with_state

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/light_client/test_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/light_client/test_sync.py
@@ -20,7 +20,7 @@ from eth_consensus_specs.test.helpers.light_client_sync import (
 @spec_test
 @with_config_overrides(
     {
-        "ELECTRA_FORK_EPOCH": 3,  # Test setup advances to epoch 2
+        "ELECTRA_FORK_EPOCH": 5,  # Test setup advances to epoch 4
     },
 )
 @with_state

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client.py
@@ -101,6 +101,7 @@ def create_update(
     spec,
     attested_state,
     attested_block,
+    finalized_state,
     finalized_block,
     with_next,
     with_finality,
@@ -111,7 +112,7 @@ def create_update(
 
     update = spec.LightClientUpdate()
 
-    update.attested_header = spec.block_to_light_client_header(attested_block)
+    update.attested_header = spec.block_to_light_client_header(attested_block, attested_state)
 
     if with_next:
         update.next_sync_committee = attested_state.next_sync_committee
@@ -120,7 +121,9 @@ def create_update(
         )
 
     if with_finality:
-        update.finalized_header = spec.block_to_light_client_header(finalized_block)
+        update.finalized_header = spec.block_to_light_client_header(
+            finalized_block, finalized_state
+        )
         update.finality_branch = spec.compute_merkle_proof(
             attested_state, latest_finalized_root_gindex(spec)
         )
@@ -168,15 +171,15 @@ def upgrade_lc_header_to_new_spec(spec, new_spec, data, phases):
 
     if needs_upgrade_to_capella(spec, new_spec):
         upgraded = phases[CAPELLA].upgrade_lc_header_to_capella(upgraded)
-        check_lc_header_equal(spec, new_spec, data, upgraded)
+        check_lc_header_equal(spec, phases[CAPELLA], data, upgraded)
 
     if needs_upgrade_to_deneb(spec, new_spec):
         upgraded = phases[DENEB].upgrade_lc_header_to_deneb(upgraded)
-        check_lc_header_equal(spec, new_spec, data, upgraded)
+        check_lc_header_equal(spec, phases[DENEB], data, upgraded)
 
     if needs_upgrade_to_electra(spec, new_spec):
         upgraded = phases[ELECTRA].upgrade_lc_header_to_electra(upgraded)
-        check_lc_header_equal(spec, new_spec, data, upgraded)
+        check_lc_header_equal(spec, phases[ELECTRA], data, upgraded)
 
     return upgraded
 
@@ -198,15 +201,15 @@ def upgrade_lc_bootstrap_to_new_spec(spec, new_spec, data, phases):
 
     if needs_upgrade_to_capella(spec, new_spec):
         upgraded = phases[CAPELLA].upgrade_lc_bootstrap_to_capella(upgraded)
-        check_lc_bootstrap_equal(spec, new_spec, data, upgraded)
+        check_lc_bootstrap_equal(spec, phases[CAPELLA], data, upgraded)
 
     if needs_upgrade_to_deneb(spec, new_spec):
         upgraded = phases[DENEB].upgrade_lc_bootstrap_to_deneb(upgraded)
-        check_lc_bootstrap_equal(spec, new_spec, data, upgraded)
+        check_lc_bootstrap_equal(spec, phases[DENEB], data, upgraded)
 
     if needs_upgrade_to_electra(spec, new_spec):
         upgraded = phases[ELECTRA].upgrade_lc_bootstrap_to_electra(upgraded)
-        check_lc_bootstrap_equal(spec, new_spec, data, upgraded)
+        check_lc_bootstrap_equal(spec, phases[ELECTRA], data, upgraded)
 
     return upgraded
 
@@ -238,15 +241,15 @@ def upgrade_lc_update_to_new_spec(spec, new_spec, data, phases):
 
     if needs_upgrade_to_capella(spec, new_spec):
         upgraded = phases[CAPELLA].upgrade_lc_update_to_capella(upgraded)
-        check_lc_update_equal(spec, new_spec, data, upgraded)
+        check_lc_update_equal(spec, phases[CAPELLA], data, upgraded)
 
     if needs_upgrade_to_deneb(spec, new_spec):
         upgraded = phases[DENEB].upgrade_lc_update_to_deneb(upgraded)
-        check_lc_update_equal(spec, new_spec, data, upgraded)
+        check_lc_update_equal(spec, phases[DENEB], data, upgraded)
 
     if needs_upgrade_to_electra(spec, new_spec):
         upgraded = phases[ELECTRA].upgrade_lc_update_to_electra(upgraded)
-        check_lc_update_equal(spec, new_spec, data, upgraded)
+        check_lc_update_equal(spec, phases[ELECTRA], data, upgraded)
 
     return upgraded
 
@@ -270,15 +273,15 @@ def upgrade_lc_finality_update_to_new_spec(spec, new_spec, data, phases):
 
     if needs_upgrade_to_capella(spec, new_spec):
         upgraded = phases[CAPELLA].upgrade_lc_finality_update_to_capella(upgraded)
-        check_lc_finality_update_equal(spec, new_spec, data, upgraded)
+        check_lc_finality_update_equal(spec, phases[CAPELLA], data, upgraded)
 
     if needs_upgrade_to_deneb(spec, new_spec):
         upgraded = phases[DENEB].upgrade_lc_finality_update_to_deneb(upgraded)
-        check_lc_finality_update_equal(spec, new_spec, data, upgraded)
+        check_lc_finality_update_equal(spec, phases[DENEB], data, upgraded)
 
     if needs_upgrade_to_electra(spec, new_spec):
         upgraded = phases[ELECTRA].upgrade_lc_finality_update_to_electra(upgraded)
-        check_lc_finality_update_equal(spec, new_spec, data, upgraded)
+        check_lc_finality_update_equal(spec, phases[ELECTRA], data, upgraded)
 
     return upgraded
 
@@ -301,14 +304,14 @@ def upgrade_lc_store_to_new_spec(spec, new_spec, data, phases):
 
     if needs_upgrade_to_capella(spec, new_spec):
         upgraded = phases[CAPELLA].upgrade_lc_store_to_capella(upgraded)
-        check_lc_store_equal(spec, new_spec, data, upgraded)
+        check_lc_store_equal(spec, phases[CAPELLA], data, upgraded)
 
     if needs_upgrade_to_deneb(spec, new_spec):
         upgraded = phases[DENEB].upgrade_lc_store_to_deneb(upgraded)
-        check_lc_store_equal(spec, new_spec, data, upgraded)
+        check_lc_store_equal(spec, phases[DENEB], data, upgraded)
 
     if needs_upgrade_to_electra(spec, new_spec):
         upgraded = phases[ELECTRA].upgrade_lc_store_to_electra(upgraded)
-        check_lc_store_equal(spec, new_spec, data, upgraded)
+        check_lc_store_equal(spec, phases[ELECTRA], data, upgraded)
 
     return upgraded

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_data_collection.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_data_collection.py
@@ -228,7 +228,10 @@ def _light_client_header_for_block(test, block):  # -> ForkedLightClientHeader
         spec = test.phases[ALTAIR]
     else:
         spec = block.spec
-    return ForkedLightClientHeader(spec=spec, data=spec.block_to_light_client_header(block.data))
+    state = test.states[block.data.message.state_root].data
+    return ForkedLightClientHeader(
+        spec=spec, data=spec.block_to_light_client_header(block.data, state)
+    )
 
 
 def _light_client_header_for_block_id(test, bid):  # -> ForkedLightClientHeader
@@ -237,7 +240,10 @@ def _light_client_header_for_block_id(test, bid):  # -> ForkedLightClientHeader
         spec = test.phases[ALTAIR]
     else:
         spec = block.spec
-    return ForkedLightClientHeader(spec=spec, data=spec.block_to_light_client_header(block.data))
+    state = test.states[block.data.message.state_root].data
+    return ForkedLightClientHeader(
+        spec=spec, data=spec.block_to_light_client_header(block.data, state)
+    )
 
 
 def _sync_aggregate_for_block_id(test, bid):  # -> Optional[SyncAggregate]
@@ -435,8 +441,9 @@ def _create_lc_bootstrap(test, spec, bid):
         test.lc_data_store.db.sync_committees[period] = (
             _get_current_sync_committee_for_finalized_period(test, period)
         )
+    state = test.states[block.data.message.state_root].data
     test.lc_data_store.db.headers[bid.root] = ForkedLightClientHeader(
-        spec=block.spec, data=block.spec.block_to_light_client_header(block.data)
+        spec=block.spec, data=block.spec.block_to_light_client_header(block.data, state)
     )
     test.lc_data_store.db.current_branches[bid.slot] = _get_light_client_data(
         test.lc_data_store, bid

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_sync.py
@@ -61,7 +61,7 @@ def setup_lc_sync_test(spec, state, s_spec=None, phases=None):
     yield "genesis_validators_root", "meta", "0x" + state.genesis_validators_root.hex()
     test.genesis_validators_root = state.genesis_validators_root
 
-    next_slots(spec, state, spec.SLOTS_PER_EPOCH * 2 - 1)
+    next_slots(spec, state, 2 * spec.SLOTS_PER_EPOCH - 1)
     trusted_block = state_transition_with_full_block(spec, state, True, True)
     trusted_block_root = trusted_block.message.hash_tree_root()
     trusted_state = state.copy()
@@ -80,7 +80,10 @@ def setup_lc_sync_test(spec, state, s_spec=None, phases=None):
     store_fork_digest = test.s_spec.compute_fork_digest(test.genesis_validators_root, store_epoch)
     yield "store_fork_digest", "meta", encode_hex(store_fork_digest)
 
-    return test
+    for _ in range(2 * spec.SLOTS_PER_EPOCH):
+        _ = state_transition_with_full_block(spec, state, True, True)
+
+    return (trusted_block, trusted_state, test)
 
 
 def finish_lc_sync_test(test):
@@ -209,12 +212,11 @@ def _emit_upgrade_store(test, new_s_spec, phases=None):
 
 def run_lc_sync_test_single_fork(spec, phases, state, fork):
     # Start test
-    test = yield from setup_lc_sync_test(spec, state, phases=phases)
+    finalized_block, finalized_state, test = yield from setup_lc_sync_test(
+        spec, state, phases=phases
+    )
 
     # Initial `LightClientUpdate`
-    finalized_block = spec.SignedBeaconBlock()
-    finalized_block.message.state_root = state.hash_tree_root()
-    finalized_state = state.copy()
     attested_block = state_transition_with_full_block(spec, state, True, True)
     attested_state = state.copy()
     sync_aggregate, _ = get_sync_aggregate(spec, state, phases=phases)
@@ -379,13 +381,10 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
 
 
 def run_lc_sync_test_multi_fork(spec, phases, state, fork_1, fork_2):
-    # Start test
-    test = yield from setup_lc_sync_test(spec, state, phases[fork_2], phases)
-
-    # Set up so that finalized is from `spec`, ...
-    finalized_block = spec.SignedBeaconBlock()
-    finalized_block.message.state_root = state.hash_tree_root()
-    finalized_state = state.copy()
+    # Start test so that finalized is from `spec`, ...
+    finalized_block, finalized_state, test = yield from setup_lc_sync_test(
+        spec, state, phases[fork_2], phases
+    )
 
     # ..., attested is from `fork_1`, ...
     fork_1_epoch = getattr(phases[fork_1].config, fork_1.upper() + "_FORK_EPOCH")

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_sync.py
@@ -64,12 +64,13 @@ def setup_lc_sync_test(spec, state, s_spec=None, phases=None):
     next_slots(spec, state, spec.SLOTS_PER_EPOCH * 2 - 1)
     trusted_block = state_transition_with_full_block(spec, state, True, True)
     trusted_block_root = trusted_block.message.hash_tree_root()
+    trusted_state = state.copy()
     yield "trusted_block_root", "meta", "0x" + trusted_block_root.hex()
 
     data_epoch = spec.compute_epoch_at_slot(trusted_block.message.slot)
     data_fork_digest = spec.compute_fork_digest(test.genesis_validators_root, data_epoch)
     d_spec = get_spec_for_fork_version(spec, spec.compute_fork_version(data_epoch), phases)
-    data = d_spec.create_light_client_bootstrap(state, trusted_block)
+    data = d_spec.create_light_client_bootstrap(trusted_block, trusted_state)
     yield "bootstrap_fork_digest", "meta", encode_hex(data_fork_digest)
     yield "bootstrap", data
 
@@ -143,12 +144,12 @@ def emit_force_update(test, spec, state):
 def emit_update(
     test,
     spec,
-    state,
     block,
-    attested_state,
+    state,
     attested_block,
-    finalized_state,
+    attested_state,
     finalized_block,
+    finalized_state,
     with_next=True,
     phases=None,
 ):
@@ -156,12 +157,12 @@ def emit_update(
     data_fork_digest = spec.compute_fork_digest(test.genesis_validators_root, data_epoch)
     d_spec = get_spec_for_fork_version(spec, spec.compute_fork_version(data_epoch), phases)
     data = d_spec.create_light_client_update(
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
     )
     if not with_next:
         data.next_sync_committee = spec.SyncCommittee()
@@ -221,12 +222,12 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
@@ -244,12 +245,12 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     update = yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
@@ -269,12 +270,12 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
@@ -291,12 +292,12 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
@@ -312,12 +313,12 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
@@ -334,12 +335,12 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
@@ -360,12 +361,12 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
@@ -416,12 +417,12 @@ def run_lc_sync_test_multi_fork(spec, phases, state, fork_1, fork_2):
     yield from emit_update(
         test,
         spec,
-        state,
         block,
-        attested_state,
+        state,
         attested_block,
-        finalized_state,
+        attested_state,
         finalized_block,
+        finalized_state,
         phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_sync.py
@@ -147,6 +147,7 @@ def emit_update(
     block,
     attested_state,
     attested_block,
+    finalized_state,
     finalized_block,
     with_next=True,
     phases=None,
@@ -155,7 +156,12 @@ def emit_update(
     data_fork_digest = spec.compute_fork_digest(test.genesis_validators_root, data_epoch)
     d_spec = get_spec_for_fork_version(spec, spec.compute_fork_version(data_epoch), phases)
     data = d_spec.create_light_client_update(
-        state, block, attested_state, attested_block, finalized_block
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
     )
     if not with_next:
         data.next_sync_committee = spec.SyncCommittee()
@@ -213,7 +219,15 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     sync_aggregate, _ = get_sync_aggregate(spec, state, phases=phases)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -228,7 +242,15 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     sync_aggregate, _ = get_sync_aggregate(spec, state, phases=phases)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     update = yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -245,7 +267,15 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     sync_aggregate, _ = get_sync_aggregate(spec, state, phases=phases)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -259,7 +289,15 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     state, block = do_fork(state, spec, phases[fork], fork_epoch, sync_aggregate=sync_aggregate)
     spec = phases[fork]
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -272,7 +310,15 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     sync_aggregate, _ = get_sync_aggregate(spec, state, phases=phases)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -286,7 +332,15 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     sync_aggregate, _ = get_sync_aggregate(spec, state, phases=phases)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -304,7 +358,15 @@ def run_lc_sync_test_single_fork(spec, phases, state, fork):
     sync_aggregate, _ = get_sync_aggregate(spec, state, phases=phases)
     block = state_transition_with_full_block(spec, state, True, True, sync_aggregate=sync_aggregate)
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee
@@ -352,7 +414,15 @@ def run_lc_sync_test_multi_fork(spec, phases, state, fork_1, fork_2):
 
     # Check that update applies
     yield from emit_update(
-        test, spec, state, block, attested_state, attested_block, finalized_block, phases=phases
+        test,
+        spec,
+        state,
+        block,
+        attested_state,
+        attested_block,
+        finalized_state,
+        finalized_block,
+        phases=phases,
     )
     assert test.store.finalized_header.beacon.slot == finalized_state.slot
     assert test.store.next_sync_committee == finalized_state.next_sync_committee


### PR DESCRIPTION
With ePBS in Gloas, we can no longer root execution data proofs in the `BeaconBlockBody`, as the payload may not become available in time. Instead, we'll have to prove based on the corresponding `BeaconState`. To prepare for this and reduce code churn when adding Gloas compatible light client specs, ensure that `BeaconState` is available when creating `LightClientHeader`. Note, prior forks simply ignore the `BeaconState`, but we want a unified flow through the code for simplicity.
