### PR TITLE
Add tests for builder payments processing

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_attestation.py
@@ -24,14 +24,14 @@ def _setup_previous_epoch_same_slot_scenario(spec, state):
     apply_empty_block(spec, state, attestation_slot)
 
     committee = spec.get_beacon_committee(state, attestation_slot, 0)
+
+    # Make sure we have only one attester (simple weight calculation)
     attestation = get_valid_attestation(
         spec,
         state,
         slot=attestation_slot,
         index=0,
-        filter_participant_set=lambda _: {
-            committee[0]
-        },  # Make sure we have only one attester (simple weight calculation)
+        filter_participant_set=lambda _: {committee[0]},
         signed=True,
     )
 
@@ -532,9 +532,10 @@ def test_builder_payment_weight_tracking_previous_epoch(spec, state):
 
 @with_gloas_and_later
 @spec_state_test
-def test_builder_payment_weight_empty_payment(spec, state):
+def test_builder_payment_weight_no_increment_for_zero_amount(spec, state):
     """
-    Test the empty withdrawal check skips the weight increment.
+    Test that the weight is not incremented when the pending payment's
+    withdrawal amount is zero.
     """
     transition_to_slot_via_block(spec, state, 2)
     attestation_slot = 0

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_attestation.py
@@ -523,7 +523,7 @@ def test_builder_payment_weight_tracking_previous_epoch(spec, state):
     assert state.builder_pending_payments[previous_epoch_idx].weight == expected_weight
     assert state.builder_pending_payments[current_epoch_idx].weight == 0
 
-    # Assert flags are set for the previous epoch, not current one.
+    # Assert flags are set for the previous epoch, not current one
     for flag_index in expected_flag_indices:
         assert spec.has_flag(state.previous_epoch_participation[attester], flag_index)
         assert not spec.has_flag(pre_prev_flags, flag_index)

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_attestation.py
@@ -518,7 +518,7 @@ def test_builder_payment_weight_tracking_previous_epoch(spec, state):
 
     yield from run_attestation_processing(spec, state, attestation, valid=True)
 
-    # Assert weight is set for the previous epoch, not current one.
+    # Assert weight is set for the previous epoch, not current one
     expected_weight = state.validators[attester].effective_balance
     assert state.builder_pending_payments[previous_epoch_idx].weight == expected_weight
     assert state.builder_pending_payments[current_epoch_idx].weight == 0

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_attestation.py
@@ -14,6 +14,31 @@ from eth_consensus_specs.test.helpers.state import (
 )
 
 
