### PR TITLE
Remove pre-capella check in BTEC gossip handler

### DIFF
--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -208,7 +208,6 @@ def validate_bls_to_execution_change_gossip(
     seen: Seen,
     state: BeaconState,
     signed_bls_to_execution_change: SignedBLSToExecutionChange,
-    current_time_ms: uint64,
 ) -> None:
     """
     Validate a SignedBLSToExecutionChange for gossip propagation.
@@ -216,14 +215,6 @@ def validate_bls_to_execution_change_gossip(
     """
     bls_to_execution_change = signed_bls_to_execution_change.message
     validator_index = bls_to_execution_change.validator_index
-
-    # [IGNORE] The current epoch is at or after the Capella fork epoch
-    # (where current_epoch is defined by the current wall-clock time)
-    time_since_genesis_ms = current_time_ms - state.genesis_time * 1000
-    current_slot = Slot(time_since_genesis_ms // SLOT_DURATION_MS)
-    current_epoch = compute_epoch_at_slot(current_slot)
-    if current_epoch < CAPELLA_FORK_EPOCH:
-        raise GossipIgnore("current epoch is pre-capella")
 
     # [IGNORE] This is the first valid bls_to_execution_change received for the validator
     if validator_index in seen.bls_to_execution_change_indices:

--- a/tests/core/pyspec/eth_consensus_specs/test/capella/networking/test_gossip_bls_to_execution_change.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/capella/networking/test_gossip_bls_to_execution_change.py
@@ -1,6 +1,6 @@
 from eth_consensus_specs.test.context import (
     always_bls,
-    spec_configured_state_test,
+    spec_state_test,
     with_capella_and_later,
 )
 from eth_consensus_specs.test.helpers.bls_to_execution_changes import (
@@ -10,18 +10,14 @@ from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
 from eth_consensus_specs.test.helpers.keys import pubkeys
 
 
-def run_validate_bls_to_execution_change_gossip(
-    spec, seen, state, signed_bls_to_execution_change, current_time_ms
-):
+def run_validate_bls_to_execution_change_gossip(spec, seen, state, signed_bls_to_execution_change):
     """
     Run validate_bls_to_execution_change_gossip and return the result.
     Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
              and reason is the exception message (or None for valid).
     """
     try:
-        spec.validate_bls_to_execution_change_gossip(
-            seen, state, signed_bls_to_execution_change, current_time_ms
-        )
+        spec.validate_bls_to_execution_change_gossip(seen, state, signed_bls_to_execution_change)
         return "valid", None
     except spec.GossipIgnore as e:
         return "ignore", str(e)
@@ -29,16 +25,8 @@ def run_validate_bls_to_execution_change_gossip(
         return "reject", str(e)
 
 
-def get_capella_fork_time_ms(spec, state):
-    """
-    Return the current time in milliseconds at the Capella fork epoch.
-    """
-    capella_slot = spec.compute_start_slot_at_epoch(spec.config.CAPELLA_FORK_EPOCH)
-    return spec.compute_time_at_slot_ms(state, capella_slot)
-
-
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_state_test
 def test_gossip_bls_to_execution_change__valid(spec, state):
     """
     Test that a valid `bls_to_execution_change` passes gossip validation.
@@ -48,13 +36,11 @@ def test_gossip_bls_to_execution_change__valid(spec, state):
 
     seen = get_seen(spec)
     signed_bls_to_execution_change = get_signed_bls_to_execution_change(spec, state)
-    current_time_ms = get_capella_fork_time_ms(spec, state)
 
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
-    yield "current_time_ms", "meta", int(current_time_ms)
 
     result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+        spec, seen, state, signed_bls_to_execution_change
     )
     assert result == "valid"
     assert reason is None
@@ -73,43 +59,7 @@ def test_gossip_bls_to_execution_change__valid(spec, state):
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 1})
-def test_gossip_bls_to_execution_change__ignore_pre_capella(spec, state):
-    """
-    Test that a `bls_to_execution_change` before the Capella fork is ignored.
-    """
-    yield "topic", "meta", "bls_to_execution_change"
-    yield "state", state
-
-    seen = get_seen(spec)
-    signed_bls_to_execution_change = get_signed_bls_to_execution_change(spec, state)
-    current_time_ms = spec.compute_time_at_slot_ms(state, spec.Slot(0))
-
-    yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
-    yield "current_time_ms", "meta", int(current_time_ms)
-
-    result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
-    )
-    assert result == "ignore"
-    assert reason == "current epoch is pre-capella"
-
-    yield (
-        "messages",
-        "meta",
-        [
-            {
-                "offset_ms": 0,
-                "message": get_filename(signed_bls_to_execution_change),
-                "expected": "ignore",
-                "reason": reason,
-            }
-        ],
-    )
-
-
-@with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_state_test
 def test_gossip_bls_to_execution_change__ignore_already_seen(spec, state):
     """
     Test that a duplicate `bls_to_execution_change` is ignored.
@@ -120,13 +70,11 @@ def test_gossip_bls_to_execution_change__ignore_already_seen(spec, state):
     messages = []
     seen = get_seen(spec)
     signed_bls_to_execution_change = get_signed_bls_to_execution_change(spec, state)
-    current_time_ms = get_capella_fork_time_ms(spec, state)
 
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
-    yield "current_time_ms", "meta", int(current_time_ms)
 
     result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+        spec, seen, state, signed_bls_to_execution_change
     )
     assert result == "valid"
     assert reason is None
@@ -139,7 +87,7 @@ def test_gossip_bls_to_execution_change__ignore_already_seen(spec, state):
     )
 
     result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+        spec, seen, state, signed_bls_to_execution_change
     )
     assert result == "ignore"
     assert reason == "already seen BLS to execution change for this validator"
