### PR TITLE
Add infra tests for with_custom_state

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/context.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/context.py
@@ -1,5 +1,5 @@
 import importlib
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from random import Random
@@ -7,9 +7,9 @@ from typing import Any
 
 import pytest
 from frozendict import frozendict
-from lru import LRU
 
 from eth_consensus_specs.utils import bls
+from tests.infra.context import with_custom_state
 from tests.infra.yield_generator import MultiPhaseResult, vector_test
 
 from .exceptions import SkippedTest
@@ -31,13 +31,11 @@ from .helpers.constants import (
     POST_FORK_OF,
 )
 from .helpers.forks import is_post_electra, is_post_fork, is_post_gloas
-from .helpers.genesis import create_genesis_state
 from .helpers.specs import (
     spec_targets,
 )
 from .helpers.typing import (
     Spec,
-    SpecForks,
 )
 from .utils import (
     with_meta_tags,
@@ -55,45 +53,6 @@ class ForkMeta:
     pre_fork_name: str
     post_fork_name: str
     fork_epoch: int
-
-
-def _prepare_state(
-    balances_fn: Callable[[Any], Sequence[int]],
-    threshold_fn: Callable[[Any], int],
-    spec: Spec,
-    phases: SpecForks,
-):
-    balances = balances_fn(spec)
-    activation_threshold = threshold_fn(spec)
-    state = create_genesis_state(
-        spec=spec, validator_balances=balances, activation_threshold=activation_threshold
-    )
-    return state
-
-
-_custom_state_cache_dict = LRU(size=10)
-
-
-def with_custom_state(
-    balances_fn: Callable[[Any], Sequence[int]], threshold_fn: Callable[[Any], int]
-):
-    def deco(fn):
-        def entry(*args, spec: Spec, phases: SpecForks, **kw):
-            # make a key for the state, unique to the fork + config (incl preset choice) and balances/activations
-            key = (spec.fork, spec.config.__hash__(), spec.__file__, balances_fn, threshold_fn)
-            if key not in _custom_state_cache_dict:
-                state = _prepare_state(balances_fn, threshold_fn, spec, phases)
-                _custom_state_cache_dict[key] = state.get_backing()
-
-            # Take an entry out of the LRU.
-            # No copy is necessary, as we wrap the immutable backing with a new view.
-            state = spec.BeaconState(backing=_custom_state_cache_dict[key])
-            kw["state"] = state
-            return fn(*args, spec=spec, phases=phases, **kw)
-
-        return entry
-
-    return deco
 
 
 def default_activation_threshold(spec: Spec):

--- a/tests/infra/context.py
+++ b/tests/infra/context.py
@@ -1,0 +1,46 @@
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from lru import LRU
+
+from eth_consensus_specs.test.helpers.genesis import create_genesis_state
+from eth_consensus_specs.test.helpers.typing import Spec, SpecForks
+
+
+def _prepare_state(
+    balances_fn: Callable[[Any], Sequence[int]],
+    threshold_fn: Callable[[Any], int],
+    spec: Spec,
+    phases: SpecForks,
+):
+    balances = balances_fn(spec)
+    activation_threshold = threshold_fn(spec)
+    state = create_genesis_state(
+        spec=spec, validator_balances=balances, activation_threshold=activation_threshold
+    )
+    return state
+
+
+_custom_state_cache_dict = LRU(size=10)
+
+
+def with_custom_state(
+    balances_fn: Callable[[Any], Sequence[int]], threshold_fn: Callable[[Any], int]
+):
+    def deco(fn):
+        def entry(*args, spec: Spec, phases: SpecForks, **kw):
+            # make a key for the state, unique to the fork + config (incl preset choice) and balances/activations
+            key = (spec.fork, spec.config.__hash__(), spec.__file__, balances_fn, threshold_fn)
+            if key not in _custom_state_cache_dict:
+                state = _prepare_state(balances_fn, threshold_fn, spec, phases)
+                _custom_state_cache_dict[key] = state.get_backing()
+
+            # Take an entry out of the LRU.
+            # No copy is necessary, as we wrap the immutable backing with a new view.
+            state = spec.BeaconState(backing=_custom_state_cache_dict[key])
+            kw["state"] = state
+            return fn(*args, spec=spec, phases=phases, **kw)
+
+        return entry
+
+    return deco

--- a/tests/infra/test_context.py
+++ b/tests/infra/test_context.py
@@ -1,18 +1,60 @@
-"""Tests for the with_config_overrides decorator."""
+"""Tests for context decorators."""
+
+import pytest
+from lru import LRU
 
 from eth_consensus_specs.test.context import (
     get_copy_of_spec,
     with_config_overrides,
+    with_custom_state as exported_with_custom_state,
 )
 from eth_consensus_specs.test.helpers.constants import MINIMAL
 from eth_consensus_specs.test.helpers.specs import spec_targets
+from tests.infra import context as infra_context
+from tests.infra.context import with_custom_state
 
 
-# Test helper to get a spec instance for testing
 def get_test_spec():
     """Get a minimal phase0 spec for testing."""
     targets = spec_targets[MINIMAL]
     return targets["phase0"]
+
+
+class FakeConfig:
+    """Minimal config stub for testing cache-key behavior."""
+
+    def __init__(self, config_hash=0):
+        self._config_hash = config_hash
+
+    def __hash__(self):
+        return self._config_hash
+
+
+class FakeState:
+    """Minimal state stub wrapping a backing object."""
+
+    def __init__(self, backing):
+        self.backing = backing
+
+    def get_backing(self):
+        return self.backing
+
+
+class FakeSpec:
+    """Minimal spec stub providing BeaconState, fork, config, and __file__."""
+
+    BeaconState = FakeState
+
+    def __init__(self, fork="phase0", config_hash=0, spec_file="phase0.py"):
+        self.fork = fork
+        self.config = FakeConfig(config_hash)
+        self.__file__ = spec_file
+
+
+@pytest.fixture(autouse=True)
+def _reset_custom_state_cache(monkeypatch):
+    """Reset the LRU cache before each test to avoid cross-test leakage."""
+    monkeypatch.setattr(infra_context, "_custom_state_cache_dict", LRU(size=10))
 
 
 class TestWithConfigOverridesDecorator:
@@ -233,9 +275,9 @@ class TestWithConfigOverridesDecorator:
 
         result = decorated_fn(spec=get_test_spec())
 
-        # Both overrides should be applied (outer one wins for spec parameter)
+        # Inner sets CHURN_LIMIT_QUOTIENT, outer sets MIN_PER_EPOCH_CHURN_LIMIT
+        # Both are present because they target different keys
         assert result["churn_limit"] == 111
-        # Inner decorator should have set this
         assert result["churn_quotient"] == 222
 
     def test_with_config_overrides_with_real_fork_versions(self):
@@ -255,3 +297,145 @@ class TestWithConfigOverridesDecorator:
 
         # Should be converted to Version type
         assert result["genesis_version"] == get_test_spec().Version("0x12345678")
+
+
+class TestWithCustomStateDecorator:
+    """Tests for with_custom_state decorator."""
+
+    def test_with_custom_state_is_reexported_from_pyspec_context(self):
+        """Test that pyspec context re-exports the infra decorator."""
+        assert exported_with_custom_state is with_custom_state
+
+    def test_with_custom_state_injects_state_and_preserves_call_arguments(self, monkeypatch):
+        spec = FakeSpec()
+        phases = {"phase0": spec}
+        prepared_backing = object()
+        calls = {}
+
+        def balances_fn(_spec):
+            return [1]
+
+        def threshold_fn(_spec):
+            return 1
+
+        def prepare_state(input_balances_fn, input_threshold_fn, input_spec, input_phases):
+            calls["prepare_args"] = (
+                input_balances_fn,
+                input_threshold_fn,
+                input_spec,
+                input_phases,
+            )
+            return FakeState(prepared_backing)
+
+        monkeypatch.setattr(infra_context, "_prepare_state", prepare_state)
+
+        @with_custom_state(balances_fn=balances_fn, threshold_fn=threshold_fn)
+        def test_case(first_arg, *, spec, phases, state, extra_kwarg):
+            return first_arg, spec, phases, state, extra_kwarg
+
+        first_arg, output_spec, output_phases, state, extra_kwarg = test_case(
+            "first",
+            spec=spec,
+            phases=phases,
+            extra_kwarg="extra",
+        )
+
+        assert calls["prepare_args"] == (balances_fn, threshold_fn, spec, phases)
+        assert first_arg == "first"
+        assert output_spec is spec
+        assert output_phases is phases
+        assert extra_kwarg == "extra"
+        assert state.backing is prepared_backing
+
+    def test_with_custom_state_caches_backing_and_returns_fresh_views(self, monkeypatch):
+        spec = FakeSpec()
+        phases = {"phase0": spec}
+        prepare_calls = []
+        received_args = {}
+
+        def balances_fn(_spec):
+            return [1]
+
+        def threshold_fn(_spec):
+            return 1
+
+        def prepare_state(input_balances_fn, input_threshold_fn, input_spec, input_phases):
+            backing = object()
+            prepare_calls.append((input_balances_fn, input_threshold_fn, input_spec, input_phases))
+            return FakeState(backing)
+
+        monkeypatch.setattr(infra_context, "_prepare_state", prepare_state)
+
+        @with_custom_state(balances_fn=balances_fn, threshold_fn=threshold_fn)
+        def test_case(*, spec, phases, state):
+            received_args["spec"] = spec
+            received_args["phases"] = phases
+            received_args["state"] = state
+            return state
+
+        first_state = test_case(spec=spec, phases=phases)
+        second_state = test_case(spec=spec, phases=phases)
+
+        assert prepare_calls == [(balances_fn, threshold_fn, spec, phases)]
+        assert first_state is not second_state
+        assert first_state.get_backing() is second_state.get_backing()
+        assert received_args["spec"] is spec
+        assert received_args["phases"] is phases
+        assert received_args["state"].get_backing() is first_state.get_backing()
+
+    def test_with_custom_state_cache_key_includes_spec_and_input_functions(self, monkeypatch):
+        phases = {}
+        prepare_calls = []
+
+        def balances_fn(_spec):
+            return [1]
+
+        def other_balances_fn(_spec):
+            return [1]
+
+        def threshold_fn(_spec):
+            return 1
+
+        def other_threshold_fn(_spec):
+            return 1
+
+        def prepare_state(input_balances_fn, input_threshold_fn, input_spec, input_phases):
+            prepare_calls.append((input_balances_fn, input_threshold_fn, input_spec))
+            return FakeState(object())
+
+        monkeypatch.setattr(infra_context, "_prepare_state", prepare_state)
+
+        @with_custom_state(balances_fn=balances_fn, threshold_fn=threshold_fn)
+        def test_case(*, spec, phases, state):
+            return state
+
+        @with_custom_state(balances_fn=other_balances_fn, threshold_fn=threshold_fn)
+        def test_case_other_balances(*, spec, phases, state):
+            return state
+
+        @with_custom_state(balances_fn=balances_fn, threshold_fn=other_threshold_fn)
+        def test_case_other_threshold(*, spec, phases, state):
+            return state
+
+        base_spec = FakeSpec()
+        same_key_spec = FakeSpec()
+        other_fork_spec = FakeSpec(fork="altair")
+        other_config_spec = FakeSpec(config_hash=1)
+        other_file_spec = FakeSpec(spec_file="altair.py")
+
+        test_case(spec=base_spec, phases=phases)
+        test_case(spec=same_key_spec, phases=phases)
+        test_case(spec=other_fork_spec, phases=phases)
+        test_case(spec=other_config_spec, phases=phases)
+        test_case(spec=other_file_spec, phases=phases)
+        test_case_other_balances(spec=base_spec, phases=phases)
+        test_case_other_threshold(spec=base_spec, phases=phases)
+
+        assert prepare_calls == [
+            (balances_fn, threshold_fn, base_spec),
+            (balances_fn, threshold_fn, other_fork_spec),
+            (balances_fn, threshold_fn, other_config_spec),
+            (balances_fn, threshold_fn, other_file_spec),
+            (other_balances_fn, threshold_fn, base_spec),
+            (balances_fn, other_threshold_fn, base_spec),
+        ]

--- a/tests/infra/test_context.py
+++ b/tests/infra/test_context.py
@@ -306,28 +306,52 @@ class TestWithCustomStateDecorator:
         """Test that pyspec context re-exports the infra decorator."""
         assert exported_with_custom_state is with_custom_state
 
+    def test_prepare_state_creates_genesis_from_input_functions(self, monkeypatch):
+        spec = FakeSpec()
+        phases = {"phase0": spec}
+        prepared_state = FakeState(object())
+        calls = {}
+
+        def balances_fn(input_spec):
+            calls["balances_spec"] = input_spec
+            return [32, 64]
+
+        def threshold_fn(input_spec):
+            calls["threshold_spec"] = input_spec
+            return 32
+
+        def create_genesis_state(*, spec, validator_balances, activation_threshold):
+            calls["genesis_args"] = (spec, validator_balances, activation_threshold)
+            return prepared_state
+
+        monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
+
+        state = infra_context._prepare_state(balances_fn, threshold_fn, spec, phases)
+
+        assert state is prepared_state
+        assert calls["balances_spec"] is spec
+        assert calls["threshold_spec"] is spec
+        assert calls["genesis_args"] == (spec, [32, 64], 32)
+
     def test_with_custom_state_injects_state_and_preserves_call_arguments(self, monkeypatch):
         spec = FakeSpec()
         phases = {"phase0": spec}
         prepared_backing = object()
         calls = {}
 
-        def balances_fn(_spec):
-            return [1]
+        def balances_fn(input_spec):
+            calls["balances_spec"] = input_spec
+            return [1, 2]
 
-        def threshold_fn(_spec):
+        def threshold_fn(input_spec):
+            calls["threshold_spec"] = input_spec
             return 1
 
-        def prepare_state(input_balances_fn, input_threshold_fn, input_spec, input_phases):
-            calls["prepare_args"] = (
-                input_balances_fn,
-                input_threshold_fn,
-                input_spec,
-                input_phases,
-            )
+        def create_genesis_state(*, spec, validator_balances, activation_threshold):
+            calls["genesis_args"] = (spec, validator_balances, activation_threshold)
             return FakeState(prepared_backing)
 
-        monkeypatch.setattr(infra_context, "_prepare_state", prepare_state)
+        monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
         @with_custom_state(balances_fn=balances_fn, threshold_fn=threshold_fn)
         def test_case(first_arg, *, spec, phases, state, extra_kwarg):
@@ -340,7 +364,9 @@ class TestWithCustomStateDecorator:
             extra_kwarg="extra",
         )
 
