### PR TITLE
Validate generated reftest artifacts

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -13,6 +13,9 @@ inputs:
   source-path:
     description: Directory to download artifacts into and to include in the tarball.
     required: true
+  require-manifest:
+    description: Require downloaded test artifacts to include manifest.yaml files.
+    default: "false"
   github-token:
     description: Token used to delete intermediate artifacts.
     required: true
@@ -27,12 +30,43 @@ runs:
         path: ${{ inputs.source-path }}
         merge-multiple: true
 
+    - name: Validate downloaded test artifacts
+      if: ${{ inputs.require-manifest == 'true' }}
+      shell: bash
+      run: |
+        source_path="${{ inputs.source-path }}"
+
+        if [[ ! -d "$source_path" ]]; then
+          echo "Missing downloaded artifact directory: $source_path" >&2
+          exit 1
+        fi
+
+        manifest="$(find "$source_path" -name manifest.yaml -type f -print -quit)"
+        if [[ -z "$manifest" ]]; then
+          echo "No manifest.yaml files found in downloaded artifacts: $source_path" >&2
+          exit 1
+        fi
+
+        missing_manifest=false
+        while IFS= read -r output_file; do
+          case_dir="$(dirname "$output_file")"
+          if [[ ! -f "$case_dir/manifest.yaml" ]]; then
+            echo "Missing manifest.yaml next to output file: $output_file" >&2
+            missing_manifest=true
+          fi
+        done < <(find "$source_path" -type f)
+
+        if [[ "$missing_manifest" == "true" ]]; then
+          exit 1
+        fi
+
     - name: Archive tests
       shell: bash
       run: |
-        # Ensure source-path exists so tar succeeds even when zero artifacts
-        # were downloaded (e.g. presets with no per-fork reftests).
-        mkdir -p ${{ inputs.source-path }}
+        if [[ "${{ inputs.require-manifest }}" != "true" ]]; then
+          # Some callers intentionally allow empty artifact sets.
+          mkdir -p ${{ inputs.source-path }}
+        fi
         tar --sort=name \
             --owner=0 \
             --group=0 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,62 @@ jobs:
       - name: Generate tests
         run: make test component=pyspec verbose=true preset=${{ matrix.preset }} fork=${{ matrix.fork }} reftests=true
 
+      - name: Validate generated reference tests
+        id: reftests
+        shell: bash
+        run: |
+          test_dir="reftests/${{ matrix.preset }}/${{ matrix.fork }}"
+          expected_reftests=true
+
+          if [[ "${{ matrix.preset }}" == "general" ]]; then
+            case "${{ matrix.fork }}" in
+              phase0|altair|deneb|fulu)
+                expected_reftests=true
+                ;;
+              *)
+                expected_reftests=false
+                ;;
+            esac
+          fi
+
+          if [[ ! -d "$test_dir" ]]; then
+            if [[ "$expected_reftests" == "true" ]]; then
+              echo "Missing generated reference tests directory: $test_dir" >&2
+              exit 1
+            fi
+            echo "has_reftests=false" >> "$GITHUB_OUTPUT"
+            echo "No reference tests generated for ${{ matrix.preset }}/${{ matrix.fork }}."
+            exit 0
+          fi
+
+          manifest="$(find "$test_dir" -name manifest.yaml -type f -print -quit)"
+          if [[ -z "$manifest" ]]; then
+            echo "No manifest.yaml files found under $test_dir." >&2
+            exit 1
+          fi
+
+          missing_manifest=false
+          while IFS= read -r output_file; do
+            case_dir="$(dirname "$output_file")"
+            if [[ ! -f "$case_dir/manifest.yaml" ]]; then
+              echo "Missing manifest.yaml next to output file: $output_file" >&2
+              missing_manifest=true
+            fi
+          done < <(find "$test_dir" -type f)
+
+          if [[ "$missing_manifest" == "true" ]]; then
+            exit 1
+          fi
+
+          echo "has_reftests=true" >> "$GITHUB_OUTPUT"
+
       - name: Upload reference tests
