### PR TITLE
Use uv for fork choice config generator docs

### DIFF
--- a/tests/generators/compliance_runners/fork_choice/README.md
+++ b/tests/generators/compliance_runners/fork_choice/README.md
@@ -50,7 +50,7 @@ generated with [`generate_test_instances.py`](generate_test_instances.py), e.g.
 
 ```
 make _pyspec  # Initialize virtual environment
-python -m tests.generators.compliance_runners.fork_choice.generate_test_instances
+uv run python -m tests.generators.compliance_runners.fork_choice.generate_test_instances
 ```
 
 But one normally doesn't need to generate them.


### PR DESCRIPTION
Related to #5062

This updates the fork choice compliance generator README so the configuration generation example runs through `uv`, matching the environment used by the repository's Makefile targets and the surrounding README examples.
