### PR TITLE
Check for conflicting payload attestation votes

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -106,6 +106,7 @@
         - [Modified `process_attestation`](#modified-process_attestation)
       - [Payload attestations](#payload-attestations)
         - [New `process_payload_attestation`](#new-process_payload_attestation)
+        - [New `verify_payload_attestation_votes`](#new-verify_payload_attestation_votes)
       - [Proposer slashing](#proposer-slashing)
         - [Modified `process_proposer_slashing`](#modified-process_proposer_slashing)
 
@@ -1515,6 +1516,9 @@ def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
     # Removed `process_consolidation_request`
     # [New in Gloas:EIP7732]
     for_ops(body.payload_attestations, process_payload_attestation)
+
+    # [New in Gloas:EIP7732]
+    verify_payload_attestation_votes(state, body.payload_attestations)
 ```
 
 ##### Deposit requests
@@ -1776,6 +1780,23 @@ def process_payload_attestation(
     # Verify signature
     indexed_payload_attestation = get_indexed_payload_attestation(state, payload_attestation)
     assert is_valid_indexed_payload_attestation(state, indexed_payload_attestation)
+```
+
+###### New `verify_payload_attestation_votes`
+
+```python
+def verify_payload_attestation_votes(
+    state: BeaconState, payload_attestations: Sequence[PayloadAttestation]
+) -> None:
+    """
+    Verify no validator appears in multiple payload attestations with conflicting votes.
+    """
+    validator_votes: Dict[ValidatorIndex, PayloadAttestationData] = {}
+    for payload_attestation in payload_attestations:
+        indexed = get_indexed_payload_attestation(state, payload_attestation)
+        for index in indexed.attesting_indices:
+            assert validator_votes.get(index, indexed.data) == indexed.data
+            validator_votes[index] = indexed.data
 ```
 
 ##### Proposer slashing

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
@@ -2,6 +2,9 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_gloas_and_later,
 )
+from eth_consensus_specs.test.gloas.block_processing.test_process_payload_attestation import (
+    prepare_signed_payload_attestation,
+)
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block,
     build_empty_block_for_next_slot,
@@ -379,4 +382,78 @@ def test_voluntary_exit_fails_after_parent_payload_withdrawal_request(spec, stat
     yield "pre", state
     signed_block = state_transition_and_sign_block(spec, state, block, expect_fail=True)
     yield "blocks", [signed_block]
+    yield "post", None
+
+
+def _build_payload_attestation_for_parent(spec, state, payload_present, attesting_indices):
+    """
+    Build a signed payload attestation voting on the parent block (the block
+    referenced by ``state.latest_block_header``). Computes the parent's root
+    with state_root filled in if needed.
+    """
+    parent_header = state.latest_block_header.copy()
+    if parent_header.state_root == spec.Root():
+        parent_header.state_root = spec.hash_tree_root(state)
+    return prepare_signed_payload_attestation(
+        spec,
+        state,
+        slot=state.latest_block_header.slot,
+        beacon_block_root=spec.hash_tree_root(parent_header),
+        attesting_indices=attesting_indices,
+        payload_present=payload_present,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_payload_attestations_duplicate_non_conflicting_votes(spec, state):
+    """
+    A block including two payload attestations that share the same PTC member
+    with matching votes is accepted.
+    """
+    parent_block = build_empty_block_for_next_slot(spec, state)
+    signed_parent_block = state_transition_and_sign_block(spec, state, parent_block)
+
+    ptc = spec.get_ptc(state, state.latest_block_header.slot)
+    payload_attestation_1 = _build_payload_attestation_for_parent(
+        spec, state, payload_present=True, attesting_indices=[ptc[0]]
+    )
+    payload_attestation_2 = _build_payload_attestation_for_parent(
+        spec, state, payload_present=True, attesting_indices=[ptc[0]]
+    )
+
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.payload_attestations = [payload_attestation_1, payload_attestation_2]
+
+    yield "pre", state
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    yield "blocks", [signed_parent_block, signed_block]
+    yield "post", state
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_payload_attestations_duplicate_conflicting_votes(spec, state):
+    """
+    A block including two payload attestations that share the same PTC member
+    with conflicting votes (different ``payload_present``) is rejected by
+    ``verify_payload_attestation_votes``.
+    """
+    parent_block = build_empty_block_for_next_slot(spec, state)
+    signed_parent_block = state_transition_and_sign_block(spec, state, parent_block)
+
+    ptc = spec.get_ptc(state, state.latest_block_header.slot)
+    payload_attestation_1 = _build_payload_attestation_for_parent(
+        spec, state, payload_present=True, attesting_indices=[ptc[0]]
+    )
+    payload_attestation_2 = _build_payload_attestation_for_parent(
+        spec, state, payload_present=False, attesting_indices=[ptc[0]]
+    )
+
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.payload_attestations = [payload_attestation_1, payload_attestation_2]
+
+    yield "pre", state
+    signed_block = state_transition_and_sign_block(spec, state, block, expect_fail=True)
+    yield "blocks", [signed_parent_block, signed_block]
     yield "post", None


### PR DESCRIPTION
I believe there should be a check in block processing which checks for a conflicting payload attestation vote. It's possible that a buggy/malicious proposer includes two or more aggregate payload attestations where the same validator index shows up in two conflicting votes. If this is detected, I believe the block should be treated as invalid to penalize the proposer. Realistically, this should not be possible due to the following gossip check:

https://github.com/ethereum/consensus-specs/blob/90cee983d1691f631d7e5f678554ff8ad95aec84/specs/gloas/p2p-interface.md?plain=1#L339-L341