### PR TITLE
Fix phase0 & add Fulu `get_dependent_root` variants

### DIFF
--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -19,6 +19,9 @@ This is the modification of the fork choice accompanying Fulu.
 
 ### Modified `get_dependent_root`
 
+*Note*: This function `get_dependent_root` now calculates the attestation
+dependent root as well as the proposer dependent root.
+
 ```python
 def get_dependent_root(store: Store, root: Root) -> Root:
     epoch = get_current_store_epoch(store)

--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -4,7 +4,7 @@
 
 - [Introduction](#introduction)
 - [Helpers](#helpers)
-  - [Modified `get_dependent_root`](#modified-get_dependent_root)
+  - [Modified `get_proposer_dependent_root`](#modified-get_proposer_dependent_root)
   - [Modified `is_data_available`](#modified-is_data_available)
 - [Handlers](#handlers)
   - [Modified `on_block`](#modified-on_block)
@@ -17,14 +17,10 @@ This is the modification of the fork choice accompanying Fulu.
 
 ## Helpers
 
-### Modified `get_dependent_root`
-
-*Note*: This function `get_dependent_root` now calculates the attestation
-dependent root as well as the proposer dependent root.
+### Modified `get_proposer_dependent_root`
 
 ```python
-def get_dependent_root(store: Store, root: Root) -> Root:
-    epoch = get_current_store_epoch(store)
+def get_proposer_dependent_root(store: Store, root: Root, epoch: Epoch) -> Root:
     if epoch <= MIN_SEED_LOOKAHEAD:
         # Genesis block parent
         return Root()

