### PR TITLE
Add new `run_validate_gossip` helper function

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/altair/networking/test_gossip_sync_committee_contribution_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/networking/test_gossip_sync_committee_contribution_and_proof.py
@@ -5,7 +5,7 @@ from eth_consensus_specs.test.context import (
     with_presets,
 )
 from eth_consensus_specs.test.helpers.constants import MAINNET
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
+from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, run_validate_gossip
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.utils import bls
 
@@ -119,24 +119,6 @@ def create_valid_signed_contribution_and_proof(
     )
 
 
-def run_validate_contribution_gossip(
-    spec, seen, state, signed_contribution_and_proof, current_time_ms
-):
-    """Run validate_sync_committee_contribution_and_proof_gossip and return the result."""
-    try:
-        spec.validate_sync_committee_contribution_and_proof_gossip(
-            seen,
-            state,
-            signed_contribution_and_proof,
-            current_time_ms,
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
-
-
 @with_altair_and_later
 @spec_state_test
 @always_bls
@@ -164,12 +146,12 @@ def test_gossip_sync_committee_contribution_and_proof__valid(spec, state):
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "valid"
     assert reason is None
@@ -214,12 +196,12 @@ def test_gossip_sync_committee_contribution_and_proof__valid_at_period_boundary(
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "valid"
     assert reason is None
@@ -259,12 +241,12 @@ def test_gossip_sync_committee_contribution_and_proof__ignore_future_slot(spec, 
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms,
     )
     assert result == "ignore"
     assert reason == "contribution is not for the current slot"
@@ -315,12 +297,12 @@ def test_gossip_sync_committee_contribution_and_proof__ignore_past_slot(spec, st
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms,
     )
     assert result == "ignore"
     assert reason == "contribution is not for the current slot"
@@ -370,12 +352,12 @@ def test_gossip_sync_committee_contribution_and_proof__reject_invalid_subcommitt
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "subcommittee index out of range"
@@ -424,12 +406,12 @@ def test_gossip_sync_committee_contribution_and_proof__reject_no_participants(sp
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "contribution has no participants"
@@ -495,12 +477,12 @@ def test_gossip_sync_committee_contribution_and_proof__reject_not_aggregator(spe
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "validator is not selected as aggregator"
@@ -553,12 +535,12 @@ def test_gossip_sync_committee_contribution_and_proof__reject_aggregator_not_in_
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "aggregator not in subcommittee"
@@ -607,12 +589,12 @@ def test_gossip_sync_committee_contribution_and_proof__reject_aggregator_index_o
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "aggregator index out of range"
@@ -709,12 +691,12 @@ def test_gossip_sync_committee_contribution_and_proof__ignore_superset_contribut
     yield "current_time_ms", "meta", int(current_time_ms)
 
     # First: superset passes
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_superset,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_superset,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "valid"
     assert reason is None
@@ -734,12 +716,12 @@ def test_gossip_sync_committee_contribution_and_proof__ignore_superset_contribut
 
     yield get_filename(signed_subset), signed_subset
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_subset,
-        current_time_ms + 600,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_subset,
+        current_time_ms=current_time_ms + 600,
     )
     assert result == "ignore"
     assert reason == "already seen contribution for this data"
@@ -806,12 +788,12 @@ def test_gossip_sync_committee_contribution_and_proof__valid_non_superset_contri
 
     yield get_filename(signed_subset), signed_subset
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_subset,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_subset,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "valid"
     assert reason is None
@@ -858,12 +840,12 @@ def test_gossip_sync_committee_contribution_and_proof__valid_non_superset_contri
     yield get_filename(signed_superset), signed_superset
 
     # Superset has new bits → is_non_strict_superset=False, passes the check → valid
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_superset,
-        current_time_ms + 600,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_superset,
+        current_time_ms=current_time_ms + 600,
     )
     assert result == "valid"
     assert reason is None
@@ -905,12 +887,12 @@ def test_gossip_sync_committee_contribution_and_proof__ignore_duplicate_aggregat
     yield "current_time_ms", "meta", int(current_time_ms)
 
     # First validation should pass
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap1,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap1,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "valid"
     assert reason is None
@@ -930,12 +912,12 @@ def test_gossip_sync_committee_contribution_and_proof__ignore_duplicate_aggregat
 
     yield get_filename(signed_cap2), signed_cap2
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap2,
-        current_time_ms + 600,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap2,
+        current_time_ms=current_time_ms + 600,
     )
     assert result == "ignore"
     assert reason == "already seen contribution from this aggregator"
@@ -988,12 +970,12 @@ def test_gossip_sync_committee_contribution_and_proof__reject_invalid_selection_
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "invalid selection proof signature"
@@ -1048,12 +1030,12 @@ def test_gossip_sync_committee_contribution_and_proof__reject_invalid_aggregator
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "invalid aggregator signature"
@@ -1115,12 +1097,12 @@ def test_gossip_sync_committee_contribution_and_proof__reject_invalid_aggregate_
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_contribution_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        signed_cap,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        signed_contribution_and_proof=signed_cap,
+        current_time_ms=current_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "invalid aggregate signature"

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/networking/test_gossip_sync_committee_message.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/networking/test_gossip_sync_committee_message.py
@@ -3,7 +3,7 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_altair_and_later,
 )
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
+from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, run_validate_gossip
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.utils import bls
 
@@ -37,25 +37,6 @@ def create_valid_sync_committee_message(spec, state, validator_index, slot=None,
     )
 
 
-def run_validate_sync_committee_message_gossip(
-    spec, seen, state, message, subnet_id, current_time_ms
-):
-    """Run validate_sync_committee_message_gossip and return the result."""
-    try:
-        spec.validate_sync_committee_message_gossip(
-            seen,
-            state,
-            message,
-            current_time_ms,
-            subnet_id,
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
-
-
 @with_altair_and_later
 @spec_state_test
 @always_bls
@@ -74,13 +55,13 @@ def test_gossip_sync_committee_message__valid(spec, state):
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_sync_committee_message_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        message,
-        subnet_id,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        sync_committee_message=message,
+        current_time_ms=current_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -119,13 +100,13 @@ def test_gossip_sync_committee_message__ignore_future_slot(spec, state):
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_sync_committee_message_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        message,
-        subnet_id,
-        current_time_ms,
+        seen=seen,
+        state=state,
+        sync_committee_message=message,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "message is not for the current slot"
@@ -169,13 +150,13 @@ def test_gossip_sync_committee_message__ignore_past_slot(spec, state):
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_sync_committee_message_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        message,
-        subnet_id,
-        current_time_ms,
+        seen=seen,
+        state=state,
+        sync_committee_message=message,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "message is not for the current slot"
@@ -215,13 +196,13 @@ def test_gossip_sync_committee_message__reject_wrong_subnet(spec, state):
     # Use a wrong subnet_id
     wrong_subnet_id = (correct_subnet_id + 1) % spec.SYNC_COMMITTEE_SUBNET_COUNT
 
-    result, reason = run_validate_sync_committee_message_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        message,
-        wrong_subnet_id,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        sync_committee_message=message,
+        current_time_ms=current_time_ms + 500,
+        subnet_id=wrong_subnet_id,
     )
     assert result == "reject"
     assert reason == "subnet_id is not valid for the validator"
@@ -260,13 +241,13 @@ def test_gossip_sync_committee_message__reject_validator_index_out_of_range(spec
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_sync_committee_message_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        message,
-        subnet_id,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        sync_committee_message=message,
+        current_time_ms=current_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "validator index out of range"
@@ -305,13 +286,13 @@ def test_gossip_sync_committee_message__ignore_duplicate(spec, state):
     yield "current_time_ms", "meta", int(current_time_ms)
 
     # First validation should pass
-    result, reason = run_validate_sync_committee_message_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        message,
-        subnet_id,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        sync_committee_message=message,
+        current_time_ms=current_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -325,13 +306,13 @@ def test_gossip_sync_committee_message__ignore_duplicate(spec, state):
     )
 
     # Second validation should be ignored
-    result, reason = run_validate_sync_committee_message_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        message,
-        subnet_id,
-        current_time_ms + 600,
+        seen=seen,
+        state=state,
+        sync_committee_message=message,
+        current_time_ms=current_time_ms + 600,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "already seen message from this validator for this slot and subnet"
@@ -381,13 +362,13 @@ def test_gossip_sync_committee_message__reject_invalid_signature(spec, state):
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_sync_committee_message_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        state,
-        message,
-        subnet_id,
-        current_time_ms + 500,
+        seen=seen,
+        state=state,
+        sync_committee_message=message,
+        current_time_ms=current_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid sync committee message signature"

