### PR TITLE
Optimize strategy for onboarding builders at the fork

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -536,11 +536,14 @@ def is_valid_indexed_payload_attestation(
 Implementations SHOULD cache verification results to avoid repeated work.
 
 ```python
-def is_pending_validator(state: BeaconState, pubkey: BLSPubkey) -> bool:
+def is_pending_validator(
+    pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT],
+    pubkey: BLSPubkey,
+) -> bool:
     """
     Check if a pending deposit with a valid signature is in the queue for the given pubkey.
     """
-    for pending_deposit in state.pending_deposits:
+    for pending_deposit in pending_deposits:
         if pending_deposit.pubkey != pubkey:
             continue
         if is_valid_deposit_signature(
@@ -1598,7 +1601,7 @@ def process_deposit_request(state: BeaconState, deposit_request: DepositRequest)
     if is_builder or (
         is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
         and not is_validator
-        and not is_pending_validator(state, deposit_request.pubkey)
+        and not is_pending_validator(state.pending_deposits, deposit_request.pubkey)
     ):
         # Apply builder deposits immediately
         apply_deposit_for_builder(

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -536,10 +536,7 @@ def is_valid_indexed_payload_attestation(
 Implementations SHOULD cache verification results to avoid repeated work.
 
 ```python
-def is_pending_validator(
-    pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT],
-    pubkey: BLSPubkey,
-) -> bool:
+def is_pending_validator(pending_deposits: Sequence[PendingDeposit], pubkey: BLSPubkey) -> bool:
     """
     Check if a pending deposit with a valid signature is in the queue for the given pubkey.
     """

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -72,16 +72,22 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
             pending_deposits.append(deposit)
             continue
 
-        # If the pubkey is associated with a builder that was created in a
-        # previous iteration or it is a builder deposit, try to apply the
-        # deposit to the new/existing builder. Note that the function
-        # apply_deposit_for_builder can mutate the state and may add a builder
-        # to the registry. For this reason, the list of builder pubkeys must
-        # be recomputed each iteration.
+        # Note that the function apply_deposit_for_builder can mutate the
+        # state and may add a builder to the registry. For this reason, the
+        # list of builder pubkeys must be recomputed each iteration.
         builder_pubkeys = [b.pubkey for b in state.builders]
-        is_existing_builder = deposit.pubkey in builder_pubkeys
-        has_builder_credentials = is_builder_withdrawal_credential(deposit.withdrawal_credentials)
-        if is_existing_builder or has_builder_credentials:
+        if deposit.pubkey in builder_pubkeys:
+            apply_deposit_for_builder(
+                state,
+                deposit.pubkey,
+                deposit.withdrawal_credentials,
+                deposit.amount,
+                deposit.signature,
+                deposit.slot,
+            )
+            continue
+
+        if is_builder_withdrawal_credential(deposit.withdrawal_credentials):
             # Check if there is a valid pending deposit for a new validator
             # with this pubkey. If there is, the deposit should instead be
             # applied to that validator later.

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -67,7 +67,7 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
 
     pending_deposits = []
     for deposit in state.pending_deposits:
-        # Deposits for existing validators stay in pending queue
+        # Deposits for existing validators stay in the pending queue
         if deposit.pubkey in validator_pubkeys:
             pending_deposits.append(deposit)
             continue
@@ -76,36 +76,26 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
         # state and may add a builder to the registry. For this reason, the
         # list of builder pubkeys must be recomputed each iteration.
         builder_pubkeys = [b.pubkey for b in state.builders]
-        if deposit.pubkey in builder_pubkeys:
-            apply_deposit_for_builder(
-                state,
-                deposit.pubkey,
-                deposit.withdrawal_credentials,
-                deposit.amount,
-                deposit.signature,
-                deposit.slot,
-            )
-            continue
 
-        if is_builder_withdrawal_credential(deposit.withdrawal_credentials):
-            # Check if there is a valid pending deposit for a new validator
-            # with this pubkey. If there is, the deposit should instead be
-            # applied to that validator later.
+        # Deposits for non-builders stay in the pending queue. If there is a
+        # valid pending deposit for a new validator with this pubkey, keep this
+        # deposit in the pending queue to be applied to that validator later.
+        if deposit.pubkey not in builder_pubkeys:
+            if not is_builder_withdrawal_credential(deposit.withdrawal_credentials):
+                pending_deposits.append(deposit)
+                continue
             if is_pending_validator(pending_deposits, deposit.pubkey):
                 pending_deposits.append(deposit)
-            else:
-                apply_deposit_for_builder(
-                    state,
-                    deposit.pubkey,
-                    deposit.withdrawal_credentials,
-                    deposit.amount,
-                    deposit.signature,
-                    deposit.slot,
-                )
-            continue
+                continue
 
