### PR TITLE
Add test for `on_execution_payload_envelope`

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_execution_payload_envelope.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_execution_payload_envelope.py
@@ -3,6 +3,9 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_gloas_and_later,
 )
+from eth_consensus_specs.test.helpers.block import (
+    build_empty_block_for_next_slot,
+)
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_empty_execution_payload,
     build_signed_execution_payload_envelope,
@@ -10,9 +13,15 @@ from eth_consensus_specs.test.helpers.execution_payload import (
 from eth_consensus_specs.test.helpers.fork_choice import (
     add_execution_payload,
     check_head_against_root,
+    output_head_check,
     setup_one_block_store,
+    tick_and_add_block,
+    tick_store_to_slot,
 )
 from eth_consensus_specs.test.helpers.keys import builder_privkeys, privkeys
+from eth_consensus_specs.test.helpers.state import (
+    state_transition_and_sign_block,
+)
 
 
 def _build_invalid_envelope(spec, state, block_root, signed_block, **overrides):
@@ -414,4 +423,42 @@ def test_on_execution_payload_envelope_wrong_timestamp(spec, state):
 
     assert block_root not in store.payloads
 
+    yield "steps", test_steps
+
+
+@with_gloas_and_later
+@spec_state_test
+@always_bls
+def test_on_execution_payload_envelope_invalid_full_child(spec, state):
+    """
+    Test that a rejected invalid envelope cannot mark the parent payload as
+    verified and make a later FULL child pass on_block validation.
+    """
+    store, block_root, block_state, signed_block, test_steps = yield from setup_one_block_store(
+        spec, state
+    )
+
+    envelope = _build_invalid_envelope(
+        spec,
+        block_state,
+        block_root,
+        signed_block,
+        valid_signature=False,
+    )
+    yield from add_execution_payload(spec, store, envelope, test_steps, valid=False)
+
+    tick_store_to_slot(spec, store, block_state.slot + 1, test_steps)
+
+    # Build a child that points its bid at parent.bid.block_hash so it claims
+    # the parent is FULL
+    child_state = block_state.copy()
+    child = build_empty_block_for_next_slot(spec, child_state)
+    child.body.signed_execution_payload_bid.message.parent_block_hash = (
+        signed_block.message.body.signed_execution_payload_bid.message.block_hash
+    )
+    signed_child = state_transition_and_sign_block(spec, child_state, child)
+
+    # The FULL child must fail because the parent's invalid envelope did not verify its payload
+    yield from tick_and_add_block(spec, store, signed_child, test_steps, valid=False)
+    output_head_check(spec, store, test_steps)
     yield "steps", test_steps


### PR DESCRIPTION
# Description

This PR adds a fork choice test checking that a rejected execution payload envelope does not update the store.

The test submits an envelope with an invalid signature for a known parent block, then a child block claiming the parent is FULL. The child must fail `on_block` validation because the parent payload was never verified.

## Changes

- Add `test_on_execution_payload_envelope_invalid_full_child`
