### PR TITLE
Add gloas sanity tests for missed payload withdrawal recovery

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
@@ -160,6 +160,59 @@ def test_missed_payload_next_block_with_withdrawals_satisfying_payload(spec, sta
 
 @with_gloas_and_later
 @spec_state_test
+def test_missed_payload_recovery_resumes_with_remaining_withdrawals(spec, state):
+    """
+    Block 1: has withdrawal-eligible validators (more than MAX_WITHDRAWALS_PER_PAYLOAD).
+    Payload for Block 1 does not arrive.
+    Block 2: remaining validators are still withdrawal-eligible and must still accept
+    Block 1's stale withdrawals (W_1).
+    Block 3: declares Block 2 as a FULL parent, causing Block 2's payload to be
+    applied during normal block processing. Withdrawals then resume normally and
+    compute a fresh set for the remaining validators.
+    """
+    # Set up MAX + 2 validators. Block 1 processes exactly MAX, leaving 2 remaining.
+    pre_state, signed_block_1, block_1_withdrawals = _setup_missed_payload_with_withdrawals(
+        spec, state, num_withdrawal_validators=spec.MAX_WITHDRAWALS_PER_PAYLOAD + 2
+    )
+
+    # Process Block 2 (parent empty -> process_withdrawals returns early)
+    block_2 = build_empty_block_for_next_slot(spec, state)
+    signed_block_2 = state_transition_and_sign_block(spec, state, block_2)
+
+    # Block 2 must still accept Block 1's stale withdrawals.
+    satisfying = spec.List[spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD](block_1_withdrawals)
+    assert _attempt_payload_with_withdrawals(spec, state, satisfying)
+
+    # Build Block 3 so block processing treats Block 2 as a FULL parent.
+    # This triggers process_parent_execution_payload for Block 2 before
+    # process_withdrawals computes Block 3's fresh expected withdrawals.
+    block_3 = build_empty_block_for_next_slot(spec, state)
+    block_3.body.signed_execution_payload_bid.message.parent_block_hash = (
+        state.latest_execution_payload_bid.block_hash
+    )
+    signed_block_3 = state_transition_and_sign_block(spec, state, block_3)
+
+    yield "pre", pre_state
+    yield "blocks", [signed_block_1, signed_block_2, signed_block_3]
+    yield "post", state
+
+    # Block 3 applied Block 2's payload, so the parent is now marked FULL.
+    block_2_hash = signed_block_2.message.body.signed_execution_payload_bid.message.block_hash
+    assert state.latest_block_hash == block_2_hash
+
+    resumed_withdrawals = list(state.payload_expected_withdrawals)
+    assert len(resumed_withdrawals) > 0
+    assert resumed_withdrawals != block_1_withdrawals
+
+    # Exactly two validators remained after Block 1's full payload-sized sweep.
+    assert len(resumed_withdrawals) == 2
+
+    resumed = spec.List[spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD](resumed_withdrawals)
+    assert _attempt_payload_with_withdrawals(spec, state, resumed)
+
+
+@with_gloas_and_later
+@spec_state_test
 def test_missed_payload_next_block_with_withdrawals_unsatisfying_payload(spec, state):
     """
     Block 1: has withdrawal-eligible validators (more than MAX_WITHDRAWALS_PER_PAYLOAD).

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
@@ -210,6 +210,9 @@ def test_missed_payload_recovery_resumes_with_remaining_withdrawals(spec, state)
     resumed = spec.List[spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD](resumed_withdrawals)
     assert _attempt_payload_with_withdrawals(spec, state, resumed)
 
+    # Once recovery resumes, Block 1's stale withdrawals must be rejected.
+    assert not _attempt_payload_with_withdrawals(spec, state, satisfying)
+
 
 @with_gloas_and_later
 @spec_state_test

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
@@ -261,7 +261,7 @@ def test_missed_payload_recovery_resumes_without_remaining_withdrawals(spec, sta
 
     # Once recovery is complete, the stale Block 1 withdrawals must no longer be accepted.
     assert not _attempt_payload_with_withdrawals(spec, state, satisfying)
-    
+
 
 @with_gloas_and_later
 @spec_state_test

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
@@ -213,6 +213,58 @@ def test_missed_payload_recovery_resumes_with_remaining_withdrawals(spec, state)
 
 @with_gloas_and_later
 @spec_state_test
+def test_missed_payload_recovery_resumes_without_remaining_withdrawals(spec, state):
+    """
+    Block 1: has withdrawal-eligible validators.
+    Payload for Block 1 does not arrive.
+    Block 2: no new withdrawal-eligible validators and must still accept
+    Block 1's stale withdrawals (W_1).
+    Block 3: declares Block 2 as a FULL parent, causing Block 2's payload to be
+    applied during normal block processing. Withdrawals then resume normally and
+    compute an empty set.
+    """
+    # Set up MAX validators. Block 1 processes exactly MAX, leaving 0 remaining.
+    pre_state, signed_block_1, block_1_withdrawals = _setup_missed_payload_with_withdrawals(
+        spec, state, num_withdrawal_validators=spec.MAX_WITHDRAWALS_PER_PAYLOAD
+    )
+
+    # Process Block 2 (parent empty -> process_withdrawals returns early)
+    block_2 = build_empty_block_for_next_slot(spec, state)
+    signed_block_2 = state_transition_and_sign_block(spec, state, block_2)
+
+    # Block 2 must still accept Block 1's stale withdrawals.
+    satisfying = spec.List[spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD](block_1_withdrawals)
+    assert _attempt_payload_with_withdrawals(spec, state, satisfying)
+
+    # Build Block 3 so block processing treats Block 2 as a FULL parent.
+    # This triggers process_parent_execution_payload for Block 2 before
+    # process_withdrawals computes Block 3's fresh expected withdrawals.
+    block_3 = build_empty_block_for_next_slot(spec, state)
+    block_3.body.signed_execution_payload_bid.message.parent_block_hash = (
+        state.latest_execution_payload_bid.block_hash
+    )
+    signed_block_3 = state_transition_and_sign_block(spec, state, block_3)
+
+    yield "pre", pre_state
+    yield "blocks", [signed_block_1, signed_block_2, signed_block_3]
+    yield "post", state
+
+    # Block 3 applied Block 2's payload, so the parent is now marked FULL.
+    block_2_hash = signed_block_2.message.body.signed_execution_payload_bid.message.block_hash
+    assert state.latest_block_hash == block_2_hash
+
+    resumed_withdrawals = list(state.payload_expected_withdrawals)
+    assert resumed_withdrawals == []
+
+    empty_withdrawals = spec.List[spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD]()
+    assert _attempt_payload_with_withdrawals(spec, state, empty_withdrawals)
+
+    # Once recovery is complete, the stale Block 1 withdrawals must no longer be accepted.
+    assert not _attempt_payload_with_withdrawals(spec, state, satisfying)
+    
+
+@with_gloas_and_later
+@spec_state_test
 def test_missed_payload_next_block_with_withdrawals_unsatisfying_payload(spec, state):
     """
     Block 1: has withdrawal-eligible validators (more than MAX_WITHDRAWALS_PER_PAYLOAD).


### PR DESCRIPTION
**Description**

This PR adds tests to verify that withdrawal processing resumes normally after missed payload recovery in both cases: 
- when withdrawals remain
- when none remain.

**Checklist**
  - [ ] Update documentation (if applicable)
  - [x] Add tests for new functionality (if applicable)
  - [x] Run `make lint` to check formatting
  - [x] Run `make test` to check tests

  Fixes #5038
