### PR TITLE
Use `MIN_SEED_LOOKAHEAD` in proposer preferences

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -404,9 +404,9 @@ The following validations MUST pass before forwarding the
 `signed_proposer_preferences` on the network, assuming the alias
 `preferences = signed_proposer_preferences.message`:
 
-- _[IGNORE]_ `preferences.proposal_slot` is in the current or next epoch -- i.e.
-  `compute_epoch_at_slot(preferences.proposal_slot)` is in
-  `[compute_epoch_at_slot(current_slot), compute_epoch_at_slot(current_slot) + 1]`.
+- _[IGNORE]_ `preferences.proposal_slot` is within the proposer lookahead range
+  -- i.e. `compute_epoch_at_slot(preferences.proposal_slot)` is in
+  `[compute_epoch_at_slot(current_slot), compute_epoch_at_slot(current_slot) + MIN_SEED_LOOKAHEAD]`.
 - _[IGNORE]_ `preferences.proposal_slot` has not already passed -- i.e.
   `preferences.proposal_slot > current_slot`.
 - _[IGNORE]_ The block with root `preferences.dependent_root` has been seen (via
@@ -414,8 +414,8 @@ The following validations MUST pass before forwarding the
   re-processing once the block is retrieved).
 - _[REJECT]_ `is_valid_proposal_slot(state, preferences)` returns `True`, where
   `state` is the checkpoint state at the epoch
-  `compute_epoch_at_slot(preferences.proposal_slot) - 1` and the root
-  `preferences.dependent_root`.
+  `compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD` and
+  the root `preferences.dependent_root`.
 - _[IGNORE]_ The `signed_proposer_preferences` is the first valid message seen
   for the tuple
   `(preferences.dependent_root, preferences.proposal_slot, preferences.validator_index)`.
@@ -425,14 +425,14 @@ The following validations MUST pass before forwarding the
 ```python
 def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences) -> bool:
     """
-    Check if the validator is the proposer for the given slot in the current or
-    next epoch.
+    Check if the validator is the proposer for the given slot within the
+    proposer lookahead range.
     """
     current_epoch = get_current_epoch(state)
     proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
     if proposal_epoch < current_epoch:
         return False
-    if proposal_epoch > current_epoch + Epoch(1):
+    if proposal_epoch > current_epoch + Epoch(MIN_SEED_LOOKAHEAD):
         return False
 
     index = (proposal_epoch - current_epoch) * SLOTS_PER_EPOCH
@@ -445,7 +445,9 @@ def get_proposer_dependent_root(state: BeaconState, epoch: Epoch) -> Root:
     """
     Return the dependent root for the proposer lookahead at ``epoch``.
     """
-    return get_block_root_at_slot(state, Slot(compute_start_slot_at_epoch(Epoch(epoch - 1)) - 1))
+    return get_block_root_at_slot(
+        state, Slot(compute_start_slot_at_epoch(Epoch(epoch - MIN_SEED_LOOKAHEAD)) - 1)
+    )
 ```
 
 *Note*: Nodes SHOULD subscribe to this topic at least one epoch before the fork

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -405,7 +405,7 @@ The following validations MUST pass before forwarding the
 `preferences = signed_proposer_preferences.message`:
 
 - _[IGNORE]_ `preferences.proposal_slot` is within the proposer lookahead --
-  i.e. `compute_epoch_at_slot(preferences.proposal_slot)` is in
+  i.e. `compute_epoch_at_slot(preferences.proposal_slot)` is in the range
   `[compute_epoch_at_slot(current_slot), compute_epoch_at_slot(current_slot) + MIN_SEED_LOOKAHEAD]`.
 - _[IGNORE]_ `preferences.proposal_slot` has not already passed -- i.e.
   `preferences.proposal_slot > current_slot`.

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -404,8 +404,8 @@ The following validations MUST pass before forwarding the
 `signed_proposer_preferences` on the network, assuming the alias
 `preferences = signed_proposer_preferences.message`:
 
