### PR TITLE
Enable independent CL/EL sync (EIP-8237)

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -47,6 +47,7 @@
     - [New `is_valid_indexed_payload_attestation`](#new-is_valid_indexed_payload_attestation)
     - [New `is_pending_validator`](#new-is_pending_validator)
   - [Misc](#misc-2)
+    - [New `compute_partial_header_hash`](#new-compute_partial_header_hash)
     - [New `convert_builder_index_to_validator_index`](#new-convert_builder_index_to_validator_index)
     - [New `convert_validator_index_to_builder_index`](#new-convert_validator_index_to_builder_index)
     - [New `get_pending_balance_to_withdraw_for_builder`](#new-get_pending_balance_to_withdraw_for_builder)
@@ -270,7 +271,6 @@ class ExecutionPayloadBid(Container):
     value: Gwei
     execution_payment: Gwei
     blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    execution_requests_root: Root
 ```
 
 #### `SignedExecutionPayloadBid`
@@ -331,6 +331,8 @@ class BeaconBlockBody(Container):
     payload_attestations: List[PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS]
     # [New in Gloas:EIP7732]
     parent_execution_requests: ExecutionRequests
+    # [New in Gloas:EIP8237]
+    partial_header_hash: Hash32
 ```
 
 #### `BeaconState`
@@ -538,6 +540,31 @@ def is_pending_validator(state: BeaconState, pubkey: BLSPubkey) -> bool:
 ```
 
 ### Misc
+
+#### New `compute_partial_header_hash`
+
+```python
+def compute_partial_header_hash(
+    parent_hash: Hash32,
+    prev_randao: Bytes32,
+    gas_limit: uint64,
+    timestamp: uint64,
+    withdrawals: Sequence[Withdrawal],
+    slot_number: uint64,
+    execution_requests: ExecutionRequests,
+) -> Hash32:
+    withdrawals_bytes = sum(ssz_serialize(w) for w in withdrawals)
+    requests_bytes = sum(ssz_serialize(r) for l in execution_requests for r in l)
+    return hash(
+        ssz_serialize(parent_hash)
+        + prev_randao
+        + ssz_serialize(gas_limit)
+        + ssz_serialize(timestamp)
+        + withdrawals_bytes
+        + ssz_serialize(slot_number)
+        + requests_bytes
+    )
+```
 
 #### New `convert_builder_index_to_validator_index`
 
@@ -1007,7 +1034,16 @@ def process_parent_execution_payload(state: BeaconState, block: BeaconBlock) -> 
         return
 
     # Parent was FULL -- verify the bid commitment and apply the payload
-    assert hash_tree_root(requests) == parent_bid.execution_requests_root
+    partial_header_hash = compute_partial_header_hash(
+        parent_bid.parent_block_hash,
+        parent_bid.prev_randao,
+        parent_bid.gas_limit,
+        compute_time_at_slot(state, parent_bid.slot),
+        state.payload_expected_withdrawals,
+        parent_bid.slot,
+        requests,
+    )
+    assert block.body.partial_header_hash == partial_header_hash
     apply_parent_execution_payload(state, requests)
 ```
 

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -791,7 +791,16 @@ def verify_execution_payload_envelope(
     assert payload.prev_randao == bid.prev_randao
     assert payload.gas_limit == bid.gas_limit
     assert payload.block_hash == bid.block_hash
-    assert hash_tree_root(envelope.execution_requests) == bid.execution_requests_root
+    partial_header_hash = compute_partial_header_hash(
+        bid.parent_block_hash,
+        bid.prev_randao,
+        bid.gas_limit,
+        compute_time_at_slot(state, bid.slot),
+        state.payload_expected_withdrawals,
+        bid.slot,
+        envelope.execution_requests,
+    )
+    assert payload.partial_header_hash == partial_header_hash
 
     # Verify the execution payload is valid
     assert payload.slot_number == state.slot


### PR DESCRIPTION
This PR implements EIP 8237 that allows for independent sync on the EL and the CL so that the CL does not download payloads on range sync. 