### PR TITLE
Add separate pending builder deposits queue

### DIFF
--- a/presets/mainnet/gloas.yaml
+++ b/presets/mainnet/gloas.yaml
@@ -21,3 +21,8 @@ BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
 # ---------------------------------------------------------------
 # 2**14 (= 16,384) builders
 MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: 16384
+
+# Pending deposits processing
+# ---------------------------------------------------------------
+# 2**7 (= 128) builder pending deposits per epoch
+MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH: 128

--- a/presets/minimal/gloas.yaml
+++ b/presets/minimal/gloas.yaml
@@ -21,3 +21,8 @@ BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
 # ---------------------------------------------------------------
 # [customized] 2**4 (= 16) builders
 MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: 16
+
+# Pending deposits processing
+# ---------------------------------------------------------------
+# [customized] 2**4 (= 16) builder pending deposits per epoch
+MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH: 16

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -47,7 +47,6 @@
     - [New `is_builder_withdrawal_credential`](#new-is_builder_withdrawal_credential)
     - [New `is_attestation_same_slot`](#new-is_attestation_same_slot)
     - [New `is_valid_indexed_payload_attestation`](#new-is_valid_indexed_payload_attestation)
-    - [New `is_pending_validator`](#new-is_pending_validator)
   - [Misc](#misc-2)
     - [New `convert_builder_index_to_validator_index`](#new-convert_builder_index_to_validator_index)
     - [New `convert_validator_index_to_builder_index`](#new-convert_validator_index_to_builder_index)
@@ -532,29 +531,6 @@ def is_valid_indexed_payload_attestation(
     domain = get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(attestation.data.slot))
     signing_root = compute_signing_root(attestation.data, domain)
     return bls.FastAggregateVerify(pubkeys, signing_root, attestation.signature)
-```
-
-#### New `is_pending_validator`
-
-*Note*: This function naively revalidates deposit signatures on every call.
-Implementations SHOULD cache verification results to avoid repeated work.
-
-```python
-def is_pending_validator(state: BeaconState, pubkey: BLSPubkey) -> bool:
-    """
-    Check if a pending deposit with a valid signature is in the queue for the given pubkey.
-    """
-    for pending_deposit in state.pending_deposits:
-        if pending_deposit.pubkey != pubkey:
-            continue
-        if is_valid_deposit_signature(
-            pending_deposit.pubkey,
-            pending_deposit.withdrawal_credentials,
-            pending_deposit.amount,
-            pending_deposit.signature,
-        ):
-            return True
-    return False
 ```
 
 ### Misc
@@ -1628,8 +1604,20 @@ def process_deposit_request(state: BeaconState, deposit_request: DepositRequest)
     )
 
     # [New in Gloas:EIP7732]
-    # Route by withdrawal credential prefix into the appropriate pending queue.
-    if is_builder_withdrawal_credential(deposit_request.withdrawal_credentials):
+    # Route to the path that already covers this pubkey (existing entry in
+    # builders, validators, or either pending queue) so top-ups reach the
+    # right target and a pubkey cannot exist as both a builder and a
+    # validator. Otherwise route by withdrawal credential prefix.
+    pubkey = deposit_request.pubkey
+    builder_pubkeys = [b.pubkey for b in state.builders]
+    validator_pubkeys = [v.pubkey for v in state.validators]
+    is_pending_builder = any(d.pubkey == pubkey for d in state.pending_builder_deposits)
+    is_pending_validator = any(d.pubkey == pubkey for d in state.pending_deposits)
+    if pubkey in builder_pubkeys or is_pending_builder:
+        state.pending_builder_deposits.append(pending_deposit)
+    elif pubkey in validator_pubkeys or is_pending_validator:
+        state.pending_deposits.append(pending_deposit)
+    elif is_builder_withdrawal_credential(deposit_request.withdrawal_credentials):
         state.pending_builder_deposits.append(pending_deposit)
     else:
         state.pending_deposits.append(pending_deposit)

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -16,6 +16,7 @@
   - [Max operations per block](#max-operations-per-block)
   - [State list lengths](#state-list-lengths)
   - [Withdrawals processing](#withdrawals-processing)
+  - [Pending deposits processing](#pending-deposits-processing)
 - [Configuration](#configuration)
   - [Validator cycle](#validator-cycle)
   - [Time parameters](#time-parameters)
@@ -73,6 +74,7 @@
   - [Epoch processing](#epoch-processing)
     - [Modified `process_epoch`](#modified-process_epoch)
     - [Modified `process_pending_deposits`](#modified-process_pending_deposits)
+    - [New `process_builder_pending_deposits`](#new-process_builder_pending_deposits)
     - [New `process_builder_pending_payments`](#new-process_builder_pending_payments)
     - [New `process_ptc_window`](#new-process_ptc_window)
   - [Block processing](#block-processing)
@@ -185,6 +187,12 @@ Gloas is a consensus-layer upgrade containing a number of features. Including:
 | ------------------------------------ | ------------------ |
 | `MAX_BUILDERS_PER_WITHDRAWALS_SWEEP` | `2**14` (= 16,384) |
 
+### Pending deposits processing
+
+| Name                                     | Value                  | Description                                                     |
+| ---------------------------------------- | ---------------------- | --------------------------------------------------------------- |
+| `MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH` | `uint64(2**7)` (= 128) | Maximum number of builder pending deposits to process per epoch |
+
 ## Configuration
 
 ### Validator cycle
@@ -213,7 +221,6 @@ class Builder(Container):
     version: uint8
     execution_address: ExecutionAddress
     balance: Gwei
-    deposit_epoch: Epoch
     withdrawable_epoch: Epoch
 ```
 
@@ -391,6 +398,8 @@ class BeaconState(Container):
     consolidation_balance_to_consume: Gwei
     earliest_consolidation_epoch: Epoch
     pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
+    # [New in Gloas:EIP7732]
+    pending_builder_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
     pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
     pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
     proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
@@ -476,12 +485,7 @@ def is_active_builder(state: BeaconState, builder_index: BuilderIndex) -> bool:
     Check if the builder at ``builder_index`` is active for the given ``state``.
     """
     builder = state.builders[builder_index]
-    return (
-        # Placement in builder list is finalized
-        builder.deposit_epoch < state.finalized_checkpoint.epoch
-        # Has not initiated exit
-        and builder.withdrawable_epoch == FAR_FUTURE_EPOCH
-    )
+    return builder.withdrawable_epoch == FAR_FUTURE_EPOCH
 ```
 
 #### New `is_builder_withdrawal_credential`
@@ -953,7 +957,8 @@ def process_slot(state: BeaconState) -> None:
 #### Modified `process_epoch`
 
 *Note*: The function `process_epoch` is modified in Gloas to call the new
-helpers `process_builder_pending_payments` and `process_ptc_window`.
+helpers `process_builder_pending_deposits`, `process_builder_pending_payments`,
+and `process_ptc_window`.
 
 ```python
 def process_epoch(state: BeaconState) -> None:
@@ -965,6 +970,8 @@ def process_epoch(state: BeaconState) -> None:
     process_eth1_data_reset(state)
     # [Modified in Gloas:EIP8061]
     process_pending_deposits(state)
+    # [New in Gloas:EIP7732]
+    process_builder_pending_deposits(state)
     process_pending_consolidations(state)
     # [New in Gloas:EIP7732]
     process_builder_pending_payments(state)
@@ -1047,6 +1054,31 @@ def process_pending_deposits(state: BeaconState) -> None:
         state.deposit_balance_to_consume = available_for_processing - processed_amount
     else:
         state.deposit_balance_to_consume = Gwei(0)
+```
+
+#### New `process_builder_pending_deposits`
+
+```python
+def process_builder_pending_deposits(state: BeaconState) -> None:
+    finalized_slot = compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
+
+    next_deposit_index = 0
+    for deposit in state.pending_builder_deposits:
+        if deposit.slot > finalized_slot:
+            break
+        if next_deposit_index >= MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH:
+            break
+
+        apply_deposit_for_builder(
+            state,
+            deposit.pubkey,
+            deposit.withdrawal_credentials,
+            deposit.amount,
+            deposit.signature,
+        )
+        next_deposit_index += 1
+
+    state.pending_builder_deposits = state.pending_builder_deposits[next_deposit_index:]
 ```
 
 #### New `process_builder_pending_payments`
@@ -1537,7 +1569,6 @@ def add_builder_to_registry(
     pubkey: BLSPubkey,
     withdrawal_credentials: Bytes32,
     amount: uint64,
-    slot: Slot,
 ) -> None:
     set_or_append_list(
         state.builders,
@@ -1547,7 +1578,6 @@ def add_builder_to_registry(
             version=uint8(withdrawal_credentials[0]),
             execution_address=ExecutionAddress(withdrawal_credentials[12:]),
             balance=amount,
-            deposit_epoch=compute_epoch_at_slot(slot),
             withdrawable_epoch=FAR_FUTURE_EPOCH,
         ),
     )
@@ -1569,13 +1599,12 @@ def apply_deposit_for_builder(
     withdrawal_credentials: Bytes32,
     amount: uint64,
     signature: BLSSignature,
-    slot: Slot,
 ) -> None:
     builder_pubkeys = [b.pubkey for b in state.builders]
     if pubkey not in builder_pubkeys:
         # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
         if is_valid_deposit_signature(pubkey, withdrawal_credentials, amount, signature):
-            add_builder_to_registry(state, pubkey, withdrawal_credentials, amount, slot)
+            add_builder_to_registry(state, pubkey, withdrawal_credentials, amount)
     else:
         # Increase balance by deposit amount
         builder_index = builder_pubkeys.index(pubkey)
@@ -1586,41 +1615,24 @@ def apply_deposit_for_builder(
 
 ```python
 def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
-    # [New in Gloas:EIP7732]
-    builder_pubkeys = [b.pubkey for b in state.builders]
-    validator_pubkeys = [v.pubkey for v in state.validators]
+    # Set deposit request start index
+    if state.deposit_requests_start_index == UNSET_DEPOSIT_REQUESTS_START_INDEX:
+        state.deposit_requests_start_index = deposit_request.index
 
-    # [New in Gloas:EIP7732]
-    # Regardless of the withdrawal credentials prefix, if a builder/validator
-    # already exists with this pubkey, apply the deposit to their balance
-    is_builder = deposit_request.pubkey in builder_pubkeys
-    is_validator = deposit_request.pubkey in validator_pubkeys
-    if is_builder or (
-        is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
-        and not is_validator
-        and not is_pending_validator(state, deposit_request.pubkey)
-    ):
-        # Apply builder deposits immediately
-        apply_deposit_for_builder(
-            state,
-            deposit_request.pubkey,
-            deposit_request.withdrawal_credentials,
-            deposit_request.amount,
-            deposit_request.signature,
-            state.slot,
-        )
-        return
-
-    # Add validator deposits to the queue
-    state.pending_deposits.append(
-        PendingDeposit(
-            pubkey=deposit_request.pubkey,
-            withdrawal_credentials=deposit_request.withdrawal_credentials,
-            amount=deposit_request.amount,
-            signature=deposit_request.signature,
-            slot=state.slot,
-        )
+    pending_deposit = PendingDeposit(
+        pubkey=deposit_request.pubkey,
+        withdrawal_credentials=deposit_request.withdrawal_credentials,
+        amount=deposit_request.amount,
+        signature=deposit_request.signature,
+        slot=state.slot,
     )
+
+    # [New in Gloas:EIP7732]
+    # Route by withdrawal credential prefix into the appropriate pending queue.
+    if is_builder_withdrawal_credential(deposit_request.withdrawal_credentials):
+        state.pending_builder_deposits.append(pending_deposit)
+    else:
+        state.pending_deposits.append(pending_deposit)
 ```
 
 ##### Voluntary exits

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -75,16 +75,20 @@ identify the builder in execution payload bids and envelopes.
 
 ### Activation
 
-Builders become active once the epoch in which they were registered (assigned an
-index) has been finalized. Since registrations occur as soon as deposits reach
-the beacon chain, builders typically become active two epochs after submitting
-their deposit.
+Builders become active as soon as they are registered (assigned an index in
+`state.builders`). Registration only occurs through `apply_deposit_for_builder`,
+which is invoked from `process_builder_pending_deposits` once the originating
+deposit has been finalized. Since deposits typically finalize about two epochs
+after reaching the beacon chain, builders typically become active two epochs
+after submitting their deposit.
 
 *Note*: At the fork, pending deposits with the `BUILDER_WITHDRAWAL_PREFIX` are
-applied to the builder registry. The builder's `deposit_epoch` is set to the
-epoch of the pending deposit, not the fork epoch. Therefore, if that epoch is
-finalized at the fork, the builder will be immediately active. See
-`onboard_builders_from_pending_deposits` for details.
+applied to the builder registry up to `MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH`
+per epoch (and only if the deposit's slot is already finalized at the fork); any
+remaining builder-routed deposits are appended to
+`state.pending_builder_deposits` and drained over subsequent epochs by
+`process_builder_pending_deposits`. See `onboard_builders_from_pending_deposits`
+for details.
 
 ## Builder activities
 

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -60,11 +60,15 @@ def initialize_ptc_window(
 ```python
 def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
     """
-    Applies any pending deposit for builders, effectively
-    onboarding builders at the fork.
+    Applies up to ``MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH`` pending deposits for builders
+    inline at the fork, onboarding those builders. Builder-routed deposits beyond
+    the limit are appended to ``state.pending_builder_deposits`` for later draining
+    by ``process_builder_pending_deposits``.
     """
     validator_pubkeys = [v.pubkey for v in state.validators]
+    finalized_slot = compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
 
+    processed = 0
     pending_deposits = []
     for deposit in state.pending_deposits:
         # Deposits for existing validators stay in pending queue
@@ -73,23 +77,27 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
             continue
 
         # If the pubkey is associated with a builder that was created in a
-        # previous iteration or it is a builder deposit, try to apply the
-        # deposit to the new/existing builder. Note that the function
-        # apply_deposit_for_builder can mutate the state and may add a builder
-        # to the registry. For this reason, the list of builder pubkeys must
-        # be recomputed each iteration.
+        # previous iteration or it is a builder deposit, route to the builder
+        # path. Note that the function apply_deposit_for_builder can mutate the
+        # state and may add a builder to the registry. For this reason, the
+        # list of builder pubkeys must be recomputed each iteration.
         builder_pubkeys = [b.pubkey for b in state.builders]
         is_existing_builder = deposit.pubkey in builder_pubkeys
         has_builder_credentials = is_builder_withdrawal_credential(deposit.withdrawal_credentials)
         if is_existing_builder or has_builder_credentials:
-            apply_deposit_for_builder(
-                state,
-                deposit.pubkey,
-                deposit.withdrawal_credentials,
-                deposit.amount,
-                deposit.signature,
-                deposit.slot,
-            )
+            is_deposit_finalized = deposit.slot <= finalized_slot
+            is_within_limit = processed < MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH
+            if is_deposit_finalized and is_within_limit:
+                apply_deposit_for_builder(
+                    state,
+                    deposit.pubkey,
+                    deposit.withdrawal_credentials,
+                    deposit.amount,
+                    deposit.signature,
+                )
+                processed += 1
+            else:
+                state.pending_builder_deposits.append(deposit)
             continue
 
         # If there is a pending deposit for a new validator that has a valid
@@ -166,6 +174,8 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         consolidation_balance_to_consume=pre.consolidation_balance_to_consume,
         earliest_consolidation_epoch=pre.earliest_consolidation_epoch,
         pending_deposits=pre.pending_deposits,
+        # [New in Gloas:EIP7732]
+        pending_builder_deposits=[],
         pending_partial_withdrawals=pre.pending_partial_withdrawals,
         pending_consolidations=pre.pending_consolidations,
         proposer_lookahead=pre.proposer_lookahead,

--- a/specs/heze/beacon-chain.md
+++ b/specs/heze/beacon-chain.md
@@ -140,6 +140,7 @@ class BeaconState(Container):
     consolidation_balance_to_consume: Gwei
     earliest_consolidation_epoch: Epoch
     pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
+    pending_builder_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
     pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
     pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
     proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]

--- a/specs/heze/fork.md
+++ b/specs/heze/fork.md
@@ -93,6 +93,7 @@ def upgrade_to_heze(pre: gloas.BeaconState) -> BeaconState:
         consolidation_balance_to_consume=pre.consolidation_balance_to_consume,
         earliest_consolidation_epoch=pre.earliest_consolidation_epoch,
         pending_deposits=pre.pending_deposits,
+        pending_builder_deposits=pre.pending_builder_deposits,
         pending_partial_withdrawals=pre.pending_partial_withdrawals,
         pending_consolidations=pre.pending_consolidations,
         proposer_lookahead=pre.proposer_lookahead,

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_deposit_request.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_deposit_request.py
@@ -42,12 +42,18 @@ def run_builder_deposit_request_processing(
     yield "post", state
 
     if not valid:
-        # Invalid deposit should not change state (builder not created)
+        # Under Gloas+, builder deposits queue into ``pending_builder_deposits``
+        # regardless of signature; the signature is only verified at drain time.
+        # The assertion helper drains the queued entry on a copy, so for an
+        # invalid-signature new-builder deposit no builder is added to the
+        # registry. The queue invariants are still validated.
         assert_process_deposit_request(
             spec,
             state,
             pre_state,
-            state_unchanged=True,
+            deposit_request=deposit_request,
+            is_builder_deposit=True,
+            expected_builder_count=pre_builder_count,
         )
     elif is_new_builder:
         # New builder should be added to registry
@@ -607,85 +613,9 @@ def test_process_deposit_request__builder_top_up_last_index(spec, state):
 # Deposit routing tests
 #
 # These tests verify the routing logic in process_deposit_request:
-# - Existing builder pubkey → builder (regardless of credentials)
-# - Existing validator pubkey → validator queue (regardless of credentials)
-# - New pubkey + builder credentials → new builder
-# - New pubkey + validator credentials → validator queue
+# - Builder credentials → pending_builder_deposits
+# - Anything else → pending_deposits
 #
-
-
-@with_gloas_and_later
-@spec_state_test
-def test_process_deposit_request__routing__builder_pubkey_validator_credentials(spec, state):
-    """Test that existing builder pubkey with validator credentials still tops up builder."""
-    builder_pubkey = state.builders[0].pubkey
-    amount = spec.MIN_DEPOSIT_AMOUNT
-    pre_balance = state.builders[0].balance
-    pre_builder_count = len(state.builders)
-
-    # Create validator-style withdrawal credentials (BLS prefix) - but use builder pubkey
-    withdrawal_credentials = spec.BLS_WITHDRAWAL_PREFIX + spec.hash(builder_pubkey)[1:]
-
-    # Use builder_index=0 to use existing builder's pubkey with validator credentials
-    deposit_request = prepare_process_deposit_request(
-        spec,
-        state,
-        builder_index=0,
-        amount=amount,
-        signed=True,
-        withdrawal_credentials=withdrawal_credentials,
-    )
-    pre_state = state.copy()
-
-    yield from run_deposit_request_processing(spec, state, deposit_request)
-
-    # Should top up existing builder (credentials are ignored for existing builders)
-    # is_builder_deposit=True because the pubkey belongs to an existing builder
-    assert_process_deposit_request(
-        spec,
-        state,
-        pre_state,
-        deposit_request=deposit_request,
-        is_builder_deposit=True,
-        expected_builder_count=pre_builder_count,
-        expected_builder_balance=pre_balance + amount,
-    )
-
-
-@with_gloas_and_later
-@spec_state_test
-def test_process_deposit_request__routing__validator_pubkey_builder_credentials(spec, state):
-    """Test that existing validator pubkey with builder credentials goes to validator queue."""
-    validator_pubkey = state.validators[0].pubkey
-    amount = spec.MIN_DEPOSIT_AMOUNT
-
-    # Create builder withdrawal credentials - but use existing validator pubkey
-    withdrawal_credentials = spec.BUILDER_WITHDRAWAL_PREFIX + b"\x00" * 11 + b"\x59" * 20
-
-    # Use validator_index=0 to use existing validator's pubkey with builder credentials
-    deposit_request = prepare_process_deposit_request(
-        spec,
-        state,
-        validator_index=0,
-        amount=amount,
-        signed=True,
-        withdrawal_credentials=withdrawal_credentials,
-    )
-    pre_state = state.copy()
-
-    yield from run_deposit_request_processing(spec, state, deposit_request)
-
-    # Should route to validator queue (pubkey lookup finds validator first)
-    # is_builder_deposit=False because it goes to validator queue
-    assert_process_deposit_request(
-        spec,
-        state,
-        pre_state,
-        deposit_request=deposit_request,
-        is_builder_deposit=False,
-        expected_pending_deposit_pubkey=validator_pubkey,
-        expected_pending_deposit_amount=amount,
-    )
 
 
 @with_gloas_and_later
@@ -852,54 +782,6 @@ def test_process_deposit_request__routing__new_pubkey_compounding_credentials(sp
 @with_gloas_and_later
 @spec_state_test
 @always_bls
-def test_process_deposit_request__routing__pending_deposit_valid_signature(spec, state):
-    """Test that pubkey with pending deposit with valid signature goes to validator queue."""
-    # Use a pubkey that doesn't exist as validator or builder yet
-    new_validator_index = len(state.validators)
-    amount = spec.MIN_DEPOSIT_AMOUNT
-
-    # Add a pending deposit with a valid signature for this pubkey
-    pending_withdrawal_credentials = make_withdrawal_credentials(
-        spec, spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX, b"\xab"
-    )
-    pending_deposit = prepare_pending_deposit(
-        spec,
-        new_validator_index,
-        amount,
-        withdrawal_credentials=pending_withdrawal_credentials,
-        signed=True,
-    )
-    state.pending_deposits.append(pending_deposit)
-
-    # Now create a deposit request with builder credentials for the same pubkey
-    deposit_request = prepare_deposit_request(
-        spec,
-        new_validator_index,
-        amount,
-        index=0,
-        withdrawal_credentials=make_withdrawal_credentials(
-            spec, spec.BUILDER_WITHDRAWAL_PREFIX, b"\x59"
-        ),
-        signed=True,
-    )
-
-    pre_state = state.copy()
-
-    yield from run_deposit_request_processing(spec, state, deposit_request)
-
-    # Should NOT create a new builder (pubkey is a pending validator)
-    assert_process_deposit_request(
-        spec,
-        state,
-        pre_state,
-        deposit_request=deposit_request,
-        is_builder_deposit=False,
-    )
-
-
-@with_gloas_and_later
-@spec_state_test
-@always_bls
 def test_process_deposit_request__routing__pending_deposit_invalid_signature(spec, state):
     """Test that pubkey with pending deposit with invalid signature becomes builder."""
     # Use a pubkey from builder_pubkeys that doesn't exist as validator or builder yet
@@ -1012,183 +894,6 @@ def test_process_deposit_request__nonstandard_credential_padding(spec, state):
         expected_builder_count=pre_builder_count + 1,
         expected_builder_balance=amount,
         expected_execution_address=spec.ExecutionAddress(execution_address),
-    )
-
-
-@with_gloas_and_later
-@spec_state_test
-@always_bls
-def test_process_deposit_request__routing__pending_deposits_invalid_then_valid(spec, state):
-    """Test that pubkey with invalid pending deposits followed by valid one goes to validator queue."""
-    # Use a pubkey that doesn't exist as validator or builder yet
-    new_validator_index = len(state.validators)
-    new_pubkey = pubkeys[new_validator_index]
-    amount = spec.MIN_DEPOSIT_AMOUNT
-
-    # Add multiple pending deposits with invalid signatures first
-    for _ in range(3):
-        invalid_pending_deposit = spec.PendingDeposit(
-            pubkey=new_pubkey,
-            amount=amount,
-            withdrawal_credentials=make_withdrawal_credentials(
-                spec, spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX, b"\xab"
-            ),
-            signature=spec.BLSSignature(),  # Invalid empty signature
-            slot=spec.GENESIS_SLOT,
-        )
-        state.pending_deposits.append(invalid_pending_deposit)
-
-    # Add a valid pending deposit after the invalid ones
-    valid_withdrawal_credentials = make_withdrawal_credentials(
-        spec, spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX, b"\xcd"
-    )
-    valid_pending_deposit = prepare_pending_deposit(
-        spec,
-        new_validator_index,
-        amount,
-        withdrawal_credentials=valid_withdrawal_credentials,
-        signed=True,
-    )
-    state.pending_deposits.append(valid_pending_deposit)
-
-    # Now create a deposit request with builder credentials for the same pubkey
-    deposit_request = prepare_deposit_request(
-        spec,
-        new_validator_index,
-        amount,
-        index=0,
-        withdrawal_credentials=make_withdrawal_credentials(
-            spec, spec.BUILDER_WITHDRAWAL_PREFIX, b"\x59"
-        ),
-        signed=True,
-    )
-
-    pre_state = state.copy()
-
-    yield from run_deposit_request_processing(spec, state, deposit_request)
-
-    # Should NOT create a new builder (there's a valid pending deposit in the queue)
-    assert_process_deposit_request(
-        spec,
-        state,
-        pre_state,
-        deposit_request=deposit_request,
-        is_builder_deposit=False,
-    )
-
-
-@with_gloas_and_later
-@spec_state_test
-@always_bls
-def test_process_deposit_request__routing__pending_deposit_builder_credentials(spec, state):
-    """Test that pubkey with pending deposit with builder credentials goes to validator queue."""
-    # Use a pubkey that doesn't exist as validator or builder yet
-    new_validator_index = len(state.validators)
-    amount = spec.MIN_DEPOSIT_AMOUNT
-
-    # Add a pending deposit with builder credentials and a valid signature
-    pending_withdrawal_credentials = make_withdrawal_credentials(
-        spec, spec.BUILDER_WITHDRAWAL_PREFIX, b"\xab"
-    )
-    pending_deposit = prepare_pending_deposit(
-        spec,
-        new_validator_index,
-        amount,
-        withdrawal_credentials=pending_withdrawal_credentials,
-        signed=True,
-    )
-    state.pending_deposits.append(pending_deposit)
-
-    # Now create another deposit request with builder credentials for the same pubkey
-    deposit_request = prepare_deposit_request(
-        spec,
-        new_validator_index,
-        amount,
-        index=0,
-        withdrawal_credentials=make_withdrawal_credentials(
-            spec, spec.BUILDER_WITHDRAWAL_PREFIX, b"\x59"
-        ),
-        signed=True,
-    )
-
-    pre_state = state.copy()
-
-    yield from run_deposit_request_processing(spec, state, deposit_request)
-
-    # Should NOT create a new builder (pubkey has valid pending deposit)
-    assert_process_deposit_request(
-        spec,
-        state,
-        pre_state,
-        deposit_request=deposit_request,
-        is_builder_deposit=False,
-    )
-
-
-@with_gloas_and_later
-@spec_state_test
-def test_process_deposit_request__routing__pending_deposit_different_pubkeys(spec, state):
-    """
-    Test is_pending_validator skips non-matching pubkeys before finding matching one.
-
-    Exercises the `continue` branch in is_pending_validator when pending deposits
-    with different pubkeys exist before the matching deposit.
-
-    Input State Configured:
-        - Pending deposits for two unrelated validator pubkeys
-        - Pending deposit for the target pubkey
-        - Builder-credential deposit request for the target pubkey
-
-    Output State Verified:
-        - Deposit routed to validator queue (not builder)
-        - is_pending_validator returns True after skipping non-matching deposits
-    """
-    new_validator_index = len(state.validators)
-    amount = spec.MIN_DEPOSIT_AMOUNT
-
-    # Add pending deposits with different pubkeys (these will be skipped via `continue`)
-    for i in range(2):
-        unrelated_index = new_validator_index + 1 + i
-        unrelated_pending = prepare_pending_deposit(
-            spec,
-            unrelated_index,
-            amount,
-            signed=True,
-        )
-        state.pending_deposits.append(unrelated_pending)
-
-    # Add a pending deposit with the target pubkey (this will match)
-    target_pending = prepare_pending_deposit(
-        spec,
-        new_validator_index,
-        amount,
-        signed=True,
-    )
-    state.pending_deposits.append(target_pending)
-
-    # Create a deposit request with builder credentials for the target pubkey
-    deposit_request = prepare_deposit_request(
-        spec,
-        new_validator_index,
-        amount,
-        index=0,
-        withdrawal_credentials=make_withdrawal_credentials(
-            spec, spec.BUILDER_WITHDRAWAL_PREFIX, b"\x59"
-        ),
-        signed=True,
-    )
-
-    pre_state = state.copy()
-
-    yield from run_deposit_request_processing(spec, state, deposit_request)
-
-    # Should NOT create a new builder (is_pending_validator finds matching deposit)
-    assert_process_deposit_request(
-        spec,
-        state,
-        pre_state,
-        deposit_request=deposit_request,
-        is_builder_deposit=False,
     )
 
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_deposit_request.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_deposit_request.py
@@ -6,7 +6,6 @@ from eth_consensus_specs.test.helpers.deposits import (
     prepare_pending_deposit,
 )
 from eth_consensus_specs.test.helpers.keys import (
-    builder_pubkey_to_privkey,
     pubkeys,
 )
 from tests.infra.helpers.deposit_requests import (
@@ -782,62 +781,99 @@ def test_process_deposit_request__routing__new_pubkey_compounding_credentials(sp
 @with_gloas_and_later
 @spec_state_test
 @always_bls
-def test_process_deposit_request__routing__pending_deposit_invalid_signature(spec, state):
-    """Test that pubkey with pending deposit with invalid signature becomes builder."""
-    # Use a pubkey from builder_pubkeys that doesn't exist as validator or builder yet
-    existing_builder_pubkeys = {builder.pubkey for builder in state.builders}
-    new_builder_pubkey = None
-    for pk in builder_pubkey_to_privkey:
-        if pk not in existing_builder_pubkeys:
-            new_builder_pubkey = pk
-            break
-    assert new_builder_pubkey is not None
-    privkey = builder_pubkey_to_privkey[new_builder_pubkey]
+def test_process_deposit_request__routing__pending_validator_locks_pubkey(spec, state):
+    """A builder-credentialed deposit_request whose pubkey already has any
+    entry in ``pending_deposits`` (even an invalid-signature one) routes to
+    the validator path. Pending checks are signature-agnostic so the routing
+    fast path doesn't have to verify signatures."""
+    new_validator_index = len(state.validators)
+    new_pubkey = pubkeys[new_validator_index]
     amount = spec.MIN_DEPOSIT_AMOUNT
 
-    # Add a pending deposit with an invalid signature (won't create a validator)
-    invalid_pending_deposit = spec.PendingDeposit(
-        pubkey=new_builder_pubkey,
-        amount=amount,
-        withdrawal_credentials=make_withdrawal_credentials(
-            spec, spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX, b"\xab"
-        ),
-        signature=spec.BLSSignature(),  # Invalid empty signature
-        slot=spec.GENESIS_SLOT,
+    # Plant an invalid-signature pending validator deposit for the pubkey.
+    state.pending_deposits.append(
+        spec.PendingDeposit(
+            pubkey=new_pubkey,
+            amount=amount,
+            withdrawal_credentials=make_withdrawal_credentials(
+                spec, spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX, b"\xab"
+            ),
+            signature=spec.BLSSignature(),
+            slot=spec.GENESIS_SLOT,
+        )
     )
-    state.pending_deposits.append(invalid_pending_deposit)
 
-    # Now create a deposit request with builder credentials for the same pubkey
+    # Now a builder-credentialed deposit_request for the same pubkey arrives.
     deposit_request = prepare_deposit_request(
         spec,
-        0,
+        new_validator_index,
         amount,
         index=0,
-        pubkey=new_builder_pubkey,
-        privkey=privkey,
         withdrawal_credentials=make_withdrawal_credentials(
             spec, spec.BUILDER_WITHDRAWAL_PREFIX, b"\x59"
         ),
         signed=True,
     )
 
-    pre_builder_count = len(state.builders)
     pre_state = state.copy()
-
     yield from run_deposit_request_processing(spec, state, deposit_request)
 
-    # SHOULD create a new builder (pending deposit has invalid sig, so is_pending_validator is False)
+    # The pending-validator entry locks the pubkey to the validator path.
+    assert_process_deposit_request(
+        spec,
+        state,
+        pre_state,
+        deposit_request=deposit_request,
+        is_builder_deposit=False,
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+@always_bls
+def test_process_deposit_request__routing__pending_builder_locks_pubkey(spec, state):
+    """A validator-credentialed deposit_request whose pubkey already has any
+    entry in ``pending_builder_deposits`` routes to the builder path,
+    preventing the pubkey from existing as both a builder and a validator."""
+    new_validator_index = len(state.validators)
+    new_pubkey = pubkeys[new_validator_index]
+    amount = spec.MIN_DEPOSIT_AMOUNT
+
+    # Plant a pending builder deposit for the pubkey.
+    state.pending_builder_deposits.append(
+        spec.PendingDeposit(
+            pubkey=new_pubkey,
+            amount=amount,
+            withdrawal_credentials=make_withdrawal_credentials(
+                spec, spec.BUILDER_WITHDRAWAL_PREFIX, b"\x59"
+            ),
+            signature=spec.BLSSignature(),
+            slot=spec.GENESIS_SLOT,
+        )
+    )
+
+    # Now a validator-credentialed deposit_request for the same pubkey arrives.
+    deposit_request = prepare_deposit_request(
+        spec,
+        new_validator_index,
+        amount,
+        index=0,
+        withdrawal_credentials=make_withdrawal_credentials(
+            spec, spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX, b"\xab"
+        ),
+        signed=True,
+    )
+
+    pre_state = state.copy()
+    yield from run_deposit_request_processing(spec, state, deposit_request)
+
+    # The pending-builder entry locks the pubkey to the builder path.
     assert_process_deposit_request(
         spec,
         state,
         pre_state,
         deposit_request=deposit_request,
         is_builder_deposit=True,
-        expected_builder_count=pre_builder_count + 1,
-        expected_builder_balance=amount,
-        expected_execution_address=spec.ExecutionAddress(
-            deposit_request.withdrawal_credentials[12:]
-        ),
     )
 
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
@@ -313,39 +313,6 @@ def test_process_execution_payload_bid_invalid_signature_regular_builder(spec, s
 
 @with_gloas_and_later
 @spec_state_test
-def test_process_execution_payload_bid_inactive_builder_deposit_not_finalized(spec, state):
-    """
-    Test inactive builder fails
-    """
-    block, builder_index = prepare_block_with_non_proposer_builder(spec, state)
-
-    # Set the builder's deposit epoch as a non-finalized (future) epoch
-    state.builders[builder_index].deposit_epoch = spec.get_current_epoch(state) + 1
-    assert state.builders[builder_index].withdrawable_epoch == spec.FAR_FUTURE_EPOCH
-    assert spec.is_active_builder(state, builder_index) is False
-
-    # Ensure builder has sufficient balance for the bid to avoid balance check failure
-    value = spec.Gwei(1000000)
-    required_balance = value + spec.MIN_DEPOSIT_AMOUNT
-    state.builders[builder_index].balance = required_balance
-
-    # Create bid with this non-proposer builder
-    signed_bid = prepare_signed_execution_payload_bid(
-        spec,
-        state,
-        builder_index=builder_index,
-        value=value,
-        slot=block.slot,
-        parent_block_root=block.parent_root,
-    )
-
-    block.body.signed_execution_payload_bid = signed_bid
-
-    yield from run_execution_payload_bid_processing(spec, state, block, valid=False)
-
-
-@with_gloas_and_later
-@spec_state_test
 def test_process_execution_payload_bid_inactive_builder_exiting(spec, state):
     """
     Test inactive builder fails

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
@@ -293,17 +293,18 @@ def test_process_parent_execution_payload__full_parent_with_execution_requests(s
 
 @with_gloas_and_later
 @spec_state_test
-def test_process_parent_execution_payload__builder_deposit_after_pending_validator(spec, state):
+def test_process_parent_execution_payload__deposit_routing_by_credentials(spec, state):
     """
-    Test that a builder deposit cannot claim a pubkey that is already a pending validator
-    earlier in the same parent execution requests batch.
+    Test that two deposits for the same pubkey route by credential prefix:
+    validator credentials go to ``pending_deposits``, builder credentials go to
+    ``pending_builder_deposits``. Routing is independent of any pubkey already
+    sitting in either queue.
     """
     new_validator_index = len(state.validators)
     new_validator_pubkey = pubkeys[new_validator_index]
     amount = spec.MIN_DEPOSIT_AMOUNT
 
-    # First deposit: regular validator credentials with valid signature.
-    # Since no validator/builder/pending deposit exists for this pubkey, it is queued as a pending validator.
+    # First deposit: regular validator credentials.
     deposit_request_1 = prepare_deposit_request(
         spec,
         new_validator_index,
@@ -317,9 +318,6 @@ def test_process_parent_execution_payload__builder_deposit_after_pending_validat
     )
 
     # Second deposit: builder credentials for the same pubkey.
-    # ``is_pending_validator`` must see the first deposit (just queued) and route this one
-    # to the pending queue instead of the builder registry, preventing a builder from
-    # claiming a pubkey already in the validator queue.
     deposit_request_2 = prepare_deposit_request(
         spec,
         new_validator_index,
@@ -347,19 +345,24 @@ def test_process_parent_execution_payload__builder_deposit_after_pending_validat
     block = build_empty_block_for_next_slot(spec, state)
     block.body.parent_execution_requests = requests
     pre_pending_deposits_len = len(state.pending_deposits)
+    pre_pending_builder_deposits_len = len(state.pending_builder_deposits)
     pre_builder_count = len(state.builders)
 
     spec.process_slots(state, block.slot)
     yield from run_parent_execution_payload_processing(spec, state, block)
 
-    # Both deposits must end up in the pending queue, with no new builder created
-    assert len(state.pending_deposits) == pre_pending_deposits_len + 2
+    # Validator-credential deposit goes to pending_deposits; builder-credential
+    # deposit goes to pending_builder_deposits. No new builder is created at
+    # block time (drain happens at epoch).
+    assert len(state.pending_deposits) == pre_pending_deposits_len + 1
+    assert len(state.pending_builder_deposits) == pre_pending_builder_deposits_len + 1
     assert len(state.builders) == pre_builder_count
-    first = state.pending_deposits[pre_pending_deposits_len]
-    second = state.pending_deposits[pre_pending_deposits_len + 1]
-    assert first.pubkey == deposit_request_1.pubkey
-    assert first.withdrawal_credentials == deposit_request_1.withdrawal_credentials
-    assert first.amount == deposit_request_1.amount
-    assert second.pubkey == deposit_request_2.pubkey
-    assert second.withdrawal_credentials == deposit_request_2.withdrawal_credentials
-    assert second.amount == deposit_request_2.amount
+
+    queued_validator = state.pending_deposits[pre_pending_deposits_len]
+    queued_builder = state.pending_builder_deposits[pre_pending_builder_deposits_len]
+    assert queued_validator.pubkey == deposit_request_1.pubkey
+    assert queued_validator.withdrawal_credentials == deposit_request_1.withdrawal_credentials
+    assert queued_validator.amount == deposit_request_1.amount
+    assert queued_builder.pubkey == deposit_request_2.pubkey
+    assert queued_builder.withdrawal_credentials == deposit_request_2.withdrawal_credentials
+    assert queued_builder.amount == deposit_request_2.amount

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
@@ -293,12 +293,12 @@ def test_process_parent_execution_payload__full_parent_with_execution_requests(s
 
 @with_gloas_and_later
 @spec_state_test
-def test_process_parent_execution_payload__deposit_routing_by_credentials(spec, state):
+def test_process_parent_execution_payload__same_pubkey_locked_to_first_path(spec, state):
     """
-    Test that two deposits for the same pubkey route by credential prefix:
-    validator credentials go to ``pending_deposits``, builder credentials go to
-    ``pending_builder_deposits``. Routing is independent of any pubkey already
-    sitting in either queue.
+    Test that the first deposit for a pubkey locks it to that path: a later
+    deposit in the same batch with conflicting credentials still routes to the
+    first deposit's queue, preventing the same pubkey from existing as both a
+    builder and a validator.
     """
     new_validator_index = len(state.validators)
     new_validator_pubkey = pubkeys[new_validator_index]
@@ -351,18 +351,18 @@ def test_process_parent_execution_payload__deposit_routing_by_credentials(spec, 
     spec.process_slots(state, block.slot)
     yield from run_parent_execution_payload_processing(spec, state, block)
 
-    # Validator-credential deposit goes to pending_deposits; builder-credential
-    # deposit goes to pending_builder_deposits. No new builder is created at
-    # block time (drain happens at epoch).
-    assert len(state.pending_deposits) == pre_pending_deposits_len + 1
-    assert len(state.pending_builder_deposits) == pre_pending_builder_deposits_len + 1
+    # Both deposits land in pending_deposits — the first locks the pubkey to
+    # the validator path, and the second is routed there despite its builder
+    # credentials.
+    assert len(state.pending_deposits) == pre_pending_deposits_len + 2
+    assert len(state.pending_builder_deposits) == pre_pending_builder_deposits_len
     assert len(state.builders) == pre_builder_count
 
-    queued_validator = state.pending_deposits[pre_pending_deposits_len]
-    queued_builder = state.pending_builder_deposits[pre_pending_builder_deposits_len]
-    assert queued_validator.pubkey == deposit_request_1.pubkey
-    assert queued_validator.withdrawal_credentials == deposit_request_1.withdrawal_credentials
-    assert queued_validator.amount == deposit_request_1.amount
-    assert queued_builder.pubkey == deposit_request_2.pubkey
-    assert queued_builder.withdrawal_credentials == deposit_request_2.withdrawal_credentials
-    assert queued_builder.amount == deposit_request_2.amount
+    first_queued = state.pending_deposits[pre_pending_deposits_len]
+    second_queued = state.pending_deposits[pre_pending_deposits_len + 1]
+    assert first_queued.pubkey == deposit_request_1.pubkey
+    assert first_queued.withdrawal_credentials == deposit_request_1.withdrawal_credentials
+    assert first_queued.amount == deposit_request_1.amount
+    assert second_queued.pubkey == deposit_request_2.pubkey
+    assert second_queued.withdrawal_credentials == deposit_request_2.withdrawal_credentials
+    assert second_queued.amount == deposit_request_2.amount

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_voluntary_exit.py
@@ -51,34 +51,6 @@ def test_builder_voluntary_exit__success(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
-def test_builder_voluntary_exit__invalid__inactive_deposit_epoch(spec, state):
-    """Test that inactive builders cannot exit."""
-    builder_index = 0
-    pubkey = state.builders[builder_index].pubkey
-    privkey = builder_pubkey_to_privkey[pubkey]
-
-    # Set builder's deposit epoch to a non-finalized epoch
-    state.builders[builder_index].deposit_epoch = spec.Epoch(1)
-
-    advance_past_finalization(spec, state)
-    assert state.finalized_checkpoint.epoch == state.builders[builder_index].deposit_epoch
-    assert not spec.is_active_builder(state, builder_index)
-
-    validator_index = spec.convert_builder_index_to_validator_index(builder_index)
-    voluntary_exit = spec.VoluntaryExit(
-        epoch=spec.get_current_epoch(state),
-        validator_index=validator_index,
-    )
-    signed_voluntary_exit = sign_voluntary_exit(spec, state, voluntary_exit, privkey)
-
-    yield "pre", state
-    yield "voluntary_exit", signed_voluntary_exit
-    expect_assertion_error(lambda: spec.process_voluntary_exit(state, signed_voluntary_exit))
-    yield "post", None
-
-
-@with_gloas_and_later
-@spec_state_test
 def test_builder_voluntary_exit__invalid__inactive_already_exited(spec, state):
     """Test that already-exited builders cannot exit again."""
     builder_index = 0

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/epoch_processing/test_process_builder_pending_deposits.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/epoch_processing/test_process_builder_pending_deposits.py
@@ -1,0 +1,199 @@
+from eth_consensus_specs.test.context import (
+    spec_state_test,
+    with_gloas_and_later,
+)
+from eth_consensus_specs.test.helpers.deposits import build_deposit_data
+from eth_consensus_specs.test.helpers.epoch_processing import run_epoch_processing_with
+from eth_consensus_specs.test.helpers.keys import (
+    builder_pubkey_to_privkey,
+    builder_pubkeys,
+)
+
+
+def _builder_withdrawal_credentials(spec, pubkey):
+    return spec.BUILDER_WITHDRAWAL_PREFIX + b"\x00" * 11 + spec.hash(pubkey)[12:]
+
+
+def _make_pending_builder_deposit(spec, pubkey, amount, slot, signed=True):
+    """Create a PendingDeposit with builder withdrawal credentials."""
+    privkey = builder_pubkey_to_privkey[pubkey]
+    withdrawal_credentials = _builder_withdrawal_credentials(spec, pubkey)
+    deposit_data = build_deposit_data(
+        spec, pubkey, privkey, amount, withdrawal_credentials, signed=signed
+    )
+    return spec.PendingDeposit(
+        pubkey=deposit_data.pubkey,
+        withdrawal_credentials=deposit_data.withdrawal_credentials,
+        amount=deposit_data.amount,
+        signature=deposit_data.signature,
+        slot=slot,
+    )
+
+
+def _set_finalized_to_current_epoch(spec, state):
+    """Mark the current epoch's start slot as finalized so queued deposits drain."""
+    state.finalized_checkpoint.epoch = spec.get_current_epoch(state)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_builder_pending_deposits__empty_queue(spec, state):
+    """No-op when ``pending_builder_deposits`` is empty."""
+    _set_finalized_to_current_epoch(spec, state)
+    state.pending_builder_deposits = []
+
+    pre_builder_count = len(state.builders)
+
+    yield from run_epoch_processing_with(spec, state, "process_builder_pending_deposits")
+
+    assert len(state.pending_builder_deposits) == 0
+    assert len(state.builders) == pre_builder_count
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_builder_pending_deposits__creates_new_builder(spec, state):
+    """A finalized, valid-signature pending builder deposit is drained and a
+    new builder is added to the registry."""
+    _set_finalized_to_current_epoch(spec, state)
+    pre_builder_count = len(state.builders)
+    amount = spec.MIN_DEPOSIT_AMOUNT
+
+    pubkey = builder_pubkeys[pre_builder_count + 0]
+    pending = _make_pending_builder_deposit(
+        spec, pubkey, amount, slot=spec.GENESIS_SLOT, signed=True
+    )
+    state.pending_builder_deposits = [pending]
+
+    yield from run_epoch_processing_with(spec, state, "process_builder_pending_deposits")
+
+    assert len(state.pending_builder_deposits) == 0
+    assert len(state.builders) == pre_builder_count + 1
+    assert state.builders[pre_builder_count].pubkey == pubkey
+    assert state.builders[pre_builder_count].balance == amount
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_builder_pending_deposits__top_up_existing_builder(spec, state):
+    """A pending deposit for a pubkey already in the builder registry tops up
+    the existing builder's balance (no signature check needed)."""
+    _set_finalized_to_current_epoch(spec, state)
+    pre_builder_count = len(state.builders)
+    builder_index = 0
+    pubkey = state.builders[builder_index].pubkey
+    pre_balance = state.builders[builder_index].balance
+    amount = spec.MIN_DEPOSIT_AMOUNT
+
+    # Top-ups don't need a valid signature for existing builders.
+    pending = spec.PendingDeposit(
+        pubkey=pubkey,
+        withdrawal_credentials=_builder_withdrawal_credentials(spec, pubkey),
+        amount=amount,
+        signature=spec.bls.G2_POINT_AT_INFINITY,
+        slot=spec.GENESIS_SLOT,
+    )
+    state.pending_builder_deposits = [pending]
+
+    yield from run_epoch_processing_with(spec, state, "process_builder_pending_deposits")
+
+    assert len(state.pending_builder_deposits) == 0
+    assert len(state.builders) == pre_builder_count
+    assert state.builders[builder_index].balance == pre_balance + amount
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_builder_pending_deposits__cap_overflow(spec, state):
+    """When more than ``MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH`` deposits are
+    queued, exactly the cap are drained this epoch and the rest stay queued
+    for subsequent epochs."""
+    _set_finalized_to_current_epoch(spec, state)
+    cap = spec.MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH
+    overflow = 3
+    pre_builder_count = len(state.builders)
+    amount = spec.MIN_DEPOSIT_AMOUNT
+
+    # All deposits unsigned: the cap is enforced regardless of signature
+    # validity (apply_deposit_for_builder is still invoked, just doesn't add
+    # a builder for invalid sigs). This isolates the cap mechanism.
+    deposits = []
+    for i in range(cap + overflow):
+        pubkey = builder_pubkeys[pre_builder_count + i]
+        deposits.append(
+            _make_pending_builder_deposit(
+                spec, pubkey, amount, slot=spec.GENESIS_SLOT, signed=False
+            )
+        )
+    state.pending_builder_deposits = deposits
+
+    yield from run_epoch_processing_with(spec, state, "process_builder_pending_deposits")
+
+    # First ``cap`` were attempted (none added since unsigned); the prefix is
+    # consumed and exactly ``overflow`` entries remain at the front of the
+    # queue, in their original order.
+    assert len(state.pending_builder_deposits) == overflow
+    assert len(state.builders) == pre_builder_count
+    for i in range(overflow):
+        assert (
+            state.pending_builder_deposits[i].pubkey == builder_pubkeys[pre_builder_count + cap + i]
+        )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_builder_pending_deposits__unfinalized_deposit_blocks(spec, state):
+    """A deposit whose slot exceeds the finalized slot blocks the drain — it
+    and all later entries stay in the queue this epoch."""
+    state.finalized_checkpoint.epoch = spec.Epoch(0)
+    finalized_slot = spec.compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
+    pre_builder_count = len(state.builders)
+    amount = spec.MIN_DEPOSIT_AMOUNT
+
+    # First entry: finalized (slot <= finalized_slot)
+    finalized_pubkey = builder_pubkeys[pre_builder_count + 0]
+    finalized_pending = _make_pending_builder_deposit(
+        spec, finalized_pubkey, amount, slot=finalized_slot, signed=True
+    )
+
+    # Second entry: not finalized (slot > finalized_slot)
+    unfinalized_pubkey = builder_pubkeys[pre_builder_count + 1]
+    unfinalized_pending = _make_pending_builder_deposit(
+        spec,
+        unfinalized_pubkey,
+        amount,
+        slot=spec.Slot(finalized_slot + spec.SLOTS_PER_EPOCH * 2),
+        signed=True,
+    )
+
+    state.pending_builder_deposits = [finalized_pending, unfinalized_pending]
+
+    yield from run_epoch_processing_with(spec, state, "process_builder_pending_deposits")
+
+    # Only the finalized one was drained; the unfinalized one remains.
+    assert len(state.builders) == pre_builder_count + 1
+    assert state.builders[pre_builder_count].pubkey == finalized_pubkey
+    assert len(state.pending_builder_deposits) == 1
+    assert state.pending_builder_deposits[0].pubkey == unfinalized_pubkey
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_builder_pending_deposits__invalid_signature_skipped(spec, state):
+    """An invalid-signature pending deposit for a NEW pubkey is consumed (the
+    cap counter advances) but no builder is added to the registry."""
+    _set_finalized_to_current_epoch(spec, state)
+    pre_builder_count = len(state.builders)
+    amount = spec.MIN_DEPOSIT_AMOUNT
+
+    pubkey = builder_pubkeys[pre_builder_count + 0]
+    invalid = _make_pending_builder_deposit(
+        spec, pubkey, amount, slot=spec.GENESIS_SLOT, signed=False
+    )
+    state.pending_builder_deposits = [invalid]
+
+    yield from run_epoch_processing_with(spec, state, "process_builder_pending_deposits")
+
+    # Drained from queue but no builder created for invalid signature.
+    assert len(state.pending_builder_deposits) == 0
+    assert len(state.builders) == pre_builder_count

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
@@ -124,34 +124,6 @@ def test_fork_single_builder_deposit(spec, phases, state):
 @spec_test
 @with_state
 @with_meta_tags(GLOAS_FORK_TEST_META_TAGS)
-def test_fork_builder_deposit_uses_deposit_slot_epoch(spec, phases, state):
-    """
-    Test fork uses the deposit's slot epoch when onboarding builders.
-    """
-    post_spec = phases[GLOAS]
-    amount = post_spec.MIN_DEPOSIT_AMOUNT
-
-    # Set state slot to a later epoch than the deposit slot
-    state.slot = post_spec.SLOTS_PER_EPOCH * 2
-
-    builder_pubkey = builder_pubkeys[0]
-    pending_deposit = create_pending_deposit_for_builder(post_spec, builder_pubkey, amount)
-    pending_deposit.slot = state.slot - 1
-    state.pending_deposits = [pending_deposit]
-
-    post_state = yield from run_fork_test(post_spec, state)
-
-    assert len(post_state.builders) == 1
-    builder = post_state.builders[0]
-    assert builder.deposit_epoch == post_spec.compute_epoch_at_slot(pending_deposit.slot)
-    assert builder.deposit_epoch != post_spec.get_current_epoch(post_state)
-    assert len(post_state.pending_deposits) == 0
-
-
-@with_phases(phases=[FULU], other_phases=[GLOAS])
-@spec_test
-@with_state
-@with_meta_tags(GLOAS_FORK_TEST_META_TAGS)
 def test_fork_multiple_builder_deposits(spec, phases, state):
     """
     Test fork with multiple pending deposits with builder credentials.
@@ -609,4 +581,127 @@ def test_fork_valid_builder_deposit_followed_by_invalid_builder_deposit(spec, ph
     assert post_state.builders[0].balance == amount * 2
 
     # No pending deposits should remain
+    assert len(post_state.pending_deposits) == 0
+
+
+@with_phases(phases=[FULU], other_phases=[GLOAS])
+@spec_test
+@with_state
+@with_meta_tags(GLOAS_FORK_TEST_META_TAGS)
+def test_fork_too_many_builder_deposits(spec, phases, state):
+    """
+    Test that fork-time builder onboarding caps inline applications at
+    ``MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH`` and routes the rest to
+    ``state.pending_builder_deposits`` for later draining by
+    ``process_builder_pending_deposits``.
+    """
+    post_spec = phases[GLOAS]
+    cap = post_spec.MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH
+    overflow = 5
+    amount = post_spec.MIN_DEPOSIT_AMOUNT
+
+    # Create cap+overflow pending builder deposits with distinct pubkeys.
+    pending_deposits = []
+    for i in range(cap + overflow):
+        builder_pubkey = builder_pubkeys[i]
+        pending_deposits.append(
+            create_pending_deposit_for_builder(post_spec, builder_pubkey, amount)
+        )
+    state.pending_deposits = pending_deposits
+
+    post_state = yield from run_fork_test(post_spec, state)
+
+    # Exactly ``cap`` builders applied inline; the first ``cap`` pubkeys are in
+    # the registry in the same order they appeared in pre.pending_deposits.
+    assert len(post_state.builders) == cap
+    for i in range(cap):
+        assert post_state.builders[i].pubkey == builder_pubkeys[i]
+        assert post_state.builders[i].balance == amount
+
+    # Remaining ``overflow`` deposits are queued for later draining.
+    assert len(post_state.pending_builder_deposits) == overflow
+    for i in range(overflow):
+        queued = post_state.pending_builder_deposits[i]
+        assert queued.pubkey == builder_pubkeys[cap + i]
+        assert queued.amount == amount
+
+    # Validator queue is empty (all deposits had builder credentials).
+    assert len(post_state.pending_deposits) == 0
+
+
+@with_phases(phases=[FULU], other_phases=[GLOAS])
+@spec_test
+@with_state
+@with_meta_tags(GLOAS_FORK_TEST_META_TAGS)
+def test_fork_unfinalized_builder_deposit(spec, phases, state):
+    """
+    Test that a builder-credentialed pending deposit whose ``slot`` exceeds
+    ``state.finalized_checkpoint.epoch``'s start slot is queued in
+    ``state.pending_builder_deposits`` at the fork rather than applied inline.
+    """
+    post_spec = phases[GLOAS]
+    amount = post_spec.MIN_DEPOSIT_AMOUNT
+
+    # Advance past genesis and leave finalization behind so the deposit's slot
+    # is unfinalized at the fork boundary.
+    state.slot = post_spec.SLOTS_PER_EPOCH * 4
+    state.finalized_checkpoint.epoch = post_spec.Epoch(1)
+
+    builder_pubkey = builder_pubkeys[0]
+    pending_deposit = create_pending_deposit_for_builder(post_spec, builder_pubkey, amount)
+    pending_deposit.slot = state.slot
+    state.pending_deposits = [pending_deposit]
+
+    post_state = yield from run_fork_test(post_spec, state)
+
+    # Not finalized at fork → no inline application.
+    assert len(post_state.builders) == 0
+
+    # Deposit is queued in pending_builder_deposits for a later epoch drain.
+    assert len(post_state.pending_builder_deposits) == 1
+    queued = post_state.pending_builder_deposits[0]
+    assert queued.pubkey == builder_pubkey
+    assert queued.amount == amount
+    assert queued.slot == pending_deposit.slot
+
+    # Validator queue is empty.
+    assert len(post_state.pending_deposits) == 0
+
+
+@with_phases(phases=[FULU], other_phases=[GLOAS])
+@spec_test
+@with_state
+@with_meta_tags(GLOAS_FORK_TEST_META_TAGS)
+def test_fork_mixed_finalized_and_unfinalized_builder_deposits(spec, phases, state):
+    """
+    Test fork onboarding with mixed finalized and unfinalized builder deposits:
+    finalized ones (within the cap) are applied inline, unfinalized ones are
+    appended to ``state.pending_builder_deposits``.
+    """
+    post_spec = phases[GLOAS]
+    amount = post_spec.MIN_DEPOSIT_AMOUNT
+
+    # State has progressed; finalization covers epoch 1.
+    state.slot = post_spec.SLOTS_PER_EPOCH * 4
+    state.finalized_checkpoint.epoch = post_spec.Epoch(1)
+    finalized_slot = post_spec.compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
+
+    finalized_deposit = create_pending_deposit_for_builder(post_spec, builder_pubkeys[0], amount)
+    finalized_deposit.slot = finalized_slot
+
+    unfinalized_deposit = create_pending_deposit_for_builder(post_spec, builder_pubkeys[1], amount)
+    unfinalized_deposit.slot = state.slot
+
+    state.pending_deposits = [finalized_deposit, unfinalized_deposit]
+
+    post_state = yield from run_fork_test(post_spec, state)
+
+    # The finalized deposit becomes a builder; the unfinalized one is queued.
+    assert len(post_state.builders) == 1
+    assert post_state.builders[0].pubkey == builder_pubkeys[0]
+    assert post_state.builders[0].balance == amount
+
+    assert len(post_state.pending_builder_deposits) == 1
+    assert post_state.pending_builder_deposits[0].pubkey == builder_pubkeys[1]
+
     assert len(post_state.pending_deposits) == 0

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -31,7 +31,6 @@ def build_mock_builder(spec, i: int, balance: int):
         pubkey=builder_pubkeys[i],
         execution_address=spec.ExecutionAddress(spec.hash(builder_pubkeys[i])[12:]),
         balance=balance,
-        deposit_epoch=0,
         withdrawable_epoch=spec.FAR_FUTURE_EPOCH,
     )
 

--- a/tests/formats/epoch_processing/README.md
+++ b/tests/formats/epoch_processing/README.md
@@ -62,6 +62,10 @@ Sub-transitions:
 - `effective_balance_updates` (>=Electra)
 - `pending_consolidations` (>=Electra)
 - `pending_deposits` (>=Electra)
+- `proposer_lookahead` (>=Fulu)
+- `builder_pending_deposits` (>=Gloas)
+- `builder_pending_payments` (>=Gloas)
+- `ptc_window` (>=Gloas)
 
 The resulting state should match the expected `post` state.
 

--- a/tests/infra/helpers/builders.py
+++ b/tests/infra/helpers/builders.py
@@ -8,7 +8,6 @@ def add_builder_to_registry(
     pubkey=None,
     execution_address=None,
     balance=None,
-    deposit_epoch=None,
     withdrawable_epoch=None,
 ):
     """
@@ -21,7 +20,6 @@ def add_builder_to_registry(
         pubkey: Builder's BLS public key (default: derived from builder_index)
         execution_address: Builder's execution layer address (default: derived from builder_index)
         balance: Builder's balance in Gwei (default: spec.MIN_DEPOSIT_AMOUNT)
-        deposit_epoch: Epoch when builder deposited (default: 0)
         withdrawable_epoch: Epoch when builder can withdraw (default: spec.FAR_FUTURE_EPOCH)
     """
     # Grow registry if needed
@@ -35,7 +33,6 @@ def add_builder_to_registry(
         execution_address if execution_address is not None else builder_index.to_bytes(20, "little")
     )
     builder.balance = balance if balance is not None else spec.MIN_DEPOSIT_AMOUNT
-    builder.deposit_epoch = deposit_epoch if deposit_epoch is not None else 0
     builder.withdrawable_epoch = (
         withdrawable_epoch if withdrawable_epoch is not None else spec.FAR_FUTURE_EPOCH
     )

--- a/tests/infra/helpers/deposit_requests.py
+++ b/tests/infra/helpers/deposit_requests.py
@@ -170,11 +170,23 @@ def prepare_process_deposit_request(
 def _is_builder_deposit(spec, pre_state, deposit_request):
     """Check if request routes to builder path under Gloas+ deposit routing rules.
 
-    Under the simplified routing, this is determined purely by the credential
-    prefix: builder credentials route to ``state.pending_builder_deposits``,
-    everything else routes to ``state.pending_deposits``.
+    A deposit routes to ``state.pending_builder_deposits`` when:
+      1. the pubkey is already a builder in the registry, or
+      2. the pubkey already has an entry in ``pending_builder_deposits``, or
+      3. the pubkey is unknown to validators / builders / either pending queue
+         and the withdrawal credentials use the builder prefix.
+    Otherwise it routes to ``state.pending_deposits``.
     """
     if not is_post_gloas(spec):
+        return False
+    pubkey = deposit_request.pubkey
+    if pubkey in {b.pubkey for b in pre_state.builders}:
+        return True
+    if pubkey in {v.pubkey for v in pre_state.validators}:
+        return False
+    if any(d.pubkey == pubkey for d in pre_state.pending_builder_deposits):
+        return True
+    if any(d.pubkey == pubkey for d in pre_state.pending_deposits):
         return False
     return spec.is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
 

--- a/tests/infra/helpers/deposit_requests.py
+++ b/tests/infra/helpers/deposit_requests.py
@@ -168,18 +168,15 @@ def prepare_process_deposit_request(
 
 
 def _is_builder_deposit(spec, pre_state, deposit_request):
-    """Check if request routes to builder path under Gloas+ deposit routing rules."""
+    """Check if request routes to builder path under Gloas+ deposit routing rules.
+
+    Under the simplified routing, this is determined purely by the credential
+    prefix: builder credentials route to ``state.pending_builder_deposits``,
+    everything else routes to ``state.pending_deposits``.
+    """
     if not is_post_gloas(spec):
         return False
-    builder_pubkeys = {builder.pubkey for builder in pre_state.builders}
-    validator_pubkeys = {v.pubkey for v in pre_state.validators}
-    is_builder = deposit_request.pubkey in builder_pubkeys
-    is_validator = deposit_request.pubkey in validator_pubkeys
-    return is_builder or (
-        spec.is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
-        and not is_validator
-        and not spec.is_pending_validator(pre_state, deposit_request.pubkey)
-    )
+    return spec.is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
 
 
 def assert_process_deposit_request(
@@ -264,26 +261,106 @@ def assert_process_deposit_request(
 
     if is_builder_deposit and is_post_gloas(spec):
         # BUILDER DEPOSIT ASSERTIONS (Gloas+)
-        # Builder deposits are applied immediately, not queued
+        #
+        # Builder-credentialed deposit_requests are appended to
+        # ``state.pending_builder_deposits`` and applied later by
+        # ``process_builder_pending_deposits``. The assertions below first verify
+        # the queue routing, then drain the just-queued entry on a state copy
+        # via ``apply_deposit_for_builder`` so end-state assertions about the
+        # builder registry can be checked uniformly.
 
-        # INVARIANT: pending_deposits unchanged for builder deposits
+        # INVARIANT: pending_deposits (validator queue) unchanged
         assert len(state.pending_deposits) == len(pre_state.pending_deposits), (
             f"pending_deposits should not change for builder deposits: "
             f"pre={len(pre_state.pending_deposits)}, post={len(state.pending_deposits)}"
         )
 
-        # Find the builder by pubkey
+        # INVARIANT: pending_builder_deposits gained exactly 1 entry
+        assert len(state.pending_builder_deposits) == len(pre_state.pending_builder_deposits) + 1, (
+            f"pending_builder_deposits should increase by 1: "
+            f"pre={len(pre_state.pending_builder_deposits)}, "
+            f"post={len(state.pending_builder_deposits)}"
+        )
+
+        # INVARIANT: builder registry unchanged at this stage (deferred to drain)
+        assert len(state.builders) == len(pre_state.builders), (
+            "Builder count should not change during process_deposit_request "
+            "(builders are applied later by process_builder_pending_deposits)"
+        )
+        for i in range(len(pre_state.builders)):
+            assert state.builders[i] == pre_state.builders[i], (
+                f"Builder at index {i} should be unchanged during process_deposit_request"
+            )
+
+        # New entry sits at the tail of pending_builder_deposits
+        new_pending_idx = len(state.pending_builder_deposits) - 1
+        new_pending = state.pending_builder_deposits[new_pending_idx]
+
+        # New entry's fields match the deposit_request, slot equals state.slot
+        assert new_pending.pubkey == deposit_request.pubkey, (
+            "Pending builder deposit pubkey must match deposit request"
+        )
+        assert new_pending.withdrawal_credentials == deposit_request.withdrawal_credentials, (
+            "Pending builder deposit withdrawal_credentials must match deposit request"
+        )
+        assert new_pending.amount == deposit_request.amount, (
+            "Pending builder deposit amount must match deposit request"
+        )
+        assert new_pending.signature == deposit_request.signature, (
+            "Pending builder deposit signature must match deposit request"
+        )
+        assert new_pending.slot == state.slot, (
+            f"Pending builder deposit slot must equal state.slot: "
+            f"deposit.slot={new_pending.slot}, state.slot={state.slot}"
+        )
+
+        # INVARIANT: deposit_requests_start_index is set if previously UNSET
+        was_unset = (
+            pre_state.deposit_requests_start_index == spec.UNSET_DEPOSIT_REQUESTS_START_INDEX
+        )
+        if was_unset:
+            assert state.deposit_requests_start_index == deposit_request.index, (
+                f"deposit_requests_start_index should be set to request index: "
+                f"expected={deposit_request.index}, got={state.deposit_requests_start_index}"
+            )
+        else:
+            assert state.deposit_requests_start_index == pre_state.deposit_requests_start_index, (
+                "deposit_requests_start_index should not change when already set"
+            )
+
+        # INVARIANT: validator state unchanged
+        assert len(state.validators) == len(pre_state.validators), (
+            "Validator count should not change during builder deposit processing"
+        )
+        assert list(state.balances) == list(pre_state.balances), (
+            "Validator balances should not change during builder deposit processing"
+        )
+
+        # Drain the queued builder deposit on a state copy and run end-state
+        # assertions about the builder registry against the drained copy. This
+        # bypasses the spec's finalization gate in ``process_builder_pending_deposits``
+        # since end-state assertions are about ``apply_deposit_for_builder``'s
+        # behavior, not the gating policy.
+        drained_state = state.copy()
+        drained_state.pending_builder_deposits = drained_state.pending_builder_deposits[
+            :new_pending_idx
+        ]
+        spec.apply_deposit_for_builder(
+            drained_state,
+            new_pending.pubkey,
+            new_pending.withdrawal_credentials,
+            new_pending.amount,
+            new_pending.signature,
+        )
+
+        # Find the builder by pubkey in the drained state
         builder_index = None
-        for i, builder in enumerate(state.builders):
+        for i, builder in enumerate(drained_state.builders):
             if builder.pubkey == deposit_request.pubkey:
                 builder_index = i
                 break
 
-        assert builder_index is not None, (
-            f"Builder with pubkey {deposit_request.pubkey[:8]}... should exist after deposit"
-        )
-
-        # Check if this was a new builder or top-up
+        # Was there an existing builder for this pubkey before the deposit?
         pre_builder_index = None
         for i, builder in enumerate(pre_state.builders):
             if builder.pubkey == deposit_request.pubkey:
@@ -291,61 +368,54 @@ def assert_process_deposit_request(
                 break
 
         if pre_builder_index is None:
-            # New builder was created (could be appended or reused slot)
-            # The count either increases by 1 (append) or stays the same (slot reuse)
-            # If slot_reused is specified, that takes precedence for the check
-            if slot_reused is None:
-                # Allow either case (append or reuse) if not explicitly specified
-                assert len(state.builders) >= len(pre_state.builders), (
-                    "Builder count should not decrease for new builder deposit"
-                )
+            # New-builder path: builder is added only if signature is valid.
+            if builder_index is not None:
+                # The count either grew by 1 (append) or stayed the same (slot reuse)
+                if slot_reused is None:
+                    assert len(drained_state.builders) >= len(pre_state.builders), (
+                        "Builder count should not decrease for new builder deposit"
+                    )
         else:
-            # Top-up of existing builder
-            assert len(state.builders) == len(pre_state.builders), (
+            # Top-up of existing builder: balance increases regardless of signature.
+            assert len(drained_state.builders) == len(pre_state.builders), (
                 "Builder count should not change for top-up deposit"
             )
-            # Balance should increase
             pre_balance = pre_state.builders[pre_builder_index].balance
-            post_balance = state.builders[builder_index].balance
+            post_balance = drained_state.builders[builder_index].balance
             assert post_balance == pre_balance + deposit_request.amount, (
                 f"Builder balance should increase by deposit amount: "
                 f"pre={pre_balance}, post={post_balance}, amount={deposit_request.amount}"
             )
-            # All other builders should remain unchanged
             for i in range(len(pre_state.builders)):
                 if i != pre_builder_index:
-                    assert state.builders[i] == pre_state.builders[i], (
+                    assert drained_state.builders[i] == pre_state.builders[i], (
                         f"Builder at index {i} should be unchanged during top-up"
                     )
 
-        # INVARIANT: Validator count unchanged
-        assert len(state.validators) == len(pre_state.validators), (
-            "Validator count should not change during builder deposit processing"
-        )
-
-        # INVARIANT: Validator balances unchanged
-        assert list(state.balances) == list(pre_state.balances), (
-            "Validator balances should not change during builder deposit processing"
-        )
-
-        # Test-specific checks for builders
+        # Test-specific checks for builders (against drained_state)
         if expected_builder_balance is not None:
-            assert state.builders[builder_index].balance == expected_builder_balance
+            assert builder_index is not None, (
+                "expected_builder_balance set but no builder was created (invalid signature?)"
+            )
+            assert drained_state.builders[builder_index].balance == expected_builder_balance
 
         if expected_builder_balance_delta is not None:
+            assert builder_index is not None, (
+                "expected_builder_balance_delta set but no builder was created"
+            )
             if pre_builder_index is not None:
                 pre_balance = pre_state.builders[pre_builder_index].balance
             else:
                 pre_balance = 0
             assert (
-                state.builders[builder_index].balance
+                drained_state.builders[builder_index].balance
                 == pre_balance + expected_builder_balance_delta
             )
 
         if expected_builder_count is not None:
-            assert len(state.builders) == expected_builder_count, (
+            assert len(drained_state.builders) == expected_builder_count, (
                 f"expected_builder_count: expected={expected_builder_count}, "
-                f"got={len(state.builders)}"
+                f"got={len(drained_state.builders)}"
             )
 
         if expected_builder_index is not None:
@@ -354,30 +424,38 @@ def assert_process_deposit_request(
             )
 
         if expected_execution_address is not None:
-            assert state.builders[builder_index].execution_address == expected_execution_address, (
+            assert builder_index is not None, (
+                "expected_execution_address set but no builder was created"
+            )
+            assert (
+                drained_state.builders[builder_index].execution_address
+                == expected_execution_address
+            ), (
                 f"expected_execution_address: expected={expected_execution_address}, "
-                f"got={state.builders[builder_index].execution_address}"
+                f"got={drained_state.builders[builder_index].execution_address}"
             )
 
         if expected_builder_withdrawable_epoch is not None:
+            assert builder_index is not None, (
+                "expected_builder_withdrawable_epoch set but no builder was created"
+            )
             assert (
-                state.builders[builder_index].withdrawable_epoch
+                drained_state.builders[builder_index].withdrawable_epoch
                 == expected_builder_withdrawable_epoch
             ), (
                 f"expected_builder_withdrawable_epoch: expected={expected_builder_withdrawable_epoch}, "
-                f"got={state.builders[builder_index].withdrawable_epoch}"
+                f"got={drained_state.builders[builder_index].withdrawable_epoch}"
             )
 
         if slot_reused is True:
-            assert len(state.builders) == len(pre_state.builders), (
+            assert len(drained_state.builders) == len(pre_state.builders), (
                 f"slot_reused=True: builder count should be unchanged: "
-                f"pre={len(pre_state.builders)}, post={len(state.builders)}"
+                f"pre={len(pre_state.builders)}, post={len(drained_state.builders)}"
             )
-            # Verify exactly one original builder was replaced and it met reuse criteria
             changed_indices = [
                 i
                 for i in range(len(pre_state.builders))
-                if state.builders[i] != pre_state.builders[i]
+                if drained_state.builders[i] != pre_state.builders[i]
             ]
             assert len(changed_indices) == 1, (
                 f"slot_reused=True: exactly one builder should change: "
@@ -396,13 +474,12 @@ def assert_process_deposit_request(
                 f"zero balance: balance={pre_builder.balance}"
             )
         elif slot_reused is False:
-            assert len(state.builders) == len(pre_state.builders) + 1, (
+            assert len(drained_state.builders) == len(pre_state.builders) + 1, (
                 f"slot_reused=False: builder count should increase by 1: "
-                f"pre={len(pre_state.builders)}, post={len(state.builders)}"
+                f"pre={len(pre_state.builders)}, post={len(drained_state.builders)}"
             )
-            # Verify original builders are unchanged when new builder is appended
             for i in range(len(pre_state.builders)):
-                assert state.builders[i] == pre_state.builders[i], (
+                assert drained_state.builders[i] == pre_state.builders[i], (
                     f"slot_reused=False: original builder at index {i} should be unchanged"
                 )
 
@@ -445,26 +522,18 @@ def assert_process_deposit_request(
             f"deposit.slot={new_pending_deposit.slot}, state.slot={state.slot}"
         )
 
-        # INVARIANT: deposit_requests_start_index logic (Electra/Fulu only, removed in Gloas)
-        if not is_post_gloas(spec):
-            was_unset = (
-                pre_state.deposit_requests_start_index == spec.UNSET_DEPOSIT_REQUESTS_START_INDEX
+        # INVARIANT: deposit_requests_start_index is set if previously UNSET
+        was_unset = (
+            pre_state.deposit_requests_start_index == spec.UNSET_DEPOSIT_REQUESTS_START_INDEX
+        )
+        if was_unset:
+            assert state.deposit_requests_start_index == deposit_request.index, (
+                f"deposit_requests_start_index should be set to request index: "
+                f"expected={deposit_request.index}, got={state.deposit_requests_start_index}"
             )
-            if was_unset:
-                # Should be set to deposit_request.index
-                assert state.deposit_requests_start_index == deposit_request.index, (
-                    f"deposit_requests_start_index should be set to request index: "
-                    f"expected={deposit_request.index}, got={state.deposit_requests_start_index}"
-                )
-            else:
-                # Should remain unchanged
-                assert (
-                    state.deposit_requests_start_index == pre_state.deposit_requests_start_index
-                ), "deposit_requests_start_index should not change when already set"
         else:
-            # In Gloas+, deposit_requests_start_index is not modified by process_deposit_request
             assert state.deposit_requests_start_index == pre_state.deposit_requests_start_index, (
-                "deposit_requests_start_index should not change in Gloas+"
+                "deposit_requests_start_index should not change when already set"
             )
 
         # INVARIANT: Builder count unchanged (Gloas+ only, builders don't exist pre-Gloas)

--- a/tests/infra/helpers/test_builders.py
+++ b/tests/infra/helpers/test_builders.py
@@ -28,7 +28,6 @@ class TestAddBuilderToRegistry:
         assert builder.pubkey == (0).to_bytes(48, "little")
         assert builder.execution_address == (0).to_bytes(20, "little")
         assert builder.balance == spec.MIN_DEPOSIT_AMOUNT
-        assert builder.deposit_epoch == 0
         assert builder.withdrawable_epoch == spec.FAR_FUTURE_EPOCH
         assert builder.version == 0
 
@@ -60,7 +59,6 @@ class TestAddBuilderToRegistry:
         custom_pubkey = b"\xab" * 48
         custom_address = b"\xcd" * 20
         custom_balance = 5_000_000_000
-        custom_deposit_epoch = 100
         custom_withdrawable_epoch = 200
 
         add_builder_to_registry(
@@ -70,7 +68,6 @@ class TestAddBuilderToRegistry:
             pubkey=custom_pubkey,
             execution_address=custom_address,
             balance=custom_balance,
-            deposit_epoch=custom_deposit_epoch,
             withdrawable_epoch=custom_withdrawable_epoch,
         )
 
@@ -78,7 +75,6 @@ class TestAddBuilderToRegistry:
         assert builder.pubkey == custom_pubkey
         assert builder.execution_address == custom_address
         assert builder.balance == custom_balance
-        assert builder.deposit_epoch == custom_deposit_epoch
         assert builder.withdrawable_epoch == custom_withdrawable_epoch
 
     def test_add_builder_updates_existing(self):

--- a/tests/infra/helpers/test_deposit_requests.py
+++ b/tests/infra/helpers/test_deposit_requests.py
@@ -255,46 +255,6 @@ def test_prepare_process_deposit_request_builder_custom_amount(spec, state):
     assert deposit_request.amount == custom_amount
 
 
-def test_assert_new_builder_deposit():
-    """Test assert_process_deposit_request passes for a new builder deposit."""
-    spec = MagicMock()
-
-    builder_pubkey = b"\x03" * 48
-    deposit_request = MagicMock()
-    deposit_request.pubkey = builder_pubkey
-    deposit_request.withdrawal_credentials = b"\x03" + b"\x00" * 11 + b"\x59" * 20
-    deposit_request.amount = 32_000_000_000
-    deposit_request.signature = b"\x02" * 96
-    deposit_request.index = 0
-
-    # Pre state: no builders
-    pre_state = MagicMock()
-    pre_state.pending_deposits = []
-    pre_state.validators = [MagicMock()]
-    pre_state.balances = [32_000_000_000]
-    pre_state.builders = []
-
-    # Post state: one new builder with matching pubkey
-    new_builder = MagicMock()
-    new_builder.pubkey = builder_pubkey
-    new_builder.balance = deposit_request.amount
-
-    state = MagicMock()
-    state.pending_deposits = []
-    state.validators = [MagicMock()]
-    state.balances = [32_000_000_000]
-    state.builders = [new_builder]
-
-    with patch("tests.infra.helpers.deposit_requests.is_post_gloas", return_value=True):
-        assert_process_deposit_request(
-            spec,
-            state,
-            pre_state,
-            deposit_request=deposit_request,
-            is_builder_deposit=True,
-        )
-
-
 @with_all_phases_from_to(ELECTRA, GLOAS)
 @spec_state_test
 def test_prepare_process_deposit_request_builder_credentials_before_gloas(spec, state):


### PR DESCRIPTION
- New field `pending_builder_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]` in `BeaconState`
- New preset constant `MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH` (mainnet: 128, minimal: 16)
- Removed `deposit_epoch` field in `Builder`, now unnecessary
- `is_active_builder` simplified to just check `withdrawable_epoch == FAR_FUTURE_EPOCH`
- `add_builder_to_registry` dropped unused `slot` parameter
- `apply_deposit_for_builder` dropped unused `slot` parameter
- `process_deposit_request` routes by credentials
- `process_builder_pending_deposits` is a new function just for builders
- `upgrade_to_gloas` initializes `pending_builder_deposits=[]`
- `onboard_builders_from_pending_deposits` applies up to `MAX_PENDING_BUILDER_DEPOSITS_PER_EPOCH`
  builder-routed deposits inline (only if their slot is finalized at fork time); the rest get
  appended to `state.pending_builder_deposits` for later. When working on this PR, I realized that if an attacker could queue ~10k builder deposits to be onboarded at the upgrade, it would probably cause a lot of issues. This changes fixes that issue.