### PR TITLE
Avoid attestations with incompatible shuffling

### DIFF
--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -28,6 +28,7 @@ from .helpers import (
     BranchTip,
     build_random_payload_attestation_messages,
     FCTestData,
+    get_dependent_root,
     is_attestation_eligible_for_block,
     produce_block,
     ProtocolMessage,
@@ -597,11 +598,15 @@ class ProtocolState:
 
 
 class RuntimeState:
-    def __init__(self, anchor_tip: BranchTip):
+    def __init__(self, spec, anchor_tip: BranchTip):
+        self.spec = spec
         self.current_slot = anchor_tip.beacon_state.slot
         self.post_states = [anchor_tip.beacon_state.copy()]
         self.block_tree_tips = {0}
         self.payload_known_block_indices = set()
+        self.att_dependent_roots = {}
+        for att in anchor_tip.attestations:
+            self.apply_att_dependent_root(anchor_tip.beacon_state, att)
 
     def append_post_state(self, post_state):
         self.post_states.append(post_state)
@@ -610,6 +615,12 @@ class RuntimeState:
         self.append_post_state(post_state)
         self.block_tree_tips.discard(parent_index)
         self.block_tree_tips.add(block_index)
+
+    def apply_att_dependent_root(self, state, attestation):
+        data = attestation.data
+        self.att_dependent_roots[(data.beacon_block_root, data.slot)] = get_dependent_root(
+            self.spec, state, data.slot
+        )
 
 
 class StateCache:
@@ -757,7 +768,7 @@ def _generate_block_tree(
     with_invalid_messages,
 ) -> ([], [], [], [], []):
     protocol = ProtocolState(spec, anchor_tip)
-    runtime = RuntimeState(anchor_tip)
+    runtime = RuntimeState(spec, anchor_tip)
     # Tracks every validator selected for a generated attester slashing in this
     # scenario, so later selections cannot target the same validator again.
     validators_to_be_slashed = set()
@@ -822,6 +833,13 @@ def _generate_block_tree(
         return signed_block, parent_state, None
 
     def produce_valid_block(parent_state, parent_index, block_index):
+        def shuffling_compatibility_filter(a):
+            block_dependent_root = get_dependent_root(spec, parent_state, a.data.slot)
+            att_dependent_root = runtime.att_dependent_roots[
+                (a.data.beacon_block_root, a.data.slot)
+            ]
+            return block_dependent_root == att_dependent_root
+
         (
             candidate_attestations,
             ignored_attestations,
@@ -839,6 +857,7 @@ def _generate_block_tree(
             candidate_attestations,
             protocol.in_block_attester_slashings,
             protocol.in_block_pa_messages,
+            custom_att_filter_fn=shuffling_compatibility_filter,
         )
 
         copied_included_attestations = _subtract_items_once(
@@ -943,6 +962,8 @@ def _generate_block_tree(
                 lambda comm: set(comm) & attesters,
                 payload_index=payload_index,
             )
+            if any(attestations_in_slot):
+                runtime.apply_att_dependent_root(attesting_state, attestations_in_slot[0])
 
             for attestation in attestations_in_slot:
                 if att_payload_index_invalid:

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -227,19 +227,25 @@ def is_attestation_eligible_for_block(spec, state, attestation) -> bool:
     return state.slot <= attestation.data.slot + spec.SLOTS_PER_EPOCH
 
 
-def _get_eligible_attestations(spec, state, attestations) -> []:
-    def _get_voting_source(target: spec.Checkpoint) -> spec.Checkpoint:
-        if target.epoch == spec.get_current_epoch(state):
-            return state.current_justified_checkpoint
-        else:
-            return state.previous_justified_checkpoint
+def get_dependent_root(spec, state, slot):
+    epoch = spec.compute_epoch_at_slot(slot)
+    if epoch <= spec.MIN_SEED_LOOKAHEAD:
+        dependent_slot = spec.GENESIS_SLOT
+    else:
+        dependent_slot = spec.compute_start_slot_at_epoch(epoch - spec.MIN_SEED_LOOKAHEAD)
 
-    return [
-        a
-        for a in attestations
-        if is_attestation_eligible_for_block(spec, state, a)
-        and a.data.source == _get_voting_source(a.data.target)
-    ]
+    if dependent_slot > spec.GENESIS_SLOT:
+        return spec.get_block_root_at_slot(state, dependent_slot)
+    else:
+        # Default genesis block value
+        return spec.Root()
+
+
+def get_voting_source(spec, state, target):
+    if target.epoch == spec.get_current_epoch(state):
+        return state.current_justified_checkpoint
+    else:
+        return state.previous_justified_checkpoint
 
 
 def _compute_pseudo_randao_reveal(spec, proposer_index, epoch):
@@ -250,16 +256,18 @@ def _compute_pseudo_randao_reveal(spec, proposer_index, epoch):
 
 
 def produce_block(
-    spec, state, attestations, attester_slashings=[], payload_attestation_messages=[]
+    spec,
+    state,
+    attestations,
+    attester_slashings=[],
+    payload_attestation_messages=[],
+    custom_att_filter_fn=None,
 ):
     """
     Produces a block including as many attestations as it is possible.
     Accepts PayloadAttestationMessage objects and aggregates them into PayloadAttestation for on-chain inclusion.
     :return: Signed block, the post block state, and operations not included into the block.
     """
-
-    # Filter out too old attestations.
-    eligible_attestations = _get_eligible_attestations(spec, state, attestations)
 
     # Create a block with attestations
     block = build_empty_block(spec, state)
@@ -269,7 +277,16 @@ def produce_block(
 
     # Prepare attestations
     limit = type(block.body.attestations).limit()
-    attestation_in_block = eligible_attestations[:limit]
+    attestation_in_block = [
+        a
+        for a in attestations
+        # not too old
+        if is_attestation_eligible_for_block(spec, state, a)
+        # compatible data source
+        and a.data.source == get_voting_source(spec, state, a.data.target)
+        # custom filter passes
+        and (custom_att_filter_fn is None or custom_att_filter_fn(a))
+    ][:limit]
 
     for a in attestation_in_block:
         block.body.attestations.append(a)


### PR DESCRIPTION
Fixes https://github.com/ethereum/consensus-specs/issues/5271 by introducing `shuffling_compatibility_filter` which prevents attestations from being included into a block if a dependent root of an attestation and the block mismatch.