### PR TITLE
Use dependent root for proposer preferences

### DIFF
--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -122,8 +122,9 @@ to include. They produce a `SignedExecutionPayloadBid` as follows.
 06. Set `bid.fee_recipient` to be an execution address to receive the payment.
     The proposer's preferred fee recipient is obtained from the
     `SignedProposerPreferences` whose `message.proposal_slot` matches `bid.slot`
-    and whose `message.checkpoint_root` matches
-    `get_checkpoint_block(store, bid.parent_block_root, compute_epoch_at_slot(bid.slot) - 1)`.
+    and whose `message.dependent_root` matches
+    `get_proposer_dependent_root(parent_state, compute_epoch_at_slot(bid.slot))`,
+    where `parent_state` is the post-state of `bid.parent_block_root`.
 07. Set `bid.gas_limit` to be the gas limit of the constructed payload, which
     must match the `gas_limit` in the `SignedProposerPreferences` referenced in
     step 6.

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -108,7 +108,7 @@ class PartialDataColumnGroupID(Container):
 
 ```python
 class ProposerPreferences(Container):
-    checkpoint_root: Root
+    dependent_root: Root
     proposal_slot: Slot
     validator_index: ValidatorIndex
     fee_recipient: ExecutionAddress
@@ -358,9 +358,10 @@ The following validations MUST pass before forwarding the
 `signed_execution_payload_bid` on the network, assuming the alias
 `bid = signed_execution_payload_bid.message`, the alias
 `signed_proposer_preferences` for the validated `SignedProposerPreferences`
-whose `message.proposal_slot` is `bid.slot` and `message.checkpoint_root` is
-`get_checkpoint_block(store, bid.parent_block_root, compute_epoch_at_slot(bid.slot) - 1)`,
-and the alias `proposer_preferences = signed_proposer_preferences.message`:
+whose `message.proposal_slot` is `bid.slot` and `message.dependent_root` is
+`get_proposer_dependent_root(parent_state, compute_epoch_at_slot(bid.slot))`,
+where `parent_state` is the post-state of `bid.parent_block_root`, and the alias
+`proposer_preferences = signed_proposer_preferences.message`:
 
 - _[IGNORE]_ `bid.slot` is the current slot or the next slot.
 - _[IGNORE]_ The matching `signed_proposer_preferences` has been seen.
@@ -408,16 +409,16 @@ The following validations MUST pass before forwarding the
   `[compute_epoch_at_slot(current_slot), compute_epoch_at_slot(current_slot) + 1]`.
 - _[IGNORE]_ `preferences.proposal_slot` has not already passed -- i.e.
   `preferences.proposal_slot > current_slot`.
-- _[IGNORE]_ The block with root `preferences.checkpoint_root` has been seen
-  (via gossip or non-gossip sources) (a client MAY queue the message for
+- _[IGNORE]_ The block with root `preferences.dependent_root` has been seen (via
+  gossip or non-gossip sources) (a client MAY queue the message for
   re-processing once the block is retrieved).
 - _[REJECT]_ `is_valid_proposal_slot(state, preferences)` returns `True`, where
   `state` is the checkpoint state at the epoch
   `compute_epoch_at_slot(preferences.proposal_slot) - 1` and the root
-  `preferences.checkpoint_root`.
+  `preferences.dependent_root`.
 - _[IGNORE]_ The `signed_proposer_preferences` is the first valid message seen
   for the tuple
-  `(preferences.checkpoint_root, preferences.proposal_slot, preferences.validator_index)`.
+  `(preferences.dependent_root, preferences.proposal_slot, preferences.validator_index)`.
 - _[REJECT]_ `signed_proposer_preferences.signature` is valid with respect to
   the validator's public key.
 
@@ -437,6 +438,14 @@ def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences)
     index = (proposal_epoch - current_epoch) * SLOTS_PER_EPOCH
     index += preferences.proposal_slot % SLOTS_PER_EPOCH
     return state.proposer_lookahead[index] == preferences.validator_index
+```
+
+```python
+def get_proposer_dependent_root(state: BeaconState, epoch: Epoch) -> Root:
+    """
+    Return the dependent root for the proposer lookahead at ``epoch``.
+    """
+    return get_block_root_at_slot(state, Slot(compute_start_slot_at_epoch(Epoch(epoch - 1)) - 1))
 ```
 
 *Note*: Nodes SHOULD subscribe to this topic at least one epoch before the fork

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -153,9 +153,10 @@ def get_upcoming_proposal_slots(
 To construct each `SignedProposerPreferences`:
 
 1. Instantiate a new `ProposerPreferences` object as `preferences`.
-2. Set `preferences.checkpoint_root` to
-   `get_checkpoint_block(store, head_root, compute_epoch_at_slot(preferences.proposal_slot) - 1)`,
-   where `head_root` is the proposer's current head.
+2. Set `preferences.dependent_root` to
+   `get_proposer_dependent_root(state, compute_epoch_at_slot(preferences.proposal_slot))`,
+   where `state` is the proposer's current head state. Use the genesis block
+   root in case of underflow.
 3. Set `preferences.proposal_slot` to `upcoming_proposal_slots[i]`.
 4. Set `preferences.validator_index` to the validator's index.
 5. Set `preferences.fee_recipient` to the execution address where the validator


### PR DESCRIPTION
After more discussion I think it's better to use the `dependent_root` for proposer preferences as it's more aligned with the existing validator mechanism to track duties.