-        assert calls["prepare_args"] == (balances_fn, threshold_fn, spec, phases)
+        assert calls["balances_spec"] is spec
+        assert calls["threshold_spec"] is spec
+        assert calls["genesis_args"] == (spec, [1, 2], 1)
         assert first_arg == "first"
         assert output_spec is spec
         assert output_phases is phases
@@ -350,21 +376,25 @@ class TestWithCustomStateDecorator:
     def test_with_custom_state_caches_backing_and_returns_fresh_views(self, monkeypatch):
         spec = FakeSpec()
         phases = {"phase0": spec}
-        prepare_calls = []
+        balances_calls = []
+        threshold_calls = []
+        genesis_calls = []
         received_args = {}
 
-        def balances_fn(_spec):
+        def balances_fn(input_spec):
+            balances_calls.append(input_spec)
             return [1]
 
-        def threshold_fn(_spec):
+        def threshold_fn(input_spec):
+            threshold_calls.append(input_spec)
             return 1
 
-        def prepare_state(input_balances_fn, input_threshold_fn, input_spec, input_phases):
+        def create_genesis_state(*, spec, validator_balances, activation_threshold):
             backing = object()
-            prepare_calls.append((input_balances_fn, input_threshold_fn, input_spec, input_phases))
+            genesis_calls.append((spec, validator_balances, activation_threshold))
             return FakeState(backing)
 
