### PR TITLE
Add a script which enforces consistent note prefixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,6 @@ test: _pyspec
 ###############################################################################
 
 DOCS_DIR = ./docs
-FORK_CHOICE_DIR = ./fork_choice
 SPEC_DIR = ./specs
 SSZ_DIR = ./ssz
 SYNC_DIR = ./sync
@@ -251,10 +250,8 @@ SYNC_DIR = ./sync
 # Copy files to the docs directory.
 _copy_docs:
 	@cp -r $(SPEC_DIR) $(DOCS_DIR)
-	@rm -rf $(DOCS_DIR)/specs/_deprecated
 	@cp -r $(SYNC_DIR) $(DOCS_DIR)
 	@cp -r $(SSZ_DIR) $(DOCS_DIR)
-	@cp -r $(FORK_CHOICE_DIR) $(DOCS_DIR)
 	@cp $(CURDIR)/README.md $(DOCS_DIR)/README.md
 
 # Start a local documentation server.

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ help-verbose:
 	@echo "    - mypy: Static type checker for Python"
 	@echo "    - Fork comments validation (scripts/check_fork_comments.py)"
 	@echo "    - Markdown headings validation (scripts/check_markdown_headings.py)"
+	@echo "    - Markdown note style fix (scripts/fix_note_style.py)"
 	@echo "    - Trailing whitespace check"
 	@echo ""
 	@echo "  Example: make lint"
@@ -275,8 +276,9 @@ lint: _pyspec
 	@git diff > $(LINT_DIFF_BEFORE)
 	@uv --quiet lock --check
 	@$(UV_RUN) codespell
-	@$(UV_RUN) python $(CURDIR)/scripts/check_fork_comments.py
+	@$(UV_RUN) python $(CURDIR)/scripts/fix_note_style.py
 	@$(UV_RUN) python $(CURDIR)/scripts/fix_trailing_whitespace.py
+	@$(UV_RUN) python $(CURDIR)/scripts/check_fork_comments.py
 	@$(UV_RUN) python $(CURDIR)/scripts/check_markdown_headings.py
 	@$(UV_RUN) python $(CURDIR)/scripts/check_value_annotations.py
 	@$(UV_RUN) mdformat --number --wrap=80 $(MARKDOWN_FILES)

