### PR TITLE
Fix slot check in proposer preferences gossip

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -407,7 +407,7 @@ The following validations MUST pass before forwarding the
   `compute_epoch_at_slot(preferences.proposal_slot)` is in
   `[compute_epoch_at_slot(current_slot), compute_epoch_at_slot(current_slot) + 1]`.
 - _[IGNORE]_ `preferences.proposal_slot` has not already passed -- i.e.
-  `preferences.proposal_slot <= current_slot`.
+  `preferences.proposal_slot > current_slot`.
 - _[IGNORE]_ The block with root `preferences.checkpoint_root` has been seen
   (via gossip or non-gossip sources) (a client MAY queue the message for
   re-processing once the block is retrieved).


### PR DESCRIPTION
We wanna check if `proposal_slot` is greater than the `current_slot`, ie. not in the past, in https://github.com/ethereum/consensus-specs/pull/5190 this check was mistakenly inverted.