-        monkeypatch.setattr(infra_context, "_prepare_state", prepare_state)
+        monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
         @with_custom_state(balances_fn=balances_fn, threshold_fn=threshold_fn)
         def test_case(*, spec, phases, state):
@@ -376,7 +406,9 @@ class TestWithCustomStateDecorator:
         first_state = test_case(spec=spec, phases=phases)
         second_state = test_case(spec=spec, phases=phases)
 
-        assert prepare_calls == [(balances_fn, threshold_fn, spec, phases)]
+        assert balances_calls == [spec]
+        assert threshold_calls == [spec]
+        assert genesis_calls == [(spec, [1], 1)]
         assert first_state is not second_state
         assert first_state.get_backing() is second_state.get_backing()
         assert received_args["spec"] is spec
@@ -385,25 +417,25 @@ class TestWithCustomStateDecorator:
 
     def test_with_custom_state_cache_key_includes_spec_and_input_functions(self, monkeypatch):
         phases = {}
-        prepare_calls = []
+        genesis_calls = []
 
         def balances_fn(_spec):
             return [1]
 
         def other_balances_fn(_spec):
-            return [1]
+            return [2]
 
         def threshold_fn(_spec):
-            return 1
+            return 10
 
         def other_threshold_fn(_spec):
-            return 1
+            return 20
 
