### PR TITLE
Change minimal `PTC_SIZE` to 16 validators

### DIFF
--- a/presets/minimal/gloas.yaml
+++ b/presets/minimal/gloas.yaml
@@ -2,8 +2,8 @@
 
 # Misc
 # ---------------------------------------------------------------
-# [customized] 2**3 (= 8) validators
-PTC_SIZE: 8
+# [customized] 2**4 (= 16) validators
+PTC_SIZE: 16
 
 # Max operations per block
 # ---------------------------------------------------------------

--- a/presets/minimal/gloas.yaml
+++ b/presets/minimal/gloas.yaml
@@ -2,8 +2,8 @@
 
 # Misc
 # ---------------------------------------------------------------
-# [customized] 2**1 (= 2) validators
-PTC_SIZE: 2
+# [customized] 2**3 (= 8) validators
+PTC_SIZE: 8
 
 # Max operations per block
 # ---------------------------------------------------------------


### PR DESCRIPTION
Having only 2 PTC makes it quite difficult to test with minimal preset. I propose to increase it to at least 16 so it’s more likely that the PTC vote resolves.

<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What PR does (but not how it does it)
* Why this PR is necessary, including context
-->

<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->
