### PR TITLE
Define per-builder configs in `ProposerPreferences`

### DIFF
--- a/presets/mainnet/gloas.yaml
+++ b/presets/mainnet/gloas.yaml
@@ -21,3 +21,8 @@ BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
 # ---------------------------------------------------------------
 # 2**14 (= 16,384) builders
 MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: 16384
+
+# Networking
+# ---------------------------------------------------------------
+# 2**7 (= 128) builder configurations
+MAX_BUILDER_CONFIGS: 128

--- a/presets/minimal/gloas.yaml
+++ b/presets/minimal/gloas.yaml
@@ -21,3 +21,8 @@ BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
 # ---------------------------------------------------------------
 # [customized] 2**4 (= 16) builders
 MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: 16
+
+# Networking
+# ---------------------------------------------------------------
+# 2**7 (= 128) builder configurations
+MAX_BUILDER_CONFIGS: 128

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -84,6 +84,12 @@ class DataColumnSidecar(Container):
 
 *[New in Gloas:EIP7732]*
 
+*Note*: `max_execution_payment` defines the maximum trusted payment (in Gwei)
+that the proposer will accept. Builders MUST NOT set `bid.execution_payment` to
+a value greater than `max_execution_value`. A value of `0` indicates that the
+proposer does not accept any trusted payments. A value of `UINT64_MAX` indicates
+that the proposer accepts any trusted payment amount.
+
 ```python
 class ProposerPreferences(Container):
     dependent_root: Root
@@ -91,6 +97,7 @@ class ProposerPreferences(Container):
     validator_index: ValidatorIndex
     fee_recipient: ExecutionAddress
     gas_limit: uint64
+    max_execution_payment: uint64
 ```
 
 #### New `SignedProposerPreferences`

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -6,9 +6,11 @@
 
 - [Introduction](#introduction)
 - [Modification in Gloas](#modification-in-gloas)
+  - [Preset](#preset)
   - [Configuration](#configuration)
   - [Containers](#containers)
     - [Modified `DataColumnSidecar`](#modified-datacolumnsidecar)
+    - [New `BuilderConfig`](#new-builderconfig)
     - [New `ProposerPreferences`](#new-proposerpreferences)
     - [New `SignedProposerPreferences`](#new-signedproposerpreferences)
   - [Helpers](#helpers)
@@ -46,6 +48,12 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 ## Modification in Gloas
 
+### Preset
+
+| Name                  | Value                  |
+| --------------------- | ---------------------- |
+| `MAX_BUILDER_CONFIGS` | `uint64(2**7)` (= 128) |
+
 ### Configuration
 
 | Name                   | Value          | Description                                                       |
@@ -80,9 +88,7 @@ class DataColumnSidecar(Container):
     beacon_block_root: Root
 ```
 
-#### New `ProposerPreferences`
-
-*[New in Gloas:EIP7732]*
+#### New `BuilderConfig`
 
 *Note*: `max_execution_payment` defines the maximum trusted payment (in Gwei)
 that the proposer will accept. Builders MUST NOT set `bid.execution_payment` to
@@ -91,13 +97,23 @@ proposer does not accept any trusted payments. A value of `UINT64_MAX` indicates
 that the proposer accepts any trusted payment amount.
 
 ```python
+class BuilderConfig(Container):
+    builder_pubkey: BLSPubkey
+    max_execution_payment: uint64
+```
+
+#### New `ProposerPreferences`
+
+*[New in Gloas:EIP7732]*
+
+```python
 class ProposerPreferences(Container):
     dependent_root: Root
     proposal_slot: Slot
     validator_index: ValidatorIndex
     fee_recipient: ExecutionAddress
     gas_limit: uint64
-    max_execution_payment: uint64
+    builder_configs: List[BuilderConfig, MAX_BUILDER_CONFIGS]
 ```
 
 #### New `SignedProposerPreferences`


### PR DESCRIPTION
As discussed here, it would be beneficial to builders to know this before they make bids.

* https://github.com/ethereum/builder-specs/pull/138#discussion_r3226640536