-        def prepare_state(input_balances_fn, input_threshold_fn, input_spec, input_phases):
-            prepare_calls.append((input_balances_fn, input_threshold_fn, input_spec))
+        def create_genesis_state(*, spec, validator_balances, activation_threshold):
+            genesis_calls.append((spec, validator_balances, activation_threshold))
             return FakeState(object())
 
-        monkeypatch.setattr(infra_context, "_prepare_state", prepare_state)
+        monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
         @with_custom_state(balances_fn=balances_fn, threshold_fn=threshold_fn)
         def test_case(*, spec, phases, state):
@@ -431,11 +463,11 @@ class TestWithCustomStateDecorator:
         test_case_other_balances(spec=base_spec, phases=phases)
         test_case_other_threshold(spec=base_spec, phases=phases)
 
-        assert prepare_calls == [
-            (balances_fn, threshold_fn, base_spec),
-            (balances_fn, threshold_fn, other_fork_spec),
-            (balances_fn, threshold_fn, other_config_spec),
-            (balances_fn, threshold_fn, other_file_spec),
-            (other_balances_fn, threshold_fn, base_spec),
-            (balances_fn, other_threshold_fn, base_spec),
+        assert genesis_calls == [
+            (base_spec, [1], 10),
+            (other_fork_spec, [1], 10),
+            (other_config_spec, [1], 10),
+            (other_file_spec, [1], 10),
+            (base_spec, [2], 10),
+            (base_spec, [1], 20),
         ]

--- a/tests/infra/test_context.py
+++ b/tests/infra/test_context.py
@@ -30,6 +30,14 @@ class FakeConfig:
         return self._config_hash
 
 
+class FakeBacking:
+    """Backing that records the inputs used to create it."""
+
+    def __init__(self, validator_balances, activation_threshold):
+        self.validator_balances = validator_balances
+        self.activation_threshold = activation_threshold
+
+
 class FakeState:
     """Minimal state stub wrapping a backing object."""
 
@@ -309,47 +317,36 @@ class TestWithCustomStateDecorator:
     def test_prepare_state_creates_genesis_from_input_functions(self, monkeypatch):
         spec = FakeSpec()
         phases = {"phase0": spec}
-        prepared_state = FakeState(object())
-        calls = {}
 
-        def balances_fn(input_spec):
-            calls["balances_spec"] = input_spec
+        def balances_fn(_spec):
             return [32, 64]
 
-        def threshold_fn(input_spec):
-            calls["threshold_spec"] = input_spec
+        def threshold_fn(_spec):
             return 32
 
         def create_genesis_state(*, spec, validator_balances, activation_threshold):
-            calls["genesis_args"] = (spec, validator_balances, activation_threshold)
-            return prepared_state
+            return FakeState(FakeBacking(validator_balances, activation_threshold))
 
         monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
         state = infra_context._prepare_state(balances_fn, threshold_fn, spec, phases)
 
-        assert state is prepared_state
-        assert calls["balances_spec"] is spec
-        assert calls["threshold_spec"] is spec
-        assert calls["genesis_args"] == (spec, [32, 64], 32)
+        backing = state.get_backing()
+        assert backing.validator_balances == [32, 64]
+        assert backing.activation_threshold == 32
 
     def test_with_custom_state_injects_state_and_preserves_call_arguments(self, monkeypatch):
         spec = FakeSpec()
         phases = {"phase0": spec}
-        prepared_backing = object()
-        calls = {}
 
-        def balances_fn(input_spec):
-            calls["balances_spec"] = input_spec
+        def balances_fn(_spec):
             return [1, 2]
 
-        def threshold_fn(input_spec):
-            calls["threshold_spec"] = input_spec
+        def threshold_fn(_spec):
             return 1
 
         def create_genesis_state(*, spec, validator_balances, activation_threshold):
-            calls["genesis_args"] = (spec, validator_balances, activation_threshold)
-            return FakeState(prepared_backing)
+            return FakeState(FakeBacking(validator_balances, activation_threshold))
 
         monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
@@ -364,60 +361,45 @@ class TestWithCustomStateDecorator:
             extra_kwarg="extra",
         )
 