-        # Deposits for new validators stay in pending queue
-        pending_deposits.append(deposit)
+        apply_deposit_for_builder(
+            state,
+            deposit.pubkey,
+            deposit.withdrawal_credentials,
+            deposit.amount,
+            deposit.signature,
+            deposit.slot,
+        )
 
     state.pending_deposits = pending_deposits
 ```

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -82,26 +82,27 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
         is_existing_builder = deposit.pubkey in builder_pubkeys
         has_builder_credentials = is_builder_withdrawal_credential(deposit.withdrawal_credentials)
         if is_existing_builder or has_builder_credentials:
-            apply_deposit_for_builder(
-                state,
-                deposit.pubkey,
-                deposit.withdrawal_credentials,
-                deposit.amount,
-                deposit.signature,
-                deposit.slot,
-            )
+            # This is for frontrunning resistance: invalid prior
+            # deposits do not block legit builder creation.
+            if is_pending_validator(pending_deposits, deposit.pubkey):
+                pending_deposits.append(deposit)
+            else:
+                apply_deposit_for_builder(
+                    state,
+                    deposit.pubkey,
+                    deposit.withdrawal_credentials,
+                    deposit.amount,
+                    deposit.signature,
+                    deposit.slot,
+                )
             continue
 
-        # If there is a pending deposit for a new validator that has a valid
-        # signature, track the pubkey so that subsequent builder deposits for
-        # the same pubkey stay in pending (applied to the validator later)
-        # rather than creating a builder. Deposits with invalid signatures are
-        # dropped here since they would fail in apply_pending_deposit anyway.
-        if is_valid_deposit_signature(
-            deposit.pubkey, deposit.withdrawal_credentials, deposit.amount, deposit.signature
-        ):
-            validator_pubkeys.append(deposit.pubkey)
-            pending_deposits.append(deposit)
+        # Non-builder, fresh pubkey: defer signature validation. Keep the
+        # deposit in pending so a later same-pubkey builder deposit can
+        # detect a validator claim via is_pending_validator. Invalid
+        # signatures are not dropped here; they will be dropped later by
+        # apply_pending_deposit.
+        pending_deposits.append(deposit)
 
     state.pending_deposits = pending_deposits
 ```

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -82,8 +82,9 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
         is_existing_builder = deposit.pubkey in builder_pubkeys
         has_builder_credentials = is_builder_withdrawal_credential(deposit.withdrawal_credentials)
         if is_existing_builder or has_builder_credentials:
-            # This is for frontrunning resistance: invalid prior
-            # deposits do not block legit builder creation.
+            # Check if there is a valid pending deposit for a new validator
+            # with this pubkey. If there is, the deposit should instead be
+            # applied to that validator later.
             if is_pending_validator(pending_deposits, deposit.pubkey):
                 pending_deposits.append(deposit)
             else:
@@ -97,11 +98,7 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
                 )
             continue
 
-        # Non-builder, fresh pubkey: defer signature validation. Keep the
-        # deposit in pending so a later same-pubkey builder deposit can
-        # detect a validator claim via is_pending_validator. Invalid
-        # signatures are not dropped here; they will be dropped later by
-        # apply_pending_deposit.
+        # Deposits for new validators stay in pending queue
         pending_deposits.append(deposit)
 
     state.pending_deposits = pending_deposits

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
@@ -522,8 +522,14 @@ def test_fork_invalid_validator_deposit_followed_by_builder_credentials(spec, ph
     assert post_state.builders[0].pubkey == builder_pubkey
     assert post_state.builders[0].balance == amount
 
-    # Invalid validator deposit is dropped (not kept in pending)
-    assert len(post_state.pending_deposits) == 0
+    # Invalid validator deposit stays in pending; it will be dropped later
+    # by apply_pending_deposit when the queue is processed.
+    assert len(post_state.pending_deposits) == 1
+    assert post_state.pending_deposits[0].pubkey == builder_pubkey
+    assert (
+        post_state.pending_deposits[0].withdrawal_credentials
+        == compounding_withdrawal_credentials
+    )
 
 
 @with_phases(phases=[FULU], other_phases=[GLOAS])

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
@@ -522,13 +522,11 @@ def test_fork_invalid_validator_deposit_followed_by_builder_credentials(spec, ph
     assert post_state.builders[0].pubkey == builder_pubkey
     assert post_state.builders[0].balance == amount
 
-    # Invalid validator deposit stays in pending; it will be dropped later
-    # by apply_pending_deposit when the queue is processed.
+    # Invalid validator deposit stays in pending queue
     assert len(post_state.pending_deposits) == 1
     assert post_state.pending_deposits[0].pubkey == builder_pubkey
     assert (
-        post_state.pending_deposits[0].withdrawal_credentials
-        == compounding_withdrawal_credentials
+        post_state.pending_deposits[0].withdrawal_credentials == compounding_withdrawal_credentials
     )
 
 

--- a/tests/infra/helpers/deposit_requests.py
+++ b/tests/infra/helpers/deposit_requests.py
@@ -178,7 +178,7 @@ def _is_builder_deposit(spec, pre_state, deposit_request):
     return is_builder or (
         spec.is_builder_withdrawal_credential(deposit_request.withdrawal_credentials)
         and not is_validator
-        and not spec.is_pending_validator(pre_state, deposit_request.pubkey)
+        and not spec.is_pending_validator(pre_state.pending_deposits, deposit_request.pubkey)
     )
 
 


### PR DESCRIPTION
**Description**
* avoid eager signature validation for the whole `pending_deposits` queue when onboard builders at fork transition
* this keeps front-running resistance semantic of the current spec while helping the fork transition runs faster

this is under discussion, making this as Draft in the mean time