+def _setup_previous_epoch_same_slot_scenario(spec, state):
+    """
+    Build a signed same-slot attestation at slot ``SLOTS_PER_EPOCH - 1`` with a
+    single attester. Advance state one epoch so the attestation's target becomes
+    the previous epoch.
+    """
+    attestation_slot = spec.Slot(spec.SLOTS_PER_EPOCH - 1)
+    apply_empty_block(spec, state, attestation_slot)
+
+    committee = spec.get_beacon_committee(state, attestation_slot, 0)
+    attestation = get_valid_attestation(
+        spec,
+        state,
+        slot=attestation_slot,
+        index=0,
+        filter_participant_set=lambda _: {
+            committee[0]
+        },  # Make sure we have only one attester (simple weight calculation)
+        signed=True,
+    )
+
+    spec.process_slots(state, spec.SLOTS_PER_EPOCH)
+    return attestation, attestation_slot
+
+
 def _setup_missed_slot_scenario(spec, state):
     """
     Creates blocks for slots 1, 2, 3 but skips slot 4 (missed slot).
@@ -457,3 +482,86 @@ def test_mismatched_payload_no_head_flag(spec, state):
     final_head_flag = spec.has_flag(final_participation, spec.TIMELY_HEAD_FLAG_INDEX)
 
     assert not final_head_flag, "Should not get head flag when payload doesn't match"
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_payment_weight_tracking_previous_epoch(spec, state):
+    """
+    Test ``process_attestation`` updates the previous epoch payment slot and
+    sets flags in ``previous_epoch_participation`` when the attestation's
+    target is the previous epoch.
+    """
+    attestation, attestation_slot = _setup_previous_epoch_same_slot_scenario(spec, state)
+    previous_epoch_idx = attestation_slot % spec.SLOTS_PER_EPOCH
+    current_epoch_idx = spec.SLOTS_PER_EPOCH + previous_epoch_idx
+
+    # Set the previous epoch pending payments
+    state.builder_pending_payments[previous_epoch_idx] = spec.BuilderPendingPayment(
+        weight=spec.Gwei(0),
+        withdrawal=spec.BuilderPendingWithdrawal(
+            fee_recipient=spec.ExecutionAddress(b"\xab" * 20),
+            amount=spec.Gwei(1_000_000_000),
+            builder_index=0,
+        ),
+    )
+
+    assert spec.is_attestation_same_slot(state, attestation.data)
+    assert attestation.data.target.epoch == spec.get_previous_epoch(state)
+
+    attester = spec.get_beacon_committee(state, attestation_slot, 0)[0]
+    expected_flag_indices = spec.get_attestation_participation_flag_indices(
+        state, attestation.data, state.slot - attestation.data.slot
+    )
+    pre_prev_flags = state.previous_epoch_participation[attester]
+    pre_curr_flags = state.current_epoch_participation[attester]
+
+    yield from run_attestation_processing(spec, state, attestation, valid=True)
+
+    # Assert weight is set for the previous epoch, not current one.
+    expected_weight = state.validators[attester].effective_balance
+    assert state.builder_pending_payments[previous_epoch_idx].weight == expected_weight
+    assert state.builder_pending_payments[current_epoch_idx].weight == 0
+
+    # Assert flags are set for the previous epoch, not current one.
+    for flag_index in expected_flag_indices:
+        assert spec.has_flag(state.previous_epoch_participation[attester], flag_index)
+        assert not spec.has_flag(pre_prev_flags, flag_index)
+    assert state.current_epoch_participation[attester] == pre_curr_flags
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_payment_weight_empty_payment(spec, state):
+    """
+    Test the empty withdrawal check skips the weight increment.
+    """
+    transition_to_slot_via_block(spec, state, 2)
+    attestation_slot = 0
+
+    committee = spec.get_beacon_committee(state, attestation_slot, 0)
+    attestation = get_valid_attestation(
+        spec,
+        state,
+        slot=attestation_slot,
+        index=0,
+        payload_index=0,
+        filter_participant_set=lambda _: {committee[0]},
+        signed=True,
+    )
+
+    payment_idx = spec.SLOTS_PER_EPOCH + attestation_slot % spec.SLOTS_PER_EPOCH
+    state.builder_pending_payments[payment_idx] = spec.BuilderPendingPayment(
+        weight=spec.Gwei(0),
+        withdrawal=spec.BuilderPendingWithdrawal(
+            fee_recipient=spec.ExecutionAddress(b"\xab" * 20),
+            amount=spec.Gwei(0),
+            builder_index=0,
+        ),
+    )
+
+    pre_weight = state.builder_pending_payments[payment_idx].weight
+
+    yield from run_attestation_processing(spec, state, attestation, valid=True)
+
+    assert state.builder_pending_payments[payment_idx].weight == pre_weight

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
@@ -413,7 +413,7 @@ def test_process_parent_execution_payload__settle_previous_epoch(spec, state):
     assert withdrawal.builder_index == builder_index
     assert withdrawal.fee_recipient == fee_recipient
 
-    # Previous epoch slot cleared and availability bit flipped.
+    # Previous epoch slot cleared and availability bit flipped
     assert state.builder_pending_payments[previous_epoch_idx] == spec.BuilderPendingPayment()
     assert (
         state.execution_payload_availability[parent_bid.slot % spec.SLOTS_PER_HISTORICAL_ROOT]

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
@@ -43,6 +43,22 @@ def _commit_parent_requests(spec, state, requests, value=None, builder_index=Non
         )
 
 
+def _commit_full_parent_with_payment(spec, state, value, builder_index, fee_recipient):
+    """
+    Commit a FULL parent with a builder payment at slot ``SLOTS_PER_EPOCH - 1``.
+    Clear its availability bit.
+    """
+    state.latest_execution_payload_bid.slot = spec.Slot(spec.SLOTS_PER_EPOCH - 1)
+    state.latest_execution_payload_bid.fee_recipient = fee_recipient
+    _commit_parent_requests(
+        spec, state, spec.ExecutionRequests(), value=value, builder_index=builder_index
+    )
+
+    parent_bid = state.latest_execution_payload_bid.copy()
+    state.execution_payload_availability[parent_bid.slot % spec.SLOTS_PER_HISTORICAL_ROOT] = 0b0
+    return parent_bid
+
+
 def run_parent_execution_payload_processing(spec, state, block, valid=True):
     """
     Run ``process_parent_execution_payload`` against a prepared pre-state.
