### PR TITLE
Fix inconsistent `gossip_bls_to_execution_change` fixtures

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/capella/networking/test_gossip_bls_to_execution_change.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/capella/networking/test_gossip_bls_to_execution_change.py
@@ -2,10 +2,12 @@ from eth_consensus_specs.test.context import (
     always_bls,
     spec_configured_state_test,
     with_capella_and_later,
+    with_phases,
 )
 from eth_consensus_specs.test.helpers.bls_to_execution_changes import (
     get_signed_address_change as get_signed_bls_to_execution_change,
 )
+from eth_consensus_specs.test.helpers.constants import CAPELLA
 from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
 from eth_consensus_specs.test.helpers.keys import pubkeys
 
@@ -38,7 +40,7 @@ def get_capella_fork_time_ms(spec, state):
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0}, activate_at_genesis=True)
 def test_gossip_bls_to_execution_change__valid(spec, state):
     """
     Test that a valid `bls_to_execution_change` passes gossip validation.
@@ -72,7 +74,7 @@ def test_gossip_bls_to_execution_change__valid(spec, state):
     )
 
 
-@with_capella_and_later
+@with_phases([CAPELLA])
 @spec_configured_state_test({"CAPELLA_FORK_EPOCH": 1})
 def test_gossip_bls_to_execution_change__ignore_pre_capella(spec, state):
     """
@@ -109,7 +111,7 @@ def test_gossip_bls_to_execution_change__ignore_pre_capella(spec, state):
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0}, activate_at_genesis=True)
 def test_gossip_bls_to_execution_change__ignore_already_seen(spec, state):
     """
     Test that a duplicate `bls_to_execution_change` is ignored.
@@ -156,7 +158,7 @@ def test_gossip_bls_to_execution_change__ignore_already_seen(spec, state):
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0}, activate_at_genesis=True)
 def test_gossip_bls_to_execution_change__reject_validator_index_out_of_range(spec, state):
     """
     Test that a `bls_to_execution_change` with validator index out of range is rejected.
@@ -194,7 +196,7 @@ def test_gossip_bls_to_execution_change__reject_validator_index_out_of_range(spe
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0}, activate_at_genesis=True)
 def test_gossip_bls_to_execution_change__reject_not_bls_credentials(spec, state):
     """
     Test that a `bls_to_execution_change` for a validator without BLS credentials is rejected.
@@ -235,7 +237,7 @@ def test_gossip_bls_to_execution_change__reject_not_bls_credentials(spec, state)
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0}, activate_at_genesis=True)
 def test_gossip_bls_to_execution_change__reject_pubkey_mismatch(spec, state):
     """
     Test that a `bls_to_execution_change` with the wrong withdrawal pubkey is rejected.
@@ -277,7 +279,7 @@ def test_gossip_bls_to_execution_change__reject_pubkey_mismatch(spec, state):
 
 
 @with_capella_and_later
-@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0})
+@spec_configured_state_test({"CAPELLA_FORK_EPOCH": 0}, activate_at_genesis=True)
 @always_bls
 def test_gossip_bls_to_execution_change__reject_bad_signature(spec, state):
     """

--- a/tests/core/pyspec/eth_consensus_specs/test/context.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/context.py
@@ -354,10 +354,9 @@ def spec_state_test(fn):
 
 def spec_configured_state_test(conf, *, activate_at_genesis: bool = False):
     """
-    If ``activate_at_genesis`` is True, set the spec module's own ``*_FORK_EPOCH`` to
-    0 so the emitted ``config.cfg`` resolves the test's fork as the latest scheduled
-    activation. Useful for fixtures consumed by clients that resolve forks via
-    ``getForkName(slot)``. Entries in ``conf`` win on conflict.
+    If ``activate_at_genesis`` is True, set every ``*_FORK_EPOCH`` up to and
+    including the spec module's own fork to 0 so the emitted ``config.cfg``
+    matches the state's SSZ shape. Entries in ``conf`` win on conflict.
     """
     if not activate_at_genesis:
         overrides = _with_config_overrides_emit(conf)
@@ -369,7 +368,12 @@ def spec_configured_state_test(conf, *, activate_at_genesis: bool = False):
 
     def decorator(fn):
         def wrapper(*args, spec: Spec, **kw):
-            combined = {f"{spec.fork.upper()}_FORK_EPOCH": 0, **conf}
+            activate_forks = {
+                f"{f.upper()}_FORK_EPOCH": 0
+                for f in ALL_PHASES
+                if f != PHASE0 and is_post_fork(spec.fork, f)
+            }
+            combined = {**activate_forks, **conf}
             return _with_config_overrides_emit(combined)(fn)(*args, spec=spec, **kw)
 
         return spec_test(with_state(single_phase(wrapper)))


### PR DESCRIPTION
The emitted states do not match the config, for any fork after capella, the state is shaped after the later fork but the config keeps that fork's epoch at `FAR_FUTURE_EPOCH`, so we pick the wrong ssz container to deserialize the fixtures.