### PR TITLE
Add new `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS` preset

### DIFF
--- a/presets/mainnet/gloas.yaml
+++ b/presets/mainnet/gloas.yaml
@@ -19,8 +19,8 @@ BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
 
 # Execution
 # ---------------------------------------------------------------
-# 2**41 (= 2,199,023,255,552) deposit requests
-MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS: 2199023255552
+# 2**20 (= 1,048,576) deposit requests
+MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS: 1048576
 
 # Withdrawals processing
 # ---------------------------------------------------------------

--- a/presets/mainnet/gloas.yaml
+++ b/presets/mainnet/gloas.yaml
@@ -17,6 +17,11 @@ BUILDER_REGISTRY_LIMIT: 1099511627776
 # 2**20 (= 1,048,576) builder pending withdrawals
 BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
 
+# Execution
+# ---------------------------------------------------------------
+# 2**41 (= 2,199,023,255,552) deposit requests
+MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS: 2199023255552
+
 # Withdrawals processing
 # ---------------------------------------------------------------
 # 2**14 (= 16,384) builders

--- a/presets/minimal/gloas.yaml
+++ b/presets/minimal/gloas.yaml
@@ -19,8 +19,8 @@ BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
 
 # Execution
 # ---------------------------------------------------------------
-# 2**41 (= 2,199,023,255,552) deposit requests
-MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS: 2199023255552
+# 2**20 (= 1,048,576) deposit requests
+MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS: 1048576
 
 # Withdrawals processing
 # ---------------------------------------------------------------

--- a/presets/minimal/gloas.yaml
+++ b/presets/minimal/gloas.yaml
@@ -17,6 +17,11 @@ BUILDER_REGISTRY_LIMIT: 1099511627776
 # 2**20 (= 1,048,576) builder pending withdrawals
 BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
 
+# Execution
+# ---------------------------------------------------------------
+# 2**41 (= 2,199,023,255,552) deposit requests
+MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS: 2199023255552
+
 # Withdrawals processing
 # ---------------------------------------------------------------
 # [customized] 2**4 (= 16) builders

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -183,9 +183,9 @@ Gloas is a consensus-layer upgrade containing a number of features. Including:
 
 ### Execution
 