+        if: steps.reftests.outputs.has_reftests == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reftests-${{ matrix.preset }}-${{ matrix.fork }}
           path: reftests/${{ matrix.preset }}
-          if-no-files-found: ignore
+          if-no-files-found: error
 
   package:
     needs: [setup, generate]
@@ -106,6 +156,7 @@ jobs:
           name: ${{ matrix.preset }}
           artifact-prefix: reftests
           source-path: tests/${{ matrix.preset }}
+          require-manifest: "true"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload to release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,12 +161,62 @@ jobs:
       - name: Generate tests
         run: make test component=pyspec verbose=true preset=${{ matrix.preset }} fork=${{ matrix.fork }} reftests=true
 
+      - name: Validate generated reference tests
+        id: reftests
+        shell: bash
+        run: |
+          test_dir="reftests/${{ matrix.preset }}/${{ matrix.fork }}"
+          expected_reftests=true
+
+          if [[ "${{ matrix.preset }}" == "general" ]]; then
+            case "${{ matrix.fork }}" in
+              phase0|altair|deneb|fulu)
+                expected_reftests=true
+                ;;
+              *)
+                expected_reftests=false
+                ;;
+            esac
+          fi
+
+          if [[ ! -d "$test_dir" ]]; then
+            if [[ "$expected_reftests" == "true" ]]; then
+              echo "Missing generated reference tests directory: $test_dir" >&2
+              exit 1
+            fi
+            echo "has_reftests=false" >> "$GITHUB_OUTPUT"
+            echo "No reference tests generated for ${{ matrix.preset }}/${{ matrix.fork }}."
+            exit 0
+          fi
+
+          manifest="$(find "$test_dir" -name manifest.yaml -type f -print -quit)"
+          if [[ -z "$manifest" ]]; then
+            echo "No manifest.yaml files found under $test_dir." >&2
+            exit 1
+          fi
+
+          missing_manifest=false
+          while IFS= read -r output_file; do
+            case_dir="$(dirname "$output_file")"
+            if [[ ! -f "$case_dir/manifest.yaml" ]]; then
+              echo "Missing manifest.yaml next to output file: $output_file" >&2
+              missing_manifest=true
+            fi
+          done < <(find "$test_dir" -type f)
+
+          if [[ "$missing_manifest" == "true" ]]; then
+            exit 1
+          fi
+
+          echo "has_reftests=true" >> "$GITHUB_OUTPUT"
+
       - name: Upload reference tests
+        if: steps.reftests.outputs.has_reftests == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reftests-${{ matrix.preset }}-${{ matrix.fork }}
           path: reftests/${{ matrix.preset }}
-          if-no-files-found: ignore
+          if-no-files-found: error
 
   package:
     needs: [config, generate]
@@ -186,6 +236,7 @@ jobs:
           name: ${{ matrix.preset }}
           artifact-prefix: reftests
           source-path: tests/${{ matrix.preset }}
+          require-manifest: "true"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload ${{ matrix.preset }}.tar.gz

--- a/tests/formats/README.md
+++ b/tests/formats/README.md
@@ -236,6 +236,12 @@ tests/<preset>/<fork>/<runner>/<handler>/<suite>/<case>/
 Having it in a file means test vectors can be moved or distributed without
 losing context.
 
+CI packaging also uses `manifest.yaml` as the reference-test completeness
+marker. Expected generated reference-test directories must contain at least one
+manifest, every output file must live beside a manifest, and packaging fails if
+a downloaded reference-test artifact set contains no manifests. Sparse `general`
+preset fork combinations that have no reference tests are skipped before upload.
+
 ##### `config.yaml`
 
 The runtime-configurables may be different for specific tests. When present,


### PR DESCRIPTION
Related to #5243

Validates generated reference-test artifacts before they are uploaded and before release/test archives are packaged. Expected reftest matrix entries now fail if their fork directory or manifest files are missing, sparse general-preset entries skip upload explicitly, and package jobs require downloaded reftest artifacts to contain manifests before archiving.

The upload steps now use `if-no-files-found: error` on actual reftest uploads, so missing generated files cannot be silently ignored.