### PR TITLE
Ensure bids are for a higher slot than their parent

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -385,6 +385,9 @@ where `parent_state` is the post-state of `bid.parent_block_root`, and the alias
   payload.
 - _[IGNORE]_ `bid.parent_block_root` is the hash tree root of a known beacon
   block in fork choice.
+- _[REJECT]_ The bid is for a higher slot than its parent block -- i.e. validate
+  that `bid.slot` is greater than the slot of the block with root
+  `bid.parent_block_root`.
 - _[REJECT]_ `signed_execution_payload_bid.signature` is valid with respect to
   the `bid.builder_index`.
 


### PR DESCRIPTION
Without this check, a bid can pass gossip validation while referencing a parent of the same slot. Let's assume `current_slot = 100`, `bid.slot = 100`, and `bid.parent_block_root` references a known block at the current slot. The existing gossip validation rules would let this bid pass through, but it cannot be included in a valid block.