### PR TITLE
Raise `MAX_PROOF_SIZE` to 1.3125 MiB

### DIFF
--- a/specs/_features/eip8025/beacon-chain.md
+++ b/specs/_features/eip8025/beacon-chain.md
@@ -46,9 +46,9 @@ imports proof types from [proof-engine.md](./proof-engine.md).
 
 *Note*: The execution values are not definitive.
 
-| Name             | Value                |
-| ---------------- | -------------------- |
-| `MAX_PROOF_SIZE` | `409600` (= 400 KiB) |
+| Name             | Value                               |
+| ---------------- | ----------------------------------- |
+| `MAX_PROOF_SIZE` | `1376256` (= 1,344 KiB, 1.3125 MiB) |
 
 ### Domains
 


### PR DESCRIPTION
This PR raises the EIP-8025 `MAX_PROOF_SIZE` from `409600` bytes (400 KiB) to `1376256` bytes (1,344 KiB, 1.3125 MiB).

The proof systems being evaluated for EIP-8025 are still under active development. Some proofs do not yet fit within the desired long-term proof-size target, but are still useful for devnet testing.

As an interim measure, this bumps the maximum proof size to accommodate those in-development proofs while optimization work continues. The bound remains explicit, and can be tightened again once proof systems are closer to the intended production size target.

The value of `1.3125 MiB` is taken from the max proof size (+ a small buffer) of all proofs currently being used in the development of EIP8025.