### PR TITLE
Clear stale reftest case output

### DIFF
--- a/tests/infra/dumper.py
+++ b/tests/infra/dumper.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 from eth_utils import encode_hex
@@ -56,6 +57,11 @@ class Dumper:
         if not meta:
             return
         self._dump_yaml(dir, "meta", meta, self.default_yaml)
+
+    def clear_case_dir(self, dir: Path) -> None:
+        """Remove previously generated outputs for a test case."""
+        if dir.exists():
+            shutil.rmtree(dir)
 
     def dump_cfg(self, dir: Path, name: str, data: any) -> None:
         self._dump_yaml(dir, name, data, self.cfg_yaml)

--- a/tests/infra/dumper.py
+++ b/tests/infra/dumper.py
@@ -1,4 +1,3 @@
-import shutil
 from pathlib import Path
 
 from eth_utils import encode_hex
@@ -57,11 +56,6 @@ class Dumper:
         if not meta:
             return
         self._dump_yaml(dir, "meta", meta, self.default_yaml)
-
-    def clear_case_dir(self, dir: Path) -> None:
-        """Remove previously generated outputs for a test case."""
-        if dir.exists():
-            shutil.rmtree(dir)
 
     def dump_cfg(self, dir: Path, name: str, data: any) -> None:
         self._dump_yaml(dir, name, data, self.cfg_yaml)

--- a/tests/infra/pytest_plugins/test_yield_generator.py
+++ b/tests/infra/pytest_plugins/test_yield_generator.py
@@ -182,7 +182,7 @@ class TestDumpPhase:
         assert (case_dir / "data.yaml").exists()
         assert (case_dir / "manifest.yaml").exists()
 
-    def test_clear_output_dirs_removes_selected_fork_cases(self, tmp_path):
+    def test_dump_phase_does_not_remove_other_fork_cases(self, tmp_path):
         config = SimpleNamespace(getoption=lambda option: str(tmp_path))
         plugin = YieldGeneratorPlugin(config)
         manifest = Manifest(
@@ -196,15 +196,13 @@ class TestDumpPhase:
         altair_dir = tmp_path / "minimal" / "altair" / "bls" / "verify" / "pyspec_tests" / "valid"
         phase0_dir.mkdir(parents=True)
         altair_dir.mkdir(parents=True)
-        (phase0_dir / "stale.yaml").write_text("old: true\n")
-        (altair_dir / "stale.yaml").write_text("old: true\n")
+        phase0_stale_path = phase0_dir / "stale.yaml"
+        altair_stale_path = altair_dir / "stale.yaml"
+        phase0_stale_path.write_text("old: true\n")
+        altair_stale_path.write_text("old: true\n")
 
-        previous_forks = context.DEFAULT_PYTEST_FORKS
-        try:
-            context.DEFAULT_PYTEST_FORKS = {"phase0", "altair"}
-            plugin._clear_output_dirs(manifest)
-        finally:
-            context.DEFAULT_PYTEST_FORKS = previous_forks
+        plugin._dump_phase(manifest, [("data", "data", {"value": 1})], "phase0")
 
-        assert not phase0_dir.exists()
-        assert not altair_dir.exists()
+        assert not phase0_stale_path.exists()
+        assert (phase0_dir / "data.yaml").exists()
+        assert altair_stale_path.exists()

--- a/tests/infra/pytest_plugins/test_yield_generator.py
+++ b/tests/infra/pytest_plugins/test_yield_generator.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 # When context initiates the chain, the partial module resolution works correctly.
 from eth_consensus_specs.test import context  # noqa: F401
 from tests.infra.manifest import Manifest
-from tests.infra.pytest_plugins.yield_generator import SpecTestFunction
+from tests.infra.pytest_plugins.yield_generator import SpecTestFunction, YieldGeneratorPlugin
 
 
 class TestFindRunner:
@@ -156,3 +156,55 @@ class TestInferManifest:
         )
         SpecTestFunction._infer_manifest(stub2)
         assert stub2.manifest.suite_name == "custom_suite"
