### PR TITLE
Remove dangerous Hash32() genesis checks and fix genesis state

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -1001,9 +1001,8 @@ def process_parent_execution_payload(state: BeaconState, block: BeaconBlock) -> 
     parent_bid = state.latest_execution_payload_bid
     requests = block.body.parent_execution_requests
 
-    is_genesis_block = parent_bid.block_hash == Hash32()
     is_parent_block_empty = bid.parent_block_hash != parent_bid.block_hash
-    if is_genesis_block or is_parent_block_empty:
+    if is_parent_block_empty:
         # Parent was EMPTY -- no execution requests expected
         assert requests == ExecutionRequests()
         return
@@ -1212,9 +1211,8 @@ def process_withdrawals(
 ) -> None:
     # [New in Gloas:EIP7732]
     # Return early if the parent block is empty
-    is_genesis_block = state.latest_block_hash == Hash32()
     is_parent_block_empty = state.latest_block_hash != state.latest_execution_payload_bid.block_hash
-    if is_genesis_block or is_parent_block_empty:
+    if is_parent_block_empty:
         return
 
     # Get expected withdrawals

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -288,10 +288,6 @@ def get_parent_payload_status(store: Store, block: BeaconBlock) -> PayloadStatus
     parent_block_hash = block.body.signed_execution_payload_bid.message.parent_block_hash
     message_block_hash = parent.body.signed_execution_payload_bid.message.block_hash
 