-        assert calls["balances_spec"] is spec
-        assert calls["threshold_spec"] is spec
-        assert calls["genesis_args"] == (spec, [1, 2], 1)
         assert first_arg == "first"
         assert output_spec is spec
         assert output_phases is phases
         assert extra_kwarg == "extra"
-        assert state.backing is prepared_backing
+        backing = state.get_backing()
+        assert backing.validator_balances == [1, 2]
+        assert backing.activation_threshold == 1
 
     def test_with_custom_state_caches_backing_and_returns_fresh_views(self, monkeypatch):
         spec = FakeSpec()
         phases = {"phase0": spec}
-        balances_calls = []
-        threshold_calls = []
-        genesis_calls = []
-        received_args = {}
 
-        def balances_fn(input_spec):
-            balances_calls.append(input_spec)
+        def balances_fn(_spec):
             return [1]
 
-        def threshold_fn(input_spec):
-            threshold_calls.append(input_spec)
+        def threshold_fn(_spec):
             return 1
 
         def create_genesis_state(*, spec, validator_balances, activation_threshold):
-            backing = object()
-            genesis_calls.append((spec, validator_balances, activation_threshold))
-            return FakeState(backing)
+            return FakeState(FakeBacking(validator_balances, activation_threshold))
 
         monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
         @with_custom_state(balances_fn=balances_fn, threshold_fn=threshold_fn)
         def test_case(*, spec, phases, state):
