### PR TITLE
Add package action

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -30,6 +30,9 @@ runs:
     - name: Archive tests
       shell: bash
       run: |
+        # Ensure source-path exists so tar succeeds even when zero artifacts
+        # were downloaded (e.g. presets with no per-fork reftests).
+        mkdir -p ${{ inputs.source-path }}
         tar --sort=name \
             --owner=0 \
             --group=0 \

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -1,0 +1,55 @@
+name: Package tests
+description: >-
+  Download intermediate test artifacts, archive them into a tarball, and delete
+  the intermediates. The caller is responsible for uploading the tarball.
+
+inputs:
+  name:
+    description: Tarball name (without .tar.gz) and key used in artifact filtering.
+    required: true
+  artifact-prefix:
+    description: Prefix for intermediate artifact names.
+    required: true
+  source-path:
+    description: Directory to download artifacts into and to include in the tarball.
+    required: true
+  github-token:
+    description: Token used to delete intermediate artifacts.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download intermediate artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: ${{ inputs.artifact-prefix }}-${{ inputs.name }}-*
+        path: ${{ inputs.source-path }}
+        merge-multiple: true
+
+    - name: Archive tests
+      shell: bash
+      run: |
+        tar --sort=name \
+            --owner=0 \
+            --group=0 \
+            --numeric-owner \
+            --mtime='@0' \
+            --format=gnu \
+            --use-compress-program='gzip --no-name' \
+            --create \
+            --file=${{ inputs.name }}.tar.gz \
+            ${{ inputs.source-path }}
+
+    - name: Delete intermediate artifacts
+      shell: bash
+      run: |
+        gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+          --paginate --jq '.artifacts[]
+            | select(.name | startswith("${{ inputs.artifact-prefix }}-${{ inputs.name }}-"))
+            | .id' | while read id; do
+          gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
+        done
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ github.repository }}

--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -239,41 +239,19 @@ jobs:
       matrix:
         config: ${{ fromJson(needs.config.outputs.configs) }}
     steps:
-      - name: Download intermediate artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: comptests-${{ matrix.config }}-*
-          path: tests
-          merge-multiple: true
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Archive compliance tests
-        run: |
-          tar --sort=name \
-              --owner=0 \
-              --group=0 \
-              --numeric-owner \
-              --mtime='@0' \
-              --format=gnu \
-              --use-compress-program='gzip --no-name' \
-              --create \
-              --file=${{ matrix.config }}.tar.gz \
-              tests
+      - name: Package compliance tests
+        uses: ./.github/actions/package
+        with:
+          name: ${{ matrix.config }}
+          artifact-prefix: comptests
+          source-path: tests
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload ${{ matrix.config }}.tar.gz
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: ${{ matrix.config }}.tar.gz
           archive: false
-
-      - name: Delete intermediate artifacts
-        continue-on-error: true
-        run: |
-          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate --jq '.artifacts[]
-              | select(.name | startswith("comptests-${{ matrix.config }}-"))
-              | .id' | while read id; do
-            gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
-          done
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,41 +97,19 @@ jobs:
           - minimal
           - mainnet
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: reftests-${{ matrix.preset }}-*
-          path: tests/${{ matrix.preset }}
-          merge-multiple: true
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Archive reference tests
-        run: |
-          tar --sort=name \
-              --owner=0 \
-              --group=0 \
-              --numeric-owner \
-              --mtime='@0' \
-              --format=gnu \
-              --use-compress-program='gzip --no-name' \
-              --create \
-              --file=${{ matrix.preset }}.tar.gz \
-              tests/${{ matrix.preset }}
+      - name: Package reference tests
+        uses: ./.github/actions/package
+        with:
+          name: ${{ matrix.preset }}
+          artifact-prefix: reftests
+          source-path: tests/${{ matrix.preset }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload to release
         run: gh release upload "${{ needs.setup.outputs.tag }}" ${{ matrix.preset }}.tar.gz
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-
-      - name: Delete intermediate artifacts
-        continue-on-error: true
-        run: |
-          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate --jq '.artifacts[]
-              | select(.name | startswith("reftests-${{ matrix.preset }}-"))
-              | .id' | while read id; do
-            gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
-          done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,41 +177,19 @@ jobs:
       matrix:
         preset: ${{ fromJson(needs.config.outputs.presets) }}
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: reftests-${{ matrix.preset }}-*
-          path: tests/${{ matrix.preset }}
-          merge-multiple: true
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Archive reference tests
-        run: |
-          tar --sort=name \
-              --owner=0 \
-              --group=0 \
-              --numeric-owner \
-              --mtime='@0' \
-              --format=gnu \
-              --use-compress-program='gzip --no-name' \
-              --create \
-              --file=${{ matrix.preset }}.tar.gz \
-              tests/${{ matrix.preset }}
+      - name: Package reference tests
+        uses: ./.github/actions/package
+        with:
+          name: ${{ matrix.preset }}
+          artifact-prefix: reftests
+          source-path: tests/${{ matrix.preset }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload ${{ matrix.preset }}.tar.gz
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: ${{ matrix.preset }}.tar.gz
           archive: false
-
-      - name: Delete intermediate artifacts
-        continue-on-error: true
-        run: |
-          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate --jq '.artifacts[]
-              | select(.name | startswith("reftests-${{ matrix.preset }}-"))
-              | .id' | while read id; do
-            gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
-          done
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
We have three workflows which each package tests into a tarball. I have just learned that we can define our own internal actions for stuff like this. Let's do this to deduplicate a bit.