### PR TITLE
Apply proposer boost if dependent roots match

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -621,14 +621,11 @@ def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     is_first_block = store.proposer_boost_root == Root()
     # [Modified in Gloas:EIP7732]
     is_timely = store.block_timeliness[root][ATTESTATION_TIMELINESS_INDEX]
+    is_same_dependent_root = get_dependent_root(store, root) == get_dependent_root(store, head)
 
     # Add proposer score boost if the block is timely, not conflicting with an
     # existing block, with the same dependent root as the canonical chain head.
-    if (
-        is_timely
-        and is_first_block
-        and get_dependent_root(store, root) == get_dependent_root(store, head)
-    ):
+    if is_timely and is_first_block and is_same_dependent_root:
         store.proposer_boost_root = root
 ```
 

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -604,17 +604,23 @@ def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     # [Modified in Gloas:EIP7732]
     is_timely = store.block_timeliness[root][ATTESTATION_TIMELINESS_INDEX]
 
-    # Add proposer score boost if the block is the first timely block
-    # for this slot, with the same proposer as the canonical chain.
-    if is_timely and is_first_block:
-        head_state = copy(store.block_states[head])
-        slot = get_current_slot(store)
-        if head_state.slot < slot:
-            process_slots(head_state, slot)
-        block = store.blocks[root]
-        # Only update if the proposer is the same as on the canonical chain
-        if block.proposer_index == get_beacon_proposer_index(head_state):
-            store.proposer_boost_root = root
+    def get_depdendent_root(root: Root) -> Root:
+        epoch = get_current_store_epoch(store)
+        if epoch <= MIN_SEED_LOOKAHEAD:
+            # Genesis block parent
+            return Root()
+
+        node = ForkChoiceNode(
+            root=root,
+            payload_status=PAYLOAD_STATUS_PENDING,
+        )
+        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+        return get_ancestor(store, node, dependent_slot).root
+
+    # Add proposer score boost if the block is timely, not conflicting with an
+    # existing block, with the same dependent root as the canonical chain head.
+    if is_timely and is_first_block and get_depdendent_root(root) == get_depdendent_root(head):
+        store.proposer_boost_root = root
 ```
 
 ### Modified `validate_on_attestation`

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -606,6 +606,7 @@ def get_dependent_root(store: Store, root: Root) -> Root:
         # Genesis block parent
         return Root()
 
