### PR TITLE
Add `on_attestation` tests for `validate_on_attestation` updates

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_attestation.py
@@ -1,0 +1,143 @@
+from eth_consensus_specs.test.context import (
+    spec_state_test,
+    with_gloas_and_later,
+)
+from eth_consensus_specs.test.helpers.attestations import get_valid_attestation
+from eth_consensus_specs.test.helpers.execution_payload import (
+    build_signed_execution_payload_envelope,
+)
+from eth_consensus_specs.test.helpers.fork_choice import (
+    add_attestation,
+    add_execution_payload,
+    add_signed_empty_block,
+    setup_one_block_store,
+    tick_store_to_slot,
+)
+from eth_consensus_specs.test.helpers.state import transition_to
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_validate_on_attestation_same_slot_empty_vote(spec, state):
+    """
+    Test that an empty-node vote at the same slot as the
+    attested block is accepted, regardless of payload verification.
+    """
+    store, _, block_state, _, test_steps = yield from setup_one_block_store(spec, state)
+
+    # Get valid empty-node attestation at the anchor's slot.
+    att = get_valid_attestation(spec, block_state, payload_index=0, signed=True)
+
+    tick_store_to_slot(spec, store, att.data.slot + 1, test_steps)
+    yield from add_attestation(spec, store, att, test_steps)
+    yield "steps", test_steps
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_validate_on_attestation_same_slot_full_vote_rejected(spec, state):
+    """
+    Test that a full-node vote at the same slot as the
+    attested block is rejected even if the payload is verified.
+    """
+    store, block_root, block_state, signed_block, test_steps = yield from setup_one_block_store(
+        spec, state
+    )
+    envelope = build_signed_execution_payload_envelope(spec, block_state, block_root, signed_block)
+    yield from add_execution_payload(spec, store, envelope, test_steps)
+
+    # Get valid full-node attestation at the anchor's slot.
+    att = get_valid_attestation(spec, block_state, payload_index=1, signed=True)
+
+    tick_store_to_slot(spec, store, block_state.slot + 1, test_steps)
+    yield from add_attestation(spec, store, att, test_steps, valid=False)
+    yield "steps", test_steps
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_validate_on_attestation_later_slot_full_vote_valid(spec, state):
+    """
+    Test that a full-node vote at a later slot referencing a block with a
+    verified payload is accepted.
+    """
+    store, block_root, block_state, signed_block, test_steps = yield from setup_one_block_store(
+        spec, state
+    )
+    envelope = build_signed_execution_payload_envelope(spec, block_state, block_root, signed_block)
+    yield from add_execution_payload(spec, store, envelope, test_steps)
+
+    state_at_2 = block_state.copy()
+    transition_to(spec, state_at_2, spec.Slot(2))
+
+    # Get valid attestation at slot 2 for a full-node vote for slot 1.
+    att = get_valid_attestation(
+        spec,
+        state_at_2,
+        slot=spec.Slot(2),
+        payload_index=1,
+        beacon_block_root=block_root,
+        signed=True,
+    )
+
+    tick_store_to_slot(spec, store, att.data.slot + 1, test_steps)
+    yield from add_attestation(spec, store, att, test_steps)
+    yield "steps", test_steps
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_validate_on_attestation_payload_invalid_index(spec, state):
+    """
+    Test that an attestation with an invalid index is rejected.
+    """
+    store, _, block_state, _, test_steps = yield from setup_one_block_store(spec, state)
+    tick_store_to_slot(spec, store, block_state.slot + 1, test_steps)
+
+    # Get attestation with an invalid index.
+    att = get_valid_attestation(spec, block_state, payload_index=2, signed=True)
+
+    yield from add_attestation(spec, store, att, test_steps, valid=False)
+    yield "steps", test_steps
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_validate_on_attestation_beacon_root_payload_check(spec, state):
+    """
+    Test that a full-node vote requires the beacon block root's payload to
+    be verified.
+    """
+    store, _, block_state, _, test_steps = yield from setup_one_block_store(spec, state)
+
+    # Build across the epoch boundary
+    target_slot = spec.compute_start_slot_at_epoch(spec.Epoch(1))
+    beacon_slot = spec.Slot(target_slot + 1)
+    chain_state = block_state.copy()
+    while chain_state.slot < target_slot:
+        target_root, target_state, target_block = yield from add_signed_empty_block(
+            spec, store, chain_state, test_steps
+        )
+
+    # Build one more block at beacon_slot
+    beacon_root, beacon_state, _ = yield from add_signed_empty_block(
+        spec, store, chain_state, test_steps
+    )
+
+    # Verify the target's payload
+    envelope = build_signed_execution_payload_envelope(
+        spec, target_state, target_root, target_block
+    )
+    yield from add_execution_payload(spec, store, envelope, test_steps)
+
+    # Build a full-node vote past the head
+    att_slot = spec.Slot(beacon_slot + 1)
+    att_state = beacon_state.copy()
+    transition_to(spec, att_state, att_slot)
+    att = get_valid_attestation(spec, att_state, slot=att_slot, payload_index=1, signed=True)
+    assert att.data.target.root == target_root
+    assert att.data.beacon_block_root == beacon_root
+
+    tick_store_to_slot(spec, store, att_slot + 1, test_steps)
+    yield from add_attestation(spec, store, att, test_steps, valid=False)
+    yield "steps", test_steps

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_execution_payload_envelope.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_execution_payload_envelope.py
@@ -1,9 +1,7 @@
 from eth_consensus_specs.test.context import (
+    always_bls,
     spec_state_test,
     with_gloas_and_later,
-)
-from eth_consensus_specs.test.helpers.block import (
-    build_empty_block_for_next_slot,
 )
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_empty_execution_payload,
@@ -12,36 +10,9 @@ from eth_consensus_specs.test.helpers.execution_payload import (
 from eth_consensus_specs.test.helpers.fork_choice import (
     add_execution_payload,
     check_head_against_root,
-    get_genesis_forkchoice_store_and_block,
-    on_tick_and_append_step,
-    tick_and_add_block,
+    setup_one_block_store,
 )
 from eth_consensus_specs.test.helpers.keys import builder_privkeys, privkeys
-from eth_consensus_specs.test.helpers.state import (
-    state_transition_and_sign_block,
-)
-
-
-def _setup_test(spec, state):
-    """
-    Build the genesis store and apply a single empty block at the next slot.
-    """
-    test_steps = []
-
-    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
-    yield "anchor_state", state
-    yield "anchor_block", anchor_block
-
-    current_time = state.slot * (spec.config.SLOT_DURATION_MS // 1000) + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-
-    # Apply one block at slot 1
-    block = build_empty_block_for_next_slot(spec, state)
-    signed_block = state_transition_and_sign_block(spec, state, block)
-    yield from tick_and_add_block(spec, store, signed_block, test_steps)
-    block_root = signed_block.message.hash_tree_root()
-
-    return store, signed_block, block_root, test_steps
 
 
 def _build_invalid_envelope(spec, state, block_root, signed_block, **overrides):
@@ -100,7 +71,7 @@ def test_on_execution_payload_envelope_valid(spec, state):
     """
     Test that a valid envelope is accepted and moves the head's payload_status to FULL.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     # After block 1, head is the new block with EMPTY status
     check_head_against_root(spec, store, block_root)
@@ -123,11 +94,12 @@ def test_on_execution_payload_envelope_valid(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
+@always_bls
 def test_on_execution_payload_envelope_wrong_signature(spec, state):
     """
     Test that an envelope with an invalid BLS signature is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,
@@ -149,7 +121,7 @@ def test_on_execution_payload_envelope_unknown_beacon_block_root(spec, state):
     """
     Test that an envelope referencing an unknown beacon_block_root is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,
@@ -171,7 +143,7 @@ def test_on_execution_payload_envelope_wrong_parent_beacon_block_root(spec, stat
     """
     Test that an envelope whose parent_beacon_block_root doesn't match the state's is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,
@@ -193,7 +165,7 @@ def test_on_execution_payload_envelope_wrong_slot(spec, state):
     """
     Test that an envelope whose payload.slot_number doesn't match state.slot is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,
@@ -215,7 +187,7 @@ def test_on_execution_payload_envelope_wrong_builder_index(spec, state):
     """
     Test that an envelope whose builder_index doesn't match the bid is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,
@@ -237,7 +209,7 @@ def test_on_execution_payload_envelope_wrong_prev_randao(spec, state):
     """
     Test that an envelope whose payload.prev_randao doesn't match the bid is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,
@@ -259,7 +231,7 @@ def test_on_execution_payload_envelope_wrong_execution_requests_root(spec, state
     """
     Test that an envelope whose execution_requests hash differs from the bid's commitment is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     # Build envelope with non-empty requests but bid commits to empty requests
     non_empty_requests = spec.ExecutionRequests(
@@ -300,7 +272,7 @@ def test_on_execution_payload_envelope_wrong_withdrawals(spec, state):
     """
     Test that an envelope with withdrawals not matching state.payload_expected_withdrawals is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     wrong_withdrawal = spec.Withdrawal(
         index=0, validator_index=0, address=b"\x22" * 20, amount=spec.Gwei(1)
@@ -337,7 +309,7 @@ def test_on_execution_payload_envelope_missing_expected_withdrawal(spec, state):
         spec.Withdrawal, spec.MAX_WITHDRAWALS_PER_PAYLOAD
     ]([expected_withdrawal])
 
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     # Sanity check: the seeded expected withdrawal survived block_1.
     assert len(state.payload_expected_withdrawals) == 1
@@ -363,7 +335,7 @@ def test_on_execution_payload_envelope_wrong_gas_limit(spec, state):
     """
     Test that an envelope whose payload.gas_limit doesn't match the bid is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,
@@ -385,7 +357,7 @@ def test_on_execution_payload_envelope_wrong_block_hash(spec, state):
     """
     Test that an envelope whose payload.block_hash doesn't match the bid is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,
@@ -407,7 +379,7 @@ def test_on_execution_payload_envelope_wrong_parent_hash(spec, state):
     """
     Test that an envelope whose payload.parent_hash doesn't match state.latest_block_hash is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,
@@ -429,7 +401,7 @@ def test_on_execution_payload_envelope_wrong_timestamp(spec, state):
     """
     Test that an envelope whose payload.timestamp doesn't match compute_time_at_slot is rejected.
     """
-    store, signed_block, block_root, test_steps = yield from _setup_test(spec, state)
+    store, block_root, _, signed_block, test_steps = yield from setup_one_block_store(spec, state)
 
     envelope = _build_invalid_envelope(
         spec,

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_payload_attestation_message.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_payload_attestation_message.py
@@ -1,4 +1,5 @@
 from eth_consensus_specs.test.context import (
+    always_bls,
     spec_state_test,
     with_gloas_and_later,
 )
@@ -8,9 +9,9 @@ from eth_consensus_specs.test.helpers.block import (
 from eth_consensus_specs.test.helpers.fork_choice import (
     add_payload_attestation_message,
     add_payload_vote_checks,
-    get_genesis_forkchoice_store_and_block,
-    on_tick_and_append_step,
+    setup_one_block_store,
     tick_and_add_block,
+    tick_store_to_slot,
 )
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
@@ -50,32 +51,11 @@ def _build_signed_payload_attestation_message(
     )
 
 
-def _move_store_to_slot(spec, store, slot, test_steps):
-    slot_time = store.genesis_time + slot * (spec.config.SLOT_DURATION_MS // 1000)
-    if store.time < slot_time:
-        on_tick_and_append_step(spec, store, slot_time, test_steps)
-
-
 def _setup_test(spec, state):
-    test_steps = []
-
-    # Build genesis store
-    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
-    yield "anchor_state", state
-    yield "anchor_block", anchor_block
-    current_time = state.slot * (spec.config.SLOT_DURATION_MS // 1000) + store.genesis_time
-    on_tick_and_append_step(spec, store, current_time, test_steps)
-
-    # Apply one block at slot 1
-    block = build_empty_block_for_next_slot(spec, state)
-    signed_block = state_transition_and_sign_block(spec, state, block)
-    yield from tick_and_add_block(spec, store, signed_block, test_steps)
-    block_root = signed_block.message.hash_tree_root()
-    block_state = store.block_states[block_root]
+    store, block_root, block_state, _, test_steps = yield from setup_one_block_store(spec, state)
     ptc = spec.get_ptc(block_state, block_state.slot)
     assert len(ptc) > 0
-
-    _move_store_to_slot(spec, store, block_state.slot, test_steps)
+    tick_store_to_slot(spec, store, block_state.slot, test_steps)
     return store, block_root, block_state, ptc, test_steps
 
 
@@ -179,6 +159,7 @@ def test_on_payload_attestation_message_not_ptc_member(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
+@always_bls
 def test_on_payload_attestation_message_current_slot_and_signature(spec, state):
     """
     Test that current slot and signature checks reject invalid messages.
@@ -215,7 +196,7 @@ def test_on_payload_attestation_message_current_slot_and_signature(spec, state):
         ptc[0],
         payload_present=True,
     )
-    _move_store_to_slot(spec, store, block_state.slot + 1, test_steps)
+    tick_store_to_slot(spec, store, block_state.slot + 1, test_steps)
     yield from add_payload_attestation_message(
         spec,
         store,

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_choice.py
@@ -11,7 +11,9 @@ from eth_consensus_specs.test.helpers.attestations import (
     next_slots_with_attestations,
     state_transition_with_full_block,
 )
+from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
 from eth_consensus_specs.test.helpers.forks import is_post_fulu, is_post_gloas
+from eth_consensus_specs.test.helpers.state import state_transition_and_sign_block
 
 
 def check_head_against_root(spec, store, root):
@@ -702,3 +704,41 @@ def is_ancestor(spec, store, root_or_node, maybe_ancestor_root_or_node) -> bool:
         maybe_ancestor = get_fork_choice_node(spec, maybe_ancestor_root_or_node)
 
     return spec.is_ancestor(store, node, maybe_ancestor)
+
+
+def tick_store_to_slot(spec, store, slot, test_steps):
+    """
+    Tick the store forward to the start of ``slot``.
+    """
+    slot_time = store.genesis_time + slot * spec.config.SLOT_DURATION_MS // 1000
+    if store.time < slot_time:
+        on_tick_and_append_step(spec, store, slot_time, test_steps)
+
+
+def add_signed_empty_block(spec, store, state, test_steps):
+    """
+    Build, sign, and submit an empty block at ``state.slot + 1``.
+    """
+    block = build_empty_block_for_next_slot(spec, state)
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    yield from tick_and_add_block(spec, store, signed_block, test_steps)
+
+    root = signed_block.message.hash_tree_root()
+    return root, store.block_states[root], signed_block
+
+
+def setup_one_block_store(spec, state):
+    """
+    Bootstrap a fork choice store with the genesis anchor plus an empty block at slot 1.
+    """
+    test_steps = []
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+
+    yield "anchor_state", state
+    yield "anchor_block", anchor_block
+
+    tick_store_to_slot(spec, store, state.slot, test_steps)
+    block_root, block_state, signed_block = yield from add_signed_empty_block(
+        spec, store, state, test_steps
+    )
+    return store, block_root, block_state, signed_block, test_steps

--- a/tests/generators/compliance_runners/fork_choice/runner/conftest.py
+++ b/tests/generators/compliance_runners/fork_choice/runner/conftest.py
@@ -1,8 +1,3 @@
-import pytest
-
-from eth_consensus_specs.utils import bls
-
-
 def pytest_addoption(parser):
     parser.addoption(
         "--test-dir",
@@ -22,8 +17,3 @@ def pytest_addoption(parser):
         default=None,
         help="Limit number of generated tests to validate.",
     )
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _disable_bls():
-    bls.bls_active = False

--- a/tests/generators/compliance_runners/fork_choice/runner/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/runner/test_run.py
@@ -12,6 +12,7 @@ from eth_consensus_specs.test.context import expect_assertion_error
 from eth_consensus_specs.test.helpers.fork_choice import get_viable_for_head_checks
 from eth_consensus_specs.test.helpers.forks import is_post_gloas
 from eth_consensus_specs.test.helpers.specs import spec_targets
+from eth_consensus_specs.utils import bls
 from tests.generators.compliance_runners.fork_choice.instantiators.helpers import (
     payload_attestation_to_messages,
 )
@@ -21,6 +22,10 @@ def read_yaml(fp):
     with Path(fp).open() as f:
         yaml = YAML(typ="safe")
         return yaml.load(f.read())
+
+
+def read_meta(fp):
+    return (read_yaml(fp) or {}) if Path(fp).is_file() else {}
 
 
 def read_ssz_snappy(fp):
@@ -35,7 +40,7 @@ def get_test_case(spec, td):
 
     td_path = Path(td)
     return (
-        read_yaml(td_path / "meta.yaml"),
+        read_meta(td_path / "meta.yaml"),
         spec.BeaconBlock.decode_bytes(read_ssz_snappy(td_path / "anchor_block.ssz_snappy")),
         spec.BeaconState.decode_bytes(read_ssz_snappy(td_path / "anchor_state.ssz_snappy")),
         {
@@ -71,9 +76,10 @@ class ComplianceTestInfo(NamedTuple):
 def run_test(test_info):
     preset, fork, test_dir = test_info
     spec = spec_targets[preset][fork]
-    _, anchor_block, anchor_state, blocks, atts, slashings, envelopes, payload_atts, steps = (
+    meta, anchor_block, anchor_state, blocks, atts, slashings, envelopes, payload_atts, steps = (
         get_test_case(spec, test_dir)
     )
+    bls.bls_active = meta.get("bls_setting", 0) == 1
     store = spec.get_forkchoice_store(anchor_state, anchor_block)
     for step in steps:
         if "tick" in step:


### PR DESCRIPTION
# Description 

This PR adds tests for the `validate_on_attestation` Gloas changes through the `on_attestation` spec function.

## Changes

- Add `test_on_attestation.py`
- Add shared helpers.
- Update `on_execution_payload_envelope` and `on_payload_attestation_message` helpers usage.
- Remove the session BLS off fixture so the runner respects `bls_setting` per test.

## Related

- #5211 