### PR TITLE
Upload compliance tests to releases

### DIFF
--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -1,6 +1,11 @@
 name: Compliance Tests
 
-run-name: ${{ inputs.release_tag && format('{0}-compliance', inputs.release_tag) || 'Compliance Tests' }}
+run-name: >-
+  ${{
+    inputs.release_tag
+    && format('Compliance Tests for {0}', inputs.release_tag)
+    || 'Compliance Tests'
+  }}
 
 permissions:
   contents: read
@@ -15,24 +20,24 @@ on:
         description: Commit, branch, or tag
         type: string
       release_tag:
-        description: Release tag used for archive names and release upload
+        description: Release tag
         default: ""
         type: string
       altair:
         description: Generate altair fork
-        default: false
+        default: true
         type: boolean
       bellatrix:
         description: Generate bellatrix fork
-        default: false
+        default: true
         type: boolean
       capella:
         description: Generate capella fork
-        default: false
+        default: true
         type: boolean
       deneb:
         description: Generate deneb fork
-        default: false
+        default: true
         type: boolean
       electra:
         description: Generate electra fork
@@ -40,19 +45,19 @@ on:
         type: boolean
       fulu:
         description: Generate fulu fork
-        default: false
+        default: true
         type: boolean
       gloas:
         description: Generate gloas fork
-        default: false
+        default: true
         type: boolean
       tiny:
         description: Generate tiny config
-        default: true
+        default: false
         type: boolean
       small:
         description: Generate small config
-        default: false
+        default: true
         type: boolean
       standard:
         description: Generate standard config
@@ -283,22 +288,21 @@ jobs:
         id: archive
         run: |
           archive="${{ matrix.config }}.tar.gz"
-          artifact="${{ matrix.config }}"
-          release_tag="${{ needs.config.outputs.release_tag }}"
 
+          # Release archives are named comptests.tar.gz
+          release_tag="${{ needs.config.outputs.release_tag }}"
           if [[ -n "$release_tag" ]]; then
-            artifact="${release_tag}-compliance-${{ matrix.config }}"
-            mv "$archive" "$artifact.tar.gz"
-            archive="$artifact.tar.gz"
+            renamed="comptests.tar.gz"
+            mv "$archive" "$renamed"
+            archive="$renamed"
           fi
 
           echo "archive=$archive" >> "$GITHUB_OUTPUT"
-          echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
 
       - name: Upload ${{ steps.archive.outputs.archive }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.archive.outputs.artifact }}
+          name: ${{ steps.archive.outputs.archive }}
           path: ${{ steps.archive.outputs.archive }}
           archive: false
 

--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -1,5 +1,10 @@
 name: Compliance Tests
 
+run-name: ${{ inputs.release_tag && format('{0}-compliance', inputs.release_tag) || 'Compliance Tests' }}
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -8,6 +13,10 @@ on:
         type: string
       ref:
         description: Commit, branch, or tag
+        type: string
+      release_tag:
+        description: Release tag used for archive names and release upload
+        default: ""
         type: string
       altair:
         description: Generate altair fork
@@ -64,6 +73,7 @@ jobs:
     outputs:
       repo: ${{ steps.config.outputs.repo }}
       ref: ${{ steps.config.outputs.ref }}
+      release_tag: ${{ steps.config.outputs.release_tag }}
       configs: ${{ steps.config.outputs.configs }}
       seed: ${{ steps.config.outputs.seed }}
       matrix: ${{ steps.config.outputs.matrix }}
@@ -79,6 +89,20 @@ jobs:
           ref="${{ inputs.ref }}"
           if [[ -n "$ref" ]]; then
             echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Release tag