--- a/tests/core/pyspec/eth_consensus_specs/test/bellatrix/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/bellatrix/networking/test_gossip_beacon_block.py
@@ -18,10 +18,11 @@ from eth_consensus_specs.test.helpers.fork_choice import (
 from eth_consensus_specs.test.helpers.gossip import (
     get_filename,
     get_seen,
+    get_spec_block_payload_statuses,
     PAYLOAD_STATUS_INVALIDATED,
     PAYLOAD_STATUS_NOT_VALIDATED,
     PAYLOAD_STATUS_VALID,
-    run_validate_beacon_block_gossip,
+    run_validate_gossip,
     wrap_genesis_block,
 )
 from eth_consensus_specs.test.helpers.state import (
@@ -56,8 +57,14 @@ def test_gossip_beacon_block__valid_execution_enabled(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses={},
     )
     assert result == "valid"
     assert reason is None
@@ -97,8 +104,14 @@ def test_gossip_beacon_block__valid_execution_disabled(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses={},
     )
     assert result == "valid"
     assert reason is None
@@ -141,8 +154,14 @@ def test_gossip_beacon_block__reject_incorrect_execution_payload_timestamp(spec,
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses={},
     )
     assert result == "reject"
     assert reason == "incorrect execution payload timestamp"
@@ -222,16 +241,17 @@ def test_gossip_beacon_block__reject_parent_consensus_failed_execution_not_verif
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        store,
-        state,
-        signed_child,
-        block_time_ms + 500,
-        block_payload_statuses={
-            signed_block.message.hash_tree_root(): PAYLOAD_STATUS_NOT_VALIDATED,
-        },
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_child,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses=get_spec_block_payload_statuses(
+            spec,
+            {signed_block.message.hash_tree_root(): PAYLOAD_STATUS_NOT_VALIDATED},
+        ),
     )
     assert result == "reject"
     assert reason == "block's parent is invalid and EL result is unknown"
@@ -312,14 +332,14 @@ def test_gossip_beacon_block__ignore_parent_consensus_failed_execution_known(spe
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        store,
-        state,
-        signed_child,
-        block_time_ms + 500,
-        block_payload_statuses=block_payload_statuses,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_child,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses=get_spec_block_payload_statuses(spec, block_payload_statuses),
     )
     assert result == "ignore"
     assert reason == "block's parent is invalid and EL result is known"
@@ -402,14 +422,14 @@ def test_gossip_beacon_block__ignore_parent_execution_verified_invalid(spec, sta
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        store,
-        state,
-        signed_child,
-        block_time_ms + 500,
-        block_payload_statuses=block_payload_statuses,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_child,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses=get_spec_block_payload_statuses(spec, block_payload_statuses),
     )
     assert result == "ignore"
     assert reason == "block's parent is valid and EL result is invalid"
@@ -491,14 +511,14 @@ def test_gossip_beacon_block__valid_parent_execution_verified_valid(spec, state)
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        store,
-        state,
-        signed_child,
-        block_time_ms + 500,
-        block_payload_statuses=block_payload_statuses,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_child,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses=get_spec_block_payload_statuses(spec, block_payload_statuses),
     )
     assert result == "valid"
     assert reason is None
@@ -573,14 +593,14 @@ def test_gossip_beacon_block__valid_parent_optimistic(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
+    result, reason = run_validate_gossip(
         spec,
-        seen,
-        store,
-        state,
-        signed_child,
-        block_time_ms + 500,
-        block_payload_statuses=block_payload_statuses,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_child,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses=get_spec_block_payload_statuses(spec, block_payload_statuses),
     )
     assert result == "valid"
     assert reason is None

--- a/tests/core/pyspec/eth_consensus_specs/test/capella/networking/test_gossip_bls_to_execution_change.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/capella/networking/test_gossip_bls_to_execution_change.py
@@ -8,27 +8,8 @@ from eth_consensus_specs.test.helpers.bls_to_execution_changes import (
     get_signed_address_change as get_signed_bls_to_execution_change,
 )
 from eth_consensus_specs.test.helpers.constants import CAPELLA
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
+from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, run_validate_gossip
 from eth_consensus_specs.test.helpers.keys import pubkeys
-
-
-def run_validate_bls_to_execution_change_gossip(
-    spec, seen, state, signed_bls_to_execution_change, current_time_ms
-):
-    """
-    Run validate_bls_to_execution_change_gossip and return the result.
-    Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
-             and reason is the exception message (or None for valid).
-    """
-    try:
-        spec.validate_bls_to_execution_change_gossip(
-            seen, state, signed_bls_to_execution_change, current_time_ms
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 def get_capella_fork_time_ms(spec, state):
@@ -55,8 +36,12 @@ def test_gossip_bls_to_execution_change__valid(spec, state):
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        state=state,
+        signed_bls_to_execution_change=signed_bls_to_execution_change,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -90,8 +75,12 @@ def test_gossip_bls_to_execution_change__ignore_pre_capella(spec, state):
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        state=state,
+        signed_bls_to_execution_change=signed_bls_to_execution_change,
+        current_time_ms=current_time_ms,
     )
     assert result == "ignore"
     assert reason == "current epoch is pre-capella"
@@ -127,8 +116,12 @@ def test_gossip_bls_to_execution_change__ignore_already_seen(spec, state):
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        state=state,
+        signed_bls_to_execution_change=signed_bls_to_execution_change,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -140,8 +133,12 @@ def test_gossip_bls_to_execution_change__ignore_already_seen(spec, state):
         }
     )
 
-    result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        state=state,
+        signed_bls_to_execution_change=signed_bls_to_execution_change,
+        current_time_ms=current_time_ms,
     )
     assert result == "ignore"
     assert reason == "already seen BLS to execution change for this validator"
@@ -175,8 +172,12 @@ def test_gossip_bls_to_execution_change__reject_validator_index_out_of_range(spe
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        state=state,
+        signed_bls_to_execution_change=signed_bls_to_execution_change,
+        current_time_ms=current_time_ms,
     )
     assert result == "reject"
     assert reason == "validator index out of range"
@@ -216,8 +217,12 @@ def test_gossip_bls_to_execution_change__reject_not_bls_credentials(spec, state)
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        state=state,
+        signed_bls_to_execution_change=signed_bls_to_execution_change,
+        current_time_ms=current_time_ms,
     )
     assert result == "reject"
     assert reason == "validator does not have BLS withdrawal credentials"
@@ -258,8 +263,12 @@ def test_gossip_bls_to_execution_change__reject_pubkey_mismatch(spec, state):
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        state=state,
+        signed_bls_to_execution_change=signed_bls_to_execution_change,
+        current_time_ms=current_time_ms,
     )
     assert result == "reject"
     assert reason == "pubkey does not match validator withdrawal credentials"
@@ -296,8 +305,12 @@ def test_gossip_bls_to_execution_change__reject_bad_signature(spec, state):
     yield get_filename(signed_bls_to_execution_change), signed_bls_to_execution_change
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_bls_to_execution_change_gossip(
-        spec, seen, state, signed_bls_to_execution_change, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        state=state,
+        signed_bls_to_execution_change=signed_bls_to_execution_change,
+        current_time_ms=current_time_ms,
     )
     assert result == "reject"
     assert reason == "invalid BLS to execution change signature"

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -9,7 +9,12 @@ from eth_consensus_specs.test.helpers.constants import DENEB, ELECTRA, FULU
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
+from eth_consensus_specs.test.helpers.gossip import (
+    get_filename,
+    get_seen,
+    run_validate_gossip,
+    wrap_genesis_block,
+)
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import transition_to
 
@@ -37,20 +42,6 @@ def create_signed_aggregate_and_proof(spec, state, attestation):
     signature = spec.get_aggregate_and_proof_signature(state, aggregate_and_proof, privkey)
 
     return spec.SignedAggregateAndProof(message=aggregate_and_proof, signature=signature)