-    # Check for uninitialized genesis block hash
-    if message_block_hash == Hash32():
-        return PAYLOAD_STATUS_EMPTY
-
     return PAYLOAD_STATUS_FULL if parent_block_hash == message_block_hash else PAYLOAD_STATUS_EMPTY
 ```
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
@@ -135,14 +135,13 @@ def test_process_parent_execution_payload__empty_parent_requires_empty_requests(
 @spec_state_test
 def test_process_parent_execution_payload_genesis(spec, state):
     """
-    Verify that process_parent_execution_payload does not update
-    latest_block_hash when both hashes are Hash32().
+    Verify that process_parent_execution_payload treats genesis as an empty
+    parent when latest_block_hash != bid.block_hash (bid.block_hash is zero).
     """
-    state.latest_block_hash = spec.Hash32()
+    state.latest_block_hash = spec.Hash32(b"\xab" * 32)
     state.latest_execution_payload_bid.block_hash = spec.Hash32()
 
     block = build_empty_block_for_next_slot(spec, state)
-    block.body.signed_execution_payload_bid.message.parent_block_hash = spec.Hash32()
 
     pre_latest_block_hash = state.latest_block_hash
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_withdrawals.py
@@ -1118,9 +1118,9 @@ def test_full_builder_payload_reserves_sweep_slot(spec, state):
 def test_zero_hash_genesis_skips_withdrawals(spec, state):
     """
     Verify that process_withdrawals does not advance withdrawal indices
-    when both hashes are Hash32().
+    when genesis parent is empty (latest_block_hash != bid.block_hash).
     """
-    state.latest_block_hash = spec.Hash32()
+    state.latest_block_hash = spec.Hash32(b"\xab" * 32)
     state.latest_execution_payload_bid.block_hash = spec.Hash32()
 
     pre_state = state.copy()

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_get_parent_payload_status.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_get_parent_payload_status.py
@@ -21,13 +21,15 @@ from eth_consensus_specs.test.helpers.state import (
 def test_get_parent_payload_status__genesis_empty_block_hash(spec, state):
     """
     Verify that get_parent_payload_status returns EMPTY when the parent
-    block's bid has Hash32().
+    block's bid block_hash differs from the child's parent_block_hash
+    (as happens at genesis where bid.block_hash is zero).
     """
     test_steps = []
 
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     anchor_root = get_anchor_root(spec, state)
 
+    # Genesis bid has block_hash = Hash32() (zero)
     store.blocks[anchor_root].body.signed_execution_payload_bid.message.block_hash = spec.Hash32()
 
     yield "anchor_state", state
@@ -36,9 +38,9 @@ def test_get_parent_payload_status__genesis_empty_block_hash(spec, state):
     current_time = state.slot * (spec.config.SLOT_DURATION_MS // 1000) + store.genesis_time
     on_tick_and_append_step(spec, store, current_time, test_steps)
 
-    # Add a block on top of genesis
+    # Add a block on top of genesis — parent_block_hash is the eth1 block hash (non-zero),
+    # which differs from the genesis bid's block_hash (zero), so parent is EMPTY.
     block = build_empty_block_for_next_slot(spec, state)
-    block.body.signed_execution_payload_bid.message.parent_block_hash = spec.Hash32()
     signed_block = state_transition_and_sign_block(spec, state, block)
     yield from tick_and_add_block(spec, store, signed_block, test_steps)
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload.py
@@ -289,9 +289,7 @@ def build_empty_post_gloas_execution_payload_bid(spec, state):
     kzg_list = spec.List[spec.KZGCommitment, spec.MAX_BLOB_COMMITMENTS_PER_BLOCK]()
     # Use self-build: builder_index is the same as the beacon proposer index
     builder_index = spec.BUILDER_INDEX_SELF_BUILD
-    # Set block_hash to a different value than spec.Hash32(),
-    # to distinguish it from the genesis block hash and have
-    # is_parent_node_full correctly return False
+    # Use a non-zero placeholder so the test block is distinguishable
     empty_payload_hash = spec.Hash32(b"\x01" + b"\x00" * 31)
     prev_randao = spec.get_randao_mix(state, spec.get_current_epoch(state))
     return spec.ExecutionPayloadBid(

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -178,16 +178,16 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
 
     if is_post_gloas(spec):
         # Initialize the latest_execution_payload_bid (match fork upgrade in fork.md).
-        # Genesis payload is EMPTY: ``latest_block_hash`` stays at default zero while
-        # ``bid.block_hash`` is set to the eth1 block hash, so the parent of any
+        # Genesis payload is EMPTY: ``latest_block_hash`` is set to the eth1 block
+        # hash while ``bid.block_hash`` stays at default zero, so the parent of any
         # first post-genesis block is (correctly) treated as empty.
-        state.latest_block_hash = spec.Hash32()
+        state.latest_block_hash = spec.Hash32(eth1_block_hash)
         empty_requests_root = spec.hash_tree_root(spec.ExecutionRequests())
         state.latest_execution_payload_bid = spec.ExecutionPayloadBid(
-            block_hash=spec.Hash32(eth1_block_hash),
+            block_hash=spec.Hash32(),
             execution_requests_root=empty_requests_root,
         )
-        genesis_block_body.signed_execution_payload_bid.message.block_hash = eth1_block_hash
+        genesis_block_body.signed_execution_payload_bid.message.block_hash = spec.Hash32()
         genesis_block_body.signed_execution_payload_bid.message.execution_requests_root = (
             empty_requests_root
         )

--- a/tests/infra/helpers/test_withdrawals.py
+++ b/tests/infra/helpers/test_withdrawals.py
@@ -470,9 +470,9 @@ class TestPrepareWithdrawals:
             with patch("tests.infra.helpers.withdrawals.is_post_electra", return_value=True):
                 prepare_process_withdrawals(spec, state, parent_block_empty=True)
 
-        # latest_block_hash should be zeros, bid.block_hash should be non-zero (mismatch = empty)
-        assert state.latest_block_hash == b"\x00" * 32
-        assert state.latest_execution_payload_bid.block_hash == b"\x01" * 32
+        # latest_block_hash and bid.block_hash should differ (mismatch = empty)
+        assert state.latest_block_hash == b"\x01" * 32
+        assert state.latest_execution_payload_bid.block_hash == b"\x02" * 32
         assert state.latest_block_hash != state.latest_execution_payload_bid.block_hash
 
     def test_prepare_builder_balances(self):

--- a/tests/infra/helpers/withdrawals.py
+++ b/tests/infra/helpers/withdrawals.py
@@ -17,8 +17,8 @@ def set_parent_block_empty(spec, state):
     """
     Helper to set state indicating parent block was empty.
     """
-    state.latest_block_hash = b"\x00" * 32
-    state.latest_execution_payload_bid.block_hash = b"\x01" * 32
+    state.latest_block_hash = b"\x01" * 32
+    state.latest_execution_payload_bid.block_hash = b"\x02" * 32
 
 
 def prepare_process_withdrawals(


### PR DESCRIPTION
## Summary

Fixes #5168

- Remove `is_genesis_block` checks in `process_parent_execution_payload`, `process_withdrawals`, and `get_parent_payload_status` that relied on comparing bid fields to `Hash32()`. An attacker could craft a bid with `block_hash = Hash32()` to trick nodes into skipping execution request validation and withdrawal processing.
- Fix genesis state initialization: set `latest_block_hash = eth1_block_hash` (non-zero) and `bid.block_hash = Hash32()`. This makes genesis a normal "empty parent" detected by hash mismatch, removing the need for special genesis detection.
- Update tests and helpers to match the new semantics.

## Test plan

- [x] `make test fork=gloas` — 1260 passed
- [x] `make test component=fw` — 114 passed
- [x] Targeted: `test_process_parent_execution_payload` (9 passed)
- [x] Targeted: `test_get_parent_payload_status` (1 passed)
- [x] Targeted: `test_zero_hash_genesis_skips_withdrawals` (passed)