--- a/scripts/fix_note_style.py
+++ b/scripts/fix_note_style.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Enforce a consistent note prefix style in markdown files.
+
+The canonical style is `*Note*:` (italicized "Note" followed by a colon).
+This script rewrites the common variants in place:
+
+    *Note:*       -> *Note*:
+    **Note**:     -> *Note*:
+    **Note:**     -> *Note*:
+    NOTE:         -> *Note*:
+    Note:         -> *Note*:
+    *Note* <text> -> *Note*: <text>
+
+Only the start of a line (after optional whitespace and `>` blockquote
+markers) is rewritten. Lines inside fenced code blocks are left alone.
+"""
+
+import re
+import subprocess
+
+LINE_START = r"^([ \t]*(?:>[ \t]*)*)"
+
+# Order matters: longer / more specific patterns come first so we don't
+# partially match a longer variant with a shorter pattern. Matching is
+# case-insensitive so variants like `NOTE:` or `NoTe:` are also caught;
+# the replacement always normalizes to the canonical `*Note*:`.
+PATTERNS = [
+    (re.compile(LINE_START + r"\*\*Note:\*\*", re.IGNORECASE), r"\1*Note*:"),
+    (re.compile(LINE_START + r"\*\*Note\*\*:", re.IGNORECASE), r"\1*Note*:"),
+    (re.compile(LINE_START + r"\*Note:\*", re.IGNORECASE), r"\1*Note*:"),
+    (re.compile(LINE_START + r"\*Note\*(?=\s+)(?!:)", re.IGNORECASE), r"\1*Note*:"),
+    (re.compile(LINE_START + r"Note:", re.IGNORECASE), r"\1*Note*:"),
+]
+
+
+def get_markdown_files():
+    """Get tracked + untracked non-ignored markdown files."""
+    result = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "*.md"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [f for f in result.stdout.strip().split("\n") if f]
+
+
+def fix_text(text):
+    """Return (fixed_text, num_changes) for one file's contents."""
+    out_lines = []
+    changes = 0
+    in_fence = False
+
+    for line in text.split("\n"):
+        # Toggle fenced code block on lines starting (after whitespace) with ```.
+        if re.match(r"^[ \t]*```", line):
+            in_fence = not in_fence
+            out_lines.append(line)
+            continue
+
+        if in_fence:
+            out_lines.append(line)
+            continue
+
+        new_line = line
+        for pattern, repl in PATTERNS:
+            new_line, n = pattern.subn(repl, new_line, count=1)
+            if n:
+                changes += n
+                break  # one replacement per line is enough
+
+        out_lines.append(new_line)
+
+    return "\n".join(out_lines), changes
+
+
+def main():
+    total_changes = 0
+    changed_files = []
+
+    for path in get_markdown_files():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                original = f.read()
+        except (UnicodeDecodeError, FileNotFoundError, IsADirectoryError):
+            continue
+
+        fixed, changes = fix_text(original)
+        if changes and fixed != original:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(fixed)
+            total_changes += changes
+            changed_files.append((path, changes))
+
+    if changed_files:
+        for path, changes in changed_files:
+            print(f"{path}: fixed {changes} note prefix(es)")
+        print(f"Fixed {total_changes} note prefix(es) in {len(changed_files)} file(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -209,7 +209,7 @@ def get_blob_parameters(epoch: Epoch) -> BlobParameters:
 
 #### Modified `compute_fork_digest`
 
-*Note:* The `compute_fork_digest` helper is updated to account for
+*Note*: The `compute_fork_digest` helper is updated to account for
 Blob-Parameters-Only forks.
 
 ```python

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -208,7 +208,7 @@ top of a `state` MUST take the following actions in order to construct the
 - Select one bid and set
   `block.body.signed_execution_payload_bid = signed_execution_payload_bid`.
 
-*Note:* The execution address encoded in the `fee_recipient` field in the
+*Note*: The execution address encoded in the `fee_recipient` field in the
 `signed_execution_payload_bid.message` will receive the builder payment.
 
 ##### Payload attestations

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -230,7 +230,7 @@ semantics MUST be preserved.
 
 ##### `get_slot_committee`
 
-*Note:* This function returns the committee for a specific slot. It MUST support
+*Note*: This function returns the committee for a specific slot. It MUST support
 committees of epochs starting from `current_epoch - 2`.
 
 ```python
@@ -266,7 +266,7 @@ def get_pulled_up_head_state(store: Store) -> BeaconState:
 
 ##### `get_previous_balance_source`
 
-*Note:* Reconfirmation is the only place where previous balance source is used.
+*Note*: Reconfirmation is the only place where previous balance source is used.
 Implementations MAY switch to the current epoch balance source after they run
 reconfirmation and before the logic to confirm new blocks is called. In this
 case implementations will need to keep only a single balance source around.
@@ -522,7 +522,7 @@ def get_adversarial_weight(store: Store, balance_source: BeaconState, block_root
 
 ##### `compute_empty_slot_support_discount`
 
-*Note:* This function MAY compute parent's block support and adversarial weight
+*Note*: This function MAY compute parent's block support and adversarial weight
 for empty slots belonging to `current_epoch - 2`. It can only happen in
 reconfirmation, in all other cases the earliest possible epoch is
 `current_epoch - 1`.
@@ -684,7 +684,7 @@ def is_confirmed_chain_safe(fcr_store: FastConfirmationStore, confirmed_root: Ro
 
 ##### `get_current_target_score`
 
-*Note:* This function uses LMD-GHOST votes to estimate the FFG support of the
+*Note*: This function uses LMD-GHOST votes to estimate the FFG support of the
 current epoch target. Due to the way the computation happens, it MUST be used no
 later than the end of the current epoch.
 
@@ -763,7 +763,7 @@ def compute_honest_ffg_support_for_current_target(store: Store) -> Gwei:
 
 ##### `will_no_conflicting_checkpoint_be_justified`
 
-*Note:* This function assumes that all honest validators will be voting in
+*Note*: This function assumes that all honest validators will be voting in
 support of the current epoch target starting from the current moment in time.
 
 ```python
@@ -784,7 +784,7 @@ def will_no_conflicting_checkpoint_be_justified(store: Store) -> bool:
 
 ##### `will_current_target_be_justified`
 
-*Note:* This function assumes that all honest validators will be voting in
+*Note*: This function assumes that all honest validators will be voting in
 support of the current epoch target starting from the current moment in time.
 
 ```python
@@ -800,7 +800,7 @@ def will_current_target_be_justified(store: Store) -> bool:
 
 #### `update_fast_confirmation_variables`
 
-*Note:* This function updates variables used by the fast confirmation rule.
+*Note*: This function updates variables used by the fast confirmation rule.
 
 ```python
 def update_fast_confirmation_variables(fcr_store: FastConfirmationStore) -> None:

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -189,7 +189,7 @@ class Store:
 The provided anchor-state will be regarded as a trusted state, to not roll back
 beyond. This should be the genesis state for a full client.
 
-*Note* With regards to fork choice, block headers are interchangeable with
+*Note*: With regards to fork choice, block headers are interchangeable with
 blocks. The specification is likely to move to headers for reduced overhead in
 test vectors and better encapsulation. Full implementations store blocks as part
 of their database and will often use full blocks when dealing with production

--- a/tests/core/pyspec/README.md
+++ b/tests/core/pyspec/README.md
@@ -40,7 +40,7 @@ Or, to run all tests under a single fork specify `fork=<name>`:
 make test fork=phase0
 ```
 
-Note: these options can be used together, like:
+*Note*: these options can be used together, like:
 
 ```shell
 make test preset=minimal k=test_verify_kzg_proof fork=deneb

--- a/tests/formats/kzg_4844/compute_challenge.md
+++ b/tests/formats/kzg_4844/compute_challenge.md
@@ -28,5 +28,5 @@ polynomial degree, the blob, and the commitment. This is an internal helper
 function, so all inputs are assumed to be valid. The computed challenge should
 match the expected `output`.
 
-Note: This function is not a public method but an internal helper used by other
-KZG functions. It assumes all inputs are already validated.
+*Note*: This function is not a public method but an internal helper used by
+other KZG functions. It assumes all inputs are already validated.

--- a/tests/formats/kzg_7594/compute_verify_cell_kzg_proof_batch_challenge.md
+++ b/tests/formats/kzg_7594/compute_verify_cell_kzg_proof_batch_challenge.md
@@ -33,5 +33,5 @@ challenge value by hashing together all the inputs according to the Fiat-Shamir
 heuristic. This is an internal helper function, so all inputs are assumed to be
 valid. The computed challenge should match the expected `output`.
 
-Note: This function is not a public method but an internal helper used by
+*Note*: This function is not a public method but an internal helper used by
 `verify_cell_kzg_proof_batch`. It assumes all inputs are already validated.


### PR DESCRIPTION
When reviewing PRs, I often miss inconsistencies in the `*Note*:` style we use. This PR adds a script which is run with `make lint` which auto fixes common inconsistencies. Also, this fixes the website build which tried copying a now non-existent directory.