### PR TITLE
Add executable gossip validation functions for electra

### DIFF
--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -149,7 +149,7 @@ def validate_beacon_block_gossip(
 
     # [IGNORE] The block is from a slot greater than the latest finalized slot
     # (MAY choose to validate and store such blocks for additional purposes
-    # -- e.g. slashing detection, archive nodes, etc).
+    # -- e.g. slashing detection, archive nodes, etc)
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     if block.slot <= finalized_slot:
         raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
@@ -218,7 +218,7 @@ def validate_beacon_block_gossip(
     if block.proposer_index != expected_proposer:
         raise GossipReject("block proposer_index does not match expected proposer")
 
-    # Mark this block as seen for this proposer/slot combination
+    # Mark this block as seen
     seen.proposer_slots.add((block.proposer_index, block.slot))
 ```
 
@@ -263,12 +263,11 @@ def validate_beacon_aggregate_and_proof_gossip(
         raise GossipReject("committee index out of range")
 
     # [IGNORE] The aggregate attestation's slot is not from a future slot
-    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+    # (MAY be queued for processing at the appropriate slot)
     if not is_not_from_future_slot(state, aggregate.data.slot, current_time_ms):
         raise GossipIgnore("aggregate slot is from a future slot")
 
     # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
-    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
     attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
     is_previous_epoch_attestation = is_within_slot_range(
         state,
@@ -304,15 +303,9 @@ def validate_beacon_aggregate_and_proof_gossip(
     aggregate_data_root = hash_tree_root(aggregate.data)
     aggregate_cache_key = (aggregate_data_root, index)
     aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
-    seen_aggregation_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
-    for prior_aggregation_bits in seen_aggregation_bits:
-        is_non_strict_superset = True
-        for prior_bit, aggregate_bit in zip(prior_aggregation_bits, aggregate_bits):
-            if aggregate_bit and not prior_bit:
-                is_non_strict_superset = False
-                break
-        if is_non_strict_superset:
-            raise GossipIgnore("already seen aggregate for this data")
+    seen_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
+    if is_non_strict_superset(seen_bits, aggregate_bits):
+        raise GossipIgnore("already seen aggregate for this data")
 
     # [IGNORE] This is the first valid aggregate for this aggregator in this epoch
     aggregator_index = aggregate_and_proof.aggregator_index
@@ -345,7 +338,8 @@ def validate_beacon_aggregate_and_proof_gossip(
     if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
         raise GossipReject("invalid aggregate signature")
 
-    # [IGNORE] The block being voted for has been seen
+    # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+    # (MAY be queued until block is retrieved)
     if aggregate.data.beacon_block_root not in store.blocks:
         raise GossipIgnore("block being voted for has not been seen")
 
@@ -411,7 +405,7 @@ def validate_blob_sidecar_gossip(
         raise GossipReject("blob sidecar is for wrong subnet")
 
     # [IGNORE] The sidecar is not from a future slot
-    # (a client MAY queue future sidecars for processing at the appropriate slot)
+    # (MAY be queued for processing at the appropriate slot)
     if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
         raise GossipIgnore("blob sidecar is from a future slot")
 
@@ -420,9 +414,11 @@ def validate_blob_sidecar_gossip(
     if block_header.slot <= finalized_slot:
         raise GossipIgnore("blob sidecar is not from a slot greater than the latest finalized slot")
 
-    # [REJECT] The proposer signature of blob_sidecar.signed_block_header is valid
+    # [REJECT] The proposer index is a valid validator index
     if block_header.proposer_index >= len(state.validators):
         raise GossipReject("proposer index out of range")
+
+    # [REJECT] The proposer signature of blob_sidecar.signed_block_header is valid
     proposer = state.validators[block_header.proposer_index]
     domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block_header.slot))
     signing_root = compute_signing_root(block_header, domain)
@@ -430,6 +426,7 @@ def validate_blob_sidecar_gossip(
         raise GossipReject("invalid proposer signature on blob sidecar block header")
 
     # [IGNORE] The sidecar's block's parent has been seen
+    # (MAY be queued for processing once the parent block is retrieved)
     if block_header.parent_root not in store.blocks:
         raise GossipIgnore("blob sidecar's parent has not been seen")
 
@@ -448,7 +445,7 @@ def validate_blob_sidecar_gossip(
     if checkpoint_block != store.finalized_checkpoint.root:
         raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
 
-    # [REJECT] The sidecar's inclusion proof is valid
+    # [REJECT] The sidecar's inclusion proof is valid as verified by verify_blob_sidecar_inclusion_proof
     if not verify_blob_sidecar_inclusion_proof(blob_sidecar):
         raise GossipReject("invalid blob sidecar inclusion proof")
 
@@ -462,12 +459,10 @@ def validate_blob_sidecar_gossip(
     # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
     sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
     if sidecar_tuple in seen.blob_sidecar_tuples:
-        raise GossipIgnore("already seen blob sidecar for this slot/proposer/index")
+        raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
 
     # [REJECT] The sidecar is proposed by the expected proposer_index
-    # (If the proposer_index cannot immediately be verified against the expected shuffling,
-    # the sidecar MAY be queued for later processing while proposers for the block's branch
-    # are calculated -- in such a case do not REJECT, instead IGNORE this message)
+    # (if shuffling is not available, IGNORE instead and MAY be queued for later)
     parent_state = store.block_states[block_header.parent_root].copy()
     process_slots(parent_state, block_header.slot)
     expected_proposer = get_beacon_proposer_index(parent_state)
@@ -525,12 +520,11 @@ def validate_beacon_attestation_gossip(
         raise GossipReject("attestation is for wrong subnet")
 
     # [IGNORE] The attestation's slot is not from a future slot
-    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+    # (MAY be queued for processing at the appropriate slot)
     if not is_not_from_future_slot(state, data.slot, current_time_ms):
         raise GossipIgnore("attestation slot is from a future slot")
 
     # [IGNORE] The attestation's epoch is either the current or previous epoch
-    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
     attestation_epoch = compute_epoch_at_slot(data.slot)
     is_previous_epoch_attestation = is_within_slot_range(
         state,
@@ -557,6 +551,7 @@ def validate_beacon_attestation_gossip(
     if attester_index not in committee:
         raise GossipReject("attester is not a member of the committee")
 
+    # [Modified in Electra:EIP7549]
     # [IGNORE] No other valid attestation seen for this validator and target epoch
     if (attester_index, target_epoch) in seen.attestation_validator_epochs:
         raise GossipIgnore("already seen attestation from this validator for this epoch")
@@ -569,7 +564,8 @@ def validate_beacon_attestation_gossip(
     if not bls.Verify(attester.pubkey, signing_root, attestation.signature):
         raise GossipReject("invalid attestation signature")
 
-    # [IGNORE] The block being voted for has been seen
+    # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+    # (MAY be queued until block is retrieved)
     beacon_block_root = data.beacon_block_root
     if beacon_block_root not in store.blocks:
         raise GossipIgnore("block being voted for has not been seen")

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -6,6 +6,7 @@
 - [Modifications in Electra](#modifications-in-electra)
   - [Configuration](#configuration)
   - [Helpers](#helpers)
+    - [Modified `Seen`](#modified-seen)
     - [Modified `compute_fork_version`](#modified-compute_fork_version)
     - [Modified `compute_max_request_blob_sidecars`](#modified-compute_max_request_blob_sidecars)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
@@ -13,6 +14,7 @@
       - [Global topics](#global-topics)
         - [`beacon_block`](#beacon_block)
         - [`beacon_aggregate_and_proof`](#beacon_aggregate_and_proof)
+        - [`attester_slashing`](#attester_slashing)
         - [`blob_sidecar_{subnet_id}`](#blob_sidecar_subnet_id)
       - [Attestation subnets](#attestation-subnets)
         - [`beacon_attestation_{subnet_id}`](#beacon_attestation_subnet_id)
@@ -44,6 +46,26 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 | `BLOB_SIDECAR_SUBNET_COUNT_ELECTRA` | `9`   | The number of blob sidecar subnets used in the gossipsub protocol |
 
 ### Helpers
+
+#### Modified `Seen`
+
+```python
+@dataclass
+class Seen(object):
+    proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
+    aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+    # [Modified in Electra:EIP7549]
+    aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[boolean, ...]]]
+    voluntary_exit_indices: Set[ValidatorIndex]
+    proposer_slashing_indices: Set[ValidatorIndex]
+    attester_slashing_indices: Set[ValidatorIndex]
+    attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+    sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, uint64]]
+    sync_contribution_data: Dict[Tuple[Slot, Root, uint64], Set[Tuple[boolean, ...]]]
+    sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, uint64]]
+    bls_to_execution_change_indices: Set[ValidatorIndex]
+    blob_sidecar_tuples: Set[Tuple[Slot, ValidatorIndex, BlobIndex]]
+```
 
 #### Modified `compute_fork_version`
 
@@ -93,7 +115,7 @@ The `attester_slashing` topic is modified to support the gossip of the new
 `AttesterSlashing` type.
 
 The specification around the creation, validation, and dissemination of messages
-has not changed from the Capella document unless explicitly noted here.
+has not changed from the Deneb document unless explicitly noted here.
 
 The derivation of the `message-id` remains stable.
 
@@ -101,59 +123,476 @@ The derivation of the `message-id` remains stable.
 
 ###### `beacon_block`
 
-*Updated validation*
+*Note*: This function is modified per EIP-7691. The block's KZG commitment count
+is bounded by `MAX_BLOBS_PER_BLOCK_ELECTRA`.
 
-- _[REJECT]_ The length of KZG commitments is less than or equal to the
-  limitation defined in the consensus layer -- i.e. validate that
-  `len(signed_beacon_block.message.body.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK_ELECTRA`
+```python
+def validate_beacon_block_gossip(
+    seen: Seen,
+    store: Store,
+    state: BeaconState,
+    signed_beacon_block: SignedBeaconBlock,
+    current_time_ms: uint64,
+    block_payload_statuses: Dict[Root, PayloadValidationStatus] = {},
+) -> None:
+    """
+    Validate a SignedBeaconBlock for gossip propagation.
+    Raises GossipIgnore or GossipReject on validation failure.
+    """
+    block = signed_beacon_block.message
+    execution_payload = block.body.execution_payload
+
+    # [IGNORE] The block is not from a future slot
+    # (MAY be queued for processing at the appropriate slot)
+    if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        raise GossipIgnore("block is from a future slot")
+
+    # [IGNORE] The block is from a slot greater than the latest finalized slot
+    # (MAY choose to validate and store such blocks for additional purposes
+    # -- e.g. slashing detection, archive nodes, etc).
+    finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+    if block.slot <= finalized_slot:
+        raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
+
+    # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
+    if (block.proposer_index, block.slot) in seen.proposer_slots:
+        raise GossipIgnore("block is not the first valid block for this proposer and slot")
+
+    # [REJECT] The proposer index is a valid validator index
+    if block.proposer_index >= len(state.validators):
+        raise GossipReject("proposer index out of range")
+
+    # [REJECT] The proposer signature is valid
+    proposer = state.validators[block.proposer_index]
+    domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+    signing_root = compute_signing_root(block, domain)
+    if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
+        raise GossipReject("invalid proposer signature")
+
+    # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
+    # (MAY be queued until parent is retrieved)
+    if block.parent_root not in store.blocks:
+        raise GossipIgnore("block's parent has not been seen")
+
+    # [REJECT] The block's execution payload timestamp is correct with respect to the slot
+    if execution_payload.timestamp != compute_time_at_slot(state, block.slot):
+        raise GossipReject("incorrect execution payload timestamp")
+
+    parent_payload_status = PAYLOAD_STATUS_NOT_VALIDATED
+    if block.parent_root in block_payload_statuses:
+        parent_payload_status = block_payload_statuses[block.parent_root]
+
+    if block.parent_root not in store.block_states:
+        if parent_payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
+            # [REJECT] The block's parent passes validation
+            raise GossipReject("block's parent is invalid and EL result is unknown")
+
+        # [IGNORE] The block's parent passes validation
+        raise GossipIgnore("block's parent is invalid and EL result is known")
+
+    # [IGNORE] The block's parent's execution payload passes validation
+    if parent_payload_status == PAYLOAD_STATUS_INVALIDATED:
+        raise GossipIgnore("block's parent is valid and EL result is invalid")
+
+    # [REJECT] The block is from a higher slot than its parent
+    if block.slot <= store.blocks[block.parent_root].slot:
+        raise GossipReject("block is not from a higher slot than its parent")
+
+    # [REJECT] The current finalized checkpoint is an ancestor of the block
+    checkpoint_block = get_checkpoint_block(
+        store, block.parent_root, store.finalized_checkpoint.epoch
+    )
+    if checkpoint_block != store.finalized_checkpoint.root:
+        raise GossipReject("finalized checkpoint is not an ancestor of block")
+
+    # [Modified in Electra:EIP7691]
+    # [REJECT] The length of KZG commitments is less than or equal to the limit
+    if len(block.body.blob_kzg_commitments) > MAX_BLOBS_PER_BLOCK_ELECTRA:
+        raise GossipReject("too many blob kzg commitments")
+
+    # [REJECT] The block is proposed by the expected proposer for the slot
+    # (if shuffling is not available, IGNORE instead and MAY be queued for later)
+    parent_state = store.block_states[block.parent_root].copy()
+    process_slots(parent_state, block.slot)
+    expected_proposer = get_beacon_proposer_index(parent_state)
+    if block.proposer_index != expected_proposer:
+        raise GossipReject("block proposer_index does not match expected proposer")
+
+    # Mark this block as seen for this proposer/slot combination
+    seen.proposer_slots.add((block.proposer_index, block.slot))
+```
 
 ###### `beacon_aggregate_and_proof`
 
-Assuming the alias `aggregate = signed_aggregate_and_proof.message.aggregate`:
+*Note*: This function is modified per EIP-7549. The committee index is now
+encoded in `aggregate.committee_bits`, `aggregate.data.index` MUST be zero, and
+the gossip seen-cache is keyed by
+`(hash_tree_root(aggregate.data), committee_index)`.
 
-The following convenience variables are re-defined:
+```python
+def validate_beacon_aggregate_and_proof_gossip(
+    seen: Seen,
+    store: Store,
+    state: BeaconState,
+    signed_aggregate_and_proof: SignedAggregateAndProof,
+    current_time_ms: uint64,
+) -> None:
+    """
+    Validate a SignedAggregateAndProof for gossip propagation.
+    Raises GossipIgnore or GossipReject on validation failure.
+    """
+    aggregate_and_proof = signed_aggregate_and_proof.message
+    aggregate = aggregate_and_proof.aggregate
+    aggregation_bits = aggregate.aggregation_bits
 
-- `index = get_committee_indices(aggregate.committee_bits)[0]`
+    # [New in Electra:EIP7549]
+    # [REJECT] The aggregate attestation's data index is zero
+    if aggregate.data.index != 0:
+        raise GossipReject("aggregate data index is non-zero")
 
-The following validations are added:
+    # [New in Electra:EIP7549]
+    # [REJECT] Exactly one committee is specified by the committee bits
+    committee_indices = get_committee_indices(aggregate.committee_bits)
+    if len(committee_indices) != 1:
+        raise GossipReject("aggregate committee bits must specify exactly one committee")
+    index = committee_indices[0]
 
-- [REJECT] `len(committee_indices) == 1`, where
-  `committee_indices = get_committee_indices(aggregate.committee_bits)`.
-- [REJECT] `aggregate.data.index == 0`
+    # [REJECT] The committee index is within the expected range
+    committee_count = get_committee_count_per_slot(state, aggregate.data.target.epoch)
+    if index >= committee_count:
+        raise GossipReject("committee index out of range")
+
+    # [IGNORE] The aggregate attestation's slot is not from a future slot
+    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+    if not is_not_from_future_slot(state, aggregate.data.slot, current_time_ms):
+        raise GossipIgnore("aggregate slot is from a future slot")
+
+    # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
+    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+    attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
+    is_previous_epoch_attestation = is_within_slot_range(
+        state,
+        compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
+        SLOTS_PER_EPOCH - 1,
+        current_time_ms,
+    )
+    is_current_epoch_attestation = is_within_slot_range(
+        state,
+        compute_start_slot_at_epoch(attestation_epoch),
+        SLOTS_PER_EPOCH - 1,
+        current_time_ms,
+    )
+    if not (is_previous_epoch_attestation or is_current_epoch_attestation):
+        raise GossipIgnore("aggregate epoch is not previous or current epoch")
+
+    # [REJECT] The aggregate attestation's epoch matches its target
+    if aggregate.data.target.epoch != compute_epoch_at_slot(aggregate.data.slot):
+        raise GossipReject("attestation epoch does not match target epoch")
+
+    # [REJECT] The number of aggregation bits matches the committee size
+    committee = get_beacon_committee(state, aggregate.data.slot, index)
+    if len(aggregation_bits) != len(committee):
+        raise GossipReject("aggregation bits length does not match committee size")
+
+    # [REJECT] The aggregate attestation has participants
+    attesting_indices = get_attesting_indices(state, aggregate)
+    if len(attesting_indices) < 1:
+        raise GossipReject("aggregate has no participants")
+
+    # [Modified in Electra:EIP7549]
+    # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
+    aggregate_data_root = hash_tree_root(aggregate.data)
+    aggregate_cache_key = (aggregate_data_root, index)
+    aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
+    seen_aggregation_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
+    for prior_aggregation_bits in seen_aggregation_bits:
+        is_non_strict_superset = True
+        for prior_bit, aggregate_bit in zip(prior_aggregation_bits, aggregate_bits):
+            if aggregate_bit and not prior_bit:
+                is_non_strict_superset = False
+                break
+        if is_non_strict_superset:
+            raise GossipIgnore("already seen aggregate for this data")
+
+    # [IGNORE] This is the first valid aggregate for this aggregator in this epoch
+    aggregator_index = aggregate_and_proof.aggregator_index
+    target_epoch = aggregate.data.target.epoch
+    if (aggregator_index, target_epoch) in seen.aggregator_epochs:
+        raise GossipIgnore("already seen aggregate from this aggregator for this epoch")
+
+    # [REJECT] The selection proof selects the validator as an aggregator
+    if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
+        raise GossipReject("validator is not selected as aggregator")
+
+    # [REJECT] The aggregator's validator index is within the committee
+    if aggregator_index not in committee:
+        raise GossipReject("aggregator index not in committee")
+
+    # [REJECT] The selection proof signature is valid
+    aggregator = state.validators[aggregator_index]
+    domain = get_domain(state, DOMAIN_SELECTION_PROOF, target_epoch)
+    signing_root = compute_signing_root(aggregate.data.slot, domain)
+    if not bls.Verify(aggregator.pubkey, signing_root, aggregate_and_proof.selection_proof):
+        raise GossipReject("invalid selection proof signature")
+
+    # [REJECT] The aggregator signature is valid
+    domain = get_domain(state, DOMAIN_AGGREGATE_AND_PROOF, target_epoch)
+    signing_root = compute_signing_root(aggregate_and_proof, domain)
+    if not bls.Verify(aggregator.pubkey, signing_root, signed_aggregate_and_proof.signature):
+        raise GossipReject("invalid aggregator signature")
+
+    # [REJECT] The aggregate signature is valid
+    if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
+        raise GossipReject("invalid aggregate signature")
+
+    # [IGNORE] The block being voted for has been seen
+    if aggregate.data.beacon_block_root not in store.blocks:
+        raise GossipIgnore("block being voted for has not been seen")
+
+    # [REJECT] The block being voted for passes validation
+    if aggregate.data.beacon_block_root not in store.block_states:
+        raise GossipReject("block being voted for failed validation")
+
+    # [REJECT] The target block is an ancestor of the LMD vote block
+    checkpoint_block = get_checkpoint_block(
+        store, aggregate.data.beacon_block_root, aggregate.data.target.epoch
+    )
+    if checkpoint_block != aggregate.data.target.root:
+        raise GossipReject("target block is not an ancestor of LMD vote block")
+
+    # [IGNORE] The finalized checkpoint is an ancestor of the block
+    finalized_checkpoint_block = get_checkpoint_block(
+        store, aggregate.data.beacon_block_root, store.finalized_checkpoint.epoch
+    )
+    if finalized_checkpoint_block != store.finalized_checkpoint.root:
+        raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+    # Mark this aggregate as seen
+    seen.aggregator_epochs.add((aggregator_index, target_epoch))
+    if aggregate_cache_key not in seen.aggregate_data_roots:
+        seen.aggregate_data_roots[aggregate_cache_key] = set()
+    seen.aggregate_data_roots[aggregate_cache_key].add(aggregate_bits)
+```
+
+###### `attester_slashing`
+
+*Note*: This function is modified per EIP-7549. The new `AttesterSlashing` type
+wraps an `IndexedAttestation` payload sized for
+`MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT` attesting indices; the
+validation logic is otherwise unchanged.
 
 ###### `blob_sidecar_{subnet_id}`
 
-*[Modified in Electra:EIP7691]*
+*Note*: This function is modified per EIP-7691. The sidecar's index is bounded
+by `MAX_BLOBS_PER_BLOCK_ELECTRA`.
 
-The existing validations all apply as given from previous forks, with the
-following exceptions:
+```python
+def validate_blob_sidecar_gossip(
+    seen: Seen,
+    store: Store,
+    state: BeaconState,
+    blob_sidecar: BlobSidecar,
+    subnet_id: SubnetID,
+    current_time_ms: uint64,
+) -> None:
+    """
+    Validate a BlobSidecar for gossip propagation on a subnet.
+    Raises GossipIgnore or GossipReject on validation failure.
+    """
+    block_header = blob_sidecar.signed_block_header.message
 
-- Uses of `MAX_BLOBS_PER_BLOCK` in existing validations are replaced with
-  `MAX_BLOBS_PER_BLOCK_ELECTRA`.
+    # [Modified in Electra:EIP7691]
+    # [REJECT] The sidecar's index is consistent with MAX_BLOBS_PER_BLOCK_ELECTRA
+    if blob_sidecar.index >= MAX_BLOBS_PER_BLOCK_ELECTRA:
+        raise GossipReject("blob index out of range")
+
+    # [REJECT] The sidecar is for the correct subnet
+    if compute_subnet_for_blob_sidecar(blob_sidecar.index) != subnet_id:
+        raise GossipReject("blob sidecar is for wrong subnet")
+
+    # [IGNORE] The sidecar is not from a future slot
+    # (a client MAY queue future sidecars for processing at the appropriate slot)
+    if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+        raise GossipIgnore("blob sidecar is from a future slot")
+
+    # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
+    finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+    if block_header.slot <= finalized_slot:
+        raise GossipIgnore("blob sidecar is not from a slot greater than the latest finalized slot")
+
+    # [REJECT] The proposer signature of blob_sidecar.signed_block_header is valid
+    if block_header.proposer_index >= len(state.validators):
+        raise GossipReject("proposer index out of range")
+    proposer = state.validators[block_header.proposer_index]
+    domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block_header.slot))
+    signing_root = compute_signing_root(block_header, domain)
+    if not bls.Verify(proposer.pubkey, signing_root, blob_sidecar.signed_block_header.signature):
+        raise GossipReject("invalid proposer signature on blob sidecar block header")
+
+    # [IGNORE] The sidecar's block's parent has been seen
+    if block_header.parent_root not in store.blocks:
+        raise GossipIgnore("blob sidecar's parent has not been seen")
+
+    # [REJECT] The sidecar's block's parent passes validation
+    if block_header.parent_root not in store.block_states:
+        raise GossipReject("blob sidecar's parent failed validation")
+
+    # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
+    if block_header.slot <= store.blocks[block_header.parent_root].slot:
+        raise GossipReject("blob sidecar is not from a higher slot than its parent")
+
+    # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
+    checkpoint_block = get_checkpoint_block(
+        store, block_header.parent_root, store.finalized_checkpoint.epoch
+    )
+    if checkpoint_block != store.finalized_checkpoint.root:
+        raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
+
+    # [REJECT] The sidecar's inclusion proof is valid
+    if not verify_blob_sidecar_inclusion_proof(blob_sidecar):
+        raise GossipReject("invalid blob sidecar inclusion proof")
+
+    # [REJECT] The sidecar's blob is valid as verified by verify_blob_kzg_proof
+    if not verify_blob_kzg_proof(
+        blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof
+    ):
+        raise GossipReject("invalid blob kzg proof")
+
+    # [IGNORE] The sidecar is the first sidecar for the tuple
+    # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+    sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+    if sidecar_tuple in seen.blob_sidecar_tuples:
+        raise GossipIgnore("already seen blob sidecar for this slot/proposer/index")
+
+    # [REJECT] The sidecar is proposed by the expected proposer_index
+    # (If the proposer_index cannot immediately be verified against the expected shuffling,
+    # the sidecar MAY be queued for later processing while proposers for the block's branch
+    # are calculated -- in such a case do not REJECT, instead IGNORE this message)
+    parent_state = store.block_states[block_header.parent_root].copy()
+    process_slots(parent_state, block_header.slot)
+    expected_proposer = get_beacon_proposer_index(parent_state)
+    if block_header.proposer_index != expected_proposer:
+        raise GossipReject("blob sidecar proposer_index does not match expected proposer")
+
+    # Mark this blob sidecar as seen
+    seen.blob_sidecar_tuples.add(sidecar_tuple)
+```
 
 ##### Attestation subnets
 
 ###### `beacon_attestation_{subnet_id}`
 
-The topic is updated to propagate `SingleAttestation` objects.
+*Note*: This function is modified per EIP-7549. The topic now propagates
+`SingleAttestation` objects: the attesting validator's index is carried directly
+in the message, the committee index is read from `attestation.committee_index`,
+and `attestation.data.index` MUST be zero.
 
-The following convenience variables are re-defined:
+```python
+def validate_beacon_attestation_gossip(
+    seen: Seen,
+    store: Store,
+    state: BeaconState,
+    # [Modified in Electra:EIP7549]
+    attestation: SingleAttestation,
+    subnet_id: uint64,
+    current_time_ms: uint64,
+) -> None:
+    """
+    Validate a SingleAttestation for gossip propagation on a subnet.
+    Raises GossipIgnore or GossipReject on validation failure.
+    """
+    data = attestation.data
+    # [Modified in Electra:EIP7549]
+    committee_index = attestation.committee_index
+    attester_index = attestation.attester_index
+    target_epoch = data.target.epoch
 
