### PR TITLE
Clarify when to load skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -2,8 +2,8 @@
 name: commit
 description: >-
   Commit changes and open pull requests. Follow the project's conventions
-  for scope, formatting, and writing style. Use when the user asks to make
-  a commit or pull request.
+  for scope, formatting, and writing style. Always load this skill before
+  committing or opening a pull request.
 compatibility: Requires make, uv, git
 ---
 

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -2,7 +2,7 @@
 name: prepare-release
 description: >-
   Prepare for a new release. Perform checks to ensure that the release action
-  can be started. Use when the user asks for help with a new release.
+  can be started. Always load this skill before helping with a release.
 compatibility: Requires git and gh
 ---
 

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: run-tests
 description: >-
-  Run tests and generate reference tests. Use when the user asks to run tests,
-  verify changes, check a fix, or regenerate reference tests.
+  Run tests and generate reference tests. All testing goes through `make test`,
+  never `pytest` directly. Always load this skill before running tests.
 compatibility: Requires make and uv
 ---
 


### PR DESCRIPTION
This PR updates the language in skill descriptions so it's more likely to load a skill when necessary. I've noticed that it often does not load the `run-tests` skill after it writes a test and wants to execute it. It would only load the skill when I told it to run a test, which is not what I had intended.