### PR TITLE
Remove redundant path in `get_weight`

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -507,7 +507,8 @@ def get_weight(store: Store, node: ForkChoiceNode) -> Gwei:
     proposer_score = Gwei(0)
     # [Modified in Gloas:EIP7732]
     proposer_boost_node = ForkChoiceNode(
-        root=store.proposer_boost_root, payload_status=PAYLOAD_STATUS_PENDING
+        root=store.proposer_boost_root,
+        payload_status=PAYLOAD_STATUS_PENDING,
     )
     # Boost is applied if node is an ancestor of proposer_boost_node
     if is_ancestor(store, proposer_boost_node, node):

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -502,7 +502,7 @@ def get_weight(store: Store, node: ForkChoiceNode) -> Gwei:
     if not should_apply_proposer_boost(store):
         # Return only attestation score if proposer boost should not apply
         return attestation_score
-    
+
     # Calculate proposer score if proposer boost should apply
     proposer_score = Gwei(0)
     # [Modified in Gloas:EIP7732]
@@ -512,7 +512,7 @@ def get_weight(store: Store, node: ForkChoiceNode) -> Gwei:
     # Boost is applied if ``node`` is an ancestor of ``proposer_boost_node``
     if is_ancestor(store, proposer_boost_node, node):
         proposer_score = get_proposer_score(store)
-    
+
     return attestation_score + proposer_score
 ```
 

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -509,7 +509,7 @@ def get_weight(store: Store, node: ForkChoiceNode) -> Gwei:
     proposer_boost_node = ForkChoiceNode(
         root=store.proposer_boost_root, payload_status=PAYLOAD_STATUS_PENDING
     )
-    # Boost is applied if ``node`` is an ancestor of ``proposer_boost_node``
+    # Boost is applied if node is an ancestor of proposer_boost_node
     if is_ancestor(store, proposer_boost_node, node):
         proposer_score = get_proposer_score(store)
 

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -496,29 +496,24 @@ def should_apply_proposer_boost(store: Store) -> bool:
 
 ```python
 def get_weight(store: Store, node: ForkChoiceNode) -> Gwei:
-    if node.payload_status == PAYLOAD_STATUS_PENDING or store.blocks[
-        node.root
-    ].slot + 1 != get_current_slot(store):
-        state = store.checkpoint_states[store.justified_checkpoint]
-        attestation_score = get_attestation_score(store, node, state)
-        # [Modified in Gloas:EIP7732]
-        if not should_apply_proposer_boost(store):
-            # Return only attestation score if proposer boost should not apply
-            return attestation_score
-
-        # Calculate proposer score if proposer boost should apply
-        proposer_score = Gwei(0)
-        # [Modified in Gloas:EIP7732]
-        proposer_boost_node = ForkChoiceNode(
-            root=store.proposer_boost_root, payload_status=PAYLOAD_STATUS_PENDING
-        )
-        # Boost is applied if ``node`` is an ancestor of ``proposer_boost_node``
-        if is_ancestor(store, proposer_boost_node, node):
-            proposer_score = get_proposer_score(store)
-
-        return attestation_score + proposer_score
-    else:
-        return Gwei(0)
+    state = store.checkpoint_states[store.justified_checkpoint]
+    attestation_score = get_attestation_score(store, node, state)
+    # [Modified in Gloas:EIP7732]
+    if not should_apply_proposer_boost(store):
+        # Return only attestation score if proposer boost should not apply
+        return attestation_score
+    
+    # Calculate proposer score if proposer boost should apply
+    proposer_score = Gwei(0)
+    # [Modified in Gloas:EIP7732]
+    proposer_boost_node = ForkChoiceNode(
+        root=store.proposer_boost_root, payload_status=PAYLOAD_STATUS_PENDING
+    )
+    # Boost is applied if ``node`` is an ancestor of ``proposer_boost_node``
+    if is_ancestor(store, proposer_boost_node, node):
+        proposer_score = get_proposer_score(store)
+    
+    return attestation_score + proposer_score
 ```
 
 ### Modified `get_node_children`

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -358,13 +358,13 @@ def get_weight(store: Store, node: ForkChoiceNode) -> Gwei:
     state = store.checkpoint_states[store.justified_checkpoint]
     attestation_score = get_attestation_score(store, node, state)
     if store.proposer_boost_root == Root():
-        # Return only attestation score if ``proposer_boost_root`` is not set
+        # Return only attestation score if proposer_boost_root is not set
         return attestation_score
 
-    # Calculate proposer score if ``proposer_boost_root`` is set
+    # Calculate proposer score if proposer_boost_root is set
     proposer_score = Gwei(0)
     proposer_boost_node = ForkChoiceNode(root=store.proposer_boost_root)
-    # Boost is applied if ``node`` is an ancestor of ``proposer_boost_node``
+    # Boost is applied if node is an ancestor of proposer_boost_node
     if is_ancestor(store, proposer_boost_node, node):
         proposer_score = get_proposer_score(store)
 


### PR DESCRIPTION
Removes the following path from `get_weight` (the condition is negated for illustration):
```python
if (
    node.payload_status != PAYLOAD_STATUS_PENDING
    and store.blocks[node.root].slot + 1 == get_current_slot(store)
):
    return Gwei(0)
```

Cause if the **if** condition is `True` then `get_attestation_score` will return `Gwei(0)` and `is_ancestor(store, proposer_boost_node, node)` will return `False`. Therefore, `get_weight` will return `Gwei(0)`.

The main motivation is increasing readability of the spec.