-- _[IGNORE]_ `preferences.proposal_slot` is within the proposer lookahead range
-  -- i.e. `compute_epoch_at_slot(preferences.proposal_slot)` is in
+- _[IGNORE]_ `preferences.proposal_slot` is within the proposer lookahead --
+  i.e. `compute_epoch_at_slot(preferences.proposal_slot)` is in
   `[compute_epoch_at_slot(current_slot), compute_epoch_at_slot(current_slot) + MIN_SEED_LOOKAHEAD]`.
 - _[IGNORE]_ `preferences.proposal_slot` has not already passed -- i.e.
   `preferences.proposal_slot > current_slot`.
@@ -426,7 +426,7 @@ The following validations MUST pass before forwarding the
 def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences) -> bool:
     """
     Check if the validator is the proposer for the given slot within the
-    proposer lookahead range.
+    proposer lookahead.
     """
     current_epoch = get_current_epoch(state)
     proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -125,19 +125,20 @@ previous forks as follows
 A validator MAY broadcast `SignedProposerPreferences` messages to the
 `proposer_preferences` gossip topic for each slot returned by
 `get_upcoming_proposal_slots(state, validator_index)`. These include any future
-proposal slots in the current epoch and all proposal slots in the next epoch.
-This allows builders to construct execution payloads with the validator's
-preferred `fee_recipient` and `gas_limit`. If a validator does not broadcast a
-`SignedProposerPreferences` message, this implies that the validator will not
-accept any trustless bids for that slot.
+proposal slots within the proposer lookahead range, i.e. the current epoch and
+the next `MIN_SEED_LOOKAHEAD` epochs. This allows builders to construct
+execution payloads with the validator's preferred `fee_recipient` and
+`gas_limit`. If a validator does not broadcast a `SignedProposerPreferences`
+message, this implies that the validator will not accept any trustless bids for
+that slot.
 
 ```python
 def get_upcoming_proposal_slots(
     state: BeaconState, validator_index: ValidatorIndex
 ) -> Sequence[Slot]:
     """
-    Get the future slots in the current epoch and the slots in the next
-    epoch for which ``validator_index`` is proposing.
+    Get the future slots within the proposer lookahead range for which
+    ``validator_index`` is proposing.
     """
     current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
     upcoming_proposal_slots = []

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -125,19 +125,18 @@ previous forks as follows
 A validator MAY broadcast `SignedProposerPreferences` messages to the
 `proposer_preferences` gossip topic for each slot returned by
 `get_upcoming_proposal_slots(state, validator_index)`. These include any future
-proposal slots within the proposer lookahead range, i.e. the current epoch and
-the next `MIN_SEED_LOOKAHEAD` epochs. This allows builders to construct
-execution payloads with the validator's preferred `fee_recipient` and
-`gas_limit`. If a validator does not broadcast a `SignedProposerPreferences`
-message, this implies that the validator will not accept any trustless bids for
-that slot.
+proposal slots within the proposer lookahead, i.e. the current epoch up to
+`MIN_SEED_LOOKAHEAD` epochs ahead. This allows builders to construct execution
+payloads with the validator's preferred `fee_recipient` and `gas_limit`. If a
+validator does not broadcast a `SignedProposerPreferences` message, this implies
+that the validator will not accept any trustless bids for that slot.
 
 ```python
 def get_upcoming_proposal_slots(
     state: BeaconState, validator_index: ValidatorIndex
 ) -> Sequence[Slot]:
     """
-    Get the future slots within the proposer lookahead range for which
+    Get the future slots within the proposer lookahead for which
     ``validator_index`` is proposing.
     """
     current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))


### PR DESCRIPTION
Noticed there is some inconsistency between proposer preferences and `proposer_lookahead` as defined in fulu. For the latter we use `MIN_SEED_LOOKAHEAD` but proposer preferences refer to next epoch only and assume that `MIN_SEED_LOOKAHEAD == 1`, which is true for minimal/mainnet preset but this can be configured.