-- `index = attestation.committee_index`
+    # [New in Electra:EIP7549]
+    # [REJECT] The attestation's data index is zero
+    if data.index != 0:
+        raise GossipReject("attestation data index is non-zero")
 
-The following validations are added:
+    # [REJECT] The committee index is within the expected range
+    committees_per_slot = get_committee_count_per_slot(state, target_epoch)
+    if committee_index >= committees_per_slot:
+        raise GossipReject("committee index out of range")
 
-- _[REJECT]_ `attestation.data.index == 0`
-- _[REJECT]_ The attester is a member of the committee -- i.e.
-  `attestation.attester_index in get_beacon_committee(state, attestation.data.slot, index)`.
+    # [REJECT] The attestation is for the correct subnet
+    expected_subnet = compute_subnet_for_attestation(
+        committees_per_slot, data.slot, committee_index
+    )
+    if expected_subnet != subnet_id:
+        raise GossipReject("attestation is for wrong subnet")
 
-The following validations are removed:
+    # [IGNORE] The attestation's slot is not from a future slot
+    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+    if not is_not_from_future_slot(state, data.slot, current_time_ms):
+        raise GossipIgnore("attestation slot is from a future slot")
 
-- _[REJECT]_ The attestation is unaggregated -- that is, it has exactly one
-  participating validator (`len([bit for bit in aggregation_bits if bit]) == 1`,
-  i.e. exactly 1 bit is set).
-- _[REJECT]_ The number of aggregation bits matches the committee size -- i.e.
-  `len(aggregation_bits) == len(get_beacon_committee(state, attestation.data.slot, index))`.
+    # [IGNORE] The attestation's epoch is either the current or previous epoch
+    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+    attestation_epoch = compute_epoch_at_slot(data.slot)
+    is_previous_epoch_attestation = is_within_slot_range(
+        state,
+        compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
+        SLOTS_PER_EPOCH - 1,
+        current_time_ms,
+    )
+    is_current_epoch_attestation = is_within_slot_range(
+        state,
+        compute_start_slot_at_epoch(attestation_epoch),
+        SLOTS_PER_EPOCH - 1,
+        current_time_ms,
+    )
+    if not (is_previous_epoch_attestation or is_current_epoch_attestation):
+        raise GossipIgnore("attestation epoch is not previous or current epoch")
+
+    # [REJECT] The attestation's epoch matches its target
+    if target_epoch != compute_epoch_at_slot(data.slot):
+        raise GossipReject("attestation epoch does not match target epoch")
+
+    # [New in Electra:EIP7549]
+    # [REJECT] The attester is a member of the committee
+    committee = get_beacon_committee(state, data.slot, committee_index)
+    if attester_index not in committee:
+        raise GossipReject("attester is not a member of the committee")
+
+    # [IGNORE] No other valid attestation seen for this validator and target epoch
+    if (attester_index, target_epoch) in seen.attestation_validator_epochs:
+        raise GossipIgnore("already seen attestation from this validator for this epoch")
+
+    # [Modified in Electra:EIP7549]
+    # [REJECT] The attestation signature is valid
+    attester = state.validators[attester_index]
+    domain = get_domain(state, DOMAIN_BEACON_ATTESTER, target_epoch)
+    signing_root = compute_signing_root(data, domain)
+    if not bls.Verify(attester.pubkey, signing_root, attestation.signature):
+        raise GossipReject("invalid attestation signature")
+
+    # [IGNORE] The block being voted for has been seen
+    beacon_block_root = data.beacon_block_root
+    if beacon_block_root not in store.blocks:
+        raise GossipIgnore("block being voted for has not been seen")
+
+    # [REJECT] The block being voted for passes validation
+    if beacon_block_root not in store.block_states:
+        raise GossipReject("block being voted for failed validation")
+
+    # [REJECT] The attestation's target block is an ancestor of the LMD vote block
+    target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
+    if target_checkpoint_block != data.target.root:
+        raise GossipReject("target block is not an ancestor of LMD vote block")
+
+    # [IGNORE] The current finalized_checkpoint is an ancestor of the block
+    finalized_checkpoint_block = get_checkpoint_block(
+        store, beacon_block_root, store.finalized_checkpoint.epoch
+    )
+    if finalized_checkpoint_block != store.finalized_checkpoint.root:
+        raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+    # Mark this attestation as seen
+    seen.attestation_validator_epochs.add((attester_index, target_epoch))
+```
 
 ### The Req/Resp domain
 

--- a/tests/core/pyspec/eth_consensus_specs/test/bellatrix/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/bellatrix/networking/test_gossip_beacon_block.py
@@ -6,7 +6,7 @@ from eth_consensus_specs.test.helpers.block import (
     build_empty_block_for_next_slot,
     sign_block,
 )
-from eth_consensus_specs.test.helpers.constants import BELLATRIX, CAPELLA, DENEB
+from eth_consensus_specs.test.helpers.constants import BELLATRIX, CAPELLA, DENEB, ELECTRA
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_empty_execution_payload,
     build_state_with_complete_transition,
@@ -29,7 +29,7 @@ from eth_consensus_specs.test.helpers.state import (
 )
 
 
-@with_phases([BELLATRIX, CAPELLA, DENEB])
+@with_phases([BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__valid_execution_enabled(spec, state):
     """
@@ -110,7 +110,7 @@ def test_gossip_beacon_block__valid_execution_disabled(spec, state):
     )
 
 
-@with_phases([BELLATRIX, CAPELLA, DENEB])
+@with_phases([BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__reject_incorrect_execution_payload_timestamp(spec, state):
     """
@@ -161,7 +161,7 @@ def test_gossip_beacon_block__reject_incorrect_execution_payload_timestamp(spec,
     )
 
 
-@with_phases([BELLATRIX, CAPELLA, DENEB])
+@with_phases([BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__reject_parent_consensus_failed_execution_not_verified(spec, state):
     """
@@ -250,7 +250,7 @@ def test_gossip_beacon_block__reject_parent_consensus_failed_execution_not_verif
     )
 
 
-@with_phases([BELLATRIX, CAPELLA, DENEB])
+@with_phases([BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__ignore_parent_consensus_failed_execution_known(spec, state):
     """
@@ -338,7 +338,7 @@ def test_gossip_beacon_block__ignore_parent_consensus_failed_execution_known(spe
     )
 
 
-@with_phases([BELLATRIX, CAPELLA, DENEB])
+@with_phases([BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__ignore_parent_execution_verified_invalid(spec, state):
     """
@@ -428,7 +428,7 @@ def test_gossip_beacon_block__ignore_parent_execution_verified_invalid(spec, sta
     )
 
 
-@with_phases([BELLATRIX, CAPELLA, DENEB])
+@with_phases([BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__valid_parent_execution_verified_valid(spec, state):
     """
@@ -510,7 +510,7 @@ def test_gossip_beacon_block__valid_parent_execution_verified_valid(spec, state)
     )
 
 
-@with_phases([BELLATRIX, CAPELLA, DENEB])
+@with_phases([BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__valid_parent_optimistic(spec, state):
     """

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -5,7 +5,7 @@ from eth_consensus_specs.test.context import (
 from eth_consensus_specs.test.helpers.attestations import (
     get_valid_attestation,
 )
-from eth_consensus_specs.test.helpers.constants import DENEB
+from eth_consensus_specs.test.helpers.constants import DENEB, ELECTRA
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
@@ -96,7 +96,7 @@ def build_message(signed_agg, current_time_ms, offset_ms, expected, reason=None)
     return message
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__accepts_one_millisecond_before_slot_start(spec, state):
     """Test that an aggregate is accepted one millisecond before its slot starts."""
@@ -123,7 +123,7 @@ def test_gossip_beacon_aggregate_and_proof__accepts_one_millisecond_before_slot_
     yield "messages", "meta", [build_message(signed_agg, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__accepts_at_slot_start(spec, state):
     """Test that an aggregate is accepted exactly at its slot start."""
@@ -148,7 +148,7 @@ def test_gossip_beacon_aggregate_and_proof__accepts_at_slot_start(spec, state):
     yield "messages", "meta", [build_message(signed_agg, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__ignores_first_slot_before_epoch_window_opens(
     spec, state
@@ -181,7 +181,7 @@ def test_gossip_beacon_aggregate_and_proof__ignores_first_slot_before_epoch_wind
     yield "messages", "meta", [build_message(signed_agg, current_time_ms, 0, "ignore", reason)]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__accepts_first_slot_when_epoch_window_opens(spec, state):
     """Test that a first-slot aggregate is accepted when the Deneb epoch window opens."""
@@ -209,7 +209,7 @@ def test_gossip_beacon_aggregate_and_proof__accepts_first_slot_when_epoch_window
     yield "messages", "meta", [build_message(signed_agg, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__accepts_first_slot_when_epoch_window_closes(
     spec, state
@@ -239,7 +239,7 @@ def test_gossip_beacon_aggregate_and_proof__accepts_first_slot_when_epoch_window
     yield "messages", "meta", [build_message(signed_agg, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__ignores_first_slot_after_epoch_window_closes(
     spec, state
@@ -269,7 +269,7 @@ def test_gossip_beacon_aggregate_and_proof__ignores_first_slot_after_epoch_windo
     yield "messages", "meta", [build_message(signed_agg, current_time_ms, 0, "ignore", reason)]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__accepts_last_slot_one_millisecond_before_slot_start(
     spec, state
@@ -307,7 +307,7 @@ def test_gossip_beacon_aggregate_and_proof__accepts_last_slot_one_millisecond_be
     yield "messages", "meta", [build_message(signed_agg, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__accepts_last_slot_at_slot_start(spec, state):
     """Test that a last-slot aggregate is accepted exactly at its slot start."""
@@ -338,7 +338,7 @@ def test_gossip_beacon_aggregate_and_proof__accepts_last_slot_at_slot_start(spec
     yield "messages", "meta", [build_message(signed_agg, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__accepts_last_slot_when_epoch_window_closes(spec, state):
     """Test that a last-slot aggregate is accepted at the last valid Deneb epoch time."""
@@ -369,7 +369,7 @@ def test_gossip_beacon_aggregate_and_proof__accepts_last_slot_when_epoch_window_
     yield "messages", "meta", [build_message(signed_agg, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__ignores_last_slot_after_epoch_window_closes(
     spec, state

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_attestation.py
@@ -4,11 +4,13 @@ from eth_consensus_specs.test.context import (
 )
 from eth_consensus_specs.test.helpers.attestations import (
     get_valid_attestation,
+    to_single_attestation,
 )
-from eth_consensus_specs.test.helpers.constants import DENEB
+from eth_consensus_specs.test.helpers.constants import DENEB, ELECTRA
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
+from eth_consensus_specs.test.helpers.forks import is_post_electra
 from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import transition_to
@@ -16,8 +18,11 @@ from eth_consensus_specs.test.helpers.state import transition_to
 
 def get_correct_subnet_for_attestation(spec, state, attestation):
     committees_per_slot = spec.get_committee_count_per_slot(state, attestation.data.target.epoch)
+    committee_index = (
+        attestation.committee_index if is_post_electra(spec) else attestation.data.index
+    )
     return spec.compute_subnet_for_attestation(
-        committees_per_slot, attestation.data.slot, attestation.data.index
+        committees_per_slot, attestation.data.slot, committee_index
     )
 
 
@@ -39,6 +44,8 @@ def build_unaggregated_attestation(spec, state, beacon_block_root):
     attestation = get_valid_attestation(
         spec, state, signed=False, beacon_block_root=beacon_block_root
     )
+    if is_post_electra(spec):
+        return to_single_attestation(spec, state, attestation)
     committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
     single_bit = [False] * len(committee)
     single_bit[0] = True
@@ -86,7 +93,7 @@ def build_message(attestation, subnet_id, current_time_ms, offset_ms, expected, 
     return message
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__accepts_one_millisecond_before_slot_start(spec, state):
     """Test that an attestation is accepted one millisecond before its slot starts."""
@@ -112,7 +119,7 @@ def test_gossip_beacon_attestation__accepts_one_millisecond_before_slot_start(sp
     yield "messages", "meta", [build_message(attestation, subnet_id, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__accepts_at_slot_start(spec, state):
     """Test that an attestation is accepted exactly at its slot start."""
@@ -138,7 +145,7 @@ def test_gossip_beacon_attestation__accepts_at_slot_start(spec, state):
     yield "messages", "meta", [build_message(attestation, subnet_id, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__ignores_first_slot_before_epoch_window_opens(spec, state):
     """
@@ -174,7 +181,7 @@ def test_gossip_beacon_attestation__ignores_first_slot_before_epoch_window_opens
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__accepts_first_slot_when_epoch_window_opens(spec, state):
     """Test that a first-slot attestation is accepted when the Deneb epoch window opens."""
@@ -203,7 +210,7 @@ def test_gossip_beacon_attestation__accepts_first_slot_when_epoch_window_opens(s
     yield "messages", "meta", [build_message(attestation, subnet_id, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__accepts_first_slot_when_epoch_window_closes(spec, state):
     """Test that a first-slot attestation is accepted at the last valid Deneb epoch time."""
@@ -232,7 +239,7 @@ def test_gossip_beacon_attestation__accepts_first_slot_when_epoch_window_closes(
     yield "messages", "meta", [build_message(attestation, subnet_id, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__ignores_first_slot_after_epoch_window_closes(spec, state):
     """Test that a first-slot attestation is ignored after the Deneb epoch window closes."""
@@ -265,7 +272,7 @@ def test_gossip_beacon_attestation__ignores_first_slot_after_epoch_window_closes
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__accepts_last_slot_one_millisecond_before_slot_start(
     spec, state
@@ -300,7 +307,7 @@ def test_gossip_beacon_attestation__accepts_last_slot_one_millisecond_before_slo
     yield "messages", "meta", [build_message(attestation, subnet_id, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__accepts_last_slot_at_slot_start(spec, state):
     """Test that a last-slot attestation is accepted exactly at its slot start."""
@@ -330,7 +337,7 @@ def test_gossip_beacon_attestation__accepts_last_slot_at_slot_start(spec, state)
     yield "messages", "meta", [build_message(attestation, subnet_id, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__accepts_last_slot_when_epoch_window_closes(spec, state):
     """Test that a last-slot attestation is accepted at the last valid Deneb epoch time."""
@@ -360,7 +367,7 @@ def test_gossip_beacon_attestation__accepts_last_slot_when_epoch_window_closes(s
     yield "messages", "meta", [build_message(attestation, subnet_id, current_time_ms, 0, "valid")]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__ignores_last_slot_after_epoch_window_closes(spec, state):
     """Test that a last-slot attestation is ignored after the Deneb epoch window closes."""

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_block.py
@@ -6,7 +6,7 @@ from eth_consensus_specs.test.context import (
 )
 from eth_consensus_specs.test.helpers.blob import get_block_with_blob, get_max_blob_count
 from eth_consensus_specs.test.helpers.block import sign_block
-from eth_consensus_specs.test.helpers.constants import DENEB
+from eth_consensus_specs.test.helpers.constants import DENEB, ELECTRA
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_state_with_complete_transition,
 )
@@ -24,7 +24,7 @@ from eth_consensus_specs.test.helpers.state import (
 )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__valid_with_blob_kzg_commitments(spec, state):
     """
@@ -64,7 +64,7 @@ def test_gossip_beacon_block__valid_with_blob_kzg_commitments(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__reject_too_many_kzg_commitments(spec, state):
     """

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_blob_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_blob_sidecar.py
@@ -5,9 +5,9 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_phases,
 )
-from eth_consensus_specs.test.helpers.blob import get_block_with_blob
+from eth_consensus_specs.test.helpers.blob import get_block_with_blob, get_max_blob_count
 from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
-from eth_consensus_specs.test.helpers.constants import DENEB
+from eth_consensus_specs.test.helpers.constants import DENEB, ELECTRA
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_state_with_complete_transition,
 )
@@ -73,7 +73,7 @@ def resign_blob_sidecar_header(spec, state, blob_sidecar):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__valid(spec, state):
     """Test that a valid blob sidecar passes gossip validation."""
@@ -119,7 +119,7 @@ def test_gossip_blob_sidecar__valid(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__reject_index_out_of_range(spec, state):
     """Test that a blob sidecar with index >= MAX_BLOBS_PER_BLOCK is rejected."""
@@ -136,7 +136,7 @@ def test_gossip_blob_sidecar__reject_index_out_of_range(spec, state):
 
     _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
     blob_sidecar = sidecars[0]
-    blob_sidecar.index = spec.BlobIndex(spec.config.MAX_BLOBS_PER_BLOCK)
+    blob_sidecar.index = spec.BlobIndex(get_max_blob_count(spec, state))
 
     yield get_filename(blob_sidecar), blob_sidecar
 
@@ -167,7 +167,7 @@ def test_gossip_blob_sidecar__reject_index_out_of_range(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__reject_wrong_subnet(spec, state):
     """Test that a blob sidecar on the wrong subnet is rejected."""
@@ -215,7 +215,7 @@ def test_gossip_blob_sidecar__reject_wrong_subnet(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 @always_bls
 def test_gossip_blob_sidecar__reject_invalid_proposer_signature(spec, state):
@@ -265,7 +265,7 @@ def test_gossip_blob_sidecar__reject_invalid_proposer_signature(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__reject_invalid_inclusion_proof(spec, state):
     """Test that a blob sidecar with a broken inclusion proof is rejected."""
@@ -316,7 +316,7 @@ def test_gossip_blob_sidecar__reject_invalid_inclusion_proof(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__reject_invalid_kzg_proof(spec, state):
     """Test that a blob sidecar with an invalid KZG proof is rejected."""
@@ -365,7 +365,7 @@ def test_gossip_blob_sidecar__reject_invalid_kzg_proof(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__ignore_future_slot(spec, state):
     """Test that a blob sidecar from a future slot is ignored."""
@@ -413,7 +413,7 @@ def test_gossip_blob_sidecar__ignore_future_slot(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__valid_slot_within_clock_disparity(spec, state):
     """Test that a blob sidecar at the future-slot boundary is valid."""
@@ -460,7 +460,7 @@ def test_gossip_blob_sidecar__valid_slot_within_clock_disparity(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__ignore_not_later_than_finalized_slot(spec, state):
     """Test that a blob sidecar at the latest finalized slot is ignored."""
@@ -521,7 +521,7 @@ def test_gossip_blob_sidecar__ignore_not_later_than_finalized_slot(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__reject_proposer_index_out_of_range(spec, state):
     """Test that a blob sidecar with proposer_index out of range is rejected."""
@@ -571,7 +571,7 @@ def test_gossip_blob_sidecar__reject_proposer_index_out_of_range(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__ignore_parent_not_seen(spec, state):
     """Test that a blob sidecar whose parent is unknown to the store is ignored."""
@@ -622,7 +622,7 @@ def test_gossip_blob_sidecar__ignore_parent_not_seen(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__reject_parent_failed_validation(spec, state):
     """Test that a blob sidecar whose parent failed validation is rejected."""
@@ -690,7 +690,7 @@ def test_gossip_blob_sidecar__reject_parent_failed_validation(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__ignore_already_seen_tuple(spec, state):
     """
@@ -754,7 +754,7 @@ def test_gossip_blob_sidecar__ignore_already_seen_tuple(spec, state):
     yield "messages", "meta", messages
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__reject_slot_not_higher_than_parent(spec, state):
     """
@@ -824,7 +824,7 @@ def test_gossip_blob_sidecar__reject_slot_not_higher_than_parent(spec, state):
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__reject_non_ancestor_finalized_checkpoint(spec, state):
     """Test that a blob sidecar is rejected if the finalized checkpoint is not an ancestor."""
@@ -878,7 +878,7 @@ def test_gossip_blob_sidecar__reject_non_ancestor_finalized_checkpoint(spec, sta
     )
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_blob_sidecar__reject_wrong_proposer_index(spec, state):
     """Test that a blob sidecar with the wrong proposer_index is rejected."""

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_voluntary_exit.py
@@ -3,7 +3,7 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_phases,
 )
-from eth_consensus_specs.test.helpers.constants import DENEB
+from eth_consensus_specs.test.helpers.constants import DENEB, ELECTRA
 from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.voluntary_exits import (
@@ -30,7 +30,7 @@ def run_validate_voluntary_exit_gossip(spec, seen, state, signed_voluntary_exit)
         return "reject", str(e)
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_voluntary_exit__valid_capella_signature(spec, state):
     """
@@ -53,7 +53,7 @@ def test_gossip_voluntary_exit__valid_capella_signature(spec, state):
     yield "messages", "meta", [{"message": get_filename(signed_exit), "expected": "valid"}]
 
 
-@with_phases([DENEB])
+@with_phases([DENEB, ELECTRA])
 @spec_state_test
 @always_bls
 def test_gossip_voluntary_exit__reject_deneb_signature(spec, state):

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -1,0 +1,268 @@
+from eth_consensus_specs.test.context import (
+    spec_state_test,
+    with_phases,
+    with_presets,
+)
+from eth_consensus_specs.test.helpers.attestations import (
+    get_valid_attestation,
+)
+from eth_consensus_specs.test.helpers.constants import ELECTRA, MINIMAL
+from eth_consensus_specs.test.helpers.fork_choice import (
+    get_genesis_forkchoice_store_and_block,
+)
+from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
+from eth_consensus_specs.test.helpers.keys import privkeys
+from eth_consensus_specs.test.helpers.state import next_slot
+
+
+def create_signed_aggregate_and_proof(spec, state, attestation):
+    committee_index = spec.get_committee_indices(attestation.committee_bits)[0]
+    committee = spec.get_beacon_committee(state, attestation.data.slot, committee_index)
+
+    aggregator_index = None
+    for index in committee:
+        privkey = privkeys[index]
+        selection_proof = spec.get_slot_signature(state, attestation.data.slot, privkey)
+        if spec.is_aggregator(state, attestation.data.slot, committee_index, selection_proof):
+            aggregator_index = index
+            break
+
+    if aggregator_index is None:
+        aggregator_index = committee[0]
+
+    privkey = privkeys[aggregator_index]
+    aggregate_and_proof = spec.get_aggregate_and_proof(
+        state, aggregator_index, attestation, privkey
+    )
+    signature = spec.get_aggregate_and_proof_signature(state, aggregate_and_proof, privkey)
+
+    return spec.SignedAggregateAndProof(message=aggregate_and_proof, signature=signature)
+
+
+def run_validate_beacon_aggregate_and_proof_gossip(
+    spec, seen, store, state, signed_aggregate_and_proof, current_time_ms
+):
+    try:
+        spec.validate_beacon_aggregate_and_proof_gossip(
+            seen, store, state, signed_aggregate_and_proof, current_time_ms
+        )
+        return "valid", None
+    except spec.GossipIgnore as e:
+        return "ignore", str(e)
+    except spec.GossipReject as e:
+        return "reject", str(e)
+
+
+def prepare_signed_aggregate(spec, state):
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    signed_anchor = wrap_genesis_block(spec, anchor_block)
+    anchor_root = anchor_block.hash_tree_root()
+    next_slot(spec, state)
+    attestation = get_valid_attestation(spec, state, signed=True, beacon_block_root=anchor_root)
+    signed_agg = create_signed_aggregate_and_proof(spec, state, attestation)
+    return store, signed_anchor, signed_agg
+
+
+@with_phases([ELECTRA])
+@spec_state_test
+@with_presets([MINIMAL], "need multiple committees per slot")
+def test_gossip_beacon_aggregate_and_proof__accept_same_data_for_disjoint_committees(spec, state):
+    """
+    [New in Electra:EIP7549] Test that two committee-local aggregates with equal
+    ``AttestationData`` and disjoint ``committee_bits`` are both accepted.
+    """
+    yield "topic", "meta", "beacon_aggregate_and_proof"
+    yield "state", state
+
+    messages = []
+    seen = get_seen(spec)
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    signed_anchor = wrap_genesis_block(spec, anchor_block)
+    anchor_root = anchor_block.hash_tree_root()
+
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    next_slot(spec, state)
+    committees_per_slot = spec.get_committee_count_per_slot(state, spec.get_current_epoch(state))
+    assert committees_per_slot >= 2, "need at least two committees in the current slot"
+
+    attestation_1 = get_valid_attestation(
+        spec,
+        state,
+        index=0,
+        signed=True,
+        beacon_block_root=anchor_root,
+        filter_participant_set=lambda participants: {sorted(participants)[0]},
+    )
+    attestation_2 = get_valid_attestation(
+        spec,
+        state,
+        index=1,
+        signed=True,
+        beacon_block_root=anchor_root,
+        filter_participant_set=lambda participants: {sorted(participants)[0]},
+    )
+
+    assert attestation_1.data.hash_tree_root() == attestation_2.data.hash_tree_root()
+    assert attestation_1.committee_bits != attestation_2.committee_bits
+
+    signed_agg_1 = create_signed_aggregate_and_proof(spec, state, attestation_1)
+    signed_agg_2 = create_signed_aggregate_and_proof(spec, state, attestation_2)
+
+    yield get_filename(signed_agg_1), signed_agg_1
+    yield get_filename(signed_agg_2), signed_agg_2
+
+    block_time_ms = spec.compute_time_at_slot_ms(state, attestation_1.data.slot)
+    yield "current_time_ms", "meta", int(block_time_ms)
+
+    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
+        spec, seen, store, state, signed_agg_1, block_time_ms + 500
+    )
+    assert result == "valid"
+    assert reason is None
+    messages.append({"offset_ms": 500, "message": get_filename(signed_agg_1), "expected": "valid"})
+
+    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
+        spec, seen, store, state, signed_agg_2, block_time_ms + 600
+    )
+    assert result == "valid"
+    assert reason is None
+    messages.append({"offset_ms": 600, "message": get_filename(signed_agg_2), "expected": "valid"})
+
+    yield "messages", "meta", messages
+
+
+@with_phases([ELECTRA])
+@spec_state_test
+def test_gossip_beacon_aggregate_and_proof__reject_nonzero_data_index(spec, state):
+    """
+    [New in Electra:EIP7549] Test that an aggregate with ``aggregate.data.index != 0``
+    is rejected.
+    """
+    yield "topic", "meta", "beacon_aggregate_and_proof"
+    yield "state", state
+
+    seen = get_seen(spec)
+    store, signed_anchor, signed_agg = prepare_signed_aggregate(spec, state)
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    # Set a non-zero data index (EIP-7549 forbids this).
+    signed_agg.message.aggregate.data.index = spec.CommitteeIndex(1)
+
+    yield get_filename(signed_agg), signed_agg
+
+    block_time_ms = spec.compute_time_at_slot_ms(state, signed_agg.message.aggregate.data.slot)
+    yield "current_time_ms", "meta", int(block_time_ms)
+
+    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
+        spec, seen, store, state, signed_agg, block_time_ms + 500
+    )
+    assert result == "reject"
+    assert reason == "aggregate data index is non-zero"
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "offset_ms": 500,
+                "message": get_filename(signed_agg),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
+    )
+
+
+@with_phases([ELECTRA])
+@spec_state_test
+def test_gossip_beacon_aggregate_and_proof__reject_zero_committees(spec, state):
+    """
+    [New in Electra:EIP7549] Test that an aggregate with no committee bits set
+    is rejected.
+    """
+    yield "topic", "meta", "beacon_aggregate_and_proof"
+    yield "state", state
+
+    seen = get_seen(spec)
+    store, signed_anchor, signed_agg = prepare_signed_aggregate(spec, state)
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    # Clear all committee bits.
+    signed_agg.message.aggregate.committee_bits = spec.Bitvector[spec.MAX_COMMITTEES_PER_SLOT]()
+
+    yield get_filename(signed_agg), signed_agg
+
+    block_time_ms = spec.compute_time_at_slot_ms(state, signed_agg.message.aggregate.data.slot)
+    yield "current_time_ms", "meta", int(block_time_ms)
+
+    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
+        spec, seen, store, state, signed_agg, block_time_ms + 500
+    )
+    assert result == "reject"
+    assert reason == "aggregate committee bits must specify exactly one committee"
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "offset_ms": 500,
+                "message": get_filename(signed_agg),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
+    )
+
+
+@with_phases([ELECTRA])
+@spec_state_test
+def test_gossip_beacon_aggregate_and_proof__reject_multiple_committees(spec, state):
+    """
+    [New in Electra:EIP7549] Test that an aggregate with more than one committee
+    bit set is rejected.
+    """
+    yield "topic", "meta", "beacon_aggregate_and_proof"
+    yield "state", state
+
+    seen = get_seen(spec)
+    store, signed_anchor, signed_agg = prepare_signed_aggregate(spec, state)
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    # Set two committee bits.
+    assert spec.MAX_COMMITTEES_PER_SLOT >= 2
+    bits = [False] * spec.MAX_COMMITTEES_PER_SLOT
+    bits[0] = True
+    bits[1] = True
+    signed_agg.message.aggregate.committee_bits = spec.Bitvector[spec.MAX_COMMITTEES_PER_SLOT](
+        *bits
+    )
+
+    yield get_filename(signed_agg), signed_agg
+
+    block_time_ms = spec.compute_time_at_slot_ms(state, signed_agg.message.aggregate.data.slot)
+    yield "current_time_ms", "meta", int(block_time_ms)
+
+    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
+        spec, seen, store, state, signed_agg, block_time_ms + 500
+    )
+    assert result == "reject"
+    assert reason == "aggregate committee bits must specify exactly one committee"
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "offset_ms": 500,
+                "message": get_filename(signed_agg),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
+    )

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_attestation.py
@@ -1,0 +1,141 @@
+from eth_consensus_specs.test.context import (
+    spec_state_test,
+    with_phases,
+)
+from eth_consensus_specs.test.helpers.attestations import (
+    get_valid_attestation,
+    to_single_attestation,
+)
+from eth_consensus_specs.test.helpers.constants import ELECTRA
+from eth_consensus_specs.test.helpers.fork_choice import (
+    get_genesis_forkchoice_store_and_block,
+)
+from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
+from eth_consensus_specs.test.helpers.state import next_slot
+
+
+def get_correct_subnet(spec, state, attestation):
+    committees_per_slot = spec.get_committee_count_per_slot(state, attestation.data.target.epoch)
+    return spec.compute_subnet_for_attestation(
+        committees_per_slot, attestation.data.slot, attestation.committee_index
+    )
+
+
+def run_validate_beacon_attestation_gossip(
+    spec, seen, store, state, attestation, subnet_id, current_time_ms
+):
+    try:
+        spec.validate_beacon_attestation_gossip(
+            seen, store, state, attestation, subnet_id, current_time_ms
+        )
+        return "valid", None
+    except spec.GossipIgnore as e:
+        return "ignore", str(e)
+    except spec.GossipReject as e:
+        return "reject", str(e)
+
+
+def prepare_single_attestation(spec, state):
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    signed_anchor = wrap_genesis_block(spec, anchor_block)
+    anchor_root = anchor_block.hash_tree_root()
+    next_slot(spec, state)
+    attestation = get_valid_attestation(spec, state, signed=False, beacon_block_root=anchor_root)
+    single = to_single_attestation(spec, state, attestation)
+    return store, signed_anchor, single
+
+
+@with_phases([ELECTRA])
+@spec_state_test
+def test_gossip_beacon_attestation__reject_nonzero_data_index(spec, state):
+    """
+    [New in Electra:EIP7549] Test that a ``SingleAttestation`` with
+    ``data.index != 0`` is rejected.
+    """
+    yield "topic", "meta", "beacon_attestation"
+    yield "state", state
+
+    seen = get_seen(spec)
+    store, signed_anchor, attestation = prepare_single_attestation(spec, state)
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    # Set a non-zero data index (EIP-7549 forbids this).
+    attestation.data.index = spec.CommitteeIndex(1)
+
+    yield get_filename(attestation), attestation
+
+    block_time_ms = spec.compute_time_at_slot_ms(state, attestation.data.slot)
+    yield "current_time_ms", "meta", int(block_time_ms)
+
+    subnet_id = get_correct_subnet(spec, state, attestation)
+    result, reason = run_validate_beacon_attestation_gossip(
+        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    )
+    assert result == "reject"
+    assert reason == "attestation data index is non-zero"
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "subnet_id": int(subnet_id),
+                "offset_ms": 500,
+                "message": get_filename(attestation),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
+    )
+
+
+@with_phases([ELECTRA])
+@spec_state_test
+def test_gossip_beacon_attestation__reject_attester_not_in_committee(spec, state):
+    """
+    [New in Electra:EIP7549] Test that a ``SingleAttestation`` whose
+    ``attester_index`` is not a member of the encoded committee is rejected.
+    """
+    yield "topic", "meta", "beacon_attestation"
+    yield "state", state
+
+    seen = get_seen(spec)
+    store, signed_anchor, attestation = prepare_single_attestation(spec, state)
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    # Pick a validator index that is not in the committee for this slot/index.
+    committee = set(
+        spec.get_beacon_committee(state, attestation.data.slot, attestation.committee_index)
+    )
+    outsider_index = next(
+        spec.ValidatorIndex(i) for i in range(len(state.validators)) if i not in committee
+    )
+    attestation.attester_index = outsider_index
+
+    yield get_filename(attestation), attestation
+
+    block_time_ms = spec.compute_time_at_slot_ms(state, attestation.data.slot)
+    yield "current_time_ms", "meta", int(block_time_ms)
+
+    subnet_id = get_correct_subnet(spec, state, attestation)
+    result, reason = run_validate_beacon_attestation_gossip(
+        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    )
+    assert result == "reject"
+    assert reason == "attester is not a member of the committee"
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "subnet_id": int(subnet_id),
+                "offset_ms": 500,
+                "message": get_filename(attestation),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
+    )

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/attestations.py
@@ -172,6 +172,28 @@ def get_attestation_signature(spec, state, attestation_data, privkey):
     return bls.Sign(privkey, signing_root)
 
 
+def to_single_attestation(spec, state, attestation, attester_index=None):
+    """
+    Convert an Electra-style ``Attestation`` (with ``committee_bits``) into a
+    ``SingleAttestation`` signed by a single committee member. By default the
+    first member of the encoded committee is used.
+    """
+    assert is_post_electra(spec)
+    committee_indices = spec.get_committee_indices(attestation.committee_bits)
+    assert len(committee_indices) == 1
+    committee_index = committee_indices[0]
+    committee = spec.get_beacon_committee(state, attestation.data.slot, committee_index)
+    if attester_index is None:
+        attester_index = committee[0]
+    signature = get_attestation_signature(spec, state, attestation.data, privkeys[attester_index])
+    return spec.SingleAttestation(
+        committee_index=committee_index,
+        attester_index=attester_index,
+        data=attestation.data,
+        signature=signature,
+    )
+
+
 def compute_max_inclusion_slot(spec, attestation):
     if is_post_deneb(spec):
         next_epoch = spec.compute_epoch_at_slot(attestation.data.slot) + 1

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gossip.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gossip.py
@@ -96,6 +96,8 @@ def get_filename(obj):
         prefix = "block"
     elif class_name == "Attestation":
         prefix = "attestation"
+    elif class_name == "SingleAttestation":
+        prefix = "single_attestation"
     elif "AggregateAndProof" in class_name:
         prefix = "aggregate"
     elif class_name == "ProposerSlashing":

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -20,12 +20,14 @@ from eth_consensus_specs.test.helpers.constants import (
     BELLATRIX,
     CAPELLA,
     DENEB,
+    ELECTRA,
     MAINNET,
     PHASE0,
 )
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
+from eth_consensus_specs.test.helpers.forks import is_post_electra
 from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
@@ -93,7 +95,7 @@ def run_validate_beacon_aggregate_and_proof_gossip(
         return "reject", str(e)
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__valid(spec, state):
     """
@@ -134,7 +136,7 @@ def test_gossip_beacon_aggregate_and_proof__valid(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__reject_committee_index_out_of_range(spec, state):
     """
@@ -158,7 +160,17 @@ def test_gossip_beacon_aggregate_and_proof__reject_committee_index_out_of_range(
 
     # Modify committee index to be out of range
     committee_count = spec.get_committee_count_per_slot(state, attestation.data.target.epoch)
-    signed_agg.message.aggregate.data.index = committee_count + 10
+    if is_post_electra(spec):
+        # In Electra the committee index moved into ``committee_bits`` and
+        # ``data.index`` must remain zero; encode an OOB index in committee_bits
+        # at the smallest position that is both out-of-range and inside the bitvector.
+        assert committee_count < spec.MAX_COMMITTEES_PER_SLOT
+        oob_index = committee_count
+        signed_agg.message.aggregate.committee_bits = spec.Bitvector[spec.MAX_COMMITTEES_PER_SLOT](
+            *[i == oob_index for i in range(spec.MAX_COMMITTEES_PER_SLOT)]
+        )
+    else:
+        signed_agg.message.aggregate.data.index = committee_count + 10
 
     yield get_filename(signed_agg), signed_agg
 
@@ -236,7 +248,7 @@ def test_gossip_beacon_aggregate_and_proof__ignore_slot_not_within_range(spec, s
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__valid_within_clock_disparity(spec, state):
     """
@@ -285,7 +297,7 @@ def test_gossip_beacon_aggregate_and_proof__valid_within_clock_disparity(spec, s
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__reject_epoch_mismatch(spec, state):
     """
@@ -336,7 +348,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_epoch_mismatch(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__ignore_already_seen_aggregate(spec, state):
     """
@@ -390,7 +402,7 @@ def test_gossip_beacon_aggregate_and_proof__ignore_already_seen_aggregate(spec, 
     yield "messages", "meta", messages
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__ignore_same_data_root_without_superset(spec, state):
     """
@@ -445,14 +457,29 @@ def test_gossip_beacon_aggregate_and_proof__ignore_same_data_root_without_supers
     else:
         assert False, "Need at least one additional committee participant for this test"
 
+    if is_post_electra(spec):
+        # Electra ``Attestation`` carries an EIP-7549 aggregation bitlist sized for
+        # ``MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT`` and includes
+        # ``committee_bits``; preserve both from the first aggregate.
+        aggregate_2 = spec.Attestation(
+            aggregation_bits=spec.Bitlist[
+                spec.MAX_VALIDATORS_PER_COMMITTEE * spec.MAX_COMMITTEES_PER_SLOT
+            ](*modified_bits),
+            data=signed_agg_1.message.aggregate.data,
+            committee_bits=signed_agg_1.message.aggregate.committee_bits,
+            signature=signed_agg_1.message.aggregate.signature,
+        )
+    else:
+        aggregate_2 = spec.Attestation(
+            aggregation_bits=spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*modified_bits),
+            data=signed_agg_1.message.aggregate.data,
+            signature=signed_agg_1.message.aggregate.signature,
+        )
+
     signed_agg_2 = spec.SignedAggregateAndProof(
         message=spec.AggregateAndProof(
             aggregator_index=signed_agg_1.message.aggregator_index,
-            aggregate=spec.Attestation(
-                aggregation_bits=spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*modified_bits),
-                data=signed_agg_1.message.aggregate.data,
-                signature=signed_agg_1.message.aggregate.signature,
-            ),
+            aggregate=aggregate_2,
             selection_proof=signed_agg_1.message.selection_proof,
         ),
         signature=signed_agg_1.signature,
@@ -479,7 +506,7 @@ def test_gossip_beacon_aggregate_and_proof__ignore_same_data_root_without_supers
     yield "messages", "meta", messages
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__valid_two_aggregators_same_data(spec, state):
     """
@@ -563,7 +590,7 @@ def test_gossip_beacon_aggregate_and_proof__valid_two_aggregators_same_data(spec
     yield "messages", "meta", messages
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__ignore_block_not_seen(spec, state):
     """
@@ -617,7 +644,7 @@ def test_gossip_beacon_aggregate_and_proof__ignore_block_not_seen(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__reject_aggregation_bits_size_mismatch(spec, state):
     """
@@ -674,7 +701,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_aggregation_bits_size_mismatc
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__reject_no_participants(spec, state):
     """
@@ -729,7 +756,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_no_participants(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__ignore_already_seen_aggregator(spec, state):
     """
@@ -792,7 +819,7 @@ def test_gossip_beacon_aggregate_and_proof__ignore_already_seen_aggregator(spec,
     yield "messages", "meta", messages
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @with_presets([MAINNET], reason="minimal preset has committees < 16, so everyone is an aggregator")
 @spec_test
 @with_custom_state(
@@ -881,7 +908,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_not_aggregator(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__reject_aggregator_not_in_committee(spec, state):
     """
@@ -940,7 +967,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_aggregator_not_in_committee(s
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__reject_aggregator_index_out_of_range(spec, state):
     """
@@ -990,7 +1017,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_aggregator_index_out_of_range
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 @always_bls
 def test_gossip_beacon_aggregate_and_proof__reject_invalid_selection_proof(spec, state):
@@ -1042,7 +1069,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_invalid_selection_proof(spec,
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 @always_bls
 def test_gossip_beacon_aggregate_and_proof__reject_invalid_aggregator_signature(spec, state):
@@ -1094,7 +1121,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_invalid_aggregator_signature(
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 @always_bls
 def test_gossip_beacon_aggregate_and_proof__reject_invalid_aggregate_signature(spec, state):
@@ -1146,7 +1173,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_invalid_aggregate_signature(s
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__reject_block_failed_validation(spec, state):
     """
@@ -1210,7 +1237,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_block_failed_validation(spec,
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__reject_target_not_ancestor(spec, state):
     """
@@ -1262,7 +1289,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_target_not_ancestor(spec, sta
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__ignore_finalized_not_ancestor(spec, state):
     """

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
@@ -87,7 +87,7 @@ def test_gossip_beacon_attestation__valid(spec, state):
     if is_post_electra(spec):
         attestation = to_single_attestation(spec, state, attestation)
     else:
-        # Make sure it's unaggregated (exactly one bit set)
+        # Make it unaggregated (exactly one bit set)
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
@@ -755,7 +755,7 @@ def test_gossip_beacon_attestation__ignore_block_not_seen(spec, state):
     if is_post_electra(spec):
         attestation = to_single_attestation(spec, state, attestation)
     else:
-        # Make it unaggregated
+        # Make it unaggregated (exactly one bit set)
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
@@ -833,7 +833,7 @@ def test_gossip_beacon_attestation__reject_block_failed_validation(spec, state):
     if is_post_electra(spec):
         attestation = to_single_attestation(spec, state, attestation)
     else:
-        # Make it unaggregated
+        # Make it unaggregated (exactly one bit set)
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
@@ -896,7 +896,7 @@ def test_gossip_beacon_attestation__reject_invalid_signature(spec, state):
     if is_post_electra(spec):
         attestation = to_single_attestation(spec, state, attestation)
     else:
-        # Make it unaggregated
+        # Make it unaggregated (exactly one bit set)
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
@@ -959,7 +959,7 @@ def test_gossip_beacon_attestation__reject_target_not_ancestor(spec, state):
         # `to_single_attestation` signs with the (now-modified) data.
         attestation = to_single_attestation(spec, state, attestation)
     else:
-        # Make it unaggregated
+        # Make it unaggregated (exactly one bit set)
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
@@ -1039,7 +1039,7 @@ def test_gossip_beacon_attestation__ignore_finalized_not_ancestor(spec, state):
     if is_post_electra(spec):
         attestation = to_single_attestation(spec, state, attestation)
     else:
-        # Make it unaggregated
+        # Make it unaggregated (exactly one bit set)
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
@@ -5,14 +5,23 @@ from eth_consensus_specs.test.context import (
 )
 from eth_consensus_specs.test.helpers.attestations import (
     get_valid_attestation,
+    to_single_attestation,
 )
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
-from eth_consensus_specs.test.helpers.constants import ALTAIR, BELLATRIX, CAPELLA, DENEB, PHASE0
+from eth_consensus_specs.test.helpers.constants import (
+    ALTAIR,
+    BELLATRIX,
+    CAPELLA,
+    DENEB,
+    ELECTRA,
+    PHASE0,
+)
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
+from eth_consensus_specs.test.helpers.forks import is_post_electra
 from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
@@ -24,8 +33,11 @@ from eth_consensus_specs.test.helpers.state import (
 def get_correct_subnet_for_attestation(spec, state, attestation):
     """Get the correct subnet for an attestation."""
     committees_per_slot = spec.get_committee_count_per_slot(state, attestation.data.target.epoch)
+    committee_index = (
+        attestation.committee_index if is_post_electra(spec) else attestation.data.index
+    )
     return spec.compute_subnet_for_attestation(
-        committees_per_slot, attestation.data.slot, attestation.data.index
+        committees_per_slot, attestation.data.slot, committee_index
     )
 
 
@@ -48,7 +60,7 @@ def run_validate_beacon_attestation_gossip(
         return "reject", str(e)
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__valid(spec, state):
     """
@@ -72,14 +84,17 @@ def test_gossip_beacon_attestation__valid(spec, state):
         spec, state, signed=True, index=0, beacon_block_root=anchor_root
     )
 
-    # Make sure it's unaggregated (exactly one bit set)
-    committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
-    single_bit = [False] * len(committee)
-    single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
-    attestation.signature = spec.get_attestation_signature(
-        state, attestation.data, privkeys[committee[0]]
-    )
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
+    else:
+        # Make sure it's unaggregated (exactly one bit set)
+        committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
+        single_bit = [False] * len(committee)
+        single_bit[0] = True
+        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.signature = spec.get_attestation_signature(
+            state, attestation.data, privkeys[committee[0]]
+        )
 
     yield get_filename(attestation), attestation
 
@@ -108,7 +123,7 @@ def test_gossip_beacon_attestation__valid(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__reject_committee_index_out_of_range(spec, state):
     """
@@ -131,7 +146,11 @@ def test_gossip_beacon_attestation__reject_committee_index_out_of_range(spec, st
 
     # Set committee index out of range
     committees_per_slot = spec.get_committee_count_per_slot(state, attestation.data.target.epoch)
-    attestation.data.index = committees_per_slot + 10
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
+        attestation.committee_index = committees_per_slot + 10
+    else:
+        attestation.data.index = committees_per_slot + 10
 
     yield get_filename(attestation), attestation
 
@@ -161,7 +180,7 @@ def test_gossip_beacon_attestation__reject_committee_index_out_of_range(spec, st
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__reject_wrong_subnet(spec, state):
     """
@@ -181,6 +200,8 @@ def test_gossip_beacon_attestation__reject_wrong_subnet(spec, state):
     next_slot(spec, state)
 
     attestation = get_valid_attestation(spec, state, signed=True, beacon_block_root=anchor_root)
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
 
     yield get_filename(attestation), attestation
 
@@ -273,7 +294,7 @@ def test_gossip_beacon_attestation__ignore_slot_not_in_range(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__valid_within_clock_disparity(spec, state):
     """
@@ -295,14 +316,17 @@ def test_gossip_beacon_attestation__valid_within_clock_disparity(spec, state):
     # Create an unaggregated attestation referencing anchor block
     attestation = get_valid_attestation(spec, state, signed=False, beacon_block_root=anchor_root)
 
-    # Make it unaggregated (exactly one bit set)
-    committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
-    single_bit = [False] * len(committee)
-    single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
-    attestation.signature = spec.get_attestation_signature(
-        state, attestation.data, privkeys[committee[0]]
-    )
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
+    else:
+        # Make it unaggregated (exactly one bit set)
+        committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
+        single_bit = [False] * len(committee)
+        single_bit[0] = True
+        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.signature = spec.get_attestation_signature(
+            state, attestation.data, privkeys[committee[0]]
+        )
 
     yield get_filename(attestation), attestation
 
@@ -458,7 +482,7 @@ def test_gossip_beacon_attestation__ignore_slot_too_old(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__reject_epoch_mismatch(spec, state):
     """
@@ -481,6 +505,9 @@ def test_gossip_beacon_attestation__reject_epoch_mismatch(spec, state):
 
     # Modify target epoch to not match slot
     attestation.data.target.epoch = spec.Epoch(100)
+
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
 
     yield get_filename(attestation), attestation
 
@@ -624,7 +651,7 @@ def test_gossip_beacon_attestation__reject_aggregation_bits_size_mismatch(spec, 
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__ignore_already_seen(spec, state):
     """
@@ -647,14 +674,17 @@ def test_gossip_beacon_attestation__ignore_already_seen(spec, state):
     # Create an unaggregated attestation referencing anchor block
     attestation = get_valid_attestation(spec, state, signed=False, beacon_block_root=anchor_root)
 
-    # Make it unaggregated (exactly one bit set)
-    committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
-    single_bit = [False] * len(committee)
-    single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
-    attestation.signature = spec.get_attestation_signature(
-        state, attestation.data, privkeys[committee[0]]
-    )
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
+    else:
+        # Make it unaggregated (exactly one bit set)
+        committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
+        single_bit = [False] * len(committee)
+        single_bit[0] = True
+        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.signature = spec.get_attestation_signature(
+            state, attestation.data, privkeys[committee[0]]
+        )
 
     yield get_filename(attestation), attestation
 
@@ -697,7 +727,7 @@ def test_gossip_beacon_attestation__ignore_already_seen(spec, state):
     yield "messages", "meta", messages
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__ignore_block_not_seen(spec, state):
     """
@@ -722,14 +752,17 @@ def test_gossip_beacon_attestation__ignore_block_not_seen(spec, state):
     # Create an attestation for the block that's not in store
     attestation = get_valid_attestation(spec, state, signed=False)
 
-    # Make it unaggregated
-    committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
-    single_bit = [False] * len(committee)
-    single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
-    attestation.signature = spec.get_attestation_signature(
-        state, attestation.data, privkeys[committee[0]]
-    )
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
+    else:
+        # Make it unaggregated
+        committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
+        single_bit = [False] * len(committee)
+        single_bit[0] = True
+        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.signature = spec.get_attestation_signature(
+            state, attestation.data, privkeys[committee[0]]
+        )
 
     yield get_filename(attestation), attestation
 
@@ -759,7 +792,7 @@ def test_gossip_beacon_attestation__ignore_block_not_seen(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__reject_block_failed_validation(spec, state):
     """
@@ -797,14 +830,17 @@ def test_gossip_beacon_attestation__reject_block_failed_validation(spec, state):
     # Create an attestation
     attestation = get_valid_attestation(spec, state, signed=False)
 
-    # Make it unaggregated
-    committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
-    single_bit = [False] * len(committee)
-    single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
-    attestation.signature = spec.get_attestation_signature(
-        state, attestation.data, privkeys[committee[0]]
-    )
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
+    else:
+        # Make it unaggregated
+        committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
+        single_bit = [False] * len(committee)
+        single_bit[0] = True
+        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.signature = spec.get_attestation_signature(
+            state, attestation.data, privkeys[committee[0]]
+        )
 
     yield get_filename(attestation), attestation
 
@@ -834,7 +870,7 @@ def test_gossip_beacon_attestation__reject_block_failed_validation(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 @always_bls
 def test_gossip_beacon_attestation__reject_invalid_signature(spec, state):
@@ -857,11 +893,14 @@ def test_gossip_beacon_attestation__reject_invalid_signature(spec, state):
     # Create an attestation without signing, referencing anchor block
     attestation = get_valid_attestation(spec, state, signed=False, beacon_block_root=anchor_root)
 
-    # Make it unaggregated
-    committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
-    single_bit = [False] * len(committee)
-    single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
+    else:
+        # Make it unaggregated
+        committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
+        single_bit = [False] * len(committee)
+        single_bit[0] = True
+        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
     # Invalid signature (zeros)
     attestation.signature = spec.BLSSignature(b"\x00" * 96)
 
@@ -893,7 +932,7 @@ def test_gossip_beacon_attestation__reject_invalid_signature(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__reject_target_not_ancestor(spec, state):
     """
@@ -916,15 +955,19 @@ def test_gossip_beacon_attestation__reject_target_not_ancestor(spec, state):
     attestation = get_valid_attestation(spec, state, signed=False, beacon_block_root=anchor_root)
     attestation.data.target.root = spec.Root(b"\xcd" * 32)  # Invalid target root
 
-    # Make it unaggregated
-    committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
-    single_bit = [False] * len(committee)
-    single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
-    # Sign with the modified data
-    attestation.signature = spec.get_attestation_signature(
-        state, attestation.data, privkeys[committee[0]]
-    )
+    if is_post_electra(spec):
+        # `to_single_attestation` signs with the (now-modified) data.
+        attestation = to_single_attestation(spec, state, attestation)
+    else:
+        # Make it unaggregated
+        committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
+        single_bit = [False] * len(committee)
+        single_bit[0] = True
+        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        # Sign with the modified data
+        attestation.signature = spec.get_attestation_signature(
+            state, attestation.data, privkeys[committee[0]]
+        )
 
     yield get_filename(attestation), attestation
 
@@ -954,7 +997,7 @@ def test_gossip_beacon_attestation__reject_target_not_ancestor(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_attestation__ignore_finalized_not_ancestor(spec, state):
     """
@@ -993,14 +1036,17 @@ def test_gossip_beacon_attestation__ignore_finalized_not_ancestor(spec, state):
     # Create an attestation
     attestation = get_valid_attestation(spec, state, signed=False)
 
-    # Make it unaggregated
-    committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
-    single_bit = [False] * len(committee)
-    single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
-    attestation.signature = spec.get_attestation_signature(
-        state, attestation.data, privkeys[committee[0]]
-    )
+    if is_post_electra(spec):
+        attestation = to_single_attestation(spec, state, attestation)
+    else:
+        # Make it unaggregated
+        committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
+        single_bit = [False] * len(committee)
+        single_bit[0] = True
+        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.signature = spec.get_attestation_signature(
+            state, attestation.data, privkeys[committee[0]]
+        )
 
     yield get_filename(attestation), attestation
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_block.py
@@ -7,7 +7,14 @@ from eth_consensus_specs.test.helpers.block import (
     build_empty_block_for_next_slot,
     sign_block,
 )
-from eth_consensus_specs.test.helpers.constants import ALTAIR, BELLATRIX, CAPELLA, DENEB, PHASE0
+from eth_consensus_specs.test.helpers.constants import (
+    ALTAIR,
+    BELLATRIX,
+    CAPELLA,
+    DENEB,
+    ELECTRA,
+    PHASE0,
+)
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_empty_execution_payload,
     build_state_with_incomplete_transition,
@@ -27,7 +34,7 @@ from eth_consensus_specs.test.helpers.state import (
 )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__valid_block(spec, state):
     """
@@ -65,7 +72,7 @@ def test_gossip_beacon_block__valid_block(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__ignore_future_slot(spec, state):
     """
@@ -111,7 +118,7 @@ def test_gossip_beacon_block__ignore_future_slot(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__valid_within_clock_disparity(spec, state):
     """
@@ -150,7 +157,7 @@ def test_gossip_beacon_block__valid_within_clock_disparity(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__ignore_already_seen_proposer_slot(spec, state):
     """
@@ -202,7 +209,7 @@ def test_gossip_beacon_block__ignore_already_seen_proposer_slot(spec, state):
     yield "messages", "meta", messages
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__ignore_slot_not_greater_than_finalized(spec, state):
     """
@@ -274,7 +281,7 @@ def test_gossip_beacon_block__ignore_slot_not_greater_than_finalized(spec, state
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__ignore_parent_not_seen(spec, state):
     """
@@ -417,7 +424,7 @@ def test_gossip_beacon_block__reject_parent_failed_validation(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__reject_slot_not_higher_than_parent(spec, state):
     """
@@ -491,7 +498,7 @@ def test_gossip_beacon_block__reject_slot_not_higher_than_parent(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__reject_finalized_checkpoint_not_ancestor(spec, state):
     """
@@ -576,7 +583,7 @@ def test_gossip_beacon_block__reject_finalized_checkpoint_not_ancestor(spec, sta
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 @always_bls
 def test_gossip_beacon_block__reject_invalid_proposer_signature(spec, state):
@@ -625,7 +632,7 @@ def test_gossip_beacon_block__reject_invalid_proposer_signature(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__reject_invalid_proposer_index(spec, state):
     """
@@ -673,7 +680,7 @@ def test_gossip_beacon_block__reject_invalid_proposer_index(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_beacon_block__reject_wrong_proposer_index(spec, state):
     """

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
@@ -3,7 +3,14 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_phases,
 )
-from eth_consensus_specs.test.helpers.constants import ALTAIR, BELLATRIX, CAPELLA, DENEB, PHASE0
+from eth_consensus_specs.test.helpers.constants import (
+    ALTAIR,
+    BELLATRIX,
+    CAPELLA,
+    DENEB,
+    ELECTRA,
+    PHASE0,
+)
 from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
@@ -43,7 +50,7 @@ def run_validate_voluntary_exit_gossip(spec, seen, state, signed_voluntary_exit)
         return "reject", str(e)
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_voluntary_exit__valid(spec, state):
     """
@@ -72,7 +79,7 @@ def test_gossip_voluntary_exit__valid(spec, state):
     yield "messages", "meta", [{"message": get_filename(signed_exit), "expected": "valid"}]
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_voluntary_exit__ignore_already_seen(spec, state):
     """
@@ -110,7 +117,7 @@ def test_gossip_voluntary_exit__ignore_already_seen(spec, state):
     yield "messages", "meta", messages
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_voluntary_exit__reject_validator_index_out_of_range(spec, state):
     """
@@ -146,7 +153,7 @@ def test_gossip_voluntary_exit__reject_validator_index_out_of_range(spec, state)
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_voluntary_exit__reject_validator_not_active(spec, state):
     """
@@ -180,7 +187,7 @@ def test_gossip_voluntary_exit__reject_validator_not_active(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_voluntary_exit__reject_already_initiated_exit(spec, state):
     """
@@ -214,7 +221,7 @@ def test_gossip_voluntary_exit__reject_already_initiated_exit(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_voluntary_exit__reject_epoch_in_future(spec, state):
     """
@@ -248,7 +255,7 @@ def test_gossip_voluntary_exit__reject_epoch_in_future(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 def test_gossip_voluntary_exit__reject_not_active_long_enough(spec, state):
     """
@@ -283,7 +290,7 @@ def test_gossip_voluntary_exit__reject_not_active_long_enough(spec, state):
     )
 
 
-@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB])
+@with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA])
 @spec_state_test
 @always_bls
 def test_gossip_voluntary_exit__reject_invalid_signature(spec, state):


### PR DESCRIPTION
This PR adds executable gossip message validation specs for Electra.

* https://github.com/ethereum/consensus-specs/issues/4611
* https://github.com/ethereum/consensus-specs/pull/4902
* https://github.com/ethereum/consensus-specs/pull/5033
* https://github.com/ethereum/consensus-specs/pull/5047
* https://github.com/ethereum/consensus-specs/pull/5049
* https://github.com/ethereum/consensus-specs/pull/5146

Here are the mainnet reference tests for all Electra gossip tests:

* [reftests.zip](https://github.com/user-attachments/files/27641415/reftests.zip) -- *Updated May 12th 2026*