+    # [Modified in Gloas:EIP7732]
     node = ForkChoiceNode(
         root=root,
         payload_status=PAYLOAD_STATUS_PENDING,

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -35,6 +35,7 @@
   - [Modified `get_node_children`](#modified-get_node_children)
   - [Modified `get_head`](#modified-get_head)
   - [Modified `record_block_timeliness`](#modified-record_block_timeliness)
+  - [Modified `get_dependent_root`](#modified-get_dependent_root)
   - [Modified `update_proposer_boost_root`](#modified-update_proposer_boost_root)
   - [Modified `validate_on_attestation`](#modified-validate_on_attestation)
   - [Modified `is_head_late`](#modified-is_head_late)
@@ -596,6 +597,23 @@ def record_block_timeliness(store: Store, root: Root) -> None:
     ]
 ```
 
+### Modified `get_dependent_root`
+
+```python
+def get_dependent_root(store: Store, root: Root) -> Root:
+    epoch = get_current_store_epoch(store)
+    if epoch <= MIN_SEED_LOOKAHEAD:
+        # Genesis block parent
+        return Root()
+
+    node = ForkChoiceNode(
+        root=root,
+        payload_status=PAYLOAD_STATUS_PENDING,
+    )
+    dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+    return get_ancestor(store, node, dependent_slot).root
+```
+
 ### Modified `update_proposer_boost_root`
 
 ```python
@@ -604,22 +622,13 @@ def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     # [Modified in Gloas:EIP7732]
     is_timely = store.block_timeliness[root][ATTESTATION_TIMELINESS_INDEX]
 
-    def get_depdendent_root(root: Root) -> Root:
-        epoch = get_current_store_epoch(store)
-        if epoch <= MIN_SEED_LOOKAHEAD:
-            # Genesis block parent
-            return Root()
-
-        node = ForkChoiceNode(
-            root=root,
-            payload_status=PAYLOAD_STATUS_PENDING,
-        )
-        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
-        return get_ancestor(store, node, dependent_slot).root
-
     # Add proposer score boost if the block is timely, not conflicting with an
     # existing block, with the same dependent root as the canonical chain head.
-    if is_timely and is_first_block and get_depdendent_root(root) == get_depdendent_root(head):
+    if (
+        is_timely
+        and is_first_block
+        and get_dependent_root(store, root) == get_dependent_root(store, head)
+    ):
         store.proposer_boost_root = root
 ```
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -59,6 +59,7 @@
       - [`update_latest_messages`](#update_latest_messages)
     - [`on_block` helpers](#on_block-helpers)
       - [`record_block_timeliness`](#record_block_timeliness)
+      - [`get_dependent_root`](#get_dependent_root)
       - [`update_proposer_boost_root`](#update_proposer_boost_root)
   - [Handlers](#handlers)
     - [`on_tick`](#on_tick)
@@ -853,6 +854,20 @@ def record_block_timeliness(store: Store, root: Root) -> None:
     store.block_timeliness[root] = is_timely
 ```
 
+##### `get_dependent_root`
+
+```python
+def get_dependent_root(store: Store, root: Root) -> Root:
+    epoch = get_current_store_epoch(store)
+    if epoch <= MIN_SEED_LOOKAHEAD:
+        # Genesis block parent
+        return Root()
+
+    node = ForkChoiceNode(root=root)
+    dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+    return get_ancestor(store, node, dependent_slot).root
+```
+
 ##### `update_proposer_boost_root`
 
 ```python
@@ -860,19 +875,13 @@ def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     is_first_block = store.proposer_boost_root == Root()
     is_timely = store.block_timeliness[root]
 
-    def get_depdendent_root(root: Root) -> Root:
-        epoch = get_current_store_epoch(store)
-        if epoch <= MIN_SEED_LOOKAHEAD:
-            # Genesis block parent
-            return Root()
-
-        node = ForkChoiceNode(root=root)
-        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
-        return get_ancestor(store, node, dependent_slot).root
-
     # Add proposer score boost if the block is timely, not conflicting with an
     # existing block, with the same dependent root as the canonical chain head.
-    if is_timely and is_first_block and get_depdendent_root(root) == get_depdendent_root(head):
+    if (
+        is_timely
+        and is_first_block
+        and get_dependent_root(store, root) == get_dependent_root(store, head)
+    ):
         store.proposer_boost_root = root
 ```
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -874,14 +874,11 @@ def get_dependent_root(store: Store, root: Root) -> Root:
 def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     is_first_block = store.proposer_boost_root == Root()
     is_timely = store.block_timeliness[root]
+    is_same_dependent_root = get_dependent_root(store, root) == get_dependent_root(store, head)
 
     # Add proposer score boost if the block is timely, not conflicting with an
     # existing block, with the same dependent root as the canonical chain head.
-    if (
-        is_timely
-        and is_first_block
-        and get_dependent_root(store, root) == get_dependent_root(store, head)
-    ):
+    if is_timely and is_first_block and is_same_dependent_root:
         store.proposer_boost_root = root
 ```
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -860,17 +860,20 @@ def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     is_first_block = store.proposer_boost_root == Root()
     is_timely = store.block_timeliness[root]
 
+    def get_depdendent_root(root: Root) -> Root:
+        epoch = get_current_store_epoch(store)
+        if epoch <= MIN_SEED_LOOKAHEAD:
+            # Genesis block parent
+            return Root()
+
+        node = ForkChoiceNode(root=root)
+        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+        return get_ancestor(store, node, dependent_slot).root
+
     # Add proposer score boost if the block is timely, not conflicting with an
-    # existing block, with the same the proposer as the canonical chain.
-    if is_timely and is_first_block:
-        head_state = copy(store.block_states[head])
-        slot = get_current_slot(store)
-        if head_state.slot < slot:
-            process_slots(head_state, slot)
-        block = store.blocks[root]
-        # Only update if the proposer is the same as on the canonical chain
-        if block.proposer_index == get_beacon_proposer_index(head_state):
-            store.proposer_boost_root = root
+    # existing block, with the same dependent root as the canonical chain head.
+    if is_timely and is_first_block and get_depdendent_root(root) == get_depdendent_root(head):
+        store.proposer_boost_root = root
 ```
 
 ### Handlers


### PR DESCRIPTION
Follow up to https://github.com/ethereum/consensus-specs/pull/5300.

Switches from `proposer_index` to `dependent_root` check when applying proposer boost. There is an edge case where `proposer_index` is the same on the two competing chains with different dependent roots, in this case applying PB to the diverged chain can be exploited. This PR is a fix for that edge case.

There are two ways how `dependent_root` can be computed: 1) with the block tree, root and store time 2) with the post-state of a block. (1) since we do this computation in the FC context.

~~Might worth making `get_dependent_root` an outer function.~~
**UPD:** made `get_dependent_root` a top-level function.