### PR TITLE
Disable verbose mode when running tests in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,7 +44,7 @@ jobs:
           enable-cache: true
           version: ${{ vars.UV_VERSION }}
       - name: Run framework tests
-        run: make test component=fw verbose=true
+        run: make test component=fw
       - name: Prepare test results for upload
         if: always()
         run: cp -r ./tests/core/pyspec/test-reports ./tests/core/pyspec/test-results-framework-${{ github.run_number }}
@@ -139,7 +139,7 @@ jobs:
           enable-cache: true
           version: ${{ vars.UV_VERSION }}
       - name: Run pyspec tests for ${{ matrix.fork }}
-        run: make test component=pyspec verbose=true preset=minimal fork=${{ matrix.fork }}
+        run: make test component=pyspec preset=minimal fork=${{ matrix.fork }}
       - name: Prepare test results for upload
         if: always()
         run: cp -r ./tests/core/pyspec/test-reports ./tests/core/pyspec/test-results-minimal-${{ matrix.fork }}-${{ github.run_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           version: ${{ vars.UV_VERSION }}
 
       - name: Generate tests
-        run: make test component=pyspec verbose=true preset=${{ matrix.preset }} fork=${{ matrix.fork }} reftests=true
+        run: make test component=pyspec preset=${{ matrix.preset }} fork=${{ matrix.fork }} reftests=true
 
       - name: Upload reference tests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,7 +159,7 @@ jobs:
           enable-cache: true
 
       - name: Generate tests
-        run: make test component=pyspec verbose=true preset=${{ matrix.preset }} fork=${{ matrix.fork }} reftests=true
+        run: make test component=pyspec preset=${{ matrix.preset }} fork=${{ matrix.fork }} reftests=true
 
       - name: Upload reference tests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
I originally enabled verbose mode here because I thought it would be helpful when there was an issue, but it really hasn't been. If anything, it's been detrimental because it takes the page much longer to load now.