-            received_args["spec"] = spec
-            received_args["phases"] = phases
-            received_args["state"] = state
             return state
 
         first_state = test_case(spec=spec, phases=phases)
         second_state = test_case(spec=spec, phases=phases)
+        first_backing = first_state.get_backing()
+        second_backing = second_state.get_backing()
 
-        assert balances_calls == [spec]
-        assert threshold_calls == [spec]
-        assert genesis_calls == [(spec, [1], 1)]
         assert first_state is not second_state
-        assert first_state.get_backing() is second_state.get_backing()
-        assert received_args["spec"] is spec
-        assert received_args["phases"] is phases
-        assert received_args["state"].get_backing() is first_state.get_backing()
+        assert first_backing is second_backing
+        assert first_backing.validator_balances == [1]
+        assert first_backing.activation_threshold == 1
 
     def test_with_custom_state_cache_key_includes_spec_and_input_functions(self, monkeypatch):
         phases = {}
-        genesis_calls = []
 
         def balances_fn(_spec):
             return [1]
@@ -432,8 +414,7 @@ class TestWithCustomStateDecorator:
             return 20
 
         def create_genesis_state(*, spec, validator_balances, activation_threshold):
-            genesis_calls.append((spec, validator_balances, activation_threshold))
-            return FakeState(object())
+            return FakeState(FakeBacking(validator_balances, activation_threshold))
 
         monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
@@ -455,19 +436,32 @@ class TestWithCustomStateDecorator:
         other_config_spec = FakeSpec(config_hash=1)
         other_file_spec = FakeSpec(spec_file="altair.py")
 
-        test_case(spec=base_spec, phases=phases)
-        test_case(spec=same_key_spec, phases=phases)
-        test_case(spec=other_fork_spec, phases=phases)
-        test_case(spec=other_config_spec, phases=phases)
-        test_case(spec=other_file_spec, phases=phases)
-        test_case_other_balances(spec=base_spec, phases=phases)
-        test_case_other_threshold(spec=base_spec, phases=phases)
+        s1 = test_case(spec=base_spec, phases=phases)
+        s2 = test_case(spec=same_key_spec, phases=phases)
+        s3 = test_case(spec=other_fork_spec, phases=phases)
+        s4 = test_case(spec=other_config_spec, phases=phases)
+        s5 = test_case(spec=other_file_spec, phases=phases)
+        s6 = test_case_other_balances(spec=base_spec, phases=phases)
+        s7 = test_case_other_threshold(spec=base_spec, phases=phases)
 
