### PR TITLE
Set `deposit_requests_start_index` in `upgrade_to_fulu`

### DIFF
--- a/specs/fulu/fork.md
+++ b/specs/fulu/fork.md
@@ -96,7 +96,14 @@ def upgrade_to_fulu(pre: electra.BeaconState) -> BeaconState:
         next_withdrawal_index=pre.next_withdrawal_index,
         next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
         historical_summaries=pre.historical_summaries,
-        deposit_requests_start_index=pre.deposit_requests_start_index,
+        # [Modified in Fulu]
+        # The Eth1 deposit bridge was deprecated before the Fulu upgrade.
+        # If this field is still unset, set it to the current deposit count.
+        deposit_requests_start_index=(
+            pre.eth1_data.deposit_count
+            if pre.deposit_requests_start_index == UNSET_DEPOSIT_REQUESTS_START_INDEX
+            else pre.deposit_requests_start_index
+        ),
         deposit_balance_to_consume=pre.deposit_balance_to_consume,
         exit_balance_to_consume=pre.exit_balance_to_consume,
         earliest_exit_epoch=pre.earliest_exit_epoch,

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_transition.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_transition.py
@@ -35,7 +35,6 @@ from eth_consensus_specs.test.helpers.forks import (
     get_previous_fork_version,
     is_post_bellatrix,
     is_post_electra,
-    is_post_fulu,
     is_post_gloas,
 )
 from eth_consensus_specs.test.helpers.proposer_slashings import (
@@ -199,14 +198,6 @@ def do_fork(
     assert state.slot % spec.SLOTS_PER_EPOCH == 0
     assert spec.get_current_epoch(state) == fork_epoch
 
-    # The Eth1 bridge transition is complete before the Fulu fork. Tests do not
-    # process real deposit requests in pre-fork blocks, so model that completion here.
-    if (
-        is_post_fulu(post_spec)
-        and state.deposit_requests_start_index == spec.UNSET_DEPOSIT_REQUESTS_START_INDEX
-    ):
-        state.deposit_requests_start_index = state.eth1_data.deposit_count
-
     state = get_upgrade_fn(post_spec, post_spec.fork)(state)
 
     assert state.fork.epoch == fork_epoch
@@ -235,14 +226,6 @@ def do_fork_generate(
 
     assert state.slot % spec.SLOTS_PER_EPOCH == 0
     assert spec.get_current_epoch(state) == fork_epoch
-
-    # The Eth1 bridge transition is complete before the Fulu fork. Tests do not
-    # process real deposit requests in pre-fork blocks, so model that completion here.
-    if (
-        is_post_fulu(post_spec)
-        and state.deposit_requests_start_index == spec.UNSET_DEPOSIT_REQUESTS_START_INDEX
-    ):
-        state.deposit_requests_start_index = state.eth1_data.deposit_count
 
     yield "pre", state
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fulu/fork.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fulu/fork.py
@@ -41,7 +41,6 @@ def run_fork_test(post_spec, pre_state):
         "next_withdrawal_index",
         "next_withdrawal_validator_index",
         "historical_summaries",
-        "deposit_requests_start_index",
         "deposit_balance_to_consume",
         "exit_balance_to_consume",
         "earliest_exit_epoch",
@@ -77,6 +76,11 @@ def run_fork_test(post_spec, pre_state):
     assert pre_state.fork.current_version == post_state.fork.previous_version
     assert post_state.fork.current_version == post_spec.config.FULU_FORK_VERSION
     assert post_state.fork.epoch == post_spec.get_current_epoch(post_state)
+
+    if pre_state.deposit_requests_start_index == post_spec.UNSET_DEPOSIT_REQUESTS_START_INDEX:
+        assert post_state.deposit_requests_start_index == pre_state.eth1_data.deposit_count
+    else:
+        assert post_state.deposit_requests_start_index == pre_state.deposit_requests_start_index
 
     yield "post", post_state
 


### PR DESCRIPTION
Related to #4704. In that PR, I modified `do_fork` to manually set `deposit_requests_start_index` to a different value. I incorrectly thought that this mutated the prestate before it was yielded, not in the middle of a test. I'm not entirely sure what the proper fix for this should be. I dislike modifying `upgrade_to_fulu`, but it is the simplest fix and doesn't really matter. For reference, see this message from @eserilev:

<img width="741" height="651" alt="image" src="https://github.com/user-attachments/assets/a3d3ec80-3320-4216-94f1-7902ab96fa14" />