--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -4,6 +4,7 @@
 
 - [Introduction](#introduction)
 - [Helpers](#helpers)
+  - [Modified `get_dependent_root`](#modified-get_dependent_root)
   - [Modified `is_data_available`](#modified-is_data_available)
 - [Handlers](#handlers)
   - [Modified `on_block`](#modified-on_block)
@@ -15,6 +16,21 @@
 This is the modification of the fork choice accompanying Fulu.
 
 ## Helpers
+
+### Modified `get_dependent_root`
+
+```python
+def get_dependent_root(store: Store, root: Root) -> Root:
+    epoch = get_current_store_epoch(store)
+    if epoch <= MIN_SEED_LOOKAHEAD:
+        # Genesis block parent
+        return Root()
+
+    node = ForkChoiceNode(root=root)
+    # [Modified in Fulu]
+    dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+    return get_ancestor(store, node, dependent_slot).root
+```
 
 ### Modified `is_data_available`
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -120,8 +120,8 @@ to include. They produce a `SignedExecutionPayloadBid` as follows.
     The proposer's preferred fee recipient is obtained from the
     `SignedProposerPreferences` whose `message.proposal_slot` matches `bid.slot`
     and whose `message.dependent_root` matches
-    `get_proposer_dependent_root(parent_state, compute_epoch_at_slot(bid.slot))`,
-    where `parent_state` is the post-state of `bid.parent_block_root`.
+    `get_proposer_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(bid.slot))`,
+    where `store` is the fork choice store.
 07. Set `bid.gas_limit` to be the gas limit of the constructed payload, which
     **MUST** satisfy
     `is_gas_limit_target_compatible(parent_gas_limit, bid.gas_limit, target_gas_limit)`,

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -53,7 +53,7 @@
     - [Modified `update_latest_messages`](#modified-update_latest_messages)
   - [`on_block` helpers](#on_block-helpers)
     - [Modified `record_block_timeliness`](#modified-record_block_timeliness)
-    - [Modified `get_dependent_root`](#modified-get_dependent_root)
+    - [Modified `get_proposer_dependent_root`](#modified-get_proposer_dependent_root)
     - [Modified `update_proposer_boost_root`](#modified-update_proposer_boost_root)
 - [Handlers](#handlers)
   - [Modified `on_block`](#modified-on_block)
@@ -868,11 +868,10 @@ def record_block_timeliness(store: Store, root: Root) -> None:
     ]
 ```
 
-#### Modified `get_dependent_root`
+#### Modified `get_proposer_dependent_root`
 
 ```python
-def get_dependent_root(store: Store, root: Root) -> Root:
-    epoch = get_current_store_epoch(store)
+def get_proposer_dependent_root(store: Store, root: Root, epoch: Epoch) -> Root:
     if epoch <= MIN_SEED_LOOKAHEAD:
         # Genesis block parent
         return Root()
@@ -893,7 +892,10 @@ def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     is_first_block = store.proposer_boost_root == Root()
     # [Modified in Gloas:EIP7732]
     is_timely = store.block_timeliness[root][ATTESTATION_TIMELINESS_INDEX]
-    is_same_dependent_root = get_dependent_root(store, root) == get_dependent_root(store, head)
+    epoch = get_current_store_epoch(store)
+    is_same_dependent_root = get_proposer_dependent_root(
+        store, root, epoch
+    ) == get_proposer_dependent_root(store, head, epoch)
 
     # Add proposer score boost if the block is timely, not conflicting with an
     # existing block, with the same dependent root as the canonical chain head.

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -361,8 +361,8 @@ The following validations MUST pass before forwarding the
 `bid = signed_execution_payload_bid.message`, the alias
 `signed_proposer_preferences` for the validated `SignedProposerPreferences`
 whose `message.proposal_slot` is `bid.slot` and `message.dependent_root` is
-`get_proposer_dependent_root(parent_state, compute_epoch_at_slot(bid.slot))`,
-where `parent_state` is the post-state of `bid.parent_block_root`, and the alias
+`get_proposer_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(bid.slot))`,
+where `store` is the fork choice store, and the alias
 `proposer_preferences = signed_proposer_preferences.message`:
 
 - _[IGNORE]_ `bid.slot` is the current slot or the next slot.
@@ -464,16 +464,6 @@ def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences)
     index = (proposal_epoch - current_epoch) * SLOTS_PER_EPOCH
     index += preferences.proposal_slot % SLOTS_PER_EPOCH
     return state.proposer_lookahead[index] == preferences.validator_index
-```
-
-```python
-def get_proposer_dependent_root(state: BeaconState, epoch: Epoch) -> Root:
-    """
-    Return the dependent root for the proposer lookahead at ``epoch``.
-    """
-    return get_block_root_at_slot(
-        state, Slot(compute_start_slot_at_epoch(Epoch(epoch - MIN_SEED_LOOKAHEAD)) - 1)
-    )
 ```
 
 *Note*: Nodes SHOULD subscribe to this topic at least one epoch before the fork

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -155,9 +155,9 @@ To construct each `SignedProposerPreferences`:
 
 1. Instantiate a new `ProposerPreferences` object as `preferences`.
 2. Set `preferences.dependent_root` to
-   `get_proposer_dependent_root(state, compute_epoch_at_slot(preferences.proposal_slot))`,
-   where `state` is the proposer's current head state. Use the genesis block
-   root in case of underflow.
+   `get_proposer_dependent_root(store, head_root, compute_epoch_at_slot(preferences.proposal_slot))`,
+   where `store` is the fork choice store and `head_root` is the proposer's
+   current head root.
 3. Set `preferences.proposal_slot` to `upcoming_proposal_slots[i]`.
 4. Set `preferences.validator_index` to the validator's index.
 5. Set `preferences.fee_recipient` to the execution address where the validator

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -59,7 +59,7 @@
       - [`update_latest_messages`](#update_latest_messages)
     - [`on_block` helpers](#on_block-helpers)
       - [`record_block_timeliness`](#record_block_timeliness)
-      - [`get_dependent_root`](#get_dependent_root)
+      - [`get_proposer_dependent_root`](#get_proposer_dependent_root)
       - [`update_proposer_boost_root`](#update_proposer_boost_root)
   - [Handlers](#handlers)
     - [`on_tick`](#on_tick)
@@ -854,14 +854,13 @@ def record_block_timeliness(store: Store, root: Root) -> None:
     store.block_timeliness[root] = is_timely
 ```
 
-##### `get_dependent_root`
+##### `get_proposer_dependent_root`
 
 ```python
-def get_dependent_root(store: Store, root: Root) -> Root:
+def get_proposer_dependent_root(store: Store, root: Root, epoch: Epoch) -> Root:
     """
-    Return the dependent root for the proposer
+    Return the dependent root for the proposer at ``epoch``.
     """
-    epoch = get_current_store_epoch(store)
     if epoch == GENESIS_EPOCH:
         # Genesis block parent
         return Root()
@@ -877,7 +876,10 @@ def get_dependent_root(store: Store, root: Root) -> Root:
 def update_proposer_boost_root(store: Store, head: Root, root: Root) -> None:
     is_first_block = store.proposer_boost_root == Root()
     is_timely = store.block_timeliness[root]
-    is_same_dependent_root = get_dependent_root(store, root) == get_dependent_root(store, head)
+    epoch = get_current_store_epoch(store)
+    is_same_dependent_root = get_proposer_dependent_root(
+        store, root, epoch
+    ) == get_proposer_dependent_root(store, head, epoch)
 
     # Add proposer score boost if the block is timely, not conflicting with an
     # existing block, with the same dependent root as the canonical chain head.

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -864,7 +864,7 @@ def get_dependent_root(store: Store, root: Root) -> Root:
         return Root()
 
     node = ForkChoiceNode(root=root)
-    dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+    dependent_slot = Slot(compute_start_slot_at_epoch(epoch) - 1)
     return get_ancestor(store, node, dependent_slot).root
 ```
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -862,7 +862,7 @@ def get_dependent_root(store: Store, root: Root) -> Root:
     Return the dependent root for the proposer
     """
     epoch = get_current_store_epoch(store)
-    if epoch == 0:
+    if epoch == GENESIS_EPOCH:
         # Genesis block parent
         return Root()
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -862,6 +862,10 @@ def get_dependent_root(store: Store, root: Root) -> Root:
     Return the dependent root for the proposer
     """
     epoch = get_current_store_epoch(store)
+    if epoch == 0:
+        # Genesis block parent
+        return Root()
+
     node = ForkChoiceNode(root=root)
     dependent_slot = Slot(compute_start_slot_at_epoch(epoch) - 1)
     return get_ancestor(store, node, dependent_slot).root

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -858,11 +858,10 @@ def record_block_timeliness(store: Store, root: Root) -> None:
 
 ```python
 def get_dependent_root(store: Store, root: Root) -> Root:
+    """
+    Return the dependent root for the proposer
+    """
     epoch = get_current_store_epoch(store)
-    if epoch <= MIN_SEED_LOOKAHEAD:
-        # Genesis block parent
-        return Root()
-
     node = ForkChoiceNode(root=root)
     dependent_slot = Slot(compute_start_slot_at_epoch(epoch) - 1)
     return get_ancestor(store, node, dependent_slot).root


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/issues/5351

Fixes phase0 `get_dependent_root` and adds a Fulu variant with the new proposer lookahead logic. As the issue above mentions, this serves no real practical use as all networks have already upgraded to Fulu. But this change is small and might be worth it from a spec correctness perspective.