### PR TITLE
Yield mutated state in gossip block test

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_block.py
@@ -348,10 +348,11 @@ def test_gossip_beacon_block__reject_parent_failed_validation(spec, state):
     pre-merge state.
     """
     yield "topic", "meta", "beacon_block"
-    yield "state", state
 
     if is_post_bellatrix(spec):
         state = build_state_with_incomplete_transition(spec, state)
+
+    yield "state", state
 
     seen = get_seen(spec)
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)


### PR DESCRIPTION
The `state.ssz_snappy` is the unmutated state, but the anchor block's `state_root` is computed from the mutated state.