+          release_tag="${{ inputs.release_tag }}"
+          if [[ -n "$release_tag" ]]; then
+            if [[ "$repo" != "${{ github.repository }}" ]]; then
+              echo "Release-tagged compliance runs must use ${{ github.repository }} as the repository." >&2
+              exit 1
+            fi
+            if [[ "$ref" != "$release_tag" ]]; then
+              echo "Release-tagged compliance runs must use the release tag as the ref." >&2
+              exit 1
+            fi
+            echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
           fi
 
           # Presets
@@ -173,6 +197,7 @@ jobs:
           echo "Configuration:"
           echo "  repo:    $repo"
           echo "  ref:     ${ref:-<default>}"
+          echo "  release: ${release_tag:-<none>}"
           echo "  presets: $presets"
           echo "  forks:   $forks"
           echo "  configs: $configs"
@@ -184,6 +209,8 @@ jobs:
     needs: config
     name: generate (${{ matrix.fork }}, ${{ matrix.config }}, ${{ matrix.slice_index }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -194,6 +221,7 @@ jobs:
         with:
           repository: ${{ needs.config.outputs.repo }}
           ref: ${{ needs.config.outputs.ref }}
+          persist-credentials: false
 
       - name: Setup python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -235,6 +263,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: write
     strategy:
       matrix:
         config: ${{ fromJson(needs.config.outputs.configs) }}
@@ -250,8 +279,32 @@ jobs:
           source-path: tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload ${{ matrix.config }}.tar.gz
+      - name: Name packaged archive
+        id: archive
+        run: |
+          archive="${{ matrix.config }}.tar.gz"
+          artifact="${{ matrix.config }}"
+          release_tag="${{ needs.config.outputs.release_tag }}"
+
+          if [[ -n "$release_tag" ]]; then
+            artifact="${release_tag}-compliance-${{ matrix.config }}"
+            mv "$archive" "$artifact.tar.gz"
+            archive="$artifact.tar.gz"
+          fi
+
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+          echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
+
+      - name: Upload ${{ steps.archive.outputs.archive }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: ${{ matrix.config }}.tar.gz
+          name: ${{ steps.archive.outputs.artifact }}
+          path: ${{ steps.archive.outputs.archive }}
           archive: false
+
+      - name: Upload to release
+        if: ${{ needs.config.outputs.release_tag != '' }}
+        run: gh release upload "${{ needs.config.outputs.release_tag }}" "${{ steps.archive.outputs.archive }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -2,8 +2,8 @@ name: Compliance Tests
 
 run-name: >-
   ${{
-    inputs.release_tag
-    && format('Compliance Tests for {0}', inputs.release_tag)
+    inputs.release
+    && format('Compliance Tests for {0}', inputs.release)
     || 'Compliance Tests'
   }}
 
@@ -19,8 +19,8 @@ on:
       ref:
         description: Commit, branch, or tag
         type: string
-      release_tag:
-        description: Release tag
+      release:
+        description: Release (leave empty)
         default: ""
         type: string
       altair:
@@ -78,7 +78,7 @@ jobs:
     outputs:
       repo: ${{ steps.config.outputs.repo }}
       ref: ${{ steps.config.outputs.ref }}
-      release_tag: ${{ steps.config.outputs.release_tag }}
+      release: ${{ steps.config.outputs.release }}
       configs: ${{ steps.config.outputs.configs }}
       seed: ${{ steps.config.outputs.seed }}
       matrix: ${{ steps.config.outputs.matrix }}
@@ -97,17 +97,17 @@ jobs:
           fi
 
           # Release tag
-          release_tag="${{ inputs.release_tag }}"
-          if [[ -n "$release_tag" ]]; then
+          release="${{ inputs.release }}"
+          if [[ -n "$release" ]]; then
             if [[ "$repo" != "${{ github.repository }}" ]]; then
               echo "Release-tagged compliance runs must use ${{ github.repository }} as the repository." >&2
               exit 1
             fi
-            if [[ "$ref" != "$release_tag" ]]; then
+            if [[ "$ref" != "$release" ]]; then
               echo "Release-tagged compliance runs must use the release tag as the ref." >&2
               exit 1
             fi
-            echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+            echo "release=$release" >> "$GITHUB_OUTPUT"
           fi
 
           # Presets
@@ -202,7 +202,7 @@ jobs:
           echo "Configuration:"
           echo "  repo:    $repo"
           echo "  ref:     ${ref:-<default>}"
-          echo "  release: ${release_tag:-<none>}"
+          echo "  release: ${release:-<none>}"
           echo "  presets: $presets"
           echo "  forks:   $forks"
           echo "  configs: $configs"
@@ -290,8 +290,8 @@ jobs:
           archive="${{ matrix.config }}.tar.gz"
 
           # Release archives are named comptests.tar.gz
-          release_tag="${{ needs.config.outputs.release_tag }}"
-          if [[ -n "$release_tag" ]]; then
+          release="${{ needs.config.outputs.release }}"
+          if [[ -n "$release" ]]; then
             renamed="comptests.tar.gz"
             mv "$archive" "$renamed"
             archive="$renamed"
@@ -307,8 +307,8 @@ jobs:
           archive: false
 
       - name: Upload to release
-        if: ${{ needs.config.outputs.release_tag != '' }}
-        run: gh release upload "${{ needs.config.outputs.release_tag }}" "${{ steps.archive.outputs.archive }}"
+        if: ${{ needs.config.outputs.release != '' }}
+        run: gh release upload "${{ needs.config.outputs.release }}" "${{ steps.archive.outputs.archive }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,3 +149,20 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+
+  trigger-compliance-tests:
+    needs: [setup, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger compliance test generation
+        run: |
+          gh workflow run comptests.yml \
+            --ref "${{ needs.setup.outputs.tag }}" \
+            --field repo="${{ github.repository }}" \
+            --field ref="${{ needs.setup.outputs.tag }}" \
+            --field release_tag="${{ needs.setup.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
-  trigger-compliance-tests:
+  trigger-comptests:
     needs: [setup, publish]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
             --ref "${{ needs.setup.outputs.tag }}" \
             --field repo="${{ github.repository }}" \
             --field ref="${{ needs.setup.outputs.tag }}" \
-            --field release_tag="${{ needs.setup.outputs.tag }}"
+            --field release="${{ needs.setup.outputs.tag }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

This links the release workflow to the long-running compliance test workflow without merging the two workflows together.

- `release.yml` now dispatches `comptests.yml` after the release publish job succeeds.
- `comptests.yml` accepts an optional `release_tag` input, uses it in the workflow run name, and renames final tarballs as `<release-tag>-compliance-<config>.tar.gz`.
- Release-tagged compliance runs upload their final tarballs back to the matching GitHub Release once generation finishes.
- Manual and scheduled compliance runs keep their existing behavior when `release_tag` is not provided.

## Why this matters

Reference release artifacts and compliance test artifacts are currently produced independently, even though downstream consumers need to know which compliance tests correspond to which consensus-specs release. The compliance tests take long enough that they should remain in their own workflow, but the release process should still produce an explicit, discoverable link to the matching compliance tarballs.

With this change, a release can finish on its normal timeline while the compliance tests continue asynchronously. When the compliance workflow completes, its output is clearly tagged with the release version and attached to the same release page.

## Security notes

The compliance workflow keeps a read-only default token and only grants write permissions to the packaging job that needs to delete intermediate artifacts and upload release assets.

For release-tagged runs, the workflow rejects configurations where:

- `repo` is not the current repository
- `ref` does not exactly match `release_tag`

The generation checkout also disables persisted credentials, and release asset upload does not use `--clobber`, so existing release assets are not silently overwritten.

## Validation

- `actionlint -shellcheck= .github/workflows/release.yml .github/workflows/comptests.yml`
- YAML parse check for both workflow files
- `git diff --check -- .github/workflows/release.yml .github/workflows/comptests.yml`
