### PR TITLE
Use latest version of uv in workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,11 +19,10 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: "pyproject.toml"
-      - name: Install uv ${{ vars.UV_VERSION }}
+      - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-          version: ${{ vars.UV_VERSION }}
       - name: Run linter for pyspec
         run: |
           make lint
@@ -38,11 +37,10 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: "pyproject.toml"
-      - name: Install uv ${{ vars.UV_VERSION }}
+      - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-          version: ${{ vars.UV_VERSION }}
       - name: Run framework tests
         run: make test component=fw
       - name: Prepare test results for upload
@@ -134,11 +132,10 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: "pyproject.toml"
-      - name: Install uv ${{ vars.UV_VERSION }}
+      - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-          version: ${{ vars.UV_VERSION }}
       - name: Run pyspec tests for ${{ matrix.fork }}
         run: make test component=pyspec preset=minimal fork=${{ matrix.fork }}
       - name: Prepare test results for upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,6 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-          version: ${{ vars.UV_VERSION }}
 
       - name: Generate tests
         run: make test component=pyspec preset=${{ matrix.preset }} fork=${{ matrix.fork }} reftests=true
@@ -135,11 +134,10 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
 
-      - name: Install uv ${{ vars.UV_VERSION }}
+      - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-          version: ${{ vars.UV_VERSION }}
 
       - name: Generate specs
         run: uv run python -m pysetup.generate_specs --all-forks

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,11 +20,10 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
 
-      - name: Install uv ${{ vars.UV_VERSION }}
+      - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-          version: ${{ vars.UV_VERSION }}
 
       - name: Install dependencies to venv
         run: make _pyspec


### PR DESCRIPTION
I would like to automatically get `uv` improvements without having to manually bump the `UV_VERSION` secret (right now I'm the only one with permission to do this). `uv` has been so stable (not breaking backwards compatibility) that I would like to simply use the latest version by default. We've been doing this in the nightly tests action for many months. If for whatever reason there is an issue, we can quickly fix it in a PR.