### PR TITLE
Document blob_sidecar in gossip validation format

### DIFF
--- a/tests/formats/networking/gossip_validation.md
+++ b/tests/formats/networking/gossip_validation.md
@@ -19,7 +19,7 @@ validation rules for messages received via gossip topics.
 ### `meta.yaml`
 
 ```yaml
-topic: string                -- The gossip topic name (e.g., "beacon_block", "beacon_attestation").
+topic: string                -- The gossip topic name (e.g., "beacon_block", "beacon_attestation", "blob_sidecar").
 blocks: [{                   -- Optional. Blocks to import before validation (oldest to newest).
     block: string,           -- The block file (without extension).
     failed: bool,            -- Optional. If true, block failed validation (for testing descendant rejection).
@@ -58,6 +58,7 @@ tree root:
 | Topic                                   | File prefix                | SSZ type                     |
 | --------------------------------------- | -------------------------- | ---------------------------- |
 | `beacon_block`                          | `block_`                   | `SignedBeaconBlock`          |
+| `blob_sidecar`                          | `blob_sidecar_`            | `BlobSidecar`                |
 | `beacon_attestation`                    | `attestation_`             | `Attestation`                |
 | `beacon_aggregate_and_proof`            | `aggregate_`               | `SignedAggregateAndProof`    |
 | `proposer_slashing`                     | `proposer_slashing_`       | `ProposerSlashing`           |


### PR DESCRIPTION
 ## Description
                                                                                                                                                                                                 
  This PR updates the networking gossip validation format documentation to include `blob_sidecar` as a supported gossip topic and documented message type. This is necessary because Deneb-era executable gossip validation tests and helper mappings already use `blob_sidecar`, so without this update the format spec is incomplete and can mislead implementers who rely on `tests/formats/networking/gossip_validation.md` as the source of truth.                                                                                                                               
                                                                                                                                                                                                 
  ## Checklist                                                                                                                                                                                   
                                                                                                                                                                                                 
  - [x] Update documentation (if applicable)                                                                                                                                                     
  - [x] Add tests for new functionality (if applicable) — N/A (docs-only change)                                                                                                                 
  - [ ] Run `make lint` to check formatting                                                                                                                                                      
  - [ ] Run `make test` to check tests                                                                                                                                                           
                                                                                                                                                                                                 
  ## Relations                                                                                                                                                                                   
                                                                                                                                                                                                 
  Related to #5146                                                                                                                                                                               
  Related to #5049