@@ -156,7 +104,7 @@ def test_gossip_bls_to_execution_change__ignore_already_seen(spec, state):
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_state_test
 def test_gossip_bls_to_execution_change__reject_validator_index_out_of_range(spec, state):
     """
     Test that a `bls_to_execution_change` with validator index out of range is rejected.
@@ -168,13 +116,11 @@ def test_gossip_bls_to_execution_change__reject_validator_index_out_of_range(spe
     signed_bls_to_execution_change = get_signed_bls_to_execution_change(
         spec, state, validator_index=len(state.validators)
     )
-    current_time_ms = get_capella_fork_time_ms(spec, state)
 
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
-    yield "current_time_ms", "meta", int(current_time_ms)
 
     result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+        spec, seen, state, signed_bls_to_execution_change
     )
     assert result == "reject"
     assert reason == "validator index out of range"
@@ -194,7 +140,7 @@ def test_gossip_bls_to_execution_change__reject_validator_index_out_of_range(spe
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_state_test
 def test_gossip_bls_to_execution_change__reject_not_bls_credentials(spec, state):
     """
     Test that a `bls_to_execution_change` for a validator without BLS credentials is rejected.
@@ -209,13 +155,11 @@ def test_gossip_bls_to_execution_change__reject_not_bls_credentials(spec, state)
     signed_bls_to_execution_change = get_signed_bls_to_execution_change(
         spec, state, validator_index=validator_index
     )
-    current_time_ms = get_capella_fork_time_ms(spec, state)
 
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
-    yield "current_time_ms", "meta", int(current_time_ms)
 
     result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+        spec, seen, state, signed_bls_to_execution_change
     )
     assert result == "reject"
     assert reason == "validator does not have BLS withdrawal credentials"
@@ -235,7 +179,7 @@ def test_gossip_bls_to_execution_change__reject_not_bls_credentials(spec, state)
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_state_test
 def test_gossip_bls_to_execution_change__reject_pubkey_mismatch(spec, state):
     """
     Test that a `bls_to_execution_change` with the wrong withdrawal pubkey is rejected.
@@ -251,13 +195,11 @@ def test_gossip_bls_to_execution_change__reject_pubkey_mismatch(spec, state):
         validator_index=validator_index,
         withdrawal_pubkey=pubkeys[0],
     )
-    current_time_ms = get_capella_fork_time_ms(spec, state)
 
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
-    yield "current_time_ms", "meta", int(current_time_ms)
 
     result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+        spec, seen, state, signed_bls_to_execution_change
     )
     assert result == "reject"
     assert reason == "pubkey does not match validator withdrawal credentials"
@@ -277,7 +219,7 @@ def test_gossip_bls_to_execution_change__reject_pubkey_mismatch(spec, state):
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_state_test
 @always_bls
 def test_gossip_bls_to_execution_change__reject_bad_signature(spec, state):
     """
@@ -289,13 +231,11 @@ def test_gossip_bls_to_execution_change__reject_bad_signature(spec, state):
     seen = get_seen(spec)
     signed_bls_to_execution_change = get_signed_bls_to_execution_change(spec, state)
     signed_bls_to_execution_change.signature = spec.BLSSignature(b"\x42" * 96)
-    current_time_ms = get_capella_fork_time_ms(spec, state)
 
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
-    yield "current_time_ms", "meta", int(current_time_ms)
 
     result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+        spec, seen, state, signed_bls_to_execution_change
     )
     assert result == "reject"
     assert reason == "invalid BLS to execution change signature"


### PR DESCRIPTION
At the interop, I talked with clients about networking tests and there were complications with the `BLSToExecutionChange` gossip validation tests. Unlike other handlers, this handler checks that the current epoch is post-capella. This is annoying to test since the tests do not use realistic epochs. IIRC, this check exists because there were concerns that there would be a fight for inclusion between hackers and victims; see #3206 for more information. This concern is no longer relevant and it would be easier to just remove the check.