### PR TITLE
Fix `pre_epoch` and `post_epoch` test files docs

### DIFF
--- a/tests/formats/epoch_processing/README.md
+++ b/tests/formats/epoch_processing/README.md
@@ -28,13 +28,18 @@ sub-transition. No value if the sub-transition processing is aborted.
 
 ### `pre_epoch.ssz_snappy`
 
-An SSZ-snappy encoded `BeaconState`, the state before running the epoch
-transition.
+Optional. An SSZ-snappy encoded `BeaconState`, the state before running the
+epoch transition.
+
+Some test cases mutate the state between sub-transitions to exercise a specific
+one in isolation. If this is the case, this file is omitted, since
+`process_epoch(pre_epoch)` would not reproduce the mutated state.
 
 ### `post_epoch.ssz_snappy`
 
-An SSZ-snappy encoded `BeaconState`, the state after applying the epoch
-transition. No value if the transition processing is aborted.
+Optional. An SSZ-snappy encoded `BeaconState`, the state after applying the
+epoch transition. No value if the transition processing is aborted. Omitted in
+the same circumstances as `pre_epoch.ssz_snappy`.
 
 ## Condition
 
@@ -68,8 +73,9 @@ The resulting state should match the expected `post` state.
 ## Condition (alternative)
 
 Instead of having a different handler for each sub-transition, a single handler
-for all cases should load `pre_full` state, call `process_epoch` and then assert
-that the result state should match `post_full` state.
+for all cases should load `pre_epoch` state, call `process_epoch` and then
+assert that the result state should match `post_epoch` state. Because these
+files are optional, this handler must skip cases that do not provide them.
 
 This has the advantages:
 


### PR DESCRIPTION
# Description

This PR fixes `pre_epoch` and `post_epoch` test files documentation.

These are used to test full epoch transitions through `spec.process_epoch()`. However, some tests introduce specific state mutations to for sub-steps of epoch processing, making the standard way of using these files invalid.

Issue raised by @hangleang . Discussion can be found here:

- https://discord.com/channels/595666850260713488/1504949502216376370