@@ -363,3 +379,80 @@ def test_process_parent_execution_payload__builder_deposit_after_pending_validat
     assert second.pubkey == deposit_request_2.pubkey
     assert second.withdrawal_credentials == deposit_request_2.withdrawal_credentials
     assert second.amount == deposit_request_2.amount
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_parent_execution_payload__settle_previous_epoch(spec, state):
+    """
+    Test ``apply_parent_execution_payload`` settles the previous epoch payment
+    slot when the parent's slot falls in the previous epoch.
+    """
+    builder_index = 0
+    value = spec.Gwei(50_000_000)
+    fee_recipient = spec.ExecutionAddress(b"\xab" * 20)
+    parent_bid = _commit_full_parent_with_payment(spec, state, value, builder_index, fee_recipient)
+    previous_epoch_idx = parent_bid.slot % spec.SLOTS_PER_EPOCH
+
+    # Process one epoch
+    spec.process_slots(state, spec.SLOTS_PER_EPOCH)
+
+    assert spec.compute_epoch_at_slot(parent_bid.slot) == spec.get_previous_epoch(state)
+    assert state.builder_pending_payments[previous_epoch_idx].withdrawal.amount == value
+
+    block = build_empty_block_for_next_slot(spec, state)
+    spec.process_slots(state, block.slot)
+    pre_pending_withdrawals_len = len(state.builder_pending_withdrawals)
+
+    yield from run_parent_execution_payload_processing(spec, state, block)
+
+    assert len(state.builder_pending_withdrawals) == pre_pending_withdrawals_len + 1
+    withdrawal = state.builder_pending_withdrawals[pre_pending_withdrawals_len]
+    assert withdrawal.amount == value
+    assert withdrawal.builder_index == builder_index
+    assert withdrawal.fee_recipient == fee_recipient
+
+    # Previous epoch slot cleared and availability bit flipped.
+    assert state.builder_pending_payments[previous_epoch_idx] == spec.BuilderPendingPayment()
+    assert (
+        state.execution_payload_availability[parent_bid.slot % spec.SLOTS_PER_HISTORICAL_ROOT]
+        == 0b1
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_parent_execution_payload__older_than_previous_epoch(spec, state):
+    """
+    Test ``apply_parent_execution_payload`` appends the withdrawal directly when
+    the parent's slot is older than the previous epoch.
+    """
+    builder_index = 0
+    value = spec.Gwei(50_000_000)
+    fee_recipient = spec.ExecutionAddress(b"\xab" * 20)
+    parent_bid = _commit_full_parent_with_payment(spec, state, value, builder_index, fee_recipient)
+    previous_epoch_idx = parent_bid.slot % spec.SLOTS_PER_EPOCH
+
+    # Cross two epoch boundaries to evict payments
+    spec.process_slots(state, 2 * spec.SLOTS_PER_EPOCH)
+    block = build_empty_block_for_next_slot(spec, state)
+    spec.process_slots(state, block.slot)
+
+    # Assert payment was evicted from the previous epoch
+    assert spec.compute_epoch_at_slot(parent_bid.slot) < spec.get_previous_epoch(state)
+    assert state.builder_pending_payments[previous_epoch_idx] == spec.BuilderPendingPayment()
+
+    pre_pending_withdrawals_len = len(state.builder_pending_withdrawals)
+    pre_payments = state.builder_pending_payments.copy()
+
+    yield from run_parent_execution_payload_processing(spec, state, block)
+
+    # Check we have a pending withdrawal
+    assert len(state.builder_pending_withdrawals) == pre_pending_withdrawals_len + 1
+    withdrawal = state.builder_pending_withdrawals[pre_pending_withdrawals_len]
+    assert withdrawal.amount == value
+    assert withdrawal.builder_index == builder_index
+    assert withdrawal.fee_recipient == fee_recipient
+
+    # Assert no payment slot is modified
+    assert all(post == pre for post, pre in zip(state.builder_pending_payments, pre_payments))

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_parent_execution_payload.py
@@ -456,7 +456,9 @@ def test_process_parent_execution_payload__older_than_previous_epoch(spec, state
     assert withdrawal.fee_recipient == fee_recipient
 
     # Assert no payment slot is modified
-    assert all(post == pre for post, pre in zip(state.builder_pending_payments, pre_payments))
+    assert all(
+        post == pre for post, pre in zip(state.builder_pending_payments, pre_payments, strict=True)
+    )
 
 
 @with_gloas_and_later


### PR DESCRIPTION
# Description

This PR adds coverage for `apply_parent_execution_payload` and `process_attestation` for Gloas builder payments processing.