### PR TITLE
Remove Eth1 bridge transition from `process_pending_deposits`

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -994,16 +994,6 @@ def process_pending_deposits(state: BeaconState) -> None:
     finalized_slot = compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
 
     for deposit in state.pending_deposits:
-        # Do not process deposit requests if Eth1 bridge deposits are not yet applied.
-        if (
-            # Is deposit request
-            deposit.slot > GENESIS_SLOT
-            and
-            # There are pending Eth1 bridge deposits
-            state.eth1_deposit_index < state.deposit_requests_start_index
-        ):
-            break
-
         # Check if deposit has been finalized, otherwise, stop processing.
         if deposit.slot > finalized_slot:
             break


### PR DESCRIPTION
Cleans up a code implementing a transition from Eth1 bridge to deposit request mechanism introduced by Electra:EIP6110 from `process_pending_deposits`.

Another piece of that transition has already been removed from `process_deposit_request` in Gloas. And it makes sense to get rid of the whole transition code at once.

Question: do we want to mention this clean up in the Gloas beacon-chain spec preamble?