### PR TITLE
Restore `viable_for_head_roots_and_weights` for gloas

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -556,6 +556,49 @@ def get_basic_store_checks(spec, store, head_root=None):
     }
 
 
+def get_viable_for_head_checks(spec, store):
+    filtered_blocks = spec.get_filtered_block_tree(store)
+
+    if is_post_gloas(spec):
+        root_node = spec.ForkChoiceNode(
+            root=store.justified_checkpoint.root,
+            payload_status=spec.PAYLOAD_STATUS_PENDING,
+        )
+        pending_nodes = [root_node]
+        leaves_viable_for_head = []
+
+        while len(pending_nodes) > 0:
+            node = pending_nodes.pop()
+            children = spec.get_node_children(store, filtered_blocks, node)
+            if len(children) == 0:
+                leaves_viable_for_head.append(node)
+            else:
+                pending_nodes.extend(children)
+
+        return [
+            {
+                "root": encode_hex(node.root),
+                "payload_status": int(node.payload_status),
+                "weight": int(spec.get_weight(store, node)),
+            }
+            for node in leaves_viable_for_head
+        ]
+
+    filtered_block_roots = filtered_blocks.keys()
+    leaves_viable_for_head = [
+        root
+        for root in filtered_block_roots
+        if not any(c for c in filtered_block_roots if store.blocks[c].parent_root == root)
+    ]
+    return [
+        {
+            "root": encode_hex(viable_for_head_root),
+            "weight": int(spec.get_weight(store, viable_for_head_root)),
+        }
+        for viable_for_head_root in leaves_viable_for_head
+    ]
+
+
 def output_store_checks(spec, store, test_steps, with_viable_for_head_weights=False):
     if is_post_gloas(spec):
         head = spec.get_head(store)
@@ -564,22 +607,8 @@ def output_store_checks(spec, store, test_steps, with_viable_for_head_weights=Fa
     else:
         checks = get_basic_store_checks(spec, store)
 
-    if with_viable_for_head_weights and not is_post_gloas(spec):
-        filtered_block_roots = spec.get_filtered_block_tree(store).keys()
-        leaves_viable_for_head = [
-            root
-            for root in filtered_block_roots
-            if not any(c for c in filtered_block_roots if store.blocks[c].parent_root == root)
-        ]
-
-        viable_for_head_roots_and_weights = [
-            {
-                "root": encode_hex(viable_for_head_root),
-                "weight": int(spec.get_weight(store, viable_for_head_root)),
-            }
-            for viable_for_head_root in leaves_viable_for_head
-        ]
-        checks["viable_for_head_roots_and_weights"] = viable_for_head_roots_and_weights
+    if with_viable_for_head_weights:
+        checks["viable_for_head_roots_and_weights"] = get_viable_for_head_checks(spec, store)
 
     test_steps.append({"checks": checks})
 

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -251,8 +251,9 @@ finalized_checkpoint: {
 }
 proposer_boost_root: string   -- Encoded 32-byte value from store.proposer_boost_root
 viable_for_head_roots_and_weights: [{
-    root: string,             -- Encoded 32-byte value of filtered_block_tree leaf blocks
-    weight: int               -- Integer value from get_weight(store, viable_block_root)
+    root: string,             -- Encoded 32-byte value of filtered_block_tree leaf blocks/nodes
+    weight: int,              -- Integer value of the weight of the block/node
+    payload_status: int,      -- Gloas and later, the payload_status of the node
 }]
 ```
 

--- a/tests/generators/compliance_runners/fork_choice/runner/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/runner/test_run.py
@@ -8,6 +8,7 @@ from ruamel.yaml import YAML
 from snappy import uncompress
 
 from eth_consensus_specs.test.context import expect_assertion_error
+from eth_consensus_specs.test.helpers.fork_choice import get_viable_for_head_checks
 from eth_consensus_specs.test.helpers.forks import is_post_gloas
 from eth_consensus_specs.test.helpers.specs import spec_targets
 
@@ -178,20 +179,9 @@ def run_test(test_info):
                     assert checkpoint.epoch == value["epoch"]
                     assert str(checkpoint.root) == str(value["root"])
                 elif check == "viable_for_head_roots_and_weights":
-                    filtered_block_roots = spec.get_filtered_block_tree(store).keys()
-                    leaves_viable_for_head = [
-                        root
-                        for root in filtered_block_roots
-                        if not any(
-                            c for c in filtered_block_roots if store.blocks[c].parent_root == root
-                        )
-                    ]
-                    viable_for_head_roots_and_weights = {
-                        str(viable_for_head_root): int(spec.get_weight(store, viable_for_head_root))
-                        for viable_for_head_root in leaves_viable_for_head
-                    }
-                    expected = {kv["root"]: kv["weight"] for kv in value}
-                    assert expected == viable_for_head_roots_and_weights
+                    actual = value
+                    expected = get_viable_for_head_checks(spec, store)
+                    assert {frozenset(e) for e in actual} == {frozenset(e) for e in expected}
                 elif check == "head_payload_status":
                     head = get_head()
                     assert head.payload_status == value


### PR DESCRIPTION
For some reason, PR #5023 switched off outputting the `viable_for_head_roots_and_weights` check for gloas and later. As a consequence, gloas fork choice comptests have been generated without the check. The PR fixes this. Implementing the check output is somewhat different for gloas, since `get_weight` receives `ForkChoiceNode`.

Related to #5023 