+
+
+class TestDumpPhase:
+    """Tests for YieldGeneratorPlugin._dump_phase."""
+
+    def test_removes_stale_case_files_before_dumping(self, tmp_path):
+        config = SimpleNamespace(getoption=lambda option: str(tmp_path))
+        plugin = YieldGeneratorPlugin(config)
+        manifest = Manifest(
+            preset_name="minimal",
+            runner_name="bls",
+            handler_name="verify",
+            suite_name="pyspec_tests",
+            case_name="valid",
+        )
+        case_dir = tmp_path / "minimal" / "phase0" / "bls" / "verify" / "pyspec_tests" / "valid"
+        case_dir.mkdir(parents=True)
+        stale_path = case_dir / "stale.yaml"
+        stale_path.write_text("old: true\n")
+
+        plugin._dump_phase(manifest, [("data", "data", {"value": 1})], "phase0")
+
+        assert not stale_path.exists()
+        assert (case_dir / "data.yaml").exists()
+        assert (case_dir / "manifest.yaml").exists()
+
+    def test_clear_output_dirs_removes_selected_fork_cases(self, tmp_path):
+        config = SimpleNamespace(getoption=lambda option: str(tmp_path))
+        plugin = YieldGeneratorPlugin(config)
+        manifest = Manifest(
+            preset_name="minimal",
+            runner_name="bls",
+            handler_name="verify",
+            suite_name="pyspec_tests",
+            case_name="valid",
+        )
+        phase0_dir = tmp_path / "minimal" / "phase0" / "bls" / "verify" / "pyspec_tests" / "valid"
+        altair_dir = tmp_path / "minimal" / "altair" / "bls" / "verify" / "pyspec_tests" / "valid"
+        phase0_dir.mkdir(parents=True)
+        altair_dir.mkdir(parents=True)
+        (phase0_dir / "stale.yaml").write_text("old: true\n")
+        (altair_dir / "stale.yaml").write_text("old: true\n")
+
+        previous_forks = context.DEFAULT_PYTEST_FORKS
+        try:
+            context.DEFAULT_PYTEST_FORKS = {"phase0", "altair"}
+            plugin._clear_output_dirs(manifest)
+        finally:
+            context.DEFAULT_PYTEST_FORKS = previous_forks
+
+        assert not phase0_dir.exists()
+        assert not altair_dir.exists()

--- a/tests/infra/pytest_plugins/yield_generator.py
+++ b/tests/infra/pytest_plugins/yield_generator.py
@@ -327,12 +327,10 @@ class YieldGeneratorPlugin:
 
     def _case_output_dir(self, manifest: Manifest) -> Path:
         """Return the output directory for a complete case manifest."""
