### PR TITLE
Use parent slot for builder pending deposit in Gloas

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -1591,6 +1591,9 @@ def process_deposit_request(state: BeaconState, deposit_request: DepositRequest)
     validator_pubkeys = [v.pubkey for v in state.validators]
 
     # [New in Gloas:EIP7732]
+    deposit_slot = state.latest_execution_payload_bid.slot
+
+    # [New in Gloas:EIP7732]
     # Regardless of the withdrawal credentials prefix, if a builder/validator
     # already exists with this pubkey, apply the deposit to their balance
     is_builder = deposit_request.pubkey in builder_pubkeys
@@ -1607,7 +1610,7 @@ def process_deposit_request(state: BeaconState, deposit_request: DepositRequest)
             deposit_request.withdrawal_credentials,
             deposit_request.amount,
             deposit_request.signature,
-            state.slot,
+            deposit_slot,
         )
         return
 
@@ -1618,7 +1621,7 @@ def process_deposit_request(state: BeaconState, deposit_request: DepositRequest)
             withdrawal_credentials=deposit_request.withdrawal_credentials,
             amount=deposit_request.amount,
             signature=deposit_request.signature,
-            slot=state.slot,
+            slot=deposit_slot,
         )
     )
 ```

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/block_processing/test_process_deposit_request.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/block_processing/test_process_deposit_request.py
@@ -11,6 +11,7 @@ from eth_consensus_specs.test.helpers.constants import (
 from eth_consensus_specs.test.helpers.deposits import (
     prepare_deposit_request,
 )
+from eth_consensus_specs.test.helpers.forks import is_post_gloas
 from tests.infra.helpers.deposit_requests import (
     assert_process_deposit_request,
     prepare_process_deposit_request,
@@ -268,14 +269,17 @@ def test_process_deposit_request_eth1_credentials(spec, state):
 @spec_state_test
 def test_process_deposit_request_pending_deposit_slot_binding(spec, state):
     """
-    Test that pending_deposit.slot equals state.slot.
+    Test that pending_deposit.slot equals the EL block slot:
+    - state.slot pre-Gloas
+    - state.latest_execution_payload_bid.slot in Gloas+ (deposits are read
+      from the parent block's execution payload)
 
     Input State Configured:
         - State advanced to non-zero slot
         - New validator deposit
 
     Output State Verified:
-        - pending_deposit.slot == state.slot
+        - pending_deposit.slot == expected EL block slot
     """
     amount = spec.MIN_ACTIVATION_BALANCE
 
@@ -284,8 +288,11 @@ def test_process_deposit_request_pending_deposit_slot_binding(spec, state):
         spec, state, amount=amount, signed=True, advance_epochs=2
     )
 
-    expected_slot = state.slot
-    assert expected_slot > 0  # Ensure non-zero slot for meaningful test
+    if is_post_gloas(spec):
+        expected_slot = state.latest_execution_payload_bid.slot
+    else:
+        expected_slot = state.slot
+        assert expected_slot > 0  # Ensure non-zero slot for meaningful test
 
     pre_state = state.copy()
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_deposit_with_reorg.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_deposit_with_reorg.py
@@ -88,7 +88,7 @@ def test_new_validator_deposit_with_multiple_epoch_transitions(spec, state):
         withdrawal_credentials=deposit_request.withdrawal_credentials,
         amount=deposit_request.amount,
         signature=deposit_request.signature,
-        slot=child_block.slot,
+        slot=deposit_block.slot,
     )
     assert state.pending_deposits == [pending_deposit]
 

--- a/tests/infra/helpers/deposit_requests.py
+++ b/tests/infra/helpers/deposit_requests.py
@@ -208,7 +208,9 @@ def assert_process_deposit_request(
     INVARIANT CHECKS FOR VALIDATOR DEPOSITS (always run):
     - pending_deposits increases by exactly 1
     - New pending deposit has correct pubkey, withdrawal_credentials, amount, signature
-    - New pending deposit slot equals state.slot
+    - New pending deposit slot equals state.slot pre-Gloas, or
+      state.latest_execution_payload_bid.slot in Gloas+ (deposits are processed
+      from the parent block's execution payload)
     - deposit_requests_start_index is set only if previously UNSET (Electra/Fulu only)
     - Validator count unchanged (validators created during epoch processing)
     - Balances unchanged (balance applied during epoch processing)
@@ -439,10 +441,18 @@ def assert_process_deposit_request(
             "Pending deposit signature must match deposit request"
         )
 
-        # INVARIANT: New pending deposit slot equals state.slot (at time of processing)
-        assert new_pending_deposit.slot == state.slot, (
-            f"Pending deposit slot must equal state.slot: "
-            f"deposit.slot={new_pending_deposit.slot}, state.slot={state.slot}"
+        # INVARIANT: New pending deposit slot equals the EL block slot:
+        # state.slot pre-Gloas, state.latest_execution_payload_bid.slot in Gloas+
+        # (deposit requests are read from the parent block's execution payload).
+        if is_post_gloas(spec):
+            expected_slot = state.latest_execution_payload_bid.slot
+            slot_field_name = "state.latest_execution_payload_bid.slot"
+        else:
+            expected_slot = state.slot
+            slot_field_name = "state.slot"
+        assert new_pending_deposit.slot == expected_slot, (
+            f"Pending deposit slot must equal {slot_field_name}: "
+            f"deposit.slot={new_pending_deposit.slot}, expected={expected_slot}"
         )
 
         # INVARIANT: deposit_requests_start_index logic (Electra/Fulu only, removed in Gloas)


### PR DESCRIPTION
**Description**
right now to process a block, we have to process parent requests first and add builder to registry using block state's slot.
This PR uses parent slot for that because:
* that's when builder really deposit. This change will make it compliant to pre-gloas
* faster builder onboarding
* given 1 parent block, if there are 2 child blocks derived from that parent, currently a single EL builder deposit is represented by 2 CL pending deposits with different slots. This PR changes it to be the same CL pending deposit
* it helps CL clients to pre-verify pending deposits when receiving a payload and cache by deposit root
