### PR TITLE
Precompute head for `update_proposer_boost_root`

### DIFF
--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -301,13 +301,15 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     if is_merge_transition_block(pre_state, block.body):
         validate_merge_block(block)
 
+    # Compute head before applying the block
+    head = get_head(store)
     # Add new block to the store
     store.blocks[block_root] = block
     # Add new state for this block to the store
     store.block_states[block_root] = state
 
     record_block_timeliness(store, block_root)
-    update_proposer_boost_root(store, block_root)
+    update_proposer_boost_root(store, head.root, block_root)
 
     # Update checkpoints in store if necessary
     update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)

--- a/specs/capella/fork-choice.md
+++ b/specs/capella/fork-choice.md
@@ -94,13 +94,15 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     block_root = hash_tree_root(block)
     state_transition(state, signed_block, True)
 
+    # Compute head before applying the block
+    head = get_head(store)
     # Add new block to the store
     store.blocks[block_root] = block
     # Add new state for this block to the store
     store.block_states[block_root] = state
 
     record_block_timeliness(store, block_root)
-    update_proposer_boost_root(store, block_root)
+    update_proposer_boost_root(store, head.root, block_root)
 
     # Update checkpoints in store if necessary
     update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)

--- a/specs/deneb/fork-choice.md
+++ b/specs/deneb/fork-choice.md
@@ -103,13 +103,15 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     block_root = hash_tree_root(block)
     state_transition(state, signed_block, True)
 
+    # Compute head before applying the block
+    head = get_head(store)
     # Add new block to the store
     store.blocks[block_root] = block
     # Add new state for this block to the store
     store.block_states[block_root] = state
 
     record_block_timeliness(store, block_root)
-    update_proposer_boost_root(store, block_root)
+    update_proposer_boost_root(store, head.root, block_root)
 
     # Update checkpoints in store if necessary
     update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)

--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -73,13 +73,15 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     block_root = hash_tree_root(block)
     state_transition(state, signed_block, True)
 
+    # Compute head before applying the block
+    head = get_head(store)
     # Add new block to the store
     store.blocks[block_root] = block
     # Add new state for this block to the store
     store.block_states[block_root] = state
 
     record_block_timeliness(store, block_root)
-    update_proposer_boost_root(store, block_root)
+    update_proposer_boost_root(store, head.root, block_root)
 
     # Update checkpoints in store if necessary
     update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -911,7 +911,6 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
 
     # Compute head before applying the block
     head = get_head(store)
-
     # Add new block to the store
     store.blocks[block_root] = block
     # Add new state for this block to the store

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -625,7 +625,7 @@ def record_block_timeliness(store: Store, root: Root) -> None:
 ### Modified `update_proposer_boost_root`
 
 ```python
-def update_proposer_boost_root(store: Store, root: Root) -> None:
+def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     is_first_block = store.proposer_boost_root == Root()
     # [Modified in Gloas:EIP7732]
     is_timely = store.block_timeliness[root][ATTESTATION_TIMELINESS_INDEX]
@@ -633,7 +633,7 @@ def update_proposer_boost_root(store: Store, root: Root) -> None:
     # Add proposer score boost if the block is the first timely block
     # for this slot, with the same proposer as the canonical chain.
     if is_timely and is_first_block:
-        head_state = copy(store.block_states[get_head(store).root])
+        head_state = copy(store.block_states[head])
         slot = get_current_slot(store)
         if head_state.slot < slot:
             process_slots(head_state, slot)
@@ -909,6 +909,9 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     block_root = hash_tree_root(block)
     state_transition(state, signed_block, True)
 
+    # Compute head before applying the block
+    head = get_head(store)
+
     # Add new block to the store
     store.blocks[block_root] = block
     # Add new state for this block to the store
@@ -921,7 +924,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     notify_ptc_messages(store, state, block.body.payload_attestations)
 
     record_block_timeliness(store, block_root)
-    update_proposer_boost_root(store, block_root)
+    update_proposer_boost_root(store, head.root, block_root)
 
     # Update checkpoints in store if necessary
     update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -809,14 +809,14 @@ def record_block_timeliness(store: Store, root: Root) -> None:
 ##### `update_proposer_boost_root`
 
 ```python
-def update_proposer_boost_root(store: Store, root: Root) -> None:
+def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     is_first_block = store.proposer_boost_root == Root()
     is_timely = store.block_timeliness[root]
 
     # Add proposer score boost if the block is timely, not conflicting with an
     # existing block, with the same the proposer as the canonical chain.
     if is_timely and is_first_block:
-        head_state = copy(store.block_states[get_head(store)])
+        head_state = copy(store.block_states[head])
         slot = get_current_slot(store)
         if head_state.slot < slot:
             process_slots(head_state, slot)
@@ -870,13 +870,16 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     state = pre_state.copy()
     block_root = hash_tree_root(block)
     state_transition(state, signed_block, True)
+
+    # Compute head before applying the block
+    head = get_head(store)
     # Add new block to the store
     store.blocks[block_root] = block
     # Add new state for this block to the store
     store.block_states[block_root] = state
 
     record_block_timeliness(store, block_root)
-    update_proposer_boost_root(store, block_root)
+    update_proposer_boost_root(store, head.root, block_root)
 
     # Update checkpoints in store if necessary
     update_checkpoints(store, state.current_justified_checkpoint, state.finalized_checkpoint)


### PR DESCRIPTION
Fixes https://github.com/ethereum/consensus-specs/issues/5286 by computing the head before the block is added to the Store.

Depends on https://github.com/ethereum/consensus-specs/pull/5249