-| Name                                     | Value                                 | Description                                                        |
-| ---------------------------------------- | ------------------------------------- | ------------------------------------------------------------------ |
-| `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS` | `uint64(2**41)` (= 2,199,023,255,552) | Maximum number of execution-layer deposit requests in each payload |
+| Name                                     | Value                         | Description                                                        |
+| ---------------------------------------- | ----------------------------- | ------------------------------------------------------------------ |
+| `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS` | `uint64(2**20)` (= 1,048,576) | Maximum number of execution-layer deposit requests in each payload |
 
 ### Withdrawals processing
 

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -15,6 +15,7 @@
   - [Misc](#misc-1)
   - [Max operations per block](#max-operations-per-block)
   - [State list lengths](#state-list-lengths)
+  - [Execution](#execution)
   - [Withdrawals processing](#withdrawals-processing)
 - [Configuration](#configuration)
   - [Validator cycle](#validator-cycle)
@@ -33,6 +34,7 @@
     - [`ExecutionPayloadEnvelope`](#executionpayloadenvelope)
     - [`SignedExecutionPayloadEnvelope`](#signedexecutionpayloadenvelope)
   - [Modified containers](#modified-containers)
+    - [`ExecutionRequests`](#executionrequests)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`BeaconState`](#beaconstate)
     - [`ExecutionPayload`](#executionpayload)
@@ -179,6 +181,12 @@ Gloas is a consensus-layer upgrade containing a number of features. Including:
 | `BUILDER_REGISTRY_LIMIT`            | `uint64(2**40)` (= 1,099,511,627,776) | Builders                    |
 | `BUILDER_PENDING_WITHDRAWALS_LIMIT` | `uint64(2**20)` (= 1,048,576)         | Builder pending withdrawals |
 
+### Execution
+
+| Name                                     | Value                                 | Description                                                        |
+| ---------------------------------------- | ------------------------------------- | ------------------------------------------------------------------ |
+| `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS` | `uint64(2**41)` (= 2,199,023,255,552) | Maximum number of execution-layer deposit requests in each payload |
+
 ### Withdrawals processing
 
 | Name                                 | Value              |
@@ -317,6 +325,16 @@ class SignedExecutionPayloadEnvelope(Container):
 ```
 
 ### Modified containers
+
+#### `ExecutionRequests`
+
+```python
+class ExecutionRequests(Container):
+    # [Modified in Gloas]
+    deposits: List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS]
+    withdrawals: List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]
+    consolidations: List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
+```
 
 #### `BeaconBlockBody`
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -25,6 +25,7 @@
     - [Constructing the `PayloadAttestationMessage`](#constructing-the-payloadattestationmessage)
 - [Modified functions](#modified-functions)
   - [Modified `get_data_column_sidecars_from_column_sidecar`](#modified-get_data_column_sidecars_from_column_sidecar)
+  - [Modified `get_execution_requests`](#modified-get_execution_requests)
 
 <!-- mdformat-toc end -->
 
@@ -379,5 +380,54 @@ def get_data_column_sidecars_from_column_sidecar(
         sidecar.beacon_block_root,
         sidecar.slot,
         cells_and_kzg_proofs,
+    )
+```
+
+### Modified `get_execution_requests`
+
+```python
+def get_execution_requests(execution_requests_list: Sequence[bytes]) -> ExecutionRequests:
+    deposits = []
+    withdrawals = []
+    consolidations = []
+
+    request_types = [
+        DEPOSIT_REQUEST_TYPE,
+        WITHDRAWAL_REQUEST_TYPE,
+        CONSOLIDATION_REQUEST_TYPE,
+    ]
+
+    prev_request_type = None
+    for request in execution_requests_list:
+        request_type, request_data = request[0:1], request[1:]
+
+        # Check that the request type is valid
+        assert request_type in request_types
+        # Check that the request data is not empty
+        assert len(request_data) != 0
+        # Check that requests are in strictly ascending order
+        # Each successive type must be greater than the last with no duplicates
+        assert prev_request_type is None or prev_request_type < request_type
+        prev_request_type = request_type
+
+        if request_type == DEPOSIT_REQUEST_TYPE:
+            deposits = ssz_deserialize(
+                # [Modified in Gloas]
+                List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS],
+                request_data,
+            )
+        elif request_type == WITHDRAWAL_REQUEST_TYPE:
+            withdrawals = ssz_deserialize(
+                List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD], request_data
+            )
+        elif request_type == CONSOLIDATION_REQUEST_TYPE:
+            consolidations = ssz_deserialize(
+                List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD], request_data
+            )
+
+    return ExecutionRequests(
+        deposits=deposits,
+        withdrawals=withdrawals,
+        consolidations=consolidations,
     )
 ```

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
@@ -225,7 +225,7 @@ def test_process_parent_execution_payload__full_parent_with_execution_requests(s
     unknown pubkeys are no-ops.
     """
     requests = spec.ExecutionRequests(
-        deposits=spec.List[spec.DepositRequest, spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD](
+        deposits=spec.List[spec.DepositRequest, spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS](
             [
                 spec.DepositRequest(
                     pubkey=spec.BLSPubkey(b"\x01" * 48),
@@ -333,7 +333,7 @@ def test_process_parent_execution_payload__builder_deposit_after_pending_validat
     )
 
     requests = spec.ExecutionRequests(
-        deposits=spec.List[spec.DepositRequest, spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD](
+        deposits=spec.List[spec.DepositRequest, spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS](
             [deposit_request_1, deposit_request_2]
         ),
         withdrawals=spec.List[spec.WithdrawalRequest, spec.MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD](),

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_execution_payload_envelope.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_execution_payload_envelope.py
@@ -317,7 +317,7 @@ def test_on_execution_payload_envelope__wrong_execution_requests_root(spec, stat
 
     # Build envelope with non-empty requests but bid commits to empty requests
     non_empty_requests = spec.ExecutionRequests(
-        deposits=spec.List[spec.DepositRequest, spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD](
+        deposits=spec.List[spec.DepositRequest, spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS](
             [
                 spec.DepositRequest(
                     pubkey=spec.BLSPubkey(b"\x01" * 48),

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_requests.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_requests.py
@@ -1,4 +1,5 @@
 from eth_consensus_specs.test.helpers.deposits import prepare_deposit_request
+from eth_consensus_specs.test.helpers.forks import is_post_gloas
 
 
 def get_non_empty_execution_requests(spec):
@@ -10,8 +11,13 @@ def get_non_empty_execution_requests(spec):
         signed=False,
     )
 
+    if is_post_gloas(spec):
+        max_deposit_requests_per_payload = spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD_GLOAS
+    else:
+        max_deposit_requests_per_payload = spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD
+
     return spec.ExecutionRequests(
-        deposits=spec.List[spec.DepositRequest, spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD](
+        deposits=spec.List[spec.DepositRequest, max_deposit_requests_per_payload](
             [deposit_request]
         ),
         withdrawals=spec.List[spec.WithdrawalRequest, spec.MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD](),

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/multi_operations.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/multi_operations.py
@@ -12,7 +12,7 @@ from eth_consensus_specs.test.helpers.block import (
 )
 from eth_consensus_specs.test.helpers.bls_to_execution_changes import get_signed_address_change
 from eth_consensus_specs.test.helpers.deposits import build_deposit, deposit_from_context
-from eth_consensus_specs.test.helpers.forks import is_post_electra
+from eth_consensus_specs.test.helpers.forks import is_post_electra, is_post_gloas
 from eth_consensus_specs.test.helpers.keys import privkeys, pubkeys
 from eth_consensus_specs.test.helpers.proposer_slashings import get_valid_proposer_slashing
 from eth_consensus_specs.test.helpers.state import (
@@ -299,7 +299,9 @@ def get_random_execution_requests(spec, state, rng):
 
 def get_random_deposit_requests(spec, state, rng, num_deposits=None):
     if num_deposits is None:
-        num_deposits = rng.randint(0, spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD)
+        # Use an arbitrarily high number for gloas+
+        limit = spec.MAX_DEPOSIT_REQUESTS_PER_PAYLOAD if is_post_gloas(spec) else 10000
+        num_deposits = rng.randint(0, limit)
 
     deposit_data_leaves = [spec.DepositData() for _ in range(len(state.validators))]
 


### PR DESCRIPTION
We intend to raise the gas limit to 200m. If the EL provides a payload to the CL with more than 8,192 deposits, the CL will be unable to deserialize the payload and therefore unable to propose. This could potentially stall the network. This PR raises `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD` from 8,192 to 1,048,576. With this change, the number of deposits per payload will be effectively limited by the gas limit. This number would support a gas limit of ~25 gigagas. Alternatively, we could merge #4630 which also fixes this issue by using a `ProgressiveList` without any limit. I view this change as a temporary bandaid until we're ready to merge #4630.