### PR TITLE
Add gloas epoch processing functions in `get_process_calls`

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/epoch_processing.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/epoch_processing.py
@@ -18,6 +18,7 @@ def get_process_calls(spec):
         "process_eth1_data_reset",
         "process_pending_deposits",  # electra
         "process_pending_consolidations",  # electra
+        "process_builder_pending_payments",  # gloas
         "process_effective_balance_updates",
         "process_slashings_reset",
         "process_randao_mixes_reset",
@@ -35,6 +36,7 @@ def get_process_calls(spec):
         ),
         "process_sync_committee_updates",  # altair
         "process_proposer_lookahead",  # fulu
+        "process_ptc_window",  # gloas
     ]
 
 


### PR DESCRIPTION
The `get_process_calls` helper drives `run_epoch_processing_to` and `run_epoch_processing_from`, which together produce the `post_epoch` state for every epoch processing test. The list was never updated for Gloas, so `process_builder_pending_payments` and `process_ptc_window` were skipped when computing `post_epoch`. Reference fixtures generated from these tests therefore did not reflect those mutations, which caused Lighthouse's epoch processing tests to only pass when `process_ptc_window` was commented out of its `process_epoch`.

Fixes #5213.