### PR TITLE
Update light client test format to emit store forkversion

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_sync.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_sync.py
@@ -36,14 +36,14 @@ class LightClientSyncTest:
     store: Any
 
 
-def _get_store_fork_epoch(s_spec):
+def _get_store_fork_version(s_spec):
     if is_post_electra(s_spec):
-        return s_spec.config.ELECTRA_FORK_EPOCH
+        return s_spec.config.ELECTRA_FORK_VERSION
     if is_post_deneb(s_spec):
-        return s_spec.config.DENEB_FORK_EPOCH
+        return s_spec.config.DENEB_FORK_VERSION
     if is_post_capella(s_spec):
-        return s_spec.config.CAPELLA_FORK_EPOCH
-    return s_spec.config.ALTAIR_FORK_EPOCH
+        return s_spec.config.CAPELLA_FORK_VERSION
+    return s_spec.config.ALTAIR_FORK_VERSION
 
 
 def setup_lc_sync_test(spec, state, s_spec=None, phases=None):
@@ -76,9 +76,8 @@ def setup_lc_sync_test(spec, state, s_spec=None, phases=None):
 
     upgraded = upgrade_lc_bootstrap_to_new_spec(d_spec, test.s_spec, data, phases)
     test.store = test.s_spec.initialize_light_client_store(trusted_block_root, upgraded)
-    store_epoch = _get_store_fork_epoch(test.s_spec)
-    store_fork_digest = test.s_spec.compute_fork_digest(test.genesis_validators_root, store_epoch)
-    yield "store_fork_digest", "meta", encode_hex(store_fork_digest)
+    store_fork_version = _get_store_fork_version(test.s_spec)
+    yield "store_fork_version", "meta", encode_hex(store_fork_version)
 
     return test
 
@@ -183,18 +182,17 @@ def emit_update(
 
 
 def _emit_upgrade_store(test, new_s_spec, phases=None):
-    old_epoch = _get_store_fork_epoch(test.s_spec)
+    old_fork_version = _get_store_fork_version(test.s_spec)
     test.store = upgrade_lc_store_to_new_spec(test.s_spec, new_s_spec, test.store, phases)
     test.s_spec = new_s_spec
-    store_epoch = _get_store_fork_epoch(test.s_spec)
-    assert store_epoch != old_epoch
-    store_fork_digest = test.s_spec.compute_fork_digest(test.genesis_validators_root, store_epoch)
+    store_fork_version = _get_store_fork_version(test.s_spec)
+    assert store_fork_version != old_fork_version
 
     yield from []  # Consistently enable `yield from` syntax in calling tests
     test.steps.append(
         {
             "upgrade_store": {
-                "store_fork_digest": encode_hex(store_fork_digest),
+                "store_fork_version": encode_hex(store_fork_version),
                 "checks": _get_checks(test.s_spec, test.store),
             }
         }

--- a/tests/formats/light_client/sync.md
+++ b/tests/formats/light_client/sync.md
@@ -11,19 +11,20 @@ client implementing the sync protocol can sync to the latest block header.
 genesis_validators_root: Bytes32  -- string, hex encoded, with 0x prefix
 trusted_block_root: Bytes32       -- string, hex encoded, with 0x prefix
 bootstrap_fork_digest: string     -- encoded `ForkDigest`-context of `bootstrap`
-store_fork_digest: string         -- encoded `ForkDigest`-context of `store` object being tested
+store_fork_version: string        -- encoded `Version` identifying the `store` object's fork
 ```
 
 ### `bootstrap.ssz_snappy`
 
 An SSZ-snappy encoded `bootstrap` object of type `LightClientBootstrap` to
-initialize a local `store` object of type `LightClientStore` with
-`store_fork_digest` using
+initialize a local `store` object of type `LightClientStore` for fork
+`store_fork_version` using
 `initialize_light_client_store(trusted_block_rooot, bootstrap)`. The SSZ type
 can be determined from `bootstrap_fork_digest`.
 
-If `store_fork_digest` differs from `bootstrap_fork_digest`, the `bootstrap`
-object may need to be upgraded before initializing the store.
+If the fork identified by `store_fork_version` differs from the one identified
+by `bootstrap_fork_digest`, the `bootstrap` object may need to be upgraded
+before initializing the store.
 
 ### `steps.yaml`
 
@@ -76,18 +77,19 @@ should be executed with the specified parameters:
 }
 ```
 
-If `store_fork_digest` differs from `update_fork_digest`, the `update` object
-may need to be upgraded before processing the update.
+If the fork identified by `store_fork_version` differs from the one identified
+by `update_fork_digest`, the `update` object may need to be upgraded before
+processing the update.
 
 After this step, the `store` object may have been updated.
 
 #### `upgrade_store`
 
-The `store` should be upgraded to reflect the new `store_fork_digest`:
+The `store` should be upgraded to reflect the new `store_fork_version`:
 
 ```yaml
 {
-    store_fork_digest: string           -- encoded `ForkDigest`-context of `store`
+    store_fork_version: string          -- encoded `Version` identifying the `store` object's fork
     checks: {<store_attribute>: value}  -- the assertions.
 }
 ```


### PR DESCRIPTION
Since Fulu, it is no longer possible to distinguish non-scheduled forks by `ForkDigest`. In light client specs, we have a couple tests that use a `LightClientStore` from a non-scheduled fork to import objects from earlier forks. This means, that if we want to add Gloas support, that we need a way to indicate the fork to use for initializing the store. `ForkVersion` is the closest candidate that avoids ambiguity.