-
-
-def run_validate_beacon_aggregate_and_proof_gossip(
-    spec, seen, store, state, signed_aggregate_and_proof, current_time_ms
-):
-    try:
-        spec.validate_beacon_aggregate_and_proof_gossip(
-            seen, store, state, signed_aggregate_and_proof, current_time_ms
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 def build_signed_aggregate_and_proof(spec, state, beacon_block_root):
@@ -114,8 +105,13 @@ def test_gossip_beacon_aggregate_and_proof__accepts_one_millisecond_before_slot_
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -139,8 +135,13 @@ def test_gossip_beacon_aggregate_and_proof__accepts_at_slot_start(spec, state):
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -172,8 +173,13 @@ def test_gossip_beacon_aggregate_and_proof__ignores_first_slot_before_epoch_wind
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "ignore"
     assert reason == "aggregate slot is from a future slot"
@@ -200,8 +206,13 @@ def test_gossip_beacon_aggregate_and_proof__accepts_first_slot_when_epoch_window
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -230,8 +241,13 @@ def test_gossip_beacon_aggregate_and_proof__accepts_first_slot_when_epoch_window
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -260,8 +276,13 @@ def test_gossip_beacon_aggregate_and_proof__ignores_first_slot_after_epoch_windo
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "ignore"
     assert reason == "aggregate epoch is not previous or current epoch"
@@ -298,8 +319,13 @@ def test_gossip_beacon_aggregate_and_proof__accepts_last_slot_one_millisecond_be
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -329,8 +355,13 @@ def test_gossip_beacon_aggregate_and_proof__accepts_last_slot_at_slot_start(spec
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -360,8 +391,13 @@ def test_gossip_beacon_aggregate_and_proof__accepts_last_slot_when_epoch_window_
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -393,8 +429,13 @@ def test_gossip_beacon_aggregate_and_proof__ignores_last_slot_after_epoch_window
     yield "current_time_ms", "meta", int(current_time_ms)
 
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "ignore"
     assert reason == "aggregate epoch is not previous or current epoch"

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_attestation.py
@@ -11,7 +11,12 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
 from eth_consensus_specs.test.helpers.forks import is_post_electra
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
+from eth_consensus_specs.test.helpers.gossip import (
+    get_filename,
+    get_seen,
+    run_validate_gossip,
+    wrap_genesis_block,
+)
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import transition_to
 
@@ -24,20 +29,6 @@ def get_correct_subnet_for_attestation(spec, state, attestation):
     return spec.compute_subnet_for_attestation(
         committees_per_slot, attestation.data.slot, committee_index
     )
-
-
-def run_validate_beacon_attestation_gossip(
-    spec, seen, store, state, attestation, subnet_id, current_time_ms
-):
-    try:
-        spec.validate_beacon_attestation_gossip(
-            seen, store, state, attestation, current_time_ms, subnet_id
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 def build_unaggregated_attestation(spec, state, beacon_block_root):
@@ -110,8 +101,14 @@ def test_gossip_beacon_attestation__accepts_one_millisecond_before_slot_start(sp
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -136,8 +133,14 @@ def test_gossip_beacon_attestation__accepts_at_slot_start(spec, state):
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -168,8 +171,14 @@ def test_gossip_beacon_attestation__ignores_first_slot_before_epoch_window_opens
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "attestation slot is from a future slot"
@@ -201,8 +210,14 @@ def test_gossip_beacon_attestation__accepts_first_slot_when_epoch_window_opens(s
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -230,8 +245,14 @@ def test_gossip_beacon_attestation__accepts_first_slot_when_epoch_window_closes(
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -259,8 +280,14 @@ def test_gossip_beacon_attestation__ignores_first_slot_after_epoch_window_closes
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "attestation epoch is not previous or current epoch"
@@ -298,8 +325,14 @@ def test_gossip_beacon_attestation__accepts_last_slot_one_millisecond_before_slo
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -328,8 +361,14 @@ def test_gossip_beacon_attestation__accepts_last_slot_at_slot_start(spec, state)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -358,8 +397,14 @@ def test_gossip_beacon_attestation__accepts_last_slot_when_epoch_window_closes(s
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -388,8 +433,14 @@ def test_gossip_beacon_attestation__ignores_last_slot_after_epoch_window_closes(
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
     seen = get_seen(spec)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "attestation epoch is not previous or current epoch"

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_block.py
@@ -16,7 +16,7 @@ from eth_consensus_specs.test.helpers.fork_choice import (
 from eth_consensus_specs.test.helpers.gossip import (
     get_filename,
     get_seen,
-    run_validate_beacon_block_gossip,
+    run_validate_gossip,
     wrap_genesis_block,
 )
 from eth_consensus_specs.test.helpers.state import (
@@ -51,8 +51,14 @@ def test_gossip_beacon_block__valid_with_blob_kzg_commitments(spec, state):
     block_time_ms = spec.compute_time_at_slot_ms(state, signed_block.message.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses={},
     )
     assert result == "valid"
     assert reason is None
@@ -93,8 +99,14 @@ def test_gossip_beacon_block__reject_too_many_kzg_commitments(spec, state):
     block_time_ms = spec.compute_time_at_slot_ms(state, block.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses={},
     )
     assert result == "reject"
     assert reason == "too many blob kzg commitments"

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_blob_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_blob_sidecar.py
@@ -14,7 +14,12 @@ from eth_consensus_specs.test.helpers.execution_payload import (
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
+from eth_consensus_specs.test.helpers.gossip import (
+    get_filename,
+    get_seen,
+    run_validate_gossip,
+    wrap_genesis_block,
+)
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
     state_transition_and_sign_block,
@@ -40,20 +45,6 @@ def setup_store_with_anchor(spec, state):
     """Return a store seeded with the genesis anchor block."""
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     return store, anchor_block
-
-
-def run_validate_blob_sidecar_gossip(
-    spec, seen, store, state, blob_sidecar, subnet_id, current_time_ms
-):
-    try:
-        spec.validate_blob_sidecar_gossip(
-            seen, store, state, blob_sidecar, current_time_ms, subnet_id
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 def correct_subnet(spec, blob_sidecar):
@@ -99,8 +90,14 @@ def test_gossip_blob_sidecar__valid(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -146,8 +143,14 @@ def test_gossip_blob_sidecar__reject_index_out_of_range(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = spec.SubnetID(0)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "blob index out of range"
@@ -194,8 +197,14 @@ def test_gossip_blob_sidecar__reject_wrong_subnet(spec, state):
 
     expected_subnet = correct_subnet(spec, blob_sidecar)
     wrong_subnet = spec.SubnetID((int(expected_subnet) + 1) % spec.config.BLOB_SIDECAR_SUBNET_COUNT)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, wrong_subnet, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=wrong_subnet,
     )
     assert result == "reject"
     assert reason == "blob sidecar is for wrong subnet"
@@ -244,8 +253,14 @@ def test_gossip_blob_sidecar__reject_invalid_proposer_signature(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid proposer signature on blob sidecar block header"
@@ -295,8 +310,14 @@ def test_gossip_blob_sidecar__reject_invalid_inclusion_proof(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid blob sidecar inclusion proof"
@@ -344,8 +365,14 @@ def test_gossip_blob_sidecar__reject_invalid_kzg_proof(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid blob kzg proof"
@@ -392,8 +419,14 @@ def test_gossip_blob_sidecar__ignore_future_slot(spec, state):
     yield "current_time_ms", "meta", int(current_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "blob sidecar is from a future slot"
@@ -440,8 +473,14 @@ def test_gossip_blob_sidecar__valid_slot_within_clock_disparity(spec, state):
     yield "current_time_ms", "meta", int(current_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -500,8 +539,14 @@ def test_gossip_blob_sidecar__ignore_not_later_than_finalized_slot(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "blob sidecar is not from a slot greater than the latest finalized slot"
@@ -550,8 +595,14 @@ def test_gossip_blob_sidecar__reject_proposer_index_out_of_range(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "proposer index out of range"
@@ -601,8 +652,14 @@ def test_gossip_blob_sidecar__ignore_parent_not_seen(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "blob sidecar's parent has not been seen"
@@ -669,8 +726,14 @@ def test_gossip_blob_sidecar__reject_parent_failed_validation(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "blob sidecar's parent failed validation"
@@ -722,8 +785,14 @@ def test_gossip_blob_sidecar__ignore_already_seen_tuple(spec, state):
     subnet_id = correct_subnet(spec, blob_sidecar)
 
     # First delivery passes.
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     messages.append(
@@ -736,8 +805,14 @@ def test_gossip_blob_sidecar__ignore_already_seen_tuple(spec, state):
     )
 
     # Second delivery of the same sidecar is ignored.
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 600,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "already seen blob sidecar from this proposer for this slot and index"
@@ -803,8 +878,14 @@ def test_gossip_blob_sidecar__reject_slot_not_higher_than_parent(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "blob sidecar is not from a higher slot than its parent"
@@ -857,8 +938,14 @@ def test_gossip_blob_sidecar__reject_non_ancestor_finalized_checkpoint(spec, sta
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "finalized checkpoint is not an ancestor of blob sidecar's block"
@@ -909,8 +996,14 @@ def test_gossip_blob_sidecar__reject_wrong_proposer_index(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, blob_sidecar)
-    result, reason = run_validate_blob_sidecar_gossip(
-        spec, seen, store, state, blob_sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        blob_sidecar=blob_sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "blob sidecar proposer_index does not match expected proposer"

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_voluntary_exit.py
@@ -4,7 +4,7 @@ from eth_consensus_specs.test.context import (
     with_phases,
 )
 from eth_consensus_specs.test.helpers.constants import DENEB, ELECTRA, FULU
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
+from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, run_validate_gossip
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.voluntary_exits import (
     sign_voluntary_exit,
@@ -18,16 +18,6 @@ def create_signed_voluntary_exit(spec, state, validator_index, epoch=None, fork_
     return sign_voluntary_exit(
         spec, state, voluntary_exit, privkeys[validator_index], fork_version=fork_version
     )
-
-
-def run_validate_voluntary_exit_gossip(spec, seen, state, signed_voluntary_exit):
-    try:
-        spec.validate_voluntary_exit_gossip(seen, state, signed_voluntary_exit)
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 @with_phases([DENEB, ELECTRA, FULU])
@@ -46,7 +36,9 @@ def test_gossip_voluntary_exit__valid_capella_signature(spec, state):
     signed_exit = create_signed_voluntary_exit(spec, state, validator_index=0)
     yield get_filename(signed_exit), signed_exit
 
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "valid"
     assert reason is None
 
@@ -73,7 +65,9 @@ def test_gossip_voluntary_exit__reject_deneb_signature(spec, state):
     )
     yield get_filename(signed_exit), signed_exit
 
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "reject"
     assert reason == "invalid voluntary exit signature"
 

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -10,7 +10,12 @@ from eth_consensus_specs.test.helpers.constants import ELECTRA, FULU, MINIMAL
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
+from eth_consensus_specs.test.helpers.gossip import (
+    get_filename,
+    get_seen,
+    run_validate_gossip,
+    wrap_genesis_block,
+)
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import next_slot
 
@@ -37,20 +42,6 @@ def create_signed_aggregate_and_proof(spec, state, attestation):
     signature = spec.get_aggregate_and_proof_signature(state, aggregate_and_proof, privkey)
 
     return spec.SignedAggregateAndProof(message=aggregate_and_proof, signature=signature)
-
-
-def run_validate_beacon_aggregate_and_proof_gossip(
-    spec, seen, store, state, signed_aggregate_and_proof, current_time_ms
-):
-    try:
-        spec.validate_beacon_aggregate_and_proof_gossip(
-            seen, store, state, signed_aggregate_and_proof, current_time_ms
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 def prepare_signed_aggregate(spec, state):
@@ -116,15 +107,25 @@ def test_gossip_beacon_aggregate_and_proof__accept_same_data_for_disjoint_commit
     block_time_ms = spec.compute_time_at_slot_ms(state, attestation_1.data.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg_1, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg_1,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "valid"
     assert reason is None
     messages.append({"offset_ms": 500, "message": get_filename(signed_agg_1), "expected": "valid"})
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg_2, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg_2,
+        current_time_ms=block_time_ms + 600,
     )
     assert result == "valid"
     assert reason is None
@@ -156,8 +157,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_nonzero_data_index(spec, stat
     block_time_ms = spec.compute_time_at_slot_ms(state, signed_agg.message.aggregate.data.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "aggregate data index is non-zero"
@@ -199,8 +205,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_zero_committees(spec, state):
     block_time_ms = spec.compute_time_at_slot_ms(state, signed_agg.message.aggregate.data.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "aggregate committee bits must specify exactly one committee"
@@ -248,8 +259,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_multiple_committees(spec, sta
     block_time_ms = spec.compute_time_at_slot_ms(state, signed_agg.message.aggregate.data.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "aggregate committee bits must specify exactly one committee"

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_attestation.py
@@ -10,7 +10,12 @@ from eth_consensus_specs.test.helpers.constants import ELECTRA, FULU
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
+from eth_consensus_specs.test.helpers.gossip import (
+    get_filename,
+    get_seen,
+    run_validate_gossip,
+    wrap_genesis_block,
+)
 from eth_consensus_specs.test.helpers.state import next_slot
 
 
@@ -19,20 +24,6 @@ def get_correct_subnet(spec, state, attestation):
     return spec.compute_subnet_for_attestation(
         committees_per_slot, attestation.data.slot, attestation.committee_index
     )
-
-
-def run_validate_beacon_attestation_gossip(
-    spec, seen, store, state, attestation, subnet_id, current_time_ms
-):
-    try:
-        spec.validate_beacon_attestation_gossip(
-            seen, store, state, attestation, current_time_ms, subnet_id
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 def prepare_single_attestation(spec, state):
@@ -69,8 +60,14 @@ def test_gossip_beacon_attestation__reject_nonzero_data_index(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "attestation data index is non-zero"
@@ -120,8 +117,14 @@ def test_gossip_beacon_attestation__reject_attester_not_in_committee(spec, state
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "attester is not a member of the committee"

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_beacon_block.py
@@ -17,7 +17,7 @@ from eth_consensus_specs.test.helpers.fork_choice import (
 from eth_consensus_specs.test.helpers.gossip import (
     get_filename,
     get_seen,
-    run_validate_beacon_block_gossip,
+    run_validate_gossip,
     wrap_genesis_block,
 )
 from eth_consensus_specs.test.helpers.state import (
@@ -63,8 +63,14 @@ def test_gossip_beacon_block__valid_at_blob_parameters_limit(spec, state):
     block_time_ms = spec.compute_time_at_slot_ms(state, signed_block.message.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        block_payload_statuses={},
     )
     assert result == "valid"
     assert reason is None

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_data_column_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_data_column_sidecar.py
@@ -21,7 +21,7 @@ from eth_consensus_specs.test.helpers.fork_choice import (
 from eth_consensus_specs.test.helpers.gossip import (
     get_filename,
     get_seen,
-    run_validate_data_column_sidecar_gossip,
+    run_validate_gossip,
     wrap_genesis_block,
 )
 from eth_consensus_specs.test.helpers.keys import privkeys
@@ -97,8 +97,14 @@ def test_gossip_data_column_sidecar__valid(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -142,8 +148,14 @@ def test_gossip_data_column_sidecar__reject_index_out_of_range(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = spec.SubnetID(0)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid sidecar"
@@ -192,8 +204,14 @@ def test_gossip_data_column_sidecar__reject_too_many_commitments(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid sidecar"
@@ -240,8 +258,14 @@ def test_gossip_data_column_sidecar__reject_wrong_subnet(spec, state):
     wrong_subnet = spec.SubnetID(
         (int(expected_subnet) + 1) % spec.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT
     )
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, wrong_subnet, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=wrong_subnet,
     )
     assert result == "reject"
     assert reason == "sidecar is for wrong subnet"
@@ -286,8 +310,14 @@ def test_gossip_data_column_sidecar__ignore_future_slot(spec, state):
     yield "current_time_ms", "meta", int(current_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "sidecar is from a future slot"
@@ -332,8 +362,14 @@ def test_gossip_data_column_sidecar__valid_slot_within_clock_disparity(spec, sta
     yield "current_time_ms", "meta", int(current_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -392,8 +428,14 @@ def test_gossip_data_column_sidecar__ignore_not_later_than_finalized_slot(spec, 
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "sidecar is not from a slot greater than the latest finalized slot"
@@ -438,8 +480,14 @@ def test_gossip_data_column_sidecar__reject_proposer_index_out_of_range(spec, st
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "proposer index out of range"
@@ -485,8 +533,14 @@ def test_gossip_data_column_sidecar__reject_invalid_proposer_signature(spec, sta
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid proposer signature on sidecar block header"
@@ -534,8 +588,14 @@ def test_gossip_data_column_sidecar__ignore_parent_not_seen(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "sidecar's parent has not been seen"
@@ -600,8 +660,14 @@ def test_gossip_data_column_sidecar__reject_parent_failed_validation(spec, state
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "sidecar's parent failed validation"
@@ -666,8 +732,14 @@ def test_gossip_data_column_sidecar__reject_slot_not_higher_than_parent(spec, st
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "sidecar is not from a higher slot than its parent"
@@ -718,8 +790,14 @@ def test_gossip_data_column_sidecar__reject_non_ancestor_finalized_checkpoint(sp
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "finalized checkpoint is not an ancestor of sidecar's block"
@@ -765,8 +843,14 @@ def test_gossip_data_column_sidecar__reject_invalid_inclusion_proof(spec, state)
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid sidecar inclusion proof"
@@ -814,8 +898,14 @@ def test_gossip_data_column_sidecar__reject_invalid_kzg_proofs(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid sidecar kzg proofs"
@@ -865,8 +955,14 @@ def test_gossip_data_column_sidecar__ignore_already_seen_tuple(spec, state):
     subnet_id = correct_subnet(spec, sidecar)
 
     # First delivery passes.
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     messages.append(
@@ -879,8 +975,14 @@ def test_gossip_data_column_sidecar__ignore_already_seen_tuple(spec, state):
     )
 
     # Second delivery of the same sidecar is ignored.
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 600,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "already seen sidecar from this proposer for this slot and index"
@@ -926,8 +1028,14 @@ def test_gossip_data_column_sidecar__reject_wrong_proposer_index(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = correct_subnet(spec, sidecar)
-    result, reason = run_validate_data_column_sidecar_gossip(
-        spec, seen, store, state, sidecar, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=sidecar,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "sidecar proposer_index does not match expected proposer"

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_partial_data_column_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_partial_data_column_sidecar.py
@@ -21,7 +21,7 @@ from eth_consensus_specs.test.helpers.fork_choice import (
 from eth_consensus_specs.test.helpers.gossip import (
     get_filename,
     get_seen,
-    run_validate_partial_data_column_sidecar_gossip,
+    run_validate_gossip,
     wrap_genesis_block,
 )
 from eth_consensus_specs.test.helpers.keys import privkeys
@@ -120,8 +120,15 @@ def test_gossip_partial_data_column_sidecar__valid_header_only(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "valid"
     assert reason is None
@@ -177,8 +184,15 @@ def test_gossip_partial_data_column_sidecar__valid_header_and_cells(spec, state)
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "valid"
     assert reason is None
@@ -231,8 +245,15 @@ def test_gossip_partial_data_column_sidecar__valid_cells_only_with_cached_header
     column_index = sidecar.index
 
     messages = []
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, header_msg, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=header_msg,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "valid"
     messages.append(
@@ -245,8 +266,15 @@ def test_gossip_partial_data_column_sidecar__valid_cells_only_with_cached_header
         }
     )
 
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, cells_msg, block_root, column_index, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=cells_msg,
+        current_time_ms=block_time_ms + 600,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "valid"
     assert reason is None
@@ -289,8 +317,15 @@ def test_gossip_partial_data_column_sidecar__reject_semantically_empty(spec, sta
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "partial message is semantically empty"
@@ -339,8 +374,15 @@ def test_gossip_partial_data_column_sidecar__reject_cell_count_mismatch(spec, st
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "number of cells does not match number of set bits"
@@ -389,8 +431,15 @@ def test_gossip_partial_data_column_sidecar__reject_proof_count_mismatch(spec, s
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "number of proofs does not match number of set bits"
@@ -448,8 +497,15 @@ def test_gossip_partial_data_column_sidecar__reject_prior_header_differs(spec, s
     column_index = sidecar.index
 
     messages = []
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, good, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=good,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "valid"
     messages.append(
@@ -462,8 +518,15 @@ def test_gossip_partial_data_column_sidecar__reject_prior_header_differs(spec, s
         }
     )
 
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, diverging, block_root, column_index, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=diverging,
+        current_time_ms=block_time_ms + 600,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "header differs from previously validated header"
@@ -507,8 +570,15 @@ def test_gossip_partial_data_column_sidecar__reject_block_root_mismatch(spec, st
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "header's block root does not match partial message group id"
@@ -556,8 +626,15 @@ def test_gossip_partial_data_column_sidecar__reject_empty_commitments(spec, stat
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "header's kzg_commitments is empty"
@@ -605,8 +682,15 @@ def test_gossip_partial_data_column_sidecar__ignore_future_slot(spec, state):
     yield "current_time_ms", "meta", int(current_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=current_time_ms,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "ignore"
     assert reason == "header is from a future slot"
@@ -666,8 +750,15 @@ def test_gossip_partial_data_column_sidecar__ignore_not_later_than_finalized_slo
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "ignore"
     assert reason == "header is not from a slot greater than the latest finalized slot"
@@ -717,8 +808,15 @@ def test_gossip_partial_data_column_sidecar__reject_proposer_index_out_of_range(
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "proposer index out of range"
@@ -767,8 +865,15 @@ def test_gossip_partial_data_column_sidecar__reject_invalid_proposer_signature(s
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "invalid proposer signature on header"
@@ -817,8 +922,15 @@ def test_gossip_partial_data_column_sidecar__ignore_parent_not_seen(spec, state)
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "ignore"
     assert reason == "header's parent has not been seen"
@@ -881,8 +993,15 @@ def test_gossip_partial_data_column_sidecar__reject_parent_failed_validation(spe
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "header's parent failed validation"
@@ -949,8 +1068,15 @@ def test_gossip_partial_data_column_sidecar__reject_slot_not_higher_than_parent(
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "header is not from a higher slot than its parent"
@@ -1004,8 +1130,15 @@ def test_gossip_partial_data_column_sidecar__reject_non_ancestor_finalized_check
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "finalized checkpoint is not an ancestor of header's block"
@@ -1055,8 +1188,15 @@ def test_gossip_partial_data_column_sidecar__reject_invalid_inclusion_proof(spec
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "invalid header inclusion proof"
@@ -1108,8 +1248,15 @@ def test_gossip_partial_data_column_sidecar__reject_wrong_proposer_index(spec, s
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "header proposer_index does not match expected proposer"
@@ -1156,8 +1303,15 @@ def test_gossip_partial_data_column_sidecar__ignore_cells_without_cached_header(
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "ignore"
     assert reason == "valid corresponding header has not been seen"
@@ -1211,14 +1365,28 @@ def test_gossip_partial_data_column_sidecar__ignore_cells_with_cached_header_fut
 
     column_index = sidecar.index
 
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, header_msg, block_root, column_index, current_time_ms + 1
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=header_msg,
+        current_time_ms=current_time_ms + 1,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "valid"
     assert reason is None
 
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, cells_msg, block_root, column_index, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=cells_msg,
+        current_time_ms=current_time_ms,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "ignore"
     assert reason == "corresponding header is from a future slot"
@@ -1304,8 +1472,15 @@ def test_gossip_partial_data_column_sidecar__ignore_cells_with_cached_header_not
     )
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, cells_msg, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=cells_msg,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "ignore"
     assert (
@@ -1366,8 +1541,15 @@ def test_gossip_partial_data_column_sidecar__reject_bitmap_length_mismatch(spec,
     column_index = sidecar.index
 
     messages = []
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, header_msg, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=header_msg,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "valid"
     messages.append(
@@ -1380,8 +1562,15 @@ def test_gossip_partial_data_column_sidecar__reject_bitmap_length_mismatch(spec,
         }
     )
 
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, cells_msg, block_root, column_index, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=cells_msg,
+        current_time_ms=block_time_ms + 600,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "bitmap length does not match commitments length"
@@ -1429,8 +1618,15 @@ def test_gossip_partial_data_column_sidecar__reject_invalid_kzg_proofs(spec, sta
     yield "current_time_ms", "meta", int(block_time_ms)
 
     column_index = sidecar.index
-    result, reason = run_validate_partial_data_column_sidecar_gossip(
-        spec, seen, store, state, partial, block_root, column_index, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        sidecar=partial,
+        current_time_ms=block_time_ms + 500,
+        block_root=block_root,
+        column_index=column_index,
     )
     assert result == "reject"
     assert reason == "invalid sidecar kzg proofs"

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gossip.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gossip.py
@@ -1,13 +1,7 @@
-from eth_utils import encode_hex
+import inspect
+from typing import get_origin, get_type_hints
 
-from eth_consensus_specs.test.helpers.forks import (
-    is_post_altair,
-    is_post_bellatrix,
-    is_post_capella,
-    is_post_deneb,
-    is_post_fulu,
-    is_post_gloas,
-)
+from eth_utils import encode_hex
 
 PAYLOAD_STATUS_VALID = "VALID"
 PAYLOAD_STATUS_INVALIDATED = "INVALIDATED"
@@ -33,61 +27,103 @@ def get_spec_block_payload_statuses(spec, block_payload_statuses):
     return spec_block_payload_statuses
 
 
-def run_validate_beacon_block_gossip(
-    spec, seen, store, state, signed_block, current_time_ms, block_payload_statuses=None
-):
-    """
-    Run validate_beacon_block_gossip and return the result.
-    Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
-             and reason is the exception message (or None for valid).
-    """
-    kwargs = {}
-    if is_post_bellatrix(spec):
-        kwargs["block_payload_statuses"] = get_spec_block_payload_statuses(
-            spec, block_payload_statuses or {}
-        )
+_MESSAGE_INFO = {
+    ###########################################################################
+    # phase0
+    ###########################################################################
+    "Attestation": {
+        "file_prefix": "attestation",
+        "validation_fn": "validate_beacon_attestation_gossip",
+    },
+    "AttesterSlashing": {
+        "file_prefix": "attester_slashing",
+        "validation_fn": "validate_attester_slashing_gossip",
+    },
+    "ProposerSlashing": {
+        "file_prefix": "proposer_slashing",
+        "validation_fn": "validate_proposer_slashing_gossip",
+    },
+    "SignedAggregateAndProof": {
+        "file_prefix": "aggregate",
+        "validation_fn": "validate_beacon_aggregate_and_proof_gossip",
+    },
+    "SignedBeaconBlock": {
+        "file_prefix": "block",
+        "validation_fn": "validate_beacon_block_gossip",
+    },
+    "SignedVoluntaryExit": {
+        "file_prefix": "voluntary_exit",
+        "validation_fn": "validate_voluntary_exit_gossip",
+    },
+    "SingleAttestation": {
+        "file_prefix": "single_attestation",
+        "validation_fn": "validate_beacon_attestation_gossip",
+    },
+    ###########################################################################
+    # altair
+    ###########################################################################
+    "SignedContributionAndProof": {
+        "file_prefix": "contribution",
+        "validation_fn": "validate_sync_committee_contribution_and_proof_gossip",
+    },
+    "SyncCommitteeMessage": {
+        "file_prefix": "sync_committee_message",
+        "validation_fn": "validate_sync_committee_message_gossip",
+    },
+    ###########################################################################
+    # capella
+    ###########################################################################
+    "SignedBLSToExecutionChange": {
+        "file_prefix": "bls_to_execution_change",
+        "validation_fn": "validate_bls_to_execution_change_gossip",
+    },
+    ###########################################################################
+    # deneb
+    ###########################################################################
+    "BlobSidecar": {
+        "file_prefix": "blob_sidecar",
+        "validation_fn": "validate_blob_sidecar_gossip",
+    },
+    ###########################################################################
+    # fulu
+    ###########################################################################
+    "DataColumnSidecar": {
+        "file_prefix": "data_column_sidecar",
+        "validation_fn": "validate_data_column_sidecar_gossip",
+    },
+    "PartialDataColumnHeader": {
+        "file_prefix": "partial_data_column_header",
+        "validation_fn": None,
+    },
+    "PartialDataColumnSidecar": {
+        "file_prefix": "partial_data_column_sidecar",
+        "validation_fn": "validate_partial_data_column_sidecar_gossip",
+    },
+}
+
+
+def get_filename(obj):
+    """Get a filename for an SSZ object based on its type."""
+    class_name = obj.__class__.__name__
+    info = _MESSAGE_INFO.get(class_name)
+    if info is None:
+        raise Exception(f"unsupported type: {class_name}")
+    return f"{info['file_prefix']}_{encode_hex(obj.hash_tree_root())}"
+
+
+def run_validate_gossip(spec, **kwargs):
+    """Dispatch to the appropriate gossip validation function based on the message's type."""
+    matches = [v for v in kwargs.values() if type(v).__name__ in _MESSAGE_INFO]
+    assert len(matches) == 1, f"expected exactly one gossip message kwarg, got {len(matches)}"
+    func_name = _MESSAGE_INFO[type(matches[0]).__name__]["validation_fn"]
+    if func_name is None:
+        raise Exception(f"unsupported gossip message type: {type(matches[0]).__name__}")
+    spec_func = getattr(spec, func_name)
+    extras = set(kwargs) - set(inspect.signature(spec_func).parameters)
+    assert not extras, f"unexpected kwargs for {func_name}: {sorted(extras)}"
+
     try:
-        spec.validate_beacon_block_gossip(
-            seen, store, state, signed_block, current_time_ms, **kwargs
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
-
-
-def run_validate_data_column_sidecar_gossip(
-    spec, seen, store, state, sidecar, subnet_id, current_time_ms
-):
-    """
-    Run validate_data_column_sidecar_gossip and return the result.
-    Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
-             and reason is the exception message (or None for valid).
-    """
-    try:
-        spec.validate_data_column_sidecar_gossip(
-            seen, store, state, sidecar, current_time_ms, subnet_id
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
-
-
-def run_validate_partial_data_column_sidecar_gossip(
-    spec, seen, store, state, sidecar, block_root, column_index, current_time_ms
-):
-    """
-    Run validate_partial_data_column_sidecar_gossip and return the result.
-    Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
-             and reason is the exception message (or None for valid).
-    """
-    try:
-        spec.validate_partial_data_column_sidecar_gossip(
-            seen, store, state, sidecar, block_root, column_index, current_time_ms
-        )
+        spec_func(**kwargs)
         return "valid", None
     except spec.GossipIgnore as e:
         return "ignore", str(e)
@@ -96,89 +132,5 @@ def run_validate_partial_data_column_sidecar_gossip(
 
 
 def get_seen(spec):
-    """Create an empty Seen object for gossip validation."""
-    kwargs = {
-        "proposer_slots": set(),
-        "aggregator_epochs": set(),
-        "aggregate_data_roots": {},
-        "voluntary_exit_indices": set(),
-        "proposer_slashing_indices": set(),
-        "attester_slashing_indices": set(),
-        "attestation_validator_epochs": set(),
-    }
-    if is_post_altair(spec):
-        kwargs.update(
-            {
-                "sync_contribution_aggregator_slots": set(),
-                "sync_contribution_data": {},
-                "sync_message_validator_slots": set(),
-            }
-        )
-    if is_post_capella(spec):
-        kwargs.update(
-            {
-                "bls_to_execution_change_indices": set(),
-            }
-        )
-    if is_post_deneb(spec) and not is_post_fulu(spec):
-        kwargs.update(
-            {
-                "blob_sidecar_tuples": set(),
-            }
-        )
-    if is_post_fulu(spec):
-        kwargs.update(
-            {
-                "data_column_sidecar_tuples": set(),
-            }
-        )
-        if not is_post_gloas(spec):
-            kwargs.update(
-                {
-                    "partial_data_column_headers": {},
-                }
-            )
-    return spec.Seen(**kwargs)
-
-
-def get_filename(obj):
-    """Get a filename for an SSZ object based on its type."""
-    class_name = obj.__class__.__name__
-
-    # phase0
-    if "BeaconBlock" in class_name:
-        prefix = "block"
-    elif class_name == "Attestation":
-        prefix = "attestation"
-    elif class_name == "SingleAttestation":
-        prefix = "single_attestation"
-    elif "AggregateAndProof" in class_name:
-        prefix = "aggregate"
-    elif class_name == "ProposerSlashing":
-        prefix = "proposer_slashing"
-    elif class_name == "AttesterSlashing":
-        prefix = "attester_slashing"
-    elif "VoluntaryExit" in class_name:
-        prefix = "voluntary_exit"
-    # altair
-    elif "ContributionAndProof" in class_name:
-        prefix = "contribution"
-    elif class_name == "SyncCommitteeMessage":
-        prefix = "sync_committee_message"
-    # capella
-    elif "BLSToExecutionChange" in class_name:
-        prefix = "bls_to_execution_change"
-    # deneb
-    elif class_name == "BlobSidecar":
-        prefix = "blob_sidecar"
-    # fulu
-    elif class_name == "DataColumnSidecar":
-        prefix = "data_column_sidecar"
-    elif class_name == "PartialDataColumnHeader":
-        prefix = "partial_data_column_header"
-    elif class_name == "PartialDataColumnSidecar":
-        prefix = "partial_data_column_sidecar"
-    else:
-        raise Exception(f"unsupported type: {class_name}")
-
-    return f"{prefix}_{encode_hex(obj.hash_tree_root())}"
+    """Create an empty Seen object by instantiating each annotated field's container type."""
+    return spec.Seen(**{name: get_origin(t)() for name, t in get_type_hints(spec.Seen).items()})

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_attester_slashing.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_attester_slashing.py
@@ -6,22 +6,7 @@ from eth_consensus_specs.test.context import (
 from eth_consensus_specs.test.helpers.attester_slashings import (
     get_valid_attester_slashing,
 )
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
-
-
-def run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing):
-    """
-    Run validate_attester_slashing_gossip and return the result.
-    Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
-             and reason is the exception message (or None for valid).
-    """
-    try:
-        spec.validate_attester_slashing_gossip(seen, state, attester_slashing)
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
+from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, run_validate_gossip
 
 
 @with_all_phases
@@ -40,7 +25,9 @@ def test_gossip_attester_slashing__valid(spec, state):
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "valid"
     assert reason is None
 
@@ -69,13 +56,17 @@ def test_gossip_attester_slashing__ignore_already_seen(spec, state):
     yield get_filename(attester_slashing), attester_slashing
 
     # First validation should pass
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "valid"
     assert reason is None
     messages.append({"message": get_filename(attester_slashing), "expected": "valid"})
 
     # Second validation should be ignored (all indices already seen)
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "ignore"
     assert reason == "all attester slashing indices already seen"
     messages.append(
@@ -108,7 +99,9 @@ def test_gossip_attester_slashing__reject_not_slashable_data(spec, state):
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "reject"
     assert reason == "attestation data is not slashable"
 
@@ -142,7 +135,9 @@ def test_gossip_attester_slashing__reject_invalid_attestation_1(spec, state):
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "reject"
     assert reason == "invalid indexed attestation 1"
 
@@ -176,7 +171,9 @@ def test_gossip_attester_slashing__reject_invalid_attestation_2(spec, state):
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "reject"
     assert reason == "invalid indexed attestation 2"
 
@@ -212,7 +209,9 @@ def test_gossip_attester_slashing__reject_attesting_index_out_of_range_1(spec, s
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "reject"
     assert reason == "validator index out of range in indexed attestation 1"
 
@@ -248,7 +247,9 @@ def test_gossip_attester_slashing__reject_attesting_index_out_of_range_2(spec, s
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "reject"
     assert reason == "validator index out of range in indexed attestation 2"
 
@@ -281,7 +282,9 @@ def test_gossip_attester_slashing__ignore_empty_attesting_indices_1(spec, state)
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "ignore"
     assert reason == "all attester slashing indices already seen"
 
@@ -314,7 +317,9 @@ def test_gossip_attester_slashing__ignore_empty_attesting_indices_2(spec, state)
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "ignore"
     assert reason == "all attester slashing indices already seen"
 
@@ -355,7 +360,9 @@ def test_gossip_attester_slashing__reject_unsorted_indices_1(spec, state):
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "reject"
     assert reason == "invalid indexed attestation 1"
 
@@ -391,7 +398,9 @@ def test_gossip_attester_slashing__reject_unsorted_indices_2(spec, state):
 
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "reject"
     assert reason == "invalid indexed attestation 2"
 
@@ -431,7 +440,9 @@ def test_gossip_attester_slashing__reject_no_slashable_validators(spec, state):
     yield "state", state
     yield get_filename(attester_slashing), attester_slashing
 
-    result, reason = run_validate_attester_slashing_gossip(spec, seen, state, attester_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, attester_slashing=attester_slashing
+    )
     assert result == "reject"
     assert reason == "no slashable validators in intersection"
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -29,7 +29,12 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
 from eth_consensus_specs.test.helpers.forks import is_post_electra
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
+from eth_consensus_specs.test.helpers.gossip import (
+    get_filename,
+    get_seen,
+    run_validate_gossip,
+    wrap_genesis_block,
+)
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
@@ -77,25 +82,6 @@ def create_signed_aggregate_and_proof(spec, state, attestation, aggregator_index
     )
 
 
-def run_validate_beacon_aggregate_and_proof_gossip(
-    spec, seen, store, state, signed_aggregate_and_proof, current_time_ms
-):
-    """
-    Run validate_beacon_aggregate_and_proof_gossip and return the result.
-    Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
-             and reason is the exception message (or None for valid).
-    """
-    try:
-        spec.validate_beacon_aggregate_and_proof_gossip(
-            seen, store, state, signed_aggregate_and_proof, current_time_ms
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
-
-
 @with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA, FULU])
 @spec_state_test
 def test_gossip_beacon_aggregate_and_proof__valid(spec, state):
@@ -124,8 +110,13 @@ def test_gossip_beacon_aggregate_and_proof__valid(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "valid"
     assert reason is None
@@ -179,8 +170,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_committee_index_out_of_range(
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "committee index out of range"
@@ -229,8 +225,13 @@ def test_gossip_beacon_aggregate_and_proof__ignore_slot_not_within_range(spec, s
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "ignore"
     assert reason == "attestation slot not within propagation range"
@@ -279,8 +280,13 @@ def test_gossip_beacon_aggregate_and_proof__valid_within_clock_disparity(spec, s
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
@@ -329,8 +335,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_epoch_mismatch(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "attestation epoch does not match target epoch"
@@ -379,15 +390,25 @@ def test_gossip_beacon_aggregate_and_proof__ignore_already_seen_aggregate(spec, 
     yield "current_time_ms", "meta", int(block_time_ms)
 
     # First validation should pass
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "valid"
     messages.append({"offset_ms": 500, "message": get_filename(signed_agg), "expected": "valid"})
 
     # Second validation should be ignored (already seen aggregate data)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 600,
     )
     assert result == "ignore"
     assert reason == "already seen aggregate for this data"
@@ -440,8 +461,13 @@ def test_gossip_beacon_aggregate_and_proof__ignore_same_data_root_without_supers
     yield "current_time_ms", "meta", int(block_time_ms)
 
     # First validation should pass and seed dedup state.
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg_1, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg_1,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "valid"
     assert reason is None
@@ -490,8 +516,13 @@ def test_gossip_beacon_aggregate_and_proof__ignore_same_data_root_without_supers
 
     # Dedup should not trigger here; the ignore result is from the aggregator
     # uniqueness rule because aggregator/epoch are unchanged.
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg_2, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg_2,
+        current_time_ms=block_time_ms + 600,
     )
     assert result == "ignore"
     assert reason == "already seen aggregate from this aggregator for this epoch"
@@ -573,16 +604,26 @@ def test_gossip_beacon_aggregate_and_proof__valid_two_aggregators_same_data(spec
     yield "current_time_ms", "meta", int(block_time_ms)
 
     # First aggregate should pass
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg_1, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg_1,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "valid"
     assert reason is None
     messages.append({"offset_ms": 500, "message": get_filename(signed_agg_1), "expected": "valid"})
 
     # Second aggregate (different aggregator, same data root) should also pass
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg_2, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg_2,
+        current_time_ms=block_time_ms + 600,
     )
     assert result == "valid"
     assert reason is None
@@ -625,8 +666,13 @@ def test_gossip_beacon_aggregate_and_proof__ignore_block_not_seen(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "ignore"
     assert reason == "block being voted for has not been seen"
@@ -682,8 +728,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_aggregation_bits_size_mismatc
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "aggregation bits length does not match committee size"
@@ -737,8 +788,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_no_participants(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "aggregate has no participants"
@@ -787,8 +843,13 @@ def test_gossip_beacon_aggregate_and_proof__ignore_already_seen_aggregator(spec,
     yield "current_time_ms", "meta", int(block_time_ms)
 
     # First validation should pass
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg1, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg1,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "valid"
     messages.append({"offset_ms": 500, "message": get_filename(signed_agg1), "expected": "valid"})
@@ -803,8 +864,13 @@ def test_gossip_beacon_aggregate_and_proof__ignore_already_seen_aggregator(spec,
     yield get_filename(signed_agg2), signed_agg2
 
     # Second validation should be ignored (same aggregator, same epoch)
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg2, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg2,
+        current_time_ms=block_time_ms + 600,
     )
     assert result == "ignore"
     assert reason == "already seen aggregate from this aggregator for this epoch"
@@ -889,8 +955,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_not_aggregator(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "validator is not selected as aggregator"
@@ -948,8 +1019,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_aggregator_not_in_committee(s
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "aggregator index not in committee"
@@ -998,8 +1074,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_aggregator_index_out_of_range
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "aggregator index not in committee"
@@ -1050,8 +1131,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_invalid_selection_proof(spec,
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "invalid selection proof signature"
@@ -1102,8 +1188,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_invalid_aggregator_signature(
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "invalid aggregator signature"
@@ -1154,8 +1245,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_invalid_aggregate_signature(s
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "invalid aggregate signature"
@@ -1218,8 +1314,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_block_failed_validation(spec,
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "block being voted for failed validation"
@@ -1270,8 +1371,13 @@ def test_gossip_beacon_aggregate_and_proof__reject_target_not_ancestor(spec, sta
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "reject"
     assert reason == "target block is not an ancestor of LMD vote block"
@@ -1326,8 +1432,13 @@ def test_gossip_beacon_aggregate_and_proof__ignore_finalized_not_ancestor(spec, 
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_aggregate_and_proof_gossip(
-        spec, seen, store, state, signed_agg, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_aggregate_and_proof=signed_agg,
+        current_time_ms=block_time_ms + 500,
     )
     assert result == "ignore"
     assert reason == "finalized checkpoint is not an ancestor of block"

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
@@ -23,7 +23,12 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
 from eth_consensus_specs.test.helpers.forks import is_post_electra
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, wrap_genesis_block
+from eth_consensus_specs.test.helpers.gossip import (
+    get_filename,
+    get_seen,
+    run_validate_gossip,
+    wrap_genesis_block,
+)
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
@@ -40,25 +45,6 @@ def get_correct_subnet_for_attestation(spec, state, attestation):
     return spec.compute_subnet_for_attestation(
         committees_per_slot, attestation.data.slot, committee_index
     )
-
-
-def run_validate_beacon_attestation_gossip(
-    spec, seen, store, state, attestation, subnet_id, current_time_ms
-):
-    """
-    Run validate_beacon_attestation_gossip and return the result.
-    Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
-             and reason is the exception message (or None for valid).
-    """
-    try:
-        spec.validate_beacon_attestation_gossip(
-            seen, store, state, attestation, current_time_ms, subnet_id
-        )
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 @with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA, FULU])
@@ -104,8 +90,14 @@ def test_gossip_beacon_attestation__valid(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -160,8 +152,14 @@ def test_gossip_beacon_attestation__reject_committee_index_out_of_range(spec, st
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = spec.uint64(0)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "committee index out of range"
@@ -213,8 +211,14 @@ def test_gossip_beacon_attestation__reject_wrong_subnet(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, wrong_subnet, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=wrong_subnet,
     )
     assert result == "reject"
     assert reason == "attestation is for wrong subnet"
@@ -274,8 +278,14 @@ def test_gossip_beacon_attestation__ignore_slot_not_in_range(spec, state):
     yield "current_time_ms", "meta", int(current_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "attestation slot not within propagation range"
@@ -338,8 +348,14 @@ def test_gossip_beacon_attestation__valid_within_clock_disparity(spec, state):
     yield "current_time_ms", "meta", int(current_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -400,8 +416,14 @@ def test_gossip_beacon_attestation__valid_within_clock_disparity_old(spec, state
     yield "current_time_ms", "meta", int(current_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -462,8 +484,14 @@ def test_gossip_beacon_attestation__ignore_slot_too_old(spec, state):
     yield "current_time_ms", "meta", int(current_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, current_time_ms
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=current_time_ms,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "attestation slot not within propagation range"
@@ -517,8 +545,14 @@ def test_gossip_beacon_attestation__reject_epoch_mismatch(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "attestation epoch does not match target epoch"
@@ -575,8 +609,14 @@ def test_gossip_beacon_attestation__reject_not_unaggregated(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "attestation is not unaggregated"
@@ -631,8 +671,14 @@ def test_gossip_beacon_attestation__reject_aggregation_bits_size_mismatch(spec, 
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "aggregation bits length does not match committee size"
@@ -695,8 +741,14 @@ def test_gossip_beacon_attestation__ignore_already_seen(spec, state):
 
     # First validation should pass
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "valid"
     assert reason is None
@@ -710,8 +762,14 @@ def test_gossip_beacon_attestation__ignore_already_seen(spec, state):
     )
 
     # Second validation should be ignored
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 600
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 600,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "already seen attestation from this validator for this epoch"
@@ -772,8 +830,14 @@ def test_gossip_beacon_attestation__ignore_block_not_seen(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "block being voted for has not been seen"
@@ -850,8 +914,14 @@ def test_gossip_beacon_attestation__reject_block_failed_validation(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "block being voted for failed validation"
@@ -912,8 +982,14 @@ def test_gossip_beacon_attestation__reject_invalid_signature(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "invalid attestation signature"
@@ -977,8 +1053,14 @@ def test_gossip_beacon_attestation__reject_target_not_ancestor(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "reject"
     assert reason == "target block is not an ancestor of LMD vote block"
@@ -1064,8 +1146,14 @@ def test_gossip_beacon_attestation__ignore_finalized_not_ancestor(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = get_correct_subnet_for_attestation(spec, state, attestation)
-    result, reason = run_validate_beacon_attestation_gossip(
-        spec, seen, store, state, attestation, subnet_id, block_time_ms + 500
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        attestation=attestation,
+        current_time_ms=block_time_ms + 500,
+        subnet_id=subnet_id,
     )
     assert result == "ignore"
     assert reason == "finalized checkpoint is not an ancestor of block"

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_block.py
@@ -27,7 +27,7 @@ from eth_consensus_specs.test.helpers.forks import is_post_bellatrix
 from eth_consensus_specs.test.helpers.gossip import (
     get_filename,
     get_seen,
-    run_validate_beacon_block_gossip,
+    run_validate_gossip,
     wrap_genesis_block,
 )
 from eth_consensus_specs.test.helpers.state import (
@@ -60,8 +60,15 @@ def test_gossip_beacon_block__valid_block(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "valid"
     assert reason is None
@@ -99,8 +106,15 @@ def test_gossip_beacon_block__ignore_future_slot(spec, state):
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, current_time_ms
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=current_time_ms,
+        **kwargs,
     )
     assert result == "ignore"
     assert reason == "block is from a future slot"
@@ -145,8 +159,15 @@ def test_gossip_beacon_block__valid_within_clock_disparity(spec, state):
 
     yield "current_time_ms", "meta", int(current_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, current_time_ms
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=current_time_ms,
+        **kwargs,
     )
     assert result == "valid"
     assert reason is None
@@ -185,16 +206,30 @@ def test_gossip_beacon_block__ignore_already_seen_proposer_slot(spec, state):
     yield "current_time_ms", "meta", int(block_time_ms)
 
     # First block should be valid
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "valid"
     assert reason is None
     messages.append({"offset_ms": 500, "message": get_filename(signed_block), "expected": "valid"})
 
     # Second block with same proposer/slot should be ignored
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 600
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 600,
+        **kwargs,
     )
     assert result == "ignore"
     assert reason == "block is not the first valid block for this proposer and slot"
@@ -262,8 +297,15 @@ def test_gossip_beacon_block__ignore_slot_not_greater_than_finalized(spec, state
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "ignore"
     assert reason == "block is not from a slot greater than the latest finalized slot"
@@ -317,8 +359,15 @@ def test_gossip_beacon_block__ignore_parent_not_seen(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "ignore"
     assert reason == "block's parent has not been seen"
@@ -403,8 +452,15 @@ def test_gossip_beacon_block__reject_parent_failed_validation(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_child, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_child,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "reject"
     if is_post_bellatrix(spec):
@@ -480,8 +536,15 @@ def test_gossip_beacon_block__reject_slot_not_higher_than_parent(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "reject"
     assert reason == "block is not from a higher slot than its parent"
@@ -565,8 +628,15 @@ def test_gossip_beacon_block__reject_finalized_checkpoint_not_ancestor(spec, sta
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_child, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_child,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "reject"
     assert reason == "finalized checkpoint is not an ancestor of block"
@@ -614,8 +684,15 @@ def test_gossip_beacon_block__reject_invalid_proposer_signature(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "reject"
     assert reason == "invalid proposer signature"
@@ -662,8 +739,15 @@ def test_gossip_beacon_block__reject_invalid_proposer_index(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "reject"
     assert reason == "proposer index out of range"
@@ -716,8 +800,15 @@ def test_gossip_beacon_block__reject_wrong_proposer_index(spec, state):
 
     yield "current_time_ms", "meta", int(block_time_ms)
 
-    result, reason = run_validate_beacon_block_gossip(
-        spec, seen, store, state, signed_block, block_time_ms + 500
+    kwargs = {"block_payload_statuses": {}} if is_post_bellatrix(spec) else {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        state=state,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
     )
     assert result == "reject"
     assert reason == "block proposer_index does not match expected proposer"

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_proposer_slashing.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_proposer_slashing.py
@@ -3,25 +3,10 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_all_phases,
 )
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
+from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, run_validate_gossip
 from eth_consensus_specs.test.helpers.proposer_slashings import (
     get_valid_proposer_slashing,
 )
-
-
-def run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing):
-    """
-    Run validate_proposer_slashing_gossip and return the result.
-    Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
-             and reason is the exception message (or None for valid).
-    """
-    try:
-        spec.validate_proposer_slashing_gossip(seen, state, proposer_slashing)
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 @with_all_phases
@@ -40,7 +25,9 @@ def test_gossip_proposer_slashing__valid(spec, state):
 
     yield get_filename(proposer_slashing), proposer_slashing
 
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "valid"
     assert reason is None
 
@@ -69,13 +56,17 @@ def test_gossip_proposer_slashing__ignore_already_seen(spec, state):
     yield get_filename(proposer_slashing), proposer_slashing
 
     # First validation should pass
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "valid"
     assert reason is None
     messages.append({"message": get_filename(proposer_slashing), "expected": "valid"})
 
     # Second validation should be ignored
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "ignore"
     assert reason == "already seen proposer slashing for this proposer"
     messages.append(
@@ -110,7 +101,9 @@ def test_gossip_proposer_slashing__reject_slots_not_matching(spec, state):
 
     yield get_filename(proposer_slashing), proposer_slashing
 
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "reject"
     assert reason == "header slots do not match"
 
@@ -148,7 +141,9 @@ def test_gossip_proposer_slashing__reject_proposer_indices_not_matching(spec, st
 
     yield get_filename(proposer_slashing), proposer_slashing
 
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "reject"
     assert reason == "header proposer indices do not match"
 
@@ -184,7 +179,9 @@ def test_gossip_proposer_slashing__reject_headers_identical(spec, state):
 
     yield get_filename(proposer_slashing), proposer_slashing
 
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "reject"
     assert reason == "headers are not different"
 
@@ -222,7 +219,9 @@ def test_gossip_proposer_slashing__reject_proposer_index_out_of_range(spec, stat
 
     yield get_filename(proposer_slashing), proposer_slashing
 
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "reject"
     assert reason == "proposer index out of range"
 
@@ -259,7 +258,9 @@ def test_gossip_proposer_slashing__reject_proposer_not_slashable(spec, state):
     yield "state", state
     yield get_filename(proposer_slashing), proposer_slashing
 
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "reject"
     assert reason == "proposer is not slashable"
 
@@ -293,7 +294,9 @@ def test_gossip_proposer_slashing__reject_invalid_signature_1(spec, state):
 
     yield get_filename(proposer_slashing), proposer_slashing
 
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "reject"
     assert reason == "invalid proposer slashing signature"
 
@@ -327,7 +330,9 @@ def test_gossip_proposer_slashing__reject_invalid_signature_2(spec, state):
 
     yield get_filename(proposer_slashing), proposer_slashing
 
-    result, reason = run_validate_proposer_slashing_gossip(spec, seen, state, proposer_slashing)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, proposer_slashing=proposer_slashing
+    )
     assert result == "reject"
     assert reason == "invalid proposer slashing signature"
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
@@ -12,7 +12,7 @@ from eth_consensus_specs.test.helpers.constants import (
     FULU,
     PHASE0,
 )
-from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen
+from eth_consensus_specs.test.helpers.gossip import get_filename, get_seen, run_validate_gossip
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
     next_epoch_via_block,
@@ -34,21 +34,6 @@ def create_signed_voluntary_exit(spec, state, validator_index, epoch=None):
         validator_index=validator_index,
     )
     return sign_voluntary_exit(spec, state, voluntary_exit, privkeys[validator_index])
-
-
-def run_validate_voluntary_exit_gossip(spec, seen, state, signed_voluntary_exit):
-    """
-    Run validate_voluntary_exit_gossip and return the result.
-    Returns: tuple of (result, reason) where result is "valid", "ignore", or "reject"
-             and reason is the exception message (or None for valid).
-    """
-    try:
-        spec.validate_voluntary_exit_gossip(seen, state, signed_voluntary_exit)
-        return "valid", None
-    except spec.GossipIgnore as e:
-        return "ignore", str(e)
-    except spec.GossipReject as e:
-        return "reject", str(e)
 
 
 @with_phases([PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, ELECTRA, FULU])
@@ -73,7 +58,9 @@ def test_gossip_voluntary_exit__valid(spec, state):
 
     yield get_filename(signed_exit), signed_exit
 
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "valid"
     assert reason is None
 
@@ -104,13 +91,17 @@ def test_gossip_voluntary_exit__ignore_already_seen(spec, state):
     yield get_filename(signed_exit), signed_exit
 
     # First validation should pass
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "valid"
     assert reason is None
     messages.append({"message": get_filename(signed_exit), "expected": "valid"})
 
     # Second validation should be ignored
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "ignore"
     assert reason == "already seen voluntary exit for this validator"
     messages.append({"message": get_filename(signed_exit), "expected": "ignore", "reason": reason})
@@ -143,7 +134,9 @@ def test_gossip_voluntary_exit__reject_validator_index_out_of_range(spec, state)
 
     yield get_filename(signed_exit), signed_exit
 
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "reject"
     assert reason == "validator index out of range"
 
@@ -177,7 +170,9 @@ def test_gossip_voluntary_exit__reject_validator_not_active(spec, state):
 
     yield get_filename(signed_exit), signed_exit
 
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "reject"
     assert reason == "validator is not active"
 
@@ -211,7 +206,9 @@ def test_gossip_voluntary_exit__reject_already_initiated_exit(spec, state):
 
     yield get_filename(signed_exit), signed_exit
 
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "reject"
     assert reason == "validator has already initiated exit"
 
@@ -245,7 +242,9 @@ def test_gossip_voluntary_exit__reject_epoch_in_future(spec, state):
 
     yield get_filename(signed_exit), signed_exit
 
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "reject"
     assert reason == "voluntary exit epoch is in the future"
 
@@ -280,7 +279,9 @@ def test_gossip_voluntary_exit__reject_not_active_long_enough(spec, state):
 
     yield get_filename(signed_exit), signed_exit
 
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "reject"
     assert reason == "validator has not been active long enough"
 
@@ -320,7 +321,9 @@ def test_gossip_voluntary_exit__reject_invalid_signature(spec, state):
 
     yield get_filename(signed_exit), signed_exit
 
-    result, reason = run_validate_voluntary_exit_gossip(spec, seen, state, signed_exit)
+    result, reason = run_validate_gossip(
+        spec, seen=seen, state=state, signed_voluntary_exit=signed_exit
+    )
     assert result == "reject"
     assert reason == "invalid voluntary exit signature"
 


### PR DESCRIPTION
Here we add a new helper function which is used for all gossip validation tests. Rather than defining repetitive "run_<message>_gossip" functions for every possible message type. `run_validate_gossip` will use the message's type to determine what the correct handler is. Inputs are provided to the validation functions as keyword arguments, for flexibility. This also asserts that all necessary values are provided & unnecessary values are not.