### PR TITLE
Clarify `should_build_on_full` semantic

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -432,9 +432,9 @@ def should_build_on_full(store: Store, head: ForkChoiceNode) -> bool:
         return head.payload_status == PAYLOAD_STATUS_FULL
     if head.payload_status == PAYLOAD_STATUS_EMPTY:
         return False
-    if payload_data_availability(store, head.root, available=False):
-        return False
     if payload_timeliness(store, head.root, timely=False):
+        return False
+    if payload_data_availability(store, head.root, available=False):
         return False
     return True
 ```

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -419,26 +419,22 @@ def is_previous_slot_payload_decision(store: Store, node: ForkChoiceNode) -> boo
 
 ### New `should_build_on_full`
 
-*Note*: `should_build_on_full` is called by the proposer before deciding whether
-to build on top of the empty or full parent pending node. This function is
-similar to `should_extend_payload` but takes into consideration the PTC view on
-both data availability and payload timeliness. As in
-`get_payload_status_tiebreaker`, this view is only consulted for a head from the
-previous slot. For a head from an earlier slot, the *empty* or *full* node has
-already been resolved by weight in `get_head`.
+*Note*: This function is called by the proposer to decide whether to build on
+top of the *empty* or *full* parent node. For a node from an earlier slot, it
+follows the payload status resolved by `get_head`. For a *full* node from the
+previous slot, it considers the PTC view on both payload timeliness and data
+availability.
 
 ```python
 def should_build_on_full(store: Store, head: ForkChoiceNode) -> bool:
     assert head.payload_status != PAYLOAD_STATUS_PENDING
+    if store.blocks[head.root].slot + 1 != get_current_slot(store):
+        return head.payload_status == PAYLOAD_STATUS_FULL
     if head.payload_status == PAYLOAD_STATUS_EMPTY:
         return False
-    if store.blocks[head.root].slot + 1 != get_current_slot(store):
-        return True
-    if payload_data_availability(store, head.root, available=False):
-        return False
-    if payload_timeliness(store, head.root, timely=False):
-        return False
-    return True
+    is_payload_untimely = payload_timeliness(store, head.root, timely=False)
+    is_payload_data_unavailable = payload_data_availability(store, head.root, available=False)
+    return not (is_payload_untimely or is_payload_data_unavailable)
 ```
 
 ### New `should_extend_payload`

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -432,9 +432,11 @@ def should_build_on_full(store: Store, head: ForkChoiceNode) -> bool:
         return head.payload_status == PAYLOAD_STATUS_FULL
     if head.payload_status == PAYLOAD_STATUS_EMPTY:
         return False
-    is_payload_untimely = payload_timeliness(store, head.root, timely=False)
-    is_payload_data_unavailable = payload_data_availability(store, head.root, available=False)
-    return not is_payload_untimely and not is_payload_data_unavailable
+    if payload_data_availability(store, head.root, available=False):
+        return False
+    if payload_timeliness(store, head.root, timely=False):
+        return False
+    return True
 ```
 
 ### New `should_extend_payload`

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -434,7 +434,7 @@ def should_build_on_full(store: Store, head: ForkChoiceNode) -> bool:
         return False
     is_payload_untimely = payload_timeliness(store, head.root, timely=False)
     is_payload_data_unavailable = payload_data_availability(store, head.root, available=False)
-    return not (is_payload_untimely or is_payload_data_unavailable)
+    return not is_payload_untimely and not is_payload_data_unavailable
 ```
 
 ### New `should_extend_payload`


### PR DESCRIPTION
This PR clarifies `should_build_on_full` semantic by distinguishing the previous slot and earlier slots. For earlier slots, it follows the payload status resolved by attesters. For the previous slot, it takes the PTC view into account.