### PR TITLE
Add note about validating deposit signatures before the fork

### DIFF
--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -57,9 +57,9 @@ def initialize_ptc_window(
 
 ### New `onboard_builders_from_pending_deposits`
 
-*Note*: Implementations SHOULD validate deposit signatures and cache the results
-in the epochs leading up to the fork. There may be many pending deposits for new
-builders, and validating them all at the fork transition could be slow.
+*Note*: In the slots leading up to the fork, implementations SHOULD validate
+pending deposit signatures and cache the results. The pending deposit queue
+might be large and verifying many signatures at the fork could be slow.
 
 ```python
 def onboard_builders_from_pending_deposits(state: BeaconState) -> None:

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -57,6 +57,10 @@ def initialize_ptc_window(
 
 ### New `onboard_builders_from_pending_deposits`
 
+*Note*: Implementations SHOULD validate deposit signatures and cache the results
+in the epochs leading up to the fork. There may be many pending deposits for new
+builders, and validating them all at the fork transition could be slow.
+
 ```python
 def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
     """


### PR DESCRIPTION
While thinking about deposit signature validation concerns (ie #5223), I realized that there could be a lot of new/unique builder deposits at the fork. All of these signatures would be validated during the upgrade. Say an attacker decided to make 20 thousand 1 ETH deposits in the epoch before the fork. If this takes longer than 12 seconds to verify, nodes will temporarily fall behind. Clients should try to validate these signatures before the upgrade, when there are spare resources.