### PR TITLE
Note voluntary exit selection with deferred payload processing

### DIFF
--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -20,6 +20,7 @@
       - [Payload attestations](#payload-attestations)
       - [Parent execution requests](#parent-execution-requests)
       - [ExecutionPayload](#executionpayload)
+      - [Voluntary exits](#voluntary-exits)
   - [Payload timeliness attestation](#payload-timeliness-attestation)
     - [Constructing the `PayloadAttestationMessage`](#constructing-the-payloadattestationmessage)
 - [Modified functions](#modified-functions)
@@ -289,6 +290,15 @@ def prepare_execution_payload(
         payload_attributes=payload_attributes,
     )
 ```
+
+##### Voluntary exits
+
+*Note*: Because execution request processing is deferred, a request in
+`parent_execution_requests` can invalidate a voluntary exit in the same block.
+For example, a withdrawal request for a validator will cause a voluntary exit
+for the same validator to fail, invalidating the entire block. When selecting
+voluntary exits to include, proposers should use the state after execution
+requests from the parent payload are applied.
 
 ### Payload timeliness attestation
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -297,8 +297,7 @@ def prepare_execution_payload(
 `parent_execution_requests` can invalidate a voluntary exit in the same block.
 For example, a withdrawal request for a validator will cause a voluntary exit
 for the same validator to fail, invalidating the entire block. When selecting
-voluntary exits to include, proposers should use the state after execution
-requests from the parent payload are applied.
+voluntary exits to include, proposers must take heed of this interaction.
 
 ### Payload timeliness attestation
 


### PR DESCRIPTION
Document that, because execution-request processing is deferred, `parent_execution_requests` are applied to the state before `process_operations` runs, and a request touching the same validator can invalidate a voluntary exit in the same block. Proposers should select voluntary exits against the state after `apply_parent_execution_payload`.