### PR TITLE
Revert "Add PR check which reviews pull requests (#5327)"

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
+    types: [opened, edited, reopened, synchronize]
     branches:
       - master
 
@@ -150,65 +150,3 @@ jobs:
         with:
           name: test-results-minimal-${{ matrix.fork }}-${{ github.run_number }}
           path: ./tests/core/pyspec/test-results-minimal-${{ matrix.fork }}-${{ github.run_number }}
-
-  review:
-    needs: [lint, framework, title, tests]
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.action != 'edited' &&
-      github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      id-token: write
-    concurrency:
-      group: review-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version-file: "pyproject.toml"
-      - name: Install uv ${{ vars.UV_VERSION }}
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
-          version: ${{ vars.UV_VERSION }}
-      - name: Review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          prompt: |
-            /review
-
-            Get the diff with `gh pr diff ${{ github.event.pull_request.number }}`
-            and limit your review to those changes. The prerequisite CI checks
-            for this PR are already passing, so you do not need to re-run them to
-            verify the current changes. If you have feedback, post an inline
-            comment with the create_inline_comment tool. If you find no issues,
-            do not comment.
-          settings: |
-            {
-              "model": "best",
-              "permissions": {
-                "allow": [
-                  "mcp__github_inline_comment__create_inline_comment",
-                  "Read",
-                  "Write",
-                  "Edit",
-                  "Grep",
-                  "Glob",
-                  "Bash(gh pr diff:*)",
-                  "Bash(gh pr view:*)",
-                  "Bash(gh issue view:*)",
-                  "Bash(make lint:*)",
-                  "Bash(make test:*)",
-                  "WebFetch(domain:github.com)",
-                  "WebFetch(domain:raw.githubusercontent.com)"
-                ]
-              }
-            }


### PR DESCRIPTION
This reverts the following PR:

* #5327 

This wasn't properly thought out. PRs from other forks do not have access to the Anthropic API key secret and therefore the action fails. I'm not sure if there's a secure, simple fix for this so I am going to revert this for now.