### PR TITLE
Add weak-subjectivity execution proof sync

### DIFF
--- a/pysetup/helpers.py
+++ b/pysetup/helpers.py
@@ -95,6 +95,10 @@ def objects_to_spec(
     deprecate_containers = reduce(
         lambda obj, builder: obj.union(builder.deprecate_containers()), builders, set()
     )
+    undeprecate_containers = reduce(
+        lambda obj, builder: obj.union(builder.undeprecate_containers()), builders, set()
+    )
+    deprecate_containers -= undeprecate_containers
     ordered_class_objects = {
         k: v for k, v in ordered_class_objects.items() if k not in deprecate_containers
     }

--- a/pysetup/spec_builders/base.py
+++ b/pysetup/spec_builders/base.py
@@ -67,5 +67,9 @@ class BaseSpecBuilder(ABC):
         return set()
 
     @classmethod
+    def undeprecate_containers(cls) -> set[str]:
+        return set()
+
+    @classmethod
     def deprecate_functions(cls) -> set[str]:
         return set()

--- a/pysetup/spec_builders/eip8025.py
+++ b/pysetup/spec_builders/eip8025.py
@@ -13,6 +13,10 @@ from eth_consensus_specs.gloas import {preset_name} as gloas
 """
 
     @classmethod
+    def undeprecate_containers(cls) -> set[str]:
+        return {"ExecutionPayloadHeader"}
+
+    @classmethod
     def execution_engine_cls(cls) -> str:
         return """
 class NoopExecutionEngine(ExecutionEngine):
@@ -54,6 +58,10 @@ class NoopProofEngine(ProofEngine):
 
     def verify_execution_proof(self: ProofEngine,
                                execution_proof: ExecutionProof) -> bool:
+        return True
+
+    def verify_beacon_chain_proof(self: ProofEngine,
+                                  beacon_chain_proof: BeaconChainProof) -> bool:
         return True
 
     def notify_new_payload(self: ProofEngine,

--- a/specs/_features/eip8025/beacon-chain.md
+++ b/specs/_features/eip8025/beacon-chain.md
@@ -13,9 +13,14 @@
   - [Execution](#execution)
   - [Domains](#domains)
 - [Containers](#containers)
+  - [New `ExecutionPayloadHeader`](#new-executionpayloadheader)
+  - [New `BeaconBlockExecutionBinding`](#new-beaconblockexecutionbinding)
+  - [New `NewPayloadRequestHeader`](#new-newpayloadrequestheader)
   - [New `PublicInput`](#new-publicinput)
   - [New `ExecutionProof`](#new-executionproof)
   - [New `SignedExecutionProof`](#new-signedexecutionproof)
+  - [New `BeaconChainProofPublicInput`](#new-beaconchainproofpublicinput)
+  - [New `BeaconChainProof`](#new-beaconchainproof)
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
   - [Execution proof](#execution-proof)
     - [New `process_execution_proof`](#new-process_execution_proof)
@@ -54,6 +59,64 @@ and imports proof types from [proof-engine.md](./proof-engine.md).
 
 ## Containers
 
+### New `ExecutionPayloadHeader`
+
+```python
+class ExecutionPayloadHeader(Container):
+    parent_hash: Hash32
+    fee_recipient: ExecutionAddress
+    state_root: Bytes32
+    receipts_root: Bytes32
+    logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+    prev_randao: Bytes32
+    block_number: uint64
+    gas_limit: uint64
+    gas_used: uint64
+    timestamp: uint64
+    extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+    base_fee_per_gas: uint256
+    block_hash: Hash32
+    transactions_root: Root
+    withdrawals_root: Root
+    blob_gas_used: uint64
+    excess_blob_gas: uint64
+    block_access_list_root: Root
+    slot_number: uint64
+```
+
+`ExecutionPayloadHeader` is the execution payload header committed by a
+`NewPayloadRequestHeader`. It contains `transactions_root` rather than the
+transaction list, allowing proof sync to bind the execution payload without
+opening transaction data in the recursive guest.
+
+### New `BeaconBlockExecutionBinding`
+
+```python
+class BeaconBlockExecutionBinding(Container):
+    beacon_header: BeaconBlockHeader
+    execution_payload_header: ExecutionPayloadHeader
+    signed_execution_payload_bid: SignedExecutionPayloadBid
+```
+
+`BeaconBlockExecutionBinding` is the compact proof-sync projection used to bind
+a beacon block to execution proof inputs. It contains the canonical
+`BeaconBlockHeader`, the execution-payload header, and the signed payload bid
+without opening the full beacon block body.
+
+### New `NewPayloadRequestHeader`
+
+```python
+class NewPayloadRequestHeader(Container):
+    execution_payload_header: ExecutionPayloadHeader
+    versioned_hashes: List[VersionedHash, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    parent_beacon_block_root: Root
+    execution_requests_root: Root
+```
+
+`NewPayloadRequestHeader` is the public commitment used by execution proofs. It
+commits to the header of a `NewPayloadRequest` without requiring callers to
+expose the full execution payload or execution requests.
+
 ### New `PublicInput`
 
 ```python
@@ -78,6 +141,28 @@ class SignedExecutionProof(Container):
     validator_index: ValidatorIndex
     signature: BLSSignature
 ```
+
+### New `BeaconChainProofPublicInput`
+
+```python
+class BeaconChainProofPublicInput(Container):
+    ws_checkpoint_root: Root
+    ws_checkpoint_slot: Slot
+    head_root: Root
+    head_slot: Slot
+```
+
+### New `BeaconChainProof`
+
+```python
+class BeaconChainProof(Container):
+    proof_data: ByteList[MAX_PROOF_SIZE]
+    proof_type: ProofType
+    public_input: BeaconChainProofPublicInput
+```
+
+Each `BeaconChainProof` is for a single `proof_type`. Clients that require
+multiple proof types verify one `BeaconChainProof` per required type.
 
 ## Beacon chain state transition function
 

--- a/specs/_features/eip8025/proof-engine.md
+++ b/specs/_features/eip8025/proof-engine.md
@@ -10,6 +10,7 @@
 - [Introduction](#introduction)
 - [Proof engine](#proof-engine)
   - [New `verify_execution_proof`](#new-verify_execution_proof)
+  - [New `verify_beacon_chain_proof`](#new-verify_beacon_chain_proof)
   - [New `notify_new_payload`](#new-notify_new_payload)
   - [New `notify_forkchoice_updated`](#new-notify_forkchoice_updated)
   - [New `ProofAttributes`](#new-proofattributes)
@@ -31,6 +32,8 @@ sub-system logic via:
   proofs
 - a verification function `self.verify_execution_proof` to verify individual
   proofs
+- a verification function `self.verify_beacon_chain_proof` to verify beacon
+  chain proofs
 - a notification function `self.notify_new_payload` to notify the proof engine
   of the new payload
 - a notification function `self.notify_forkchoice_updated` to notify the proof
@@ -51,6 +54,19 @@ def verify_execution_proof(
 ) -> bool:
     """
     Verify an execution proof.
+    Return ``True`` if proof is valid.
+    """
+```
+
+### New `verify_beacon_chain_proof`
+
+```python
+def verify_beacon_chain_proof(
+    self: ProofEngine,
+    beacon_chain_proof: BeaconChainProof,
+) -> bool:
+    """
+    Verify a beacon chain proof.
     Return ``True`` if proof is valid.
     """
 ```

--- a/specs/_features/eip8025/proof-sync.md
+++ b/specs/_features/eip8025/proof-sync.md
@@ -1,0 +1,150 @@
+# EIP-8025 -- Proof Sync
+
+*Note*: This document is a work-in-progress for researchers and implementers.
+
+## Table of contents
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
+
+- [Table of contents](#table-of-contents)
+- [Introduction](#introduction)
+- [Beacon chain proof guest](#beacon-chain-proof-guest)
+  - [New `extend_chain`](#new-extend_chain)
+- [Binding the beacon header to the execution proof](#binding-the-beacon-header-to-the-execution-proof)
+- [Updating the weak-subjectivity checkpoint](#updating-the-weak-subjectivity-checkpoint)
+  - [New `is_checkpoint_in_beacon_chain_proof_range`](#new-is_checkpoint_in_beacon_chain_proof_range)
+  - [New `update_checkpoint`](#new-update_checkpoint)
+
+<!-- mdformat-toc end -->
+
+## Introduction
+
+This document contains the proof-sync specifications for EIP-8025. Proof sync
+allows a node that starts from a weak-subjectivity checkpoint to verify
+execution validity for a beacon chain without downloading all historical
+execution payloads. This is achieved by composing recursive proofs over the beacon
+chain.
+
+*Note*: This specification is built upon [Gloas](../../gloas/beacon-chain.md),
+imports execution proof types from [beacon-chain.md](./beacon-chain.md), and
+uses the proof engine interface from [proof-engine.md](./proof-engine.md).
+
+The base EIP-8025 `ExecutionProof` remains an Engine API proof over
+`new_payload_request_root`. A `BeaconChainProof` is a layer above that proof. A
+beacon chain proof verifies:
+
+- one parent `BeaconChainProof`;
+- one execution proof;
+- execution payload binding.
+
+## Beacon chain proof guest
+
+The beacon chain proof guest is the zkvm program that produces the beacon chain proofs.
+It consists of two methods:
+- `extend_chain` for extending the beacon chain proof by one block; and
+- `update_checkpoint` for moving the weak-subjectivity checkpoint forward.
+
+### New `extend_chain`
+
+Extend chain is used to extend the beacon chain proof by one block.
+
+```python
+def extend_chain(
+    parent_beacon_chain_proof: BeaconChainProof,
+    execution_proof: ExecutionProof,
+    execution_binding: BeaconBlockExecutionBinding,
+    proof_engine: ProofEngine,
+) -> BeaconChainProofPublicInput:
+    parent = parent_beacon_chain_proof.public_input
+    header = execution_binding.beacon_header
+    bid = execution_binding.signed_execution_payload_bid.message
+    header_root = hash_tree_root(header)
+
+    # Verify both input proofs.
+    assert proof_engine.verify_beacon_chain_proof(parent_beacon_chain_proof)
+    assert proof_engine.verify_execution_proof(execution_proof)
+    assert parent_beacon_chain_proof.proof_type == execution_proof.proof_type
+
+    # Open the header body root to the compact execution binding.
+    assert hash_tree_root(execution_binding) == header.body_root
+
+    # TODO: Refine this binding before treating it as normative. This sketch
+    # shows the intended relationship: the recursive guest rebuilds the
+    # execution proof's public input from beacon-committed execution data.
+    new_payload_request_header = NewPayloadRequestHeader(
+        execution_payload_header=execution_binding.execution_payload_header,
+        versioned_hashes=[
+            kzg_commitment_to_versioned_hash(commitment) for commitment in bid.blob_kzg_commitments
+        ],
+        parent_beacon_block_root=header.parent_root,
+        execution_requests_root=bid.execution_requests_root,
+    )
+
+    # Bind the execution proof public input to the constructed request header.
+    assert hash_tree_root(new_payload_request_header) == (
+        execution_proof.public_input.new_payload_request_root
+    )
+
+    # Check that the header extends the proven chain head.
+    assert header.parent_root == parent.head_root
+    assert header.slot > parent.head_slot
+
+    return BeaconChainProofPublicInput(
+        ws_checkpoint_root=parent.ws_checkpoint_root,
+        ws_checkpoint_slot=parent.ws_checkpoint_slot,
+        head_root=header_root,
+        head_slot=header.slot,
+    )
+```
+
+## Updating the weak-subjectivity checkpoint
+
+The `update_checkpoint` operation moves the public weak-subjectivity checkpoint
+forward.
+
+### New `is_checkpoint_in_beacon_chain_proof_range`
+
+```python
+def is_checkpoint_in_beacon_chain_proof_range(
+    beacon_chain_proof: BeaconChainProof,
+    checkpoint_root: Root,
+    checkpoint_slot: Slot,
+) -> bool:
+    """
+    Return ``True`` if the checkpoint is inside the beacon chain proof range.
+    """
+    # TODO: Consider using an MMR over proven beacon roots to make this
+    # membership check efficient.
+    raise NotImplementedError
+```
+
+### New `update_checkpoint`
+
+```python
+def update_checkpoint(
+    beacon_chain_proof: BeaconChainProof,
+    checkpoint_root: Root,
+    checkpoint_slot: Slot,
+    proof_engine: ProofEngine,
+) -> BeaconChainProofPublicInput:
+    public_input = beacon_chain_proof.public_input
+
+    assert proof_engine.verify_beacon_chain_proof(beacon_chain_proof)
+    assert is_checkpoint_in_beacon_chain_proof_range(
+        beacon_chain_proof,
+        checkpoint_root,
+        checkpoint_slot,
+    )
+    assert checkpoint_slot >= public_input.ws_checkpoint_slot
+    assert checkpoint_slot <= public_input.head_slot
+
+    return BeaconChainProofPublicInput(
+        ws_checkpoint_root=checkpoint_root,
+        ws_checkpoint_slot=checkpoint_slot,
+        head_root=public_input.head_root,
+        head_slot=public_input.head_slot,
+    )
+```
+
+The membership proof used by `is_checkpoint_in_beacon_chain_proof_range` is
+implementation-dependent. It may be supplied as a private witness to the guest.

--- a/specs/_features/eip8025/proof-sync.md
+++ b/specs/_features/eip8025/proof-sync.md
@@ -10,7 +10,6 @@
 - [Introduction](#introduction)
 - [Beacon chain proof guest](#beacon-chain-proof-guest)
   - [New `extend_chain`](#new-extend_chain)
-- [Binding the beacon header to the execution proof](#binding-the-beacon-header-to-the-execution-proof)
 - [Updating the weak-subjectivity checkpoint](#updating-the-weak-subjectivity-checkpoint)
   - [New `is_checkpoint_in_beacon_chain_proof_range`](#new-is_checkpoint_in_beacon_chain_proof_range)
   - [New `update_checkpoint`](#new-update_checkpoint)
@@ -22,8 +21,8 @@
 This document contains the proof-sync specifications for EIP-8025. Proof sync
 allows a node that starts from a weak-subjectivity checkpoint to verify
 execution validity for a beacon chain without downloading all historical
-execution payloads. This is achieved by composing recursive proofs over the beacon
-chain.
+execution payloads. This is achieved by composing recursive proofs over the
+beacon chain.
 
 *Note*: This specification is built upon [Gloas](../../gloas/beacon-chain.md),
 imports execution proof types from [beacon-chain.md](./beacon-chain.md), and
@@ -39,8 +38,9 @@ beacon chain proof verifies:
 
 ## Beacon chain proof guest
 
-The beacon chain proof guest is the zkvm program that produces the beacon chain proofs.
-It consists of two methods:
+The beacon chain proof guest is the zkvm program that produces the beacon chain
+proofs. It consists of two methods:
+
 - `extend_chain` for extending the beacon chain proof by one block; and
 - `update_checkpoint` for moving the weak-subjectivity checkpoint forward.
 


### PR DESCRIPTION
## Summary

This draft adds an EIP-8025 proof-sync sketch for weak-subjectivity checkpoint execution proof sync.

The core idea is to keep the base EIP-8025 execution proof interface unchanged, with execution proofs still proving Engine API validation for `new_payload_request_root`, and add a recursive `BeaconChainProof` layer above it.

Each `extend_chain` step verifies:

- one parent `BeaconChainProof`;
- one inner `ExecutionProof`;
- one `BeaconBlockExecutionBinding` for the beacon block being extended.

The recursive proof outputs `BeaconChainProofPublicInput`:

```python
class BeaconChainProofPublicInput(Container):
    ws_checkpoint_root: Root
    ws_checkpoint_slot: Slot
    head_root: Root
    head_slot: Slot
```

## Related writeup

Design writeup:

- Weak-Subjectivity Checkpoint Execution Proof Sync: https://frisitano.github.io/slides/writeups/weak-subjectivity-checkpoint-proof-sync.html