### PR TITLE
Deprecate two functions

### DIFF
--- a/pysetup/spec_builders/altair.py
+++ b/pysetup/spec_builders/altair.py
@@ -73,5 +73,6 @@ def compute_merkle_proof(object: SSZObject,
             "get_target_deltas",
             "get_unslashed_attesting_indices",
             "initialize_beacon_state_from_eth1",
+            "is_valid_genesis_state",
             "process_participation_record_updates",
         }

--- a/pysetup/spec_builders/fulu.py
+++ b/pysetup/spec_builders/fulu.py
@@ -51,6 +51,7 @@ class CosetEvals(list):
     @classmethod
     def deprecate_functions(cls) -> set[str]:
         return {
+            "apply_deposit",
             "compute_max_request_blob_sidecars",
             "compute_subnet_for_blob_sidecar",
             "get_blob_sidecars",


### PR DESCRIPTION
When reviewing coverage data, I noticed that these should be marked as deprecated:

* Deprecate `is_valid_genesis_state` in Altair.
* Deprecate `apply_deposit` in Fulu.