### PR TITLE
Use consistent gossip validation param order/types

### DIFF
--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -336,8 +336,8 @@ def validate_sync_committee_message_gossip(
     seen: Seen,
     state: BeaconState,
     sync_committee_message: SyncCommitteeMessage,
-    subnet_id: uint64,
     current_time_ms: uint64,
+    subnet_id: SubnetID,
 ) -> None:
     """
     Validate a SyncCommitteeMessage for gossip propagation on a subnet.

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -499,8 +499,8 @@ def validate_blob_sidecar_gossip(
     store: Store,
     state: BeaconState,
     blob_sidecar: BlobSidecar,
-    subnet_id: SubnetID,
     current_time_ms: uint64,
+    subnet_id: SubnetID,
 ) -> None:
     """
     Validate a BlobSidecar for gossip propagation on a subnet.
@@ -630,8 +630,8 @@ def validate_beacon_attestation_gossip(
     store: Store,
     state: BeaconState,
     attestation: Attestation,
-    subnet_id: uint64,
     current_time_ms: uint64,
+    subnet_id: SubnetID,
 ) -> None:
     """
     Validate an Attestation for gossip propagation on a subnet.

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -386,8 +386,8 @@ def validate_blob_sidecar_gossip(
     store: Store,
     state: BeaconState,
     blob_sidecar: BlobSidecar,
-    subnet_id: SubnetID,
     current_time_ms: uint64,
+    subnet_id: SubnetID,
 ) -> None:
     """
     Validate a BlobSidecar for gossip propagation on a subnet.
@@ -489,8 +489,8 @@ def validate_beacon_attestation_gossip(
     state: BeaconState,
     # [Modified in Electra:EIP7549]
     attestation: SingleAttestation,
-    subnet_id: uint64,
     current_time_ms: uint64,
+    subnet_id: SubnetID,
 ) -> None:
     """
     Validate a SingleAttestation for gossip propagation on a subnet.

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -357,8 +357,8 @@ def validate_data_column_sidecar_gossip(
     store: Store,
     state: BeaconState,
     sidecar: DataColumnSidecar,
-    subnet_id: SubnetID,
     current_time_ms: uint64,
+    subnet_id: SubnetID,
 ) -> None:
     """
     Validate a DataColumnSidecar for gossip propagation on a subnet.

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -931,8 +931,8 @@ def validate_beacon_attestation_gossip(
     store: Store,
     state: BeaconState,
     attestation: Attestation,
-    subnet_id: uint64,
     current_time_ms: uint64,
+    subnet_id: SubnetID,
 ) -> None:
     """
     Validate an Attestation for gossip propagation on a subnet.

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/networking/test_gossip_sync_committee_message.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/networking/test_gossip_sync_committee_message.py
@@ -46,8 +46,8 @@ def run_validate_sync_committee_message_gossip(
             seen,
             state,
             message,
-            subnet_id,
             current_time_ms,
+            subnet_id,
         )
         return "valid", None
     except spec.GossipIgnore as e:

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_attestation.py
@@ -31,7 +31,7 @@ def run_validate_beacon_attestation_gossip(
 ):
     try:
         spec.validate_beacon_attestation_gossip(
-            seen, store, state, attestation, subnet_id, current_time_ms
+            seen, store, state, attestation, current_time_ms, subnet_id
         )
         return "valid", None
     except spec.GossipIgnore as e:

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_blob_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_blob_sidecar.py
@@ -47,7 +47,7 @@ def run_validate_blob_sidecar_gossip(
 ):
     try:
         spec.validate_blob_sidecar_gossip(
-            seen, store, state, blob_sidecar, subnet_id, current_time_ms
+            seen, store, state, blob_sidecar, current_time_ms, subnet_id
         )
         return "valid", None
     except spec.GossipIgnore as e:

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_attestation.py
@@ -26,7 +26,7 @@ def run_validate_beacon_attestation_gossip(
 ):
     try:
         spec.validate_beacon_attestation_gossip(
-            seen, store, state, attestation, subnet_id, current_time_ms
+            seen, store, state, attestation, current_time_ms, subnet_id
         )
         return "valid", None
     except spec.GossipIgnore as e:

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gossip.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gossip.py
@@ -69,7 +69,7 @@ def run_validate_data_column_sidecar_gossip(
     """
     try:
         spec.validate_data_column_sidecar_gossip(
-            seen, store, state, sidecar, subnet_id, current_time_ms
+            seen, store, state, sidecar, current_time_ms, subnet_id
         )
         return "valid", None
     except spec.GossipIgnore as e:

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
@@ -52,7 +52,7 @@ def run_validate_beacon_attestation_gossip(
     """
     try:
         spec.validate_beacon_attestation_gossip(
-            seen, store, state, attestation, subnet_id, current_time_ms
+            seen, store, state, attestation, current_time_ms, subnet_id
         )
         return "valid", None
     except spec.GossipIgnore as e:


### PR DESCRIPTION
When working on executable gossip validation specs for Gloas, I noticed that (1) these subnet ID values should use a stronger type and (2) the location of this parameter should be after the current time parameter, for consistency.