### PR TITLE
Embed `payload_status` into `head` fork choice check

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -536,11 +536,15 @@ def add_payload_vote_checks(store, block_root, test_steps):
 def get_formatted_head_output(spec, store, head=None):
     if head is None:
         head = spec.get_head(store)
-    slot = store.blocks[head.root].slot
-    return {
-        "slot": int(slot),
+    formatted_head = {
+        "slot": int(store.blocks[head.root].slot),
         "root": encode_hex(head.root),
     }
+
+    if is_post_gloas(spec):
+        formatted_head["payload_status"] = int(head.payload_status)
+
+    return formatted_head
 
 
 def output_head_check(spec, store, test_steps):
@@ -555,10 +559,9 @@ def output_head_check(spec, store, test_steps):
 
 
 def get_basic_store_checks(spec, store):
-    head = spec.get_head(store)
-    checks = {
+    return {
         "time": int(store.time),
-        "head": get_formatted_head_output(spec, store, head),
+        "head": get_formatted_head_output(spec, store),
         "justified_checkpoint": {
             "epoch": int(store.justified_checkpoint.epoch),
             "root": encode_hex(store.justified_checkpoint.root),
@@ -569,11 +572,6 @@ def get_basic_store_checks(spec, store):
         },
         "proposer_boost_root": encode_hex(store.proposer_boost_root),
     }
-
-    if is_post_gloas(spec):
-        checks["head_payload_status"] = int(head.payload_status)
-
-    return checks
 
 
 def get_weighed_node_checks(spec, store, node):

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -533,9 +533,8 @@ def add_payload_vote_checks(store, block_root, test_steps):
     )
 
 
-def get_formatted_head_output(spec, store, head=None):
-    if head is None:
-        head = spec.get_head(store)
+def get_formatted_head_output(spec, store):
+    head = spec.get_head(store)
     formatted_head = {
         "slot": int(store.blocks[head.root].slot),
         "root": encode_hex(head.root),
@@ -548,11 +547,10 @@ def get_formatted_head_output(spec, store, head=None):
 
 
 def output_head_check(spec, store, test_steps):
-    head = spec.get_head(store)
     test_steps.append(
         {
             "checks": {
-                "head": get_formatted_head_output(spec, store, head),
+                "head": get_formatted_head_output(spec, store),
             }
         }
     )

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -238,6 +238,7 @@ client implementation. The fields include:
 head: {
     slot: int,
     root: string,             -- Encoded 32-byte value from get_head(store).root
+    payload_status: int,      -- Gloas and later, the head's payload_status
 }
 time: int                     -- store.time
 genesis_time: int             -- store.genesis_time
@@ -266,7 +267,6 @@ should_override_forkchoice_update: {  -- [New in Bellatrix]
     validator_is_connected: bool,     -- The mocking result of `validator_is_connected(proposer_index)` in this call
     result: bool,                     -- The result of `should_override_forkchoice_update(store, head_root)`, where head_root is the result value from get_head(store).root
 }
-head_payload_status: int              -- The payload_status field from the ForkChoiceNode returned by get_head(store)
 payload_timeliness_vote: {            -- [New in Gloas]
     block_root: string,               -- Encoded 32-byte beacon block root
     votes: [bool | null, ...]         -- Votes ordered by PTC positions. Length is `PTC_SIZE`.

--- a/tests/generators/compliance_runners/fork_choice/runner/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/runner/test_run.py
@@ -143,23 +143,16 @@ def run_test(test_info):
                 )
         elif "checks" in step:
             checks = step["checks"]
-
-            cached_head = None
-
-            def get_head():
-                nonlocal cached_head
-                if cached_head is None:
-                    cached_head = spec.get_head(store)
-                return cached_head
-
             for check, value in checks.items():
                 if check == "time":
                     expected_time = value
                     assert store.time == expected_time
                 elif check == "head":
-                    head = get_head()
+                    head = spec.get_head(store)
                     assert store.blocks[head.root].slot == value["slot"]
                     assert str(head.root) == value["root"]
+                    if is_post_gloas(spec):
+                        assert head.payload_status == value["payload_status"]
                 elif check == "proposer_boost_root":
                     assert str(store.proposer_boost_root) == str(value)
                 elif check == "justified_checkpoint":
@@ -174,9 +167,6 @@ def run_test(test_info):
                     actual = value
                     expected = get_viable_for_head_checks(spec, store)
                     assert {frozenset(e) for e in actual} == {frozenset(e) for e in expected}
-                elif check == "head_payload_status":
-                    head = get_head()
-                    assert head.payload_status == value
                 elif check in ("payload_timeliness_vote", "payload_data_availability_vote"):
                     target_root = spec.Root(decode_hex(value["block_root"]))
                     assert list(getattr(store, check)[target_root]) == value["votes"]


### PR DESCRIPTION
# Description

This PR implements an @mkalinin suggestion, to embed the `payload_status` into the `head` fork choice checks. This can be justified to follow the updated

```python
class ForkChoiceNode(Container):
    root: Root
    payload_status: PayloadStatus
```

Discussion on this topic can be found on discord:

- https://discord.com/channels/595666850260713488/1503699386578899034

This should probably be revisited after #5249 