-        assert manifest.is_complete(), (
-            f"Manifest must be complete to generate test vector for {manifest}"
-        )
+        assert manifest.is_complete()
         return (
             Path(self.output_dir)
-            / manifest.preset_name  # type: ignore
+            / manifest.preset_name
             / manifest.fork_name
             / manifest.runner_name
             / manifest.handler_name
@@ -359,9 +357,6 @@ class YieldGeneratorPlugin:
         if fork_name not in context.DEFAULT_PYTEST_FORKS:
             return
         manifest = manifest.with_defaults(Manifest(fork_name=fork_name))
-        assert manifest.is_complete(), (
-            f"Manifest must be complete to generate test vector for {manifest}"
-        )
         output_dir = self._case_output_dir(manifest)
 
         outputs: list[tuple[str, Any, Any]] = []

--- a/tests/infra/pytest_plugins/yield_generator.py
+++ b/tests/infra/pytest_plugins/yield_generator.py
@@ -279,6 +279,11 @@ class YieldGeneratorPlugin:
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_protocol(self, item, nextitem):
+        if self.reftests_enabled and isinstance(item, SpecTestFunction):
+            manifest = item.get_manifest()
+            if manifest is not None:
+                self._clear_output_dirs(manifest)
+
         yield
 
         if not self._should_generate(item):
@@ -325,6 +330,34 @@ class YieldGeneratorPlugin:
                 return data
         return default
 
+    def _case_output_dir(self, manifest: Manifest) -> Path:
+        """Return the output directory for a complete case manifest."""
+        assert manifest.is_complete(), (
+            f"Manifest must be complete to generate test vector for {manifest}"
+        )
+        return (
+            Path(self.output_dir)
+            / manifest.preset_name  # type: ignore
+            / manifest.fork_name
+            / manifest.runner_name
+            / manifest.handler_name
+            / manifest.suite_name
+            / manifest.case_name
+        )
+
+    def _clear_output_dirs(self, manifest: Manifest) -> None:
+        """Remove stale case outputs for the selected reftest forks."""
+        if manifest.fork_name is not None:
+            if manifest.fork_name not in context.DEFAULT_PYTEST_FORKS:
+                return
+            fork_names = [manifest.fork_name]
+        else:
+            fork_names = context.DEFAULT_PYTEST_FORKS
+        for fork_name in fork_names:
+            manifest_with_fork = manifest.with_defaults(Manifest(fork_name=fork_name))
+            if manifest_with_fork.is_complete():
+                self.dumper.clear_case_dir(self._case_output_dir(manifest_with_fork))
+
     def generate_test_vector(self, manifest: Manifest, result: MultiPhaseResult | list) -> None:
         if isinstance(result, dict):
             for fork_name, phase_result in result.items():
@@ -347,16 +380,7 @@ class YieldGeneratorPlugin:
         assert manifest.is_complete(), (
             f"Manifest must be complete to generate test vector for {manifest}"
         )
-
-        output_dir = (
-            Path(self.output_dir)
-            / manifest.preset_name  # type: ignore
-            / manifest.fork_name
-            / manifest.runner_name
-            / manifest.handler_name
-            / manifest.suite_name
-            / manifest.case_name
-        )
+        output_dir = self._case_output_dir(manifest)
 
         outputs: list[tuple[str, Any, Any]] = []
         meta: dict[str, Any] = {}
@@ -369,6 +393,8 @@ class YieldGeneratorPlugin:
                 if method is None:
                     raise ValueError(f"Unknown kind {kind!r}")
                 outputs.append((name, method, data))
+
+        self.dumper.clear_case_dir(output_dir)
 
         for name, method, data in outputs:
             method(output_dir, name, data)

--- a/tests/infra/pytest_plugins/yield_generator.py
+++ b/tests/infra/pytest_plugins/yield_generator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, TypedDict
@@ -325,19 +326,6 @@ class YieldGeneratorPlugin:
                 return data
         return default
 
-    def _case_output_dir(self, manifest: Manifest) -> Path:
-        """Return the output directory for a complete case manifest."""
-        assert manifest.is_complete()
-        return (
-            Path(self.output_dir)
-            / manifest.preset_name
-            / manifest.fork_name
-            / manifest.runner_name
-            / manifest.handler_name
-            / manifest.suite_name
-            / manifest.case_name
-        )
-
     def generate_test_vector(self, manifest: Manifest, result: MultiPhaseResult | list) -> None:
         if isinstance(result, dict):
             for fork_name, phase_result in result.items():
@@ -357,7 +345,19 @@ class YieldGeneratorPlugin:
         if fork_name not in context.DEFAULT_PYTEST_FORKS:
             return
         manifest = manifest.with_defaults(Manifest(fork_name=fork_name))
-        output_dir = self._case_output_dir(manifest)
+        assert manifest.is_complete(), (
+            f"Manifest must be complete to generate test vector for {manifest}"
+        )
+
+        output_dir = (
+            Path(self.output_dir)
+            / manifest.preset_name  # type: ignore
+            / manifest.fork_name
+            / manifest.runner_name
+            / manifest.handler_name
+            / manifest.suite_name
+            / manifest.case_name
+        )
 
         outputs: list[tuple[str, Any, Any]] = []
         meta: dict[str, Any] = {}
@@ -371,7 +371,8 @@ class YieldGeneratorPlugin:
                     raise ValueError(f"Unknown kind {kind!r}")
                 outputs.append((name, method, data))
 
-        self.dumper.clear_case_dir(output_dir)
+        if output_dir.exists():
+            shutil.rmtree(output_dir)
 
         for name, method, data in outputs:
             method(output_dir, name, data)

--- a/tests/infra/pytest_plugins/yield_generator.py
+++ b/tests/infra/pytest_plugins/yield_generator.py
@@ -279,11 +279,6 @@ class YieldGeneratorPlugin:
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_protocol(self, item, nextitem):
-        if self.reftests_enabled and isinstance(item, SpecTestFunction):
-            manifest = item.get_manifest()
-            if manifest is not None:
-                self._clear_output_dirs(manifest)
-
         yield
 
         if not self._should_generate(item):
@@ -344,19 +339,6 @@ class YieldGeneratorPlugin:
             / manifest.suite_name
             / manifest.case_name
         )
-
-    def _clear_output_dirs(self, manifest: Manifest) -> None:
-        """Remove stale case outputs for the selected reftest forks."""
-        if manifest.fork_name is not None:
-            if manifest.fork_name not in context.DEFAULT_PYTEST_FORKS:
-                return
-            fork_names = [manifest.fork_name]
-        else:
-            fork_names = context.DEFAULT_PYTEST_FORKS
-        for fork_name in fork_names:
-            manifest_with_fork = manifest.with_defaults(Manifest(fork_name=fork_name))
-            if manifest_with_fork.is_complete():
-                self.dumper.clear_case_dir(self._case_output_dir(manifest_with_fork))
 
     def generate_test_vector(self, manifest: Manifest, result: MultiPhaseResult | list) -> None:
         if isinstance(result, dict):


### PR DESCRIPTION
## Description

This PR clears previously generated reference-test case directories before writing the current output for that case. The pytest reftest generator currently overwrites matching filenames, which can leave stale files behind when a case yields fewer outputs or no longer emits vectors for a selected fork.
