### PR TITLE
Add `offset` and `min_slot` to `beacon_blocks_by_head`

### DIFF
--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -602,9 +602,9 @@ for _ in range(offset): start_root = get_block(start_root).parent_root
 The walk is inclusive of the block at `start_root`, in descending slot order.
 The walk stops as soon as one of the following is true:
 
-* the response contains `min(count, MAX_REQUEST_BLOCKS_DENEB)` blocks
-* the slot of a block in the response is <= min_slot
-* the next ancestor falls outside the epoch range that clients are required to
+- the response contains `min(count, MAX_REQUEST_BLOCKS_DENEB)` blocks
+- the slot of a block in the response is <= min_slot
+- the next ancestor falls outside the epoch range that clients are required to
 serve (see below).
 
 `BeaconBlocksByHead` is primarily used to backfill a contiguous range of blocks

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -603,9 +603,9 @@ The walk is inclusive of the block at `start_root`, in descending slot order.
 The walk stops as soon as one of the following is true:
 
 - the response contains `min(count, MAX_REQUEST_BLOCKS_DENEB)` blocks
-- the slot of a block in the response is <= min_slot
+- the slot of a block in the response is `<= min_slot`
 - the next ancestor falls outside the epoch range that clients are required to
-serve (see below).
+  serve (see below).
 
 `BeaconBlocksByHead` is primarily used to backfill a contiguous range of blocks
 relative to a known head.

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -576,7 +576,9 @@ Request Content:
 ```
 (
   beacon_root: Root
+  offset: uint64
   count: uint64
+  min_slot: Slot
 )
 ```
 
@@ -588,11 +590,22 @@ Response Content:
 )
 ```
 
-Requests beacon blocks along the ancestry of `beacon_root`, inclusive of the
-block at `beacon_root`, in descending slot order. The walk stops as soon as the
-response contains `min(count, MAX_REQUEST_BLOCKS_DENEB)` blocks or the next
-ancestor falls outside the epoch range that clients are required to serve (see
-below).
+Requests beacon blocks along the ancestry of `beacon_root`.
+
+The walk starts at `start_root` which is computed like so:
+
+```py
+start_root = block_root
+for _ in range(offset): start_root = get_block(start_root).parent_root
+```
+
+The walk is inclusive of the block at `start_root`, in descending slot order.
+The walk stops as soon as one of the following is true:
+
+* the response contains `min(count, MAX_REQUEST_BLOCKS_DENEB)` blocks
+* the slot of a block in the response is <= min_slot
+* the next ancestor falls outside the epoch range that clients are required to
+serve (see below).
 
 `BeaconBlocksByHead` is primarily used to backfill a contiguous range of blocks
 relative to a known head.
@@ -615,6 +628,9 @@ Clients MUST respond with at least one block, if they have the block at
 Clients SHOULD include a block in the response as soon as it passes the gossip
 validation rules. Clients SHOULD NOT respond with blocks that fail the
 beacon-chain state transition.
+
+Clients MAY respond with error code `3: ResourceUnavailable` to requests whose
+offset is greater than 1024.
 
 For each successful `response_chunk`, the `ForkDigest` context epoch is
 determined by `compute_epoch_at_slot(signed_beacon_block.message.slot)`.


### PR DESCRIPTION
When downloading blocks by head, the ancestry of the given `block_root` is not known - adding an `offset` to the requests allows clients to make requests for non-overlapping pages of history.

```
---A---B---C
     F
```

If `block_root` is `C` and `-` are other blocks, a request with `offset=4` would result in `B` being sent.

When requesting by offset, it is not known which slot the blocks have - this has several consequences:

* clients may not have a by-block index since this is not used elsewhere in the protocol making the iteration expensive - it is thus limited to 1024 blocks in the current fork - clients with an efficient index may allow larger offsets but this capability should not be used by requesting clients.
* `min_slot` is for the situation where `F` finalizes some history and this request is used to discover a new branch (for example due to an attestation arriving with unknown root). Previously, clients would use `by_root` requests and download such histories block but block - instead, they can use a by_head request and get the full branch - `min_slot` ensures that we don't transfer blocks past the block `F`, ie for histories with large slot jumps, it limits transfers to a single block proving that the history is useless. For backfilling the canonical history, 0 can be used.
