### PR TITLE
Use `Union[None, T]` instead of `Optional[T]` in SSZ datastructures

### DIFF
--- a/pysetup/helpers.py
+++ b/pysetup/helpers.py
@@ -303,6 +303,7 @@ ignored_dependencies = [
     "field",
     "floorlog2",
     "List",
+    "None",
     "Optional",
     "ProgressiveBitlist",
     "ProgressiveList",
@@ -315,6 +316,7 @@ ignored_dependencies = [
     "uint32",
     "uint64",
     "uint8",
+    "Union",
     "Vector",
 ]
 

--- a/pysetup/spec_builders/gloas.py
+++ b/pysetup/spec_builders/gloas.py
@@ -9,6 +9,7 @@ class GloasSpecBuilder(BaseSpecBuilder):
     def imports(cls, preset_name: str):
         return f"""
 from eth_consensus_specs.fulu import {preset_name} as fulu
+from eth_consensus_specs.utils.ssz.ssz_typing import Union
 """
 
     @classmethod

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -163,11 +163,11 @@ class Store(object):
     # [New in Gloas:EIP7732]
     payloads: Dict[Root, ExecutionPayloadEnvelope] = field(default_factory=dict)
     # [New in Gloas:EIP7732]
-    payload_timeliness_vote: Dict[Root, Vector[Optional[boolean], PTC_SIZE]] = field(
+    payload_timeliness_vote: Dict[Root, Vector[Union[None, boolean], PTC_SIZE]] = field(
         default_factory=dict
     )
     # [New in Gloas:EIP7732]
-    payload_data_availability_vote: Dict[Root, Vector[Optional[boolean], PTC_SIZE]] = field(
+    payload_data_availability_vote: Dict[Root, Vector[Union[None, boolean], PTC_SIZE]] = field(
         default_factory=dict
     )
 ```


### PR DESCRIPTION
Recent PR #5180 introduced `Vector[Optional[boolean], PTC_SIZE]]` in `gloas` [fork-choice.md](https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-store).

However, `Optional` is not supported as SSZ type, which breaks the generated `gloas` spec, e.g.
```
% uv run python -c "from eth_consensus_specs.test import context"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/alexvlasov/Work/GitHub/consensus-specs/tests/core/pyspec/eth_consensus_specs/test/context.py", line 35, in <module>
    from .helpers.specs import (
  File "/Users/alexvlasov/Work/GitHub/consensus-specs/tests/core/pyspec/eth_consensus_specs/test/helpers/specs.py", line 16, in <module>
    exec(
  File "<string>", line 1, in <module>
  File "/Users/alexvlasov/Work/GitHub/consensus-specs/tests/core/pyspec/eth_consensus_specs/gloas/__init__.py", line 1, in <module>
    from . import mainnet as spec  # noqa:F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexvlasov/Work/GitHub/consensus-specs/tests/core/pyspec/eth_consensus_specs/gloas/mainnet.py", line 1248, in <module>
    class Store(object):
  File "/Users/alexvlasov/Work/GitHub/consensus-specs/tests/core/pyspec/eth_consensus_specs/gloas/mainnet.py", line 1268, in Store
    payload_timeliness_vote: Dict[Root, Vector[Optional[boolean], PTC_SIZE]] = field(
                                        ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexvlasov/Work/GitHub/consensus-specs/.venv/lib/python3.11/site-packages/remerkleable/complex.py", line 605, in __class_getitem__
    if element_view_cls.is_fixed_byte_length():
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.12_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/typing.py", line 1317, in __getattr__
    return getattr(self.__origin__, attr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.12_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/typing.py", line 474, in __getattr__
    raise AttributeError(item)
AttributeError: is_fixed_byte_length
```

The PR fixes this by using `Vector[Union[None, boolean], PTC_SIZE]` instead.

Related to #5180 