### PR TITLE
Fix fork-choice comptest attester slashing limit

### DIFF
--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -278,7 +278,8 @@ def produce_block(
         block.body.attestations.append(a)
 
     # Add attester slashings
-    attester_slashings_in_block = attester_slashings[: spec.MAX_ATTESTER_SLASHINGS]
+    limit = type(block.body.attester_slashings).limit()
+    attester_slashings_in_block = attester_slashings[:limit]
     for s in attester_slashings_in_block:
         block.body.attester_slashings.append(s)
 


### PR DESCRIPTION
The PR fixes a possible test generation failure ([example](https://github.com/jtraglia/consensus-specs/actions/runs/25615586370/job/75192910819)), due to reduced `MAX_ATTESTER_SLASHINGS` in `electra`.

Thanks @jtraglia for discovering the bug.