### PR TITLE
Test that voluntary exit with withdrawal request fails

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
@@ -14,7 +14,9 @@ from eth_consensus_specs.test.helpers.state import (
     next_epoch_with_full_participation,
     state_transition_and_sign_block,
 )
+from eth_consensus_specs.test.helpers.voluntary_exits import prepare_signed_exits
 from eth_consensus_specs.test.helpers.withdrawals import (
+    prepare_withdrawal_request,
     set_validator_fully_withdrawable,
 )
 from tests.infra.helpers.withdrawals import (
@@ -342,3 +344,40 @@ def test_builder_payment_after_missed_epochs(spec, state):
 
     # Verify the builder was charged — balance decreased by the bid value
     assert state.builders[builder_index].balance == pre_builder_balance - value
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_voluntary_exit_fails_after_parent_payload_withdrawal_request(spec, state):
+    """
+    Test that a voluntary exit is rejected when the parent payload's deferred
+    execution requests have already initiated the validator's exit.
+    """
+    validator_index = spec.get_active_validator_indices(state, spec.get_current_epoch(state))[-1]
+
+    # Move state forward SHARD_COMMITTEE_PERIOD epochs so the validator can exit
+    state.slot += spec.config.SHARD_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
+
+    # Set up the parent block as FULL with a bid that commits to a full-exit
+    # withdrawal request for the validator.
+    set_parent_block_full(spec, state)
+    withdrawal_request = prepare_withdrawal_request(spec, state, validator_index)
+    requests = spec.ExecutionRequests(
+        withdrawals=spec.List[spec.WithdrawalRequest, spec.MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD](
+            [withdrawal_request]
+        ),
+    )
+    state.latest_execution_payload_bid.execution_requests_root = spec.hash_tree_root(requests)
+
+    # Build a block that delivers the parent's deferred execution requests
+    # (initiating the validator's exit) and also tries to voluntarily exit the
+    # same validator. The voluntary exit fails the FAR_FUTURE_EPOCH check.
+    signed_exits = prepare_signed_exits(spec, state, [validator_index])
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.parent_execution_requests = requests
+    block.body.voluntary_exits = signed_exits
+
+    yield "pre", state
+    signed_block = state_transition_and_sign_block(spec, state, block, expect_fail=True)
+    yield "blocks", [signed_block]
+    yield "post", None


### PR DESCRIPTION
Add a test demonstrating that a voluntary exit in a block where the parent payload has a withdrawal request (full exit in this case) for the same validator causes the block processing to fail and therefore the block to be rejected.