-        assert genesis_calls == [
-            (base_spec, [1], 10),
-            (other_fork_spec, [1], 10),
-            (other_config_spec, [1], 10),
-            (other_file_spec, [1], 10),
-            (base_spec, [2], 10),
-            (base_spec, [1], 20),
+        base_backing = s1.get_backing()
+        assert base_backing is s2.get_backing()
+        assert base_backing.validator_balances == [1]
+        assert base_backing.activation_threshold == 10
+
+        distinct_key_backings = [
+            base_backing,
+            s3.get_backing(),
+            s4.get_backing(),
+            s5.get_backing(),
+            s6.get_backing(),
+            s7.get_backing(),
         ]
+        assert len({id(backing) for backing in distinct_key_backings}) == len(
+            distinct_key_backings
+        )
+
+        assert s6.get_backing().validator_balances == [2]
+        assert s6.get_backing().activation_threshold == 10
+        assert s7.get_backing().validator_balances == [1]
+        assert s7.get_backing().activation_threshold == 20

--- a/tests/infra/test_context.py
+++ b/tests/infra/test_context.py
@@ -33,7 +33,8 @@ class FakeConfig:
 class FakeBacking:
     """Backing that records the inputs used to create it."""
 
-    def __init__(self, validator_balances, activation_threshold):
+    def __init__(self, validator_balances, activation_threshold, source_spec=None):
+        self.source_spec = source_spec
         self.validator_balances = validator_balances
         self.activation_threshold = activation_threshold
 
@@ -53,10 +54,19 @@ class FakeSpec:
 
     BeaconState = FakeState
 
-    def __init__(self, fork="phase0", config_hash=0, spec_file="phase0.py"):
+    def __init__(
+        self,
+        fork="phase0",
+        config_hash=0,
+        spec_file="phase0.py",
+        validator_balances=None,
+        activation_threshold=0,
+    ):
         self.fork = fork
         self.config = FakeConfig(config_hash)
         self.__file__ = spec_file
+        self.validator_balances = validator_balances or []
+        self.activation_threshold = activation_threshold
 
 
 @pytest.fixture(autouse=True)
@@ -315,38 +325,43 @@ class TestWithCustomStateDecorator:
         assert exported_with_custom_state is with_custom_state
 
     def test_prepare_state_creates_genesis_from_input_functions(self, monkeypatch):
-        spec = FakeSpec()
+        spec = FakeSpec(validator_balances=[32, 64], activation_threshold=32)
         phases = {"phase0": spec}
 
-        def balances_fn(_spec):
-            return [32, 64]
+        def balances_fn(spec):
+            return spec.validator_balances
 
-        def threshold_fn(_spec):
-            return 32
+        def threshold_fn(spec):
+            return spec.activation_threshold
 
         def create_genesis_state(*, spec, validator_balances, activation_threshold):
-            return FakeState(FakeBacking(validator_balances, activation_threshold))
+            return FakeState(
+                FakeBacking(validator_balances, activation_threshold, source_spec=spec)
+            )
 
         monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
         state = infra_context._prepare_state(balances_fn, threshold_fn, spec, phases)
 
         backing = state.get_backing()
+        assert backing.source_spec is spec
         assert backing.validator_balances == [32, 64]
         assert backing.activation_threshold == 32
 
     def test_with_custom_state_injects_state_and_preserves_call_arguments(self, monkeypatch):
-        spec = FakeSpec()
+        spec = FakeSpec(validator_balances=[1, 2], activation_threshold=1)
         phases = {"phase0": spec}
 
-        def balances_fn(_spec):
-            return [1, 2]
+        def balances_fn(spec):
+            return spec.validator_balances
 
-        def threshold_fn(_spec):
-            return 1
+        def threshold_fn(spec):
+            return spec.activation_threshold
 
         def create_genesis_state(*, spec, validator_balances, activation_threshold):
-            return FakeState(FakeBacking(validator_balances, activation_threshold))
+            return FakeState(
+                FakeBacking(validator_balances, activation_threshold, source_spec=spec)
+            )
 
         monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
@@ -366,21 +381,71 @@ class TestWithCustomStateDecorator:
         assert output_phases is phases
         assert extra_kwarg == "extra"
         backing = state.get_backing()
+        assert backing.source_spec is spec
         assert backing.validator_balances == [1, 2]
         assert backing.activation_threshold == 1
 
-    def test_with_custom_state_caches_backing_and_returns_fresh_views(self, monkeypatch):
-        spec = FakeSpec()
-        phases = {"phase0": spec}
+    def test_with_custom_state_builds_state_from_invocation_spec(self, monkeypatch):
+        phases = {}
 
-        def balances_fn(_spec):
-            return [1]
+        def balances_fn(spec):
+            return spec.validator_balances
 
-        def threshold_fn(_spec):
-            return 1
+        def threshold_fn(spec):
+            return spec.activation_threshold
 
         def create_genesis_state(*, spec, validator_balances, activation_threshold):
-            return FakeState(FakeBacking(validator_balances, activation_threshold))
+            return FakeState(
+                FakeBacking(validator_balances, activation_threshold, source_spec=spec)
+            )
+
+        monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
+
+        @with_custom_state(balances_fn=balances_fn, threshold_fn=threshold_fn)
+        def test_case(*, spec, phases, state):
+            return state
+
+        first_spec = FakeSpec(
+            fork="phase0",
+            config_hash=1,
+            spec_file="phase0.py",
+            validator_balances=[11, 12],
+            activation_threshold=11,
+        )
+        second_spec = FakeSpec(
+            fork="altair",
+            config_hash=2,
+            spec_file="altair.py",
+            validator_balances=[21, 22],
+            activation_threshold=21,
+        )
+
+        first_state = test_case(spec=first_spec, phases=phases)
+        second_state = test_case(spec=second_spec, phases=phases)
+
+        first_backing = first_state.get_backing()
+        second_backing = second_state.get_backing()
+        assert first_backing.source_spec is first_spec
+        assert first_backing.validator_balances == [11, 12]
+        assert first_backing.activation_threshold == 11
+        assert second_backing.source_spec is second_spec
+        assert second_backing.validator_balances == [21, 22]
+        assert second_backing.activation_threshold == 21
+
+    def test_with_custom_state_caches_backing_and_returns_fresh_views(self, monkeypatch):
+        spec = FakeSpec(validator_balances=[1], activation_threshold=1)
+        phases = {"phase0": spec}
+
+        def balances_fn(spec):
+            return spec.validator_balances
+
+        def threshold_fn(spec):
+            return spec.activation_threshold
+
+        def create_genesis_state(*, spec, validator_balances, activation_threshold):
+            return FakeState(
+                FakeBacking(validator_balances, activation_threshold, source_spec=spec)
+            )
 
         monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
@@ -395,26 +460,29 @@ class TestWithCustomStateDecorator:
 
         assert first_state is not second_state
         assert first_backing is second_backing
+        assert first_backing.source_spec is spec
         assert first_backing.validator_balances == [1]
         assert first_backing.activation_threshold == 1
 
     def test_with_custom_state_cache_key_includes_spec_and_input_functions(self, monkeypatch):
         phases = {}
 
-        def balances_fn(_spec):
-            return [1]
+        def balances_fn(spec):
+            return spec.validator_balances
 
-        def other_balances_fn(_spec):
-            return [2]
+        def other_balances_fn(spec):
+            return [balance + 1 for balance in spec.validator_balances]
 
-        def threshold_fn(_spec):
-            return 10
+        def threshold_fn(spec):
+            return spec.activation_threshold
 
-        def other_threshold_fn(_spec):
-            return 20
+        def other_threshold_fn(spec):
+            return spec.activation_threshold + 10
 
         def create_genesis_state(*, spec, validator_balances, activation_threshold):
-            return FakeState(FakeBacking(validator_balances, activation_threshold))
+            return FakeState(
+                FakeBacking(validator_balances, activation_threshold, source_spec=spec)
+            )
 
         monkeypatch.setattr(infra_context, "create_genesis_state", create_genesis_state)
 
@@ -430,11 +498,13 @@ class TestWithCustomStateDecorator:
         def test_case_other_threshold(*, spec, phases, state):
             return state
 
-        base_spec = FakeSpec()
-        same_key_spec = FakeSpec()
-        other_fork_spec = FakeSpec(fork="altair")
-        other_config_spec = FakeSpec(config_hash=1)
-        other_file_spec = FakeSpec(spec_file="altair.py")
+        base_spec = FakeSpec(validator_balances=[1], activation_threshold=10)
+        same_key_spec = FakeSpec(validator_balances=[1], activation_threshold=10)
+        other_fork_spec = FakeSpec(fork="altair", validator_balances=[3], activation_threshold=30)
+        other_config_spec = FakeSpec(config_hash=1, validator_balances=[4], activation_threshold=40)
+        other_file_spec = FakeSpec(
+            spec_file="altair.py", validator_balances=[5], activation_threshold=50
+        )
 
         s1 = test_case(spec=base_spec, phases=phases)
         s2 = test_case(spec=same_key_spec, phases=phases)
@@ -446,8 +516,19 @@ class TestWithCustomStateDecorator:
 
         base_backing = s1.get_backing()
         assert base_backing is s2.get_backing()
+        assert base_backing.source_spec is base_spec
         assert base_backing.validator_balances == [1]
         assert base_backing.activation_threshold == 10
+
+        assert s3.get_backing().source_spec is other_fork_spec
+        assert s3.get_backing().validator_balances == [3]
+        assert s3.get_backing().activation_threshold == 30
+        assert s4.get_backing().source_spec is other_config_spec
+        assert s4.get_backing().validator_balances == [4]
+        assert s4.get_backing().activation_threshold == 40
+        assert s5.get_backing().source_spec is other_file_spec
+        assert s5.get_backing().validator_balances == [5]
+        assert s5.get_backing().activation_threshold == 50
 
         distinct_key_backings = [
             base_backing,
@@ -457,11 +538,11 @@ class TestWithCustomStateDecorator:
             s6.get_backing(),
             s7.get_backing(),
         ]
-        assert len({id(backing) for backing in distinct_key_backings}) == len(
-            distinct_key_backings
-        )
+        assert len({id(backing) for backing in distinct_key_backings}) == len(distinct_key_backings)
 
+        assert s6.get_backing().source_spec is base_spec
         assert s6.get_backing().validator_balances == [2]
         assert s6.get_backing().activation_threshold == 10
+        assert s7.get_backing().source_spec is base_spec
         assert s7.get_backing().validator_balances == [1]
         assert s7.get_backing().activation_threshold == 20


### PR DESCRIPTION
### Description

This PR adds infra coverage for the `with_custom_state` decorator and moves the
decorator implementation from the pyspec test context into `tests/infra/context.py`.

The pyspec context still re-exports `with_custom_state`, so existing tests can
continue importing it from `eth_consensus_specs.test.context`.

The new infra tests cover the re-export, argument passthrough, state injection,
cached backing reuse, fresh state views, and cache key isolation across fork,
config, spec file, balances function, and threshold function.

### Checklist

- [x] Add tests for new functionality (if applicable)
- [x] Run `make lint` to check formatting
- [x] Run `make test` to check tests

### Relations

Fixes #4669
