### PR TITLE
Simplify `bid.parent_block_hash` initialization

### DIFF
--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -102,11 +102,8 @@ proposer what it promised whether it submits the payload or not.
 Builders can broadcast a payload bid for the current or the next slot's proposer
 to include. They produce a `SignedExecutionPayloadBid` as follows.
 
-01. Set `bid.parent_block_hash` to the current head of the execution chain. Let
-    `parent_root = hash_tree_root(state.latest_block_header)`. This is
-    `state.latest_execution_payload_bid.block_hash` if
-    `should_extend_payload(store, parent_root)` is true, otherwise
-    `state.latest_execution_payload_bid.parent_block_hash`.
+01. Set `bid.parent_block_hash` to be the parent hash of the constructed
+    payload, that is `payload.parent_hash`.
 02. Set `bid.parent_block_root` to be the head of the consensus chain. This can
     be obtained from the beacon state as
     `hash_tree_root(state.latest_block_header)`. The `parent_block_root` and


### PR DESCRIPTION
The parent hash should always be consistent with the block hash. The `should_extend_payload` decision was made when we prepared the payload and called the `forkchoice_updated` function. cc @StefanBratanov.
