### PR TITLE
Make fork digest for pre-fulu epoch compatible across specs

### DIFF
--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -225,6 +225,8 @@ def compute_fork_digest(
     """
     fork_version = compute_fork_version(epoch)
     base_digest = compute_fork_data_root(fork_version, genesis_validators_root)
+
+    # [New in Fulu:EIP7892]
     if epoch < FULU_FORK_EPOCH:
         return ForkDigest(base_digest[:4])
 

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -225,6 +225,8 @@ def compute_fork_digest(
     """
     fork_version = compute_fork_version(epoch)
     base_digest = compute_fork_data_root(fork_version, genesis_validators_root)
+    if epoch < FULU_FORK_EPOCH:
+        return ForkDigest(base_digest[:4])
 
     # [Modified in Fulu:EIP7892]
     # Bitmask digest with hash of blob parameters

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/validator/test_compute_fork_digest.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/validator/test_compute_fork_digest.py
@@ -11,6 +11,7 @@ from eth_consensus_specs.test.context import (
 @single_phase
 @with_config_overrides(
     {
+        "FULU_FORK_EPOCH": 0,
         "BLOB_SCHEDULE": [
             {"EPOCH": 9, "MAX_BLOBS_PER_BLOCK": 9},
             {"EPOCH": 100, "MAX_BLOBS_PER_BLOCK": 100},


### PR DESCRIPTION
Calling the post-Fulu `compute_fork_digest` on a pre-Fulu epoch returns a result that does not match the pre-Fulu `compute_fork_digest` value. This edge case does not usually occur, except in certain light client edge cases where finalized_header / attested_header around the fork boundary point to data from previous fork. Relevant for some tests.
