### PR TITLE
Raise `MAX_PROOF_SIZE` to 4 MiB

### DIFF
--- a/specs/_features/eip8025/beacon-chain.md
+++ b/specs/_features/eip8025/beacon-chain.md
@@ -46,9 +46,9 @@ imports proof types from [proof-engine.md](./proof-engine.md).
 
 *Note*: The execution values are not definitive.
 
-| Name             | Value                               |
-| ---------------- | ----------------------------------- |
-| `MAX_PROOF_SIZE` | `1376256` (= 1,344 KiB, 1.3125 MiB) |
+| Name             | Value                          |
+| ---------------- | ------------------------------ |
+| `MAX_PROOF_SIZE` | `4194304` (= 4,096 KiB, 4 MiB) |
 
 ### Domains
 


### PR DESCRIPTION
## Summary

- raise EIP-8025 `MAX_PROOF_SIZE` to `4 MiB` / `4,194,304` bytes

## Rationale

PR #5291 recently raised EIP-8025 `MAX_PROOF_SIZE` to `1.3125 MiB`. Following further discussion, this PR raises the bound to `4 MiB` to account for recent proof-size changes and to leave buffer for further changes while development continues.
