### PR TITLE
Test data column sidecar reconstruction in Gloas

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/unittests/das/test_das.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/unittests/das/test_das.py
@@ -126,11 +126,6 @@ def test_get_data_column_sidecars(spec, state):
 @with_fulu_and_later
 @spec_state_test
 def test_get_data_column_sidecars_from_column_sidecar(spec, state):
-    if is_post_gloas(spec):
-        # Skip this test for Gloas as the function hasn't been updated yet
-        # to work without signed_block_header and kzg_commitments_inclusion_proof
-        return
-
     rng = random.Random(1234)
     _, blobs, _, _, sidecars, _ = get_block_with_blob_and_sidecars(
         spec, state, rng=rng, blob_count=2


### PR DESCRIPTION
This PR enables the `get_data_column_sidecars_from_column_sidecar` test for Gloas now that the Gloas implementation reconstructs sidecars from `beacon_block_root` and `slot`.

This covers the Gloas path that no longer carries `signed_block_header` or `kzg_commitments_inclusion_proof` on data column sidecars.

Related to #4527 and #4875.