### PR TITLE
Add annotation prefixes to p2p interface spec sections

### DIFF
--- a/specs/_features/eip8025/p2p-interface.md
+++ b/specs/_features/eip8025/p2p-interface.md
@@ -13,7 +13,7 @@ and imports proof types from [proof-engine.md](./proof-engine.md).
 - [Constants](#constants)
   - [Execution](#execution)
 - [Containers](#containers)
-  - [`ProofByRootIdentifier`](#proofbyrootidentifier)
+  - [New `ProofByRootIdentifier`](#new-proofbyrootidentifier)
 - [Helpers](#helpers)
   - [New `compute_max_request_execution_proofs`](#new-compute_max_request_execution_proofs)
 - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
@@ -43,7 +43,7 @@ and imports proof types from [proof-engine.md](./proof-engine.md).
 
 ## Containers
 
-### `ProofByRootIdentifier`
+### New `ProofByRootIdentifier`
 
 ```python
 class ProofByRootIdentifier(Container):

--- a/specs/_features/eip8025/p2p-interface.md
+++ b/specs/_features/eip8025/p2p-interface.md
@@ -19,7 +19,7 @@ and imports proof types from [proof-engine.md](./proof-engine.md).
 - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
   - [Topics and messages](#topics-and-messages)
     - [Global topics](#global-topics)
-      - [`execution_proof`](#execution_proof)
+      - [New `execution_proof`](#new-execution_proof)
 - [The Req/Resp domain](#the-reqresp-domain)
   - [Messages](#messages)
     - [ExecutionProofsByRange](#executionproofsbyrange)
@@ -69,7 +69,7 @@ def compute_max_request_execution_proofs() -> uint64:
 
 #### Global topics
 
-##### `execution_proof`
+##### New `execution_proof`
 
 This topic is used to propagate `SignedExecutionProof` messages.
 

--- a/specs/altair/light-client/p2p-interface.md
+++ b/specs/altair/light-client/p2p-interface.md
@@ -7,8 +7,8 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`light_client_finality_update`](#light_client_finality_update)
-        - [`light_client_optimistic_update`](#light_client_optimistic_update)
+        - [New `light_client_finality_update`](#new-light_client_finality_update)
+        - [New `light_client_optimistic_update`](#new-light_client_optimistic_update)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [GetLightClientBootstrap](#getlightclientbootstrap)
@@ -49,7 +49,7 @@ New global topics are added to provide light clients with the latest updates.
 
 ##### Global topics
 
-###### `light_client_finality_update`
+###### New `light_client_finality_update`
 
 This topic is used to propagate the latest `LightClientFinalityUpdate` to light
 clients, allowing them to keep track of the latest `finalized_header`.
@@ -99,7 +99,7 @@ Per `fork_version = compute_fork_version(epoch)`:
 | `GENESIS_FORK_VERSION`          | n/a                                |
 | `ALTAIR_FORK_VERSION` and later | `altair.LightClientFinalityUpdate` |
 
-###### `light_client_optimistic_update`
+###### New `light_client_optimistic_update`
 
 This topic is used to propagate the latest `LightClientOptimisticUpdate` to
 light clients, allowing them to keep track of the latest `optimistic_header`.
@@ -324,8 +324,8 @@ Per `fork_version = compute_fork_version(epoch)`:
 ## Light clients
 
 Light clients using libp2p to stay in sync with the network SHOULD subscribe to
-the [`light_client_finality_update`](#light_client_finality_update) and
-[`light_client_optimistic_update`](#light_client_optimistic_update) pubsub
+the [`light_client_finality_update`](#new-light_client_finality_update) and
+[`light_client_optimistic_update`](#new-light_client_optimistic_update) pubsub
 topics and validate all received messages while the
 [light client sync process](./light-client.md#light-client-sync-process)
 supports processing `LightClientFinalityUpdate` and
@@ -350,8 +350,8 @@ additional responsibilities to enable light clients to sync with the network.
 ### Beacon chain responsibilities
 
 All full nodes SHOULD subscribe to and provide stability on the
-[`light_client_finality_update`](#light_client_finality_update) and
-[`light_client_optimistic_update`](#light_client_optimistic_update) pubsub
+[`light_client_finality_update`](#new-light_client_finality_update) and
+[`light_client_optimistic_update`](#new-light_client_optimistic_update) pubsub
 topics by validating all received messages.
 
 ### Sync committee

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -13,10 +13,10 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`beacon_block`](#beacon_block)
-        - [`sync_committee_contribution_and_proof`](#sync_committee_contribution_and_proof)
+        - [Modified `beacon_block`](#modified-beacon_block)
+        - [New `sync_committee_contribution_and_proof`](#new-sync_committee_contribution_and_proof)
       - [Sync committee subnets](#sync-committee-subnets)
-        - [`sync_committee_{subnet_id}`](#sync_committee_subnet_id)
+        - [New `sync_committee_{subnet_id}`](#new-sync_committee_subnet_id)
       - [Sync committees and aggregation](#sync-committees-and-aggregation)
     - [Transitioning the gossip](#transitioning-the-gossip)
   - [The Req/Resp domain](#the-reqresp-domain)
@@ -199,7 +199,7 @@ Altair changes the type of the global beacon block topic and adds one global
 topic to propagate partially aggregated sync committee messages to all potential
 proposers of beacon blocks.
 
-###### `beacon_block`
+###### Modified `beacon_block`
 
 The existing specification for this topic does not change from the Phase 0
 document, but the type of the payload does change to the (modified)
@@ -209,7 +209,7 @@ document, but the type of the payload does change to the (modified)
 See the [state transition document](./beacon-chain.md#beaconblockbody) for
 Altair for further details.
 
-###### `sync_committee_contribution_and_proof`
+###### New `sync_committee_contribution_and_proof`
 
 This topic is used to propagate partially aggregated sync committee messages to
 be included in future blocks. The `state` parameter is the head state.
@@ -324,7 +324,7 @@ def validate_sync_committee_contribution_and_proof_gossip(
 Sync committee subnets are used to propagate unaggregated sync committee
 messages to subsections of the network.
 
-###### `sync_committee_{subnet_id}`
+###### New `sync_committee_{subnet_id}`
 
 The `sync_committee_{subnet_id}` topics are used to propagate unaggregated sync
 committee messages to the subnet `subnet_id` to be aggregated before being

--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -11,7 +11,7 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`beacon_block`](#beacon_block)
+        - [Modified `beacon_block`](#modified-beacon_block)
     - [Transitioning the gossip](#transitioning-the-gossip)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
@@ -99,7 +99,7 @@ the new `beacon_block` topics.
 
 Bellatrix changes the type of the global beacon block topic.
 
-###### `beacon_block`
+###### Modified `beacon_block`
 
 The `beacon_block` topic is used solely for propagating new signed beacon blocks
 to all nodes on the networks. Signed blocks are sent in their entirety. The

--- a/specs/capella/light-client/p2p-interface.md
+++ b/specs/capella/light-client/p2p-interface.md
@@ -6,8 +6,8 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`light_client_finality_update`](#light_client_finality_update)
-        - [`light_client_optimistic_update`](#light_client_optimistic_update)
+        - [Modified `light_client_finality_update`](#modified-light_client_finality_update)
+        - [Modified `light_client_optimistic_update`](#modified-light_client_optimistic_update)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [GetLightClientBootstrap](#getlightclientbootstrap)
@@ -29,7 +29,7 @@ is extended to exchange [Capella light client data](./sync-protocol.md).
 
 ##### Global topics
 
-###### `light_client_finality_update`
+###### Modified `light_client_finality_update`
 
 <!-- eth_consensus_specs: skip -->
 
@@ -39,7 +39,7 @@ is extended to exchange [Capella light client data](./sync-protocol.md).
 | `ALTAIR_FORK_VERSION` through `BELLATRIX_FORK_VERSION` | `altair.LightClientFinalityUpdate`  |
 | `CAPELLA_FORK_VERSION` and later                       | `capella.LightClientFinalityUpdate` |
 
-###### `light_client_optimistic_update`
+###### Modified `light_client_optimistic_update`
 
 <!-- eth_consensus_specs: skip -->
 

--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -10,8 +10,8 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`beacon_block`](#beacon_block)
-        - [`bls_to_execution_change`](#bls_to_execution_change)
+        - [Modified `beacon_block`](#modified-beacon_block)
+        - [New `bls_to_execution_change`](#new-bls_to_execution_change)
     - [Transitioning the gossip](#transitioning-the-gossip)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
@@ -95,7 +95,7 @@ Capella changes the type of the global beacon block topic and adds one global
 topic to propagate withdrawal credential change messages to all potential
 proposers of beacon blocks.
 
-###### `beacon_block`
+###### Modified `beacon_block`
 
 The *type* of the payload of this topic changes to the (modified)
 `SignedBeaconBlock` found in Capella. Specifically, this type changes with the
@@ -197,7 +197,7 @@ def validate_beacon_block_gossip(
     seen.proposer_slots.add((block.proposer_index, block.slot))
 ```
 
-###### `bls_to_execution_change`
+###### New `bls_to_execution_change`
 
 The `bls_to_execution_change` topic is used solely for propagating signed BLS to
 execution change messages on the network. Signed messages are sent in their

--- a/specs/deneb/light-client/p2p-interface.md
+++ b/specs/deneb/light-client/p2p-interface.md
@@ -6,8 +6,8 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`light_client_finality_update`](#light_client_finality_update)
-        - [`light_client_optimistic_update`](#light_client_optimistic_update)
+        - [Modified `light_client_finality_update`](#modified-light_client_finality_update)
+        - [Modified `light_client_optimistic_update`](#modified-light_client_optimistic_update)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [GetLightClientBootstrap](#getlightclientbootstrap)
@@ -29,7 +29,7 @@ is extended to exchange [Deneb light client data](./sync-protocol.md).
 
 ##### Global topics
 
-###### `light_client_finality_update`
+###### Modified `light_client_finality_update`
 
 <!-- eth_consensus_specs: skip -->
 
@@ -40,7 +40,7 @@ is extended to exchange [Deneb light client data](./sync-protocol.md).
 | `CAPELLA_FORK_VERSION`                                 | `capella.LightClientFinalityUpdate` |
 | `DENEB_FORK_VERSION` and later                         | `deneb.LightClientFinalityUpdate`   |
 
-###### `light_client_optimistic_update`
+###### Modified `light_client_optimistic_update`
 
 <!-- eth_consensus_specs: skip -->
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -17,14 +17,14 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`beacon_block`](#beacon_block)
-        - [`beacon_aggregate_and_proof`](#beacon_aggregate_and_proof)
-        - [`voluntary_exit`](#voluntary_exit)
+        - [Modified `beacon_block`](#modified-beacon_block)
+        - [Modified `beacon_aggregate_and_proof`](#modified-beacon_aggregate_and_proof)
+        - [Modified `voluntary_exit`](#modified-voluntary_exit)
       - [Blob subnets](#blob-subnets)
-        - [`blob_sidecar_{subnet_id}`](#blob_sidecar_subnet_id)
+        - [New `blob_sidecar_{subnet_id}`](#new-blob_sidecar_subnet_id)
         - [Blob retrieval via local execution-layer client](#blob-retrieval-via-local-execution-layer-client)
       - [Attestation subnets](#attestation-subnets)
-        - [`beacon_attestation_{subnet_id}`](#beacon_attestation_subnet_id)
+        - [Modified `beacon_attestation_{subnet_id}`](#modified-beacon_attestation_subnet_id)
     - [Transitioning the gossip](#transitioning-the-gossip)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
@@ -191,7 +191,7 @@ are given in this table:
 
 ##### Global topics
 
-###### `beacon_block`
+###### Modified `beacon_block`
 
 *Note*: This function is modified to validate the number of blob kzg commitments
 included in the beacon block body.
@@ -292,7 +292,7 @@ def validate_beacon_block_gossip(
     seen.proposer_slots.add((block.proposer_index, block.slot))
 ```
 
-###### `beacon_aggregate_and_proof`
+###### Modified `beacon_aggregate_and_proof`
 
 *Note*: This function is modified to ignore aggregate attestations from future
 slots and ignore aggregate attestations whose epoch is not the current or
@@ -426,7 +426,7 @@ def validate_beacon_aggregate_and_proof_gossip(
     seen.aggregate_data_roots[aggregate_data_root].add(aggregate_bits)
 ```
 
-###### `voluntary_exit`
+###### Modified `voluntary_exit`
 
 *Note*: This function is modified to use `CAPELLA_FORK_VERSION` in the signature
 domain computation so that voluntary exits remain valid across fork boundaries.
@@ -486,7 +486,7 @@ def validate_voluntary_exit_gossip(
 
 ##### Blob subnets
 
-###### `blob_sidecar_{subnet_id}`
+###### New `blob_sidecar_{subnet_id}`
 
 The `blob_sidecar_{subnet_id}` topics, where each blob index maps to some
 `subnet_id`, are used solely for propagating new blob sidecars to all nodes on
@@ -614,7 +614,7 @@ particular they MUST:
 
 ##### Attestation subnets
 
-###### `beacon_attestation_{subnet_id}`
+###### Modified `beacon_attestation_{subnet_id}`
 
 *[Modified in Deneb:EIP7045]* Attestations from the previous epoch are now
 propagated through the entire current epoch rather than only the next

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -20,11 +20,11 @@
         - [Modified `beacon_block`](#modified-beacon_block)
         - [Modified `beacon_aggregate_and_proof`](#modified-beacon_aggregate_and_proof)
         - [Modified `voluntary_exit`](#modified-voluntary_exit)
+      - [Attestation subnets](#attestation-subnets)
+        - [Modified `beacon_attestation_{subnet_id}`](#modified-beacon_attestation_subnet_id)
       - [Blob subnets](#blob-subnets)
         - [New `blob_sidecar_{subnet_id}`](#new-blob_sidecar_subnet_id)
         - [Blob retrieval via local execution-layer client](#blob-retrieval-via-local-execution-layer-client)
-      - [Attestation subnets](#attestation-subnets)
-        - [Modified `beacon_attestation_{subnet_id}`](#modified-beacon_attestation_subnet_id)
     - [Transitioning the gossip](#transitioning-the-gossip)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
@@ -484,6 +484,122 @@ def validate_voluntary_exit_gossip(
     seen.voluntary_exit_indices.add(validator_index)
 ```
 
+##### Attestation subnets
+
+###### Modified `beacon_attestation_{subnet_id}`
+
+*[Modified in Deneb:EIP7045]* Attestations from the previous epoch are now
+propagated through the entire current epoch rather than only the next
+`ATTESTATION_PROPAGATION_SLOT_RANGE` slots.
+
+*Note*: This function is modified to ignore attestations from future slots and
+ignore attestations whose epoch is not the current or previous epoch relative to
+`current_time_ms`.
+
+```python
+def validate_beacon_attestation_gossip(
+    seen: Seen,
+    store: Store,
+    state: BeaconState,
+    attestation: Attestation,
+    current_time_ms: uint64,
+    subnet_id: SubnetID,
+) -> None:
+    """
+    Validate an Attestation for gossip propagation on a subnet.
+    Raises GossipIgnore or GossipReject on validation failure.
+    """
+    data = attestation.data
+    committee_index = data.index
+    target_epoch = data.target.epoch
+    aggregation_bits = attestation.aggregation_bits
+
+    # [REJECT] The committee index is within the expected range
+    committees_per_slot = get_committee_count_per_slot(state, target_epoch)
+    if committee_index >= committees_per_slot:
+        raise GossipReject("committee index out of range")
+
+    # [REJECT] The attestation is for the correct subnet
+    expected_subnet = compute_subnet_for_attestation(
+        committees_per_slot, data.slot, committee_index
+    )
+    if expected_subnet != subnet_id:
+        raise GossipReject("attestation is for wrong subnet")
+
+    # [Modified in Deneb:EIP7045]
+    # [IGNORE] The attestation's slot is not from a future slot
+    # (MAY be queued for processing at the appropriate slot)
+    if not is_not_from_future_slot(state, data.slot, current_time_ms):
+        raise GossipIgnore("attestation slot is from a future slot")
+
+    # [Modified in Deneb:EIP7045]
+    # [IGNORE] The attestation's epoch is either the current or previous epoch
+    attestation_epoch = compute_epoch_at_slot(data.slot)
+    is_previous_epoch_attestation = is_within_slot_range(
+        state,
+        compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
+        SLOTS_PER_EPOCH - 1,
+        current_time_ms,
+    )
+    is_current_epoch_attestation = is_within_slot_range(
+        state,
+        compute_start_slot_at_epoch(attestation_epoch),
+        SLOTS_PER_EPOCH - 1,
+        current_time_ms,
+    )
+    if not (is_previous_epoch_attestation or is_current_epoch_attestation):
+        raise GossipIgnore("attestation epoch is not previous or current epoch")
+
+    # [REJECT] The attestation's epoch matches its target
+    if target_epoch != compute_epoch_at_slot(data.slot):
+        raise GossipReject("attestation epoch does not match target epoch")
+
+    # [REJECT] The attestation is unaggregated (exactly one bit set)
+    num_bits_set = sum(1 for bit in aggregation_bits if bit)
+    if num_bits_set != 1:
+        raise GossipReject("attestation is not unaggregated")
+
+    # [REJECT] The number of aggregation bits matches the committee size
+    committee = get_beacon_committee(state, data.slot, committee_index)
+    if len(aggregation_bits) != len(committee):
+        raise GossipReject("aggregation bits length does not match committee size")
+
+    # [IGNORE] No other valid attestation seen for this validator and target epoch
+    participant_index = committee[aggregation_bits.index(True)]
+    if (participant_index, target_epoch) in seen.attestation_validator_epochs:
+        raise GossipIgnore("already seen attestation from this validator for this epoch")
+
+    # [REJECT] The attestation signature is valid
+    indexed_attestation = get_indexed_attestation(state, attestation)
+    if not is_valid_indexed_attestation(state, indexed_attestation):
+        raise GossipReject("invalid attestation signature")
+
+    # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+    # (MAY be queued until block is retrieved)
+    beacon_block_root = data.beacon_block_root
+    if beacon_block_root not in store.blocks:
+        raise GossipIgnore("block being voted for has not been seen")
+
+    # [REJECT] The block being voted for passes validation
+    if beacon_block_root not in store.block_states:
+        raise GossipReject("block being voted for failed validation")
+
+    # [REJECT] The attestation's target block is an ancestor of the LMD vote block
+    target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
+    if target_checkpoint_block != data.target.root:
+        raise GossipReject("target block is not an ancestor of LMD vote block")
+
+    # [IGNORE] The current finalized_checkpoint is an ancestor of the block
+    finalized_checkpoint_block = get_checkpoint_block(
+        store, beacon_block_root, store.finalized_checkpoint.epoch
+    )
+    if finalized_checkpoint_block != store.finalized_checkpoint.root:
+        raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+    # Mark this attestation as seen
+    seen.attestation_validator_epochs.add((participant_index, target_epoch))
+```
+
 ##### Blob subnets
 
 ###### New `blob_sidecar_{subnet_id}`
@@ -611,122 +727,6 @@ particular they MUST:
   subnet.
 - Update gossip rule related data structures (i.e. update the anti-equivocation
   cache).
-
-##### Attestation subnets
-
-###### Modified `beacon_attestation_{subnet_id}`
-
-*[Modified in Deneb:EIP7045]* Attestations from the previous epoch are now
-propagated through the entire current epoch rather than only the next
-`ATTESTATION_PROPAGATION_SLOT_RANGE` slots.
-
-*Note*: This function is modified to ignore attestations from future slots and
-ignore attestations whose epoch is not the current or previous epoch relative to
-`current_time_ms`.
-
-```python
-def validate_beacon_attestation_gossip(
-    seen: Seen,
-    store: Store,
-    state: BeaconState,
-    attestation: Attestation,
-    current_time_ms: uint64,
-    subnet_id: SubnetID,
-) -> None:
-    """
-    Validate an Attestation for gossip propagation on a subnet.
-    Raises GossipIgnore or GossipReject on validation failure.
-    """
-    data = attestation.data
-    committee_index = data.index
-    target_epoch = data.target.epoch
-    aggregation_bits = attestation.aggregation_bits
-
-    # [REJECT] The committee index is within the expected range
-    committees_per_slot = get_committee_count_per_slot(state, target_epoch)
-    if committee_index >= committees_per_slot:
-        raise GossipReject("committee index out of range")
-
-    # [REJECT] The attestation is for the correct subnet
-    expected_subnet = compute_subnet_for_attestation(
-        committees_per_slot, data.slot, committee_index
-    )
-    if expected_subnet != subnet_id:
-        raise GossipReject("attestation is for wrong subnet")
-
-    # [Modified in Deneb:EIP7045]
-    # [IGNORE] The attestation's slot is not from a future slot
-    # (MAY be queued for processing at the appropriate slot)
-    if not is_not_from_future_slot(state, data.slot, current_time_ms):
-        raise GossipIgnore("attestation slot is from a future slot")
-
-    # [Modified in Deneb:EIP7045]
-    # [IGNORE] The attestation's epoch is either the current or previous epoch
-    attestation_epoch = compute_epoch_at_slot(data.slot)
-    is_previous_epoch_attestation = is_within_slot_range(
-        state,
-        compute_start_slot_at_epoch(Epoch(attestation_epoch + 1)),
-        SLOTS_PER_EPOCH - 1,
-        current_time_ms,
-    )
-    is_current_epoch_attestation = is_within_slot_range(
-        state,
-        compute_start_slot_at_epoch(attestation_epoch),
-        SLOTS_PER_EPOCH - 1,
-        current_time_ms,
-    )
-    if not (is_previous_epoch_attestation or is_current_epoch_attestation):
-        raise GossipIgnore("attestation epoch is not previous or current epoch")
-
-    # [REJECT] The attestation's epoch matches its target
-    if target_epoch != compute_epoch_at_slot(data.slot):
-        raise GossipReject("attestation epoch does not match target epoch")
-
-    # [REJECT] The attestation is unaggregated (exactly one bit set)
-    num_bits_set = sum(1 for bit in aggregation_bits if bit)
-    if num_bits_set != 1:
-        raise GossipReject("attestation is not unaggregated")
-
-    # [REJECT] The number of aggregation bits matches the committee size
-    committee = get_beacon_committee(state, data.slot, committee_index)
-    if len(aggregation_bits) != len(committee):
-        raise GossipReject("aggregation bits length does not match committee size")
-
-    # [IGNORE] No other valid attestation seen for this validator and target epoch
-    participant_index = committee[aggregation_bits.index(True)]
-    if (participant_index, target_epoch) in seen.attestation_validator_epochs:
-        raise GossipIgnore("already seen attestation from this validator for this epoch")
-
-    # [REJECT] The attestation signature is valid
-    indexed_attestation = get_indexed_attestation(state, attestation)
-    if not is_valid_indexed_attestation(state, indexed_attestation):
-        raise GossipReject("invalid attestation signature")
-
-    # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
-    # (MAY be queued until block is retrieved)
-    beacon_block_root = data.beacon_block_root
-    if beacon_block_root not in store.blocks:
-        raise GossipIgnore("block being voted for has not been seen")
-
-    # [REJECT] The block being voted for passes validation
-    if beacon_block_root not in store.block_states:
-        raise GossipReject("block being voted for failed validation")
-
-    # [REJECT] The attestation's target block is an ancestor of the LMD vote block
-    target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
-    if target_checkpoint_block != data.target.root:
-        raise GossipReject("target block is not an ancestor of LMD vote block")
-
-    # [IGNORE] The current finalized_checkpoint is an ancestor of the block
-    finalized_checkpoint_block = get_checkpoint_block(
-        store, beacon_block_root, store.finalized_checkpoint.epoch
-    )
-    if finalized_checkpoint_block != store.finalized_checkpoint.root:
-        raise GossipIgnore("finalized checkpoint is not an ancestor of block")
-
-    # Mark this attestation as seen
-    seen.attestation_validator_epochs.add((participant_index, target_epoch))
-```
 
 #### Transitioning the gossip
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -13,7 +13,7 @@
     - [Modified `Seen`](#modified-seen)
     - [Modified `compute_fork_version`](#modified-compute_fork_version)
     - [New `compute_max_request_blob_sidecars`](#new-compute_max_request_blob_sidecars)
-    - [`verify_blob_sidecar_inclusion_proof`](#verify_blob_sidecar_inclusion_proof)
+    - [New `verify_blob_sidecar_inclusion_proof`](#new-verify_blob_sidecar_inclusion_proof)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
@@ -142,7 +142,7 @@ def compute_max_request_blob_sidecars() -> uint64:
     return uint64(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK)
 ```
 
-#### `verify_blob_sidecar_inclusion_proof`
+#### New `verify_blob_sidecar_inclusion_proof`
 
 ```python
 def verify_blob_sidecar_inclusion_proof(blob_sidecar: BlobSidecar) -> bool:

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -7,8 +7,8 @@
   - [Preset](#preset)
   - [Configuration](#configuration)
   - [Containers](#containers)
-    - [`BlobSidecar`](#blobsidecar)
-    - [`BlobIdentifier`](#blobidentifier)
+    - [New `BlobSidecar`](#new-blobsidecar)
+    - [New `BlobIdentifier`](#new-blobidentifier)
   - [Helpers](#helpers)
     - [Modified `Seen`](#modified-seen)
     - [Modified `compute_fork_version`](#modified-compute_fork_version)
@@ -66,7 +66,7 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 ### Containers
 
-#### `BlobSidecar`
+#### New `BlobSidecar`
 
 *[New in Deneb:EIP4844]*
 
@@ -82,7 +82,7 @@ class BlobSidecar(Container):
     kzg_commitment_inclusion_proof: Vector[Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH]
 ```
 
-#### `BlobIdentifier`
+#### New `BlobIdentifier`
 
 *[New in Deneb:EIP4844]*
 

--- a/specs/electra/light-client/p2p-interface.md
+++ b/specs/electra/light-client/p2p-interface.md
@@ -6,8 +6,8 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`light_client_finality_update`](#light_client_finality_update)
-        - [`light_client_optimistic_update`](#light_client_optimistic_update)
+        - [Modified `light_client_finality_update`](#modified-light_client_finality_update)
+        - [Modified `light_client_optimistic_update`](#modified-light_client_optimistic_update)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [GetLightClientBootstrap](#getlightclientbootstrap)
@@ -29,7 +29,7 @@ is extended to exchange [Electra light client data](./sync-protocol.md).
 
 ##### Global topics
 
-###### `light_client_finality_update`
+###### Modified `light_client_finality_update`
 
 <!-- eth_consensus_specs: skip -->
 
@@ -41,7 +41,7 @@ is extended to exchange [Electra light client data](./sync-protocol.md).
 | `DENEB_FORK_VERSION`                                   | `deneb.LightClientFinalityUpdate`   |
 | `ELECTRA_FORK_VERSION` and later                       | `electra.LightClientFinalityUpdate` |
 
-###### `light_client_optimistic_update`
+###### Modified `light_client_optimistic_update`
 
 <!-- eth_consensus_specs: skip -->
 

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -12,12 +12,12 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`beacon_block`](#beacon_block)
-        - [`beacon_aggregate_and_proof`](#beacon_aggregate_and_proof)
-        - [`attester_slashing`](#attester_slashing)
-        - [`blob_sidecar_{subnet_id}`](#blob_sidecar_subnet_id)
+        - [Modified `beacon_block`](#modified-beacon_block)
+        - [Modified `beacon_aggregate_and_proof`](#modified-beacon_aggregate_and_proof)
+        - [Modified `attester_slashing`](#modified-attester_slashing)
+        - [Modified `blob_sidecar_{subnet_id}`](#modified-blob_sidecar_subnet_id)
       - [Attestation subnets](#attestation-subnets)
-        - [`beacon_attestation_{subnet_id}`](#beacon_attestation_subnet_id)
+        - [Modified `beacon_attestation_{subnet_id}`](#modified-beacon_attestation_subnet_id)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [BeaconBlocksByRange v2](#beaconblocksbyrange-v2)
@@ -121,7 +121,7 @@ The derivation of the `message-id` remains stable.
 
 ##### Global topics
 
-###### `beacon_block`
+###### Modified `beacon_block`
 
 *Note*: This function is modified per EIP-7691. The block's KZG commitment count
 is bounded by `MAX_BLOBS_PER_BLOCK_ELECTRA`.
@@ -222,7 +222,7 @@ def validate_beacon_block_gossip(
     seen.proposer_slots.add((block.proposer_index, block.slot))
 ```
 
-###### `beacon_aggregate_and_proof`
+###### Modified `beacon_aggregate_and_proof`
 
 *Note*: This function is modified per EIP-7549. The committee index is now
 encoded in `aggregate.committee_bits`, `aggregate.data.index` MUST be zero, and
@@ -368,14 +368,14 @@ def validate_beacon_aggregate_and_proof_gossip(
     seen.aggregate_data_roots[aggregate_cache_key].add(aggregate_bits)
 ```
 
-###### `attester_slashing`
+###### Modified `attester_slashing`
 
 *Note*: This function is modified per EIP-7549. The new `AttesterSlashing` type
 wraps an `IndexedAttestation` payload sized for
 `MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT` attesting indices; the
 validation logic is otherwise unchanged.
 
-###### `blob_sidecar_{subnet_id}`
+###### Modified `blob_sidecar_{subnet_id}`
 
 *Note*: This function is modified per EIP-7691. The sidecar's index is bounded
 by `MAX_BLOBS_PER_BLOCK_ELECTRA`.
@@ -475,7 +475,7 @@ def validate_blob_sidecar_gossip(
 
 ##### Attestation subnets
 
-###### `beacon_attestation_{subnet_id}`
+###### Modified `beacon_attestation_{subnet_id}`
 
 *Note*: This function is modified per EIP-7549. The topic now propagates
 `SingleAttestation` objects: the attesting validator's index is carried directly

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -15,6 +15,7 @@
         - [Modified `beacon_block`](#modified-beacon_block)
         - [Modified `beacon_aggregate_and_proof`](#modified-beacon_aggregate_and_proof)
         - [Modified `attester_slashing`](#modified-attester_slashing)
+      - [Blob subnets](#blob-subnets)
         - [Modified `blob_sidecar_{subnet_id}`](#modified-blob_sidecar_subnet_id)
       - [Attestation subnets](#attestation-subnets)
         - [Modified `beacon_attestation_{subnet_id}`](#modified-beacon_attestation_subnet_id)
@@ -374,6 +375,8 @@ def validate_beacon_aggregate_and_proof_gossip(
 wraps an `IndexedAttestation` payload sized for
 `MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT` attesting indices; the
 validation logic is otherwise unchanged.
+
+##### Blob subnets
 
 ###### Modified `blob_sidecar_{subnet_id}`
 

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -15,10 +15,10 @@
         - [Modified `beacon_block`](#modified-beacon_block)
         - [Modified `beacon_aggregate_and_proof`](#modified-beacon_aggregate_and_proof)
         - [Modified `attester_slashing`](#modified-attester_slashing)
-      - [Blob subnets](#blob-subnets)
-        - [Modified `blob_sidecar_{subnet_id}`](#modified-blob_sidecar_subnet_id)
       - [Attestation subnets](#attestation-subnets)
         - [Modified `beacon_attestation_{subnet_id}`](#modified-beacon_attestation_subnet_id)
+      - [Blob subnets](#blob-subnets)
+        - [Modified `blob_sidecar_{subnet_id}`](#modified-blob_sidecar_subnet_id)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [BeaconBlocksByRange v2](#beaconblocksbyrange-v2)
@@ -376,106 +376,6 @@ wraps an `IndexedAttestation` payload sized for
 `MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT` attesting indices; the
 validation logic is otherwise unchanged.
 
-##### Blob subnets
-
-###### Modified `blob_sidecar_{subnet_id}`
-
-*Note*: This function is modified per EIP-7691. The sidecar's index is bounded
-by `MAX_BLOBS_PER_BLOCK_ELECTRA`.
-
-```python
-def validate_blob_sidecar_gossip(
-    seen: Seen,
-    store: Store,
-    state: BeaconState,
-    blob_sidecar: BlobSidecar,
-    current_time_ms: uint64,
-    subnet_id: SubnetID,
-) -> None:
-    """
-    Validate a BlobSidecar for gossip propagation on a subnet.
-    Raises GossipIgnore or GossipReject on validation failure.
-    """
-    block_header = blob_sidecar.signed_block_header.message
-
-    # [Modified in Electra:EIP7691]
-    # [REJECT] The sidecar's index is consistent with MAX_BLOBS_PER_BLOCK_ELECTRA
-    if blob_sidecar.index >= MAX_BLOBS_PER_BLOCK_ELECTRA:
-        raise GossipReject("blob index out of range")
-
-    # [REJECT] The sidecar is for the correct subnet
-    if compute_subnet_for_blob_sidecar(blob_sidecar.index) != subnet_id:
-        raise GossipReject("blob sidecar is for wrong subnet")
-
-    # [IGNORE] The sidecar is not from a future slot
-    # (MAY be queued for processing at the appropriate slot)
-    if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
-        raise GossipIgnore("blob sidecar is from a future slot")
-
-    # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
-    finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
-    if block_header.slot <= finalized_slot:
-        raise GossipIgnore("blob sidecar is not from a slot greater than the latest finalized slot")
-
-    # [REJECT] The proposer index is a valid validator index
-    if block_header.proposer_index >= len(state.validators):
-        raise GossipReject("proposer index out of range")
-
-    # [REJECT] The proposer signature of blob_sidecar.signed_block_header is valid
-    proposer = state.validators[block_header.proposer_index]
-    domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block_header.slot))
-    signing_root = compute_signing_root(block_header, domain)
-    if not bls.Verify(proposer.pubkey, signing_root, blob_sidecar.signed_block_header.signature):
-        raise GossipReject("invalid proposer signature on blob sidecar block header")
-
-    # [IGNORE] The sidecar's block's parent has been seen
-    # (MAY be queued for processing once the parent block is retrieved)
-    if block_header.parent_root not in store.blocks:
-        raise GossipIgnore("blob sidecar's parent has not been seen")
-
-    # [REJECT] The sidecar's block's parent passes validation
-    if block_header.parent_root not in store.block_states:
-        raise GossipReject("blob sidecar's parent failed validation")
-
-    # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
-    if block_header.slot <= store.blocks[block_header.parent_root].slot:
-        raise GossipReject("blob sidecar is not from a higher slot than its parent")
-
-    # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
-    checkpoint_block = get_checkpoint_block(
-        store, block_header.parent_root, store.finalized_checkpoint.epoch
-    )
-    if checkpoint_block != store.finalized_checkpoint.root:
-        raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
-
-    # [REJECT] The sidecar's inclusion proof is valid as verified by verify_blob_sidecar_inclusion_proof
-    if not verify_blob_sidecar_inclusion_proof(blob_sidecar):
-        raise GossipReject("invalid blob sidecar inclusion proof")
-
-    # [REJECT] The sidecar's blob is valid as verified by verify_blob_kzg_proof
-    if not verify_blob_kzg_proof(
-        blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof
-    ):
-        raise GossipReject("invalid blob kzg proof")
-
-    # [IGNORE] The sidecar is the first sidecar for the tuple
-    # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-    sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-    if sidecar_tuple in seen.blob_sidecar_tuples:
-        raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
-
-    # [REJECT] The sidecar is proposed by the expected proposer_index
-    # (if shuffling is not available, IGNORE instead and MAY be queued for later)
-    parent_state = store.block_states[block_header.parent_root].copy()
-    process_slots(parent_state, block_header.slot)
-    expected_proposer = get_beacon_proposer_index(parent_state)
-    if block_header.proposer_index != expected_proposer:
-        raise GossipReject("blob sidecar proposer_index does not match expected proposer")
-
-    # Mark this blob sidecar as seen
-    seen.blob_sidecar_tuples.add(sidecar_tuple)
-```
-
 ##### Attestation subnets
 
 ###### Modified `beacon_attestation_{subnet_id}`
@@ -591,6 +491,106 @@ def validate_beacon_attestation_gossip(
 
     # Mark this attestation as seen
     seen.attestation_validator_epochs.add((attester_index, target_epoch))
+```
+
+##### Blob subnets
+
+###### Modified `blob_sidecar_{subnet_id}`
+
+*Note*: This function is modified per EIP-7691. The sidecar's index is bounded
+by `MAX_BLOBS_PER_BLOCK_ELECTRA`.
+
+```python
+def validate_blob_sidecar_gossip(
+    seen: Seen,
+    store: Store,
+    state: BeaconState,
+    blob_sidecar: BlobSidecar,
+    current_time_ms: uint64,
+    subnet_id: SubnetID,
+) -> None:
+    """
+    Validate a BlobSidecar for gossip propagation on a subnet.
+    Raises GossipIgnore or GossipReject on validation failure.
+    """
+    block_header = blob_sidecar.signed_block_header.message
+
+    # [Modified in Electra:EIP7691]
+    # [REJECT] The sidecar's index is consistent with MAX_BLOBS_PER_BLOCK_ELECTRA
+    if blob_sidecar.index >= MAX_BLOBS_PER_BLOCK_ELECTRA:
+        raise GossipReject("blob index out of range")
+
+    # [REJECT] The sidecar is for the correct subnet
+    if compute_subnet_for_blob_sidecar(blob_sidecar.index) != subnet_id:
+        raise GossipReject("blob sidecar is for wrong subnet")
+
+    # [IGNORE] The sidecar is not from a future slot
+    # (MAY be queued for processing at the appropriate slot)
+    if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+        raise GossipIgnore("blob sidecar is from a future slot")
+
+    # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
+    finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+    if block_header.slot <= finalized_slot:
+        raise GossipIgnore("blob sidecar is not from a slot greater than the latest finalized slot")
+
+    # [REJECT] The proposer index is a valid validator index
+    if block_header.proposer_index >= len(state.validators):
+        raise GossipReject("proposer index out of range")
+
+    # [REJECT] The proposer signature of blob_sidecar.signed_block_header is valid
+    proposer = state.validators[block_header.proposer_index]
+    domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block_header.slot))
+    signing_root = compute_signing_root(block_header, domain)
+    if not bls.Verify(proposer.pubkey, signing_root, blob_sidecar.signed_block_header.signature):
+        raise GossipReject("invalid proposer signature on blob sidecar block header")
+
+    # [IGNORE] The sidecar's block's parent has been seen
+    # (MAY be queued for processing once the parent block is retrieved)
+    if block_header.parent_root not in store.blocks:
+        raise GossipIgnore("blob sidecar's parent has not been seen")
+
+    # [REJECT] The sidecar's block's parent passes validation
+    if block_header.parent_root not in store.block_states:
+        raise GossipReject("blob sidecar's parent failed validation")
+
+    # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
+    if block_header.slot <= store.blocks[block_header.parent_root].slot:
+        raise GossipReject("blob sidecar is not from a higher slot than its parent")
+
+    # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
+    checkpoint_block = get_checkpoint_block(
+        store, block_header.parent_root, store.finalized_checkpoint.epoch
+    )
+    if checkpoint_block != store.finalized_checkpoint.root:
+        raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
+
+    # [REJECT] The sidecar's inclusion proof is valid as verified by verify_blob_sidecar_inclusion_proof
+    if not verify_blob_sidecar_inclusion_proof(blob_sidecar):
+        raise GossipReject("invalid blob sidecar inclusion proof")
+
+    # [REJECT] The sidecar's blob is valid as verified by verify_blob_kzg_proof
+    if not verify_blob_kzg_proof(
+        blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof
+    ):
+        raise GossipReject("invalid blob kzg proof")
+
+    # [IGNORE] The sidecar is the first sidecar for the tuple
+    # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+    sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+    if sidecar_tuple in seen.blob_sidecar_tuples:
+        raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
+
+    # [REJECT] The sidecar is proposed by the expected proposer_index
+    # (if shuffling is not available, IGNORE instead and MAY be queued for later)
+    parent_state = store.block_states[block_header.parent_root].copy()
+    process_slots(parent_state, block_header.slot)
+    expected_proposer = get_beacon_proposer_index(parent_state)
+    if block_header.proposer_index != expected_proposer:
+        raise GossipReject("blob sidecar proposer_index does not match expected proposer")
+
+    # Mark this blob sidecar as seen
+    seen.blob_sidecar_tuples.add(sidecar_tuple)
 ```
 
 ### The Req/Resp domain

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -20,10 +20,10 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`beacon_block`](#beacon_block)
+        - [Modified `beacon_block`](#modified-beacon_block)
       - [Blob subnets](#blob-subnets)
         - [Deprecated `blob_sidecar_{subnet_id}`](#deprecated-blob_sidecar_subnet_id)
-        - [`data_column_sidecar_{subnet_id}`](#data_column_sidecar_subnet_id)
+        - [New `data_column_sidecar_{subnet_id}`](#new-data_column_sidecar_subnet_id)
         - [Distributed blob publishing using blobs retrieved from local execution-layer client](#distributed-blob-publishing-using-blobs-retrieved-from-local-execution-layer-client)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
@@ -236,7 +236,7 @@ Some gossip meshes are upgraded in Fulu to support upgraded types.
 
 ##### Global topics
 
-###### `beacon_block`
+###### Modified `beacon_block`
 
 *Note*: This function is modified per EIP-7892. The block's KZG commitment count
 is bounded by
@@ -347,7 +347,7 @@ def validate_beacon_block_gossip(
 
 `blob_sidecar_{subnet_id}` is deprecated.
 
-###### `data_column_sidecar_{subnet_id}`
+###### New `data_column_sidecar_{subnet_id}`
 
 The `data_column_sidecar_{subnet_id}` topics, where each column index maps to
 some `subnet_id`, are used to propagate new data column sidecars to nodes on the

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -7,15 +7,15 @@
   - [Preset](#preset)
   - [Configuration](#configuration)
   - [Containers](#containers)
-    - [`DataColumnsByRootIdentifier`](#datacolumnsbyrootidentifier)
+    - [New `DataColumnsByRootIdentifier`](#new-datacolumnsbyrootidentifier)
   - [Helpers](#helpers)
     - [Modified `Seen`](#modified-seen)
     - [Modified `compute_fork_version`](#modified-compute_fork_version)
     - [New `compute_max_request_data_column_sidecars`](#new-compute_max_request_data_column_sidecars)
-    - [`verify_data_column_sidecar`](#verify_data_column_sidecar)
-    - [`verify_data_column_sidecar_kzg_proofs`](#verify_data_column_sidecar_kzg_proofs)
-    - [`verify_data_column_sidecar_inclusion_proof`](#verify_data_column_sidecar_inclusion_proof)
-    - [`compute_subnet_for_data_column_sidecar`](#compute_subnet_for_data_column_sidecar)
+    - [New `verify_data_column_sidecar`](#new-verify_data_column_sidecar)
+    - [New `verify_data_column_sidecar_kzg_proofs`](#new-verify_data_column_sidecar_kzg_proofs)
+    - [New `verify_data_column_sidecar_inclusion_proof`](#new-verify_data_column_sidecar_inclusion_proof)
+    - [New `compute_subnet_for_data_column_sidecar`](#new-compute_subnet_for_data_column_sidecar)
   - [MetaData](#metadata)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
@@ -70,7 +70,7 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 ### Containers
 
-#### `DataColumnsByRootIdentifier`
+#### New `DataColumnsByRootIdentifier`
 
 ```python
 class DataColumnsByRootIdentifier(Container):
@@ -136,7 +136,7 @@ def compute_max_request_data_column_sidecars() -> uint64:
     return uint64(MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS)
 ```
 
-#### `verify_data_column_sidecar`
+#### New `verify_data_column_sidecar`
 
 ```python
 def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
@@ -165,7 +165,7 @@ def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
     return True
 ```
 
-#### `verify_data_column_sidecar_kzg_proofs`
+#### New `verify_data_column_sidecar_kzg_proofs`
 
 ```python
 def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
@@ -184,7 +184,7 @@ def verify_data_column_sidecar_kzg_proofs(sidecar: DataColumnSidecar) -> bool:
     )
 ```
 
-#### `verify_data_column_sidecar_inclusion_proof`
+#### New `verify_data_column_sidecar_inclusion_proof`
 
 ```python
 def verify_data_column_sidecar_inclusion_proof(sidecar: DataColumnSidecar) -> bool:
@@ -200,7 +200,7 @@ def verify_data_column_sidecar_inclusion_proof(sidecar: DataColumnSidecar) -> bo
     )
 ```
 
-#### `compute_subnet_for_data_column_sidecar`
+#### New `compute_subnet_for_data_column_sidecar`
 
 ```python
 def compute_subnet_for_data_column_sidecar(column_index: ColumnIndex) -> SubnetID:

--- a/specs/fulu/partial-columns/p2p-interface.md
+++ b/specs/fulu/partial-columns/p2p-interface.md
@@ -11,7 +11,8 @@
   - [`verify_partial_data_column_header_inclusion_proof`](#verify_partial_data_column_header_inclusion_proof)
   - [`verify_partial_data_column_sidecar_kzg_proofs`](#verify_partial_data_column_sidecar_kzg_proofs)
 - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
-  - [New `data_column_sidecar_{subnet_id}` (partial messages)](#new-data_column_sidecar_subnet_id-partial-messages)
+  - [Blob subnets](#blob-subnets)
+    - [New `data_column_sidecar_{subnet_id}` (partial messages)](#new-data_column_sidecar_subnet_id-partial-messages)
   - [Partial columns for Cell Dissemination](#partial-columns-for-cell-dissemination)
     - [Partial message group ID](#partial-message-group-id)
     - [Parts metadata](#parts-metadata)
@@ -147,7 +148,9 @@ def verify_partial_data_column_sidecar_kzg_proofs(
 
 ## The gossip domain: gossipsub
 
-### New `data_column_sidecar_{subnet_id}` (partial messages)
+### Blob subnets
+
+#### New `data_column_sidecar_{subnet_id}` (partial messages)
 
 *Note*: Validating partial messages happens in two parts. First, the
 `PartialDataColumnHeader` needs to be validated, then the cell and proof data.

--- a/specs/fulu/partial-columns/p2p-interface.md
+++ b/specs/fulu/partial-columns/p2p-interface.md
@@ -4,12 +4,12 @@
 
 - [Introduction](#introduction)
 - [Containers](#containers)
-  - [`PartialDataColumnSidecar`](#partialdatacolumnsidecar)
-  - [`PartialDataColumnPartsMetadata`](#partialdatacolumnpartsmetadata)
-  - [`PartialDataColumnHeader`](#partialdatacolumnheader)
+  - [New `PartialDataColumnSidecar`](#new-partialdatacolumnsidecar)
+  - [New `PartialDataColumnPartsMetadata`](#new-partialdatacolumnpartsmetadata)
+  - [New `PartialDataColumnHeader`](#new-partialdatacolumnheader)
 - [Helpers](#helpers)
-  - [`verify_partial_data_column_header_inclusion_proof`](#verify_partial_data_column_header_inclusion_proof)
-  - [`verify_partial_data_column_sidecar_kzg_proofs`](#verify_partial_data_column_sidecar_kzg_proofs)
+  - [New `verify_partial_data_column_header_inclusion_proof`](#new-verify_partial_data_column_header_inclusion_proof)
+  - [New `verify_partial_data_column_sidecar_kzg_proofs`](#new-verify_partial_data_column_sidecar_kzg_proofs)
 - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
   - [Blob subnets](#blob-subnets)
     - [New `data_column_sidecar_{subnet_id}` (partial messages)](#new-data_column_sidecar_subnet_id-partial-messages)
@@ -41,7 +41,7 @@ particular, this document builds on the
 
 ## Containers
 
-### `PartialDataColumnSidecar`
+### New `PartialDataColumnSidecar`
 
 The `PartialDataColumnSidecar` is similar to the `DataColumnSidecar` container,
 except that only the cells and proofs identified by the bitmap are present.
@@ -57,7 +57,7 @@ class PartialDataColumnSidecar(Container):
     header: List[PartialDataColumnHeader, 1]
 ```
 
-### `PartialDataColumnPartsMetadata`
+### New `PartialDataColumnPartsMetadata`
 
 Peers communicate the cells available with a bitmap. A set bit (`1`) at index
 `i` means that the peer has the cell at index `i`. Peers explicitly request
@@ -87,7 +87,7 @@ bit from the requests bit.
 Having a cell but not willing to provide it is functionally the same as not
 having the cell and not wanting it, so it does not need a separate state.
 
-### `PartialDataColumnHeader`
+### New `PartialDataColumnHeader`
 
 The `PartialDataColumnHeader` is the header that is common to all columns for a
 given block. It lets a peer identify which blobs are included in a block, as
@@ -104,7 +104,7 @@ class PartialDataColumnHeader(Container):
 
 ## Helpers
 
-### `verify_partial_data_column_header_inclusion_proof`
+### New `verify_partial_data_column_header_inclusion_proof`
 
 ```python
 def verify_partial_data_column_header_inclusion_proof(header: PartialDataColumnHeader) -> bool:
@@ -120,7 +120,7 @@ def verify_partial_data_column_header_inclusion_proof(header: PartialDataColumnH
     )
 ```
 
-### `verify_partial_data_column_sidecar_kzg_proofs`
+### New `verify_partial_data_column_sidecar_kzg_proofs`
 
 ```python
 def verify_partial_data_column_sidecar_kzg_proofs(

--- a/specs/fulu/partial-columns/p2p-interface.md
+++ b/specs/fulu/partial-columns/p2p-interface.md
@@ -11,7 +11,7 @@
   - [`verify_partial_data_column_header_inclusion_proof`](#verify_partial_data_column_header_inclusion_proof)
   - [`verify_partial_data_column_sidecar_kzg_proofs`](#verify_partial_data_column_sidecar_kzg_proofs)
 - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
-  - [Partial Messages on `data_column_sidecar_{subnet_id}`](#partial-messages-on-data_column_sidecar_subnet_id)
+  - [New `data_column_sidecar_{subnet_id}` (partial messages)](#new-data_column_sidecar_subnet_id-partial-messages)
   - [Partial columns for Cell Dissemination](#partial-columns-for-cell-dissemination)
     - [Partial message group ID](#partial-message-group-id)
     - [Parts metadata](#parts-metadata)
@@ -147,7 +147,7 @@ def verify_partial_data_column_sidecar_kzg_proofs(
 
 ## The gossip domain: gossipsub
 
-### Partial Messages on `data_column_sidecar_{subnet_id}`
+### New `data_column_sidecar_{subnet_id}` (partial messages)
 
 *Note*: Validating partial messages happens in two parts. First, the
 `PartialDataColumnHeader` needs to be validated, then the cell and proof data.

--- a/specs/gloas/light-client/p2p-interface.md
+++ b/specs/gloas/light-client/p2p-interface.md
@@ -6,8 +6,8 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`light_client_finality_update`](#light_client_finality_update)
-        - [`light_client_optimistic_update`](#light_client_optimistic_update)
+        - [Modified `light_client_finality_update`](#modified-light_client_finality_update)
+        - [Modified `light_client_optimistic_update`](#modified-light_client_optimistic_update)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [GetLightClientBootstrap](#getlightclientbootstrap)
@@ -29,7 +29,7 @@ is extended to exchange [Gloas light client data](./sync-protocol.md).
 
 ##### Global topics
 
-###### `light_client_finality_update`
+###### Modified `light_client_finality_update`
 
 <!-- eth_consensus_specs: skip -->
 
@@ -42,7 +42,7 @@ is extended to exchange [Gloas light client data](./sync-protocol.md).
 | `ELECTRA_FORK_VERSION` through `FULU_FORK_VERSION`     | `electra.LightClientFinalityUpdate` |
 | `GLOAS_FORK_VERSION` and later                         | `gloas.LightClientFinalityUpdate`   |
 
-###### `light_client_optimistic_update`
+###### Modified `light_client_optimistic_update`
 
 <!-- eth_consensus_specs: skip -->
 

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -19,16 +19,16 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`beacon_aggregate_and_proof`](#beacon_aggregate_and_proof)
-        - [`beacon_block`](#beacon_block)
-        - [`execution_payload`](#execution_payload)
-        - [`payload_attestation_message`](#payload_attestation_message)
-        - [`execution_payload_bid`](#execution_payload_bid)
-        - [`proposer_preferences`](#proposer_preferences)
+        - [Modified `beacon_aggregate_and_proof`](#modified-beacon_aggregate_and_proof)
+        - [Modified `beacon_block`](#modified-beacon_block)
+        - [New `execution_payload`](#new-execution_payload)
+        - [New `payload_attestation_message`](#new-payload_attestation_message)
+        - [New `execution_payload_bid`](#new-execution_payload_bid)
+        - [New `proposer_preferences`](#new-proposer_preferences)
       - [Blob subnets](#blob-subnets)
-        - [`data_column_sidecar_{subnet_id}`](#data_column_sidecar_subnet_id)
+        - [Modified `data_column_sidecar_{subnet_id}`](#modified-data_column_sidecar_subnet_id)
       - [Attestation subnets](#attestation-subnets)
-        - [`beacon_attestation_{subnet_id}`](#beacon_attestation_subnet_id)
+        - [Modified `beacon_attestation_{subnet_id}`](#modified-beacon_attestation_subnet_id)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [BeaconBlocksByRange v2](#beaconblocksbyrange-v2)
@@ -234,7 +234,7 @@ are given in this table:
 Gloas introduces new global topics for execution bid, execution payload and
 payload attestation.
 
-###### `beacon_aggregate_and_proof`
+###### Modified `beacon_aggregate_and_proof`
 
 Let `block` be the beacon block corresponding to
 `aggregate.data.beacon_block_root`.
@@ -255,7 +255,7 @@ The following validations are removed:
 
 - _[REJECT]_ `aggregate.data.index == 0`.
 
-###### `beacon_block`
+###### Modified `beacon_block`
 
 *[Modified in Gloas:EIP7732]*
 
@@ -294,7 +294,7 @@ And instead the following validations are set in place with the alias
 - [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the
   block's parent (defined by `block.parent_root`).
 
-###### `execution_payload`
+###### New `execution_payload`
 
 This topic is used to propagate execution payload messages as
 `SignedExecutionPayloadEnvelope`.
@@ -326,7 +326,7 @@ obtained from the `state.latest_execution_payload_bid`)
 - _[REJECT]_ `signed_execution_payload_envelope.signature` is valid as verified
   by `verify_execution_payload_envelope_signature`.
 
-###### `payload_attestation_message`
+###### New `payload_attestation_message`
 
 This topic is used to propagate signed payload attestation message.
 
@@ -352,7 +352,7 @@ The following validations MUST pass before forwarding the
 - _[REJECT]_ `payload_attestation_message.signature` is valid with respect to
   the validator's public key.
 
-###### `execution_payload_bid`
+###### New `execution_payload_bid`
 
 This topic is used to propagate signed bids as `SignedExecutionPayloadBid`.
 
@@ -418,7 +418,7 @@ Possible strategies include: (1) only forwarding bids that exceed the current
 highest bid by a minimum threshold, or (2) forwarding only the highest observed
 bid at regular time intervals.
 
-###### `proposer_preferences`
+###### New `proposer_preferences`
 
 *[New in Gloas:EIP7732]*
 
@@ -482,7 +482,7 @@ fork.
 
 ##### Blob subnets
 
-###### `data_column_sidecar_{subnet_id}`
+###### Modified `data_column_sidecar_{subnet_id}`
 
 *[Modified in Gloas:EIP7732]*
 
@@ -512,7 +512,7 @@ the sidecar.
 
 ##### Attestation subnets
 
-###### `beacon_attestation_{subnet_id}`
+###### Modified `beacon_attestation_{subnet_id}`
 
 Let `block` be the beacon block corresponding to
 `attestation.data.beacon_block_root`.

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -25,10 +25,10 @@
         - [New `payload_attestation_message`](#new-payload_attestation_message)
         - [New `execution_payload_bid`](#new-execution_payload_bid)
         - [New `proposer_preferences`](#new-proposer_preferences)
-      - [Blob subnets](#blob-subnets)
-        - [Modified `data_column_sidecar_{subnet_id}`](#modified-data_column_sidecar_subnet_id)
       - [Attestation subnets](#attestation-subnets)
         - [Modified `beacon_attestation_{subnet_id}`](#modified-beacon_attestation_subnet_id)
+      - [Blob subnets](#blob-subnets)
+        - [Modified `data_column_sidecar_{subnet_id}`](#modified-data_column_sidecar_subnet_id)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [BeaconBlocksByRange v2](#beaconblocksbyrange-v2)
@@ -480,6 +480,30 @@ def get_proposer_dependent_root(state: BeaconState, epoch: Epoch) -> Root:
 activation. Proposers SHOULD broadcast their preferences in the epoch before the
 fork.
 
+##### Attestation subnets
+
+###### Modified `beacon_attestation_{subnet_id}`
+
+Let `block` be the beacon block corresponding to
+`attestation.data.beacon_block_root`.
+
+The following validations are added:
+
+- _[REJECT]_ `attestation.data.index < 2`.
+- _[REJECT]_ `attestation.data.index == 0` if
+  `block.slot == attestation.data.slot`.
+- _[REJECT]_ If `attestation.data.index == 1` (payload present for a past
+  block), the execution payload for `block` passes validation.
+- _[IGNORE]_ When `attestation.data.index == 1` (payload present for a past
+  block), the execution payload for `block` has been seen (a client MAY queue
+  attestations for processing once the payload is retrieved and SHOULD request
+  the payload envelope via `ExecutionPayloadEnvelopesByRoot` using
+  `attestation.data.beacon_block_root`).
+
+The following validations are removed:
+
+- _[REJECT]_ `attestation.data.index == 0`.
+
 ##### Blob subnets
 
 ###### Modified `data_column_sidecar_{subnet_id}`
@@ -509,30 +533,6 @@ The following validations MUST pass before forwarding the
 *Note*: If the sidecar fails deferred validation, its forwarding peers MUST be
 downscored retroactively. If validation succeeds, the client MUST re-broadcast
 the sidecar.
-
-##### Attestation subnets
-
-###### Modified `beacon_attestation_{subnet_id}`
-
-Let `block` be the beacon block corresponding to
-`attestation.data.beacon_block_root`.
-
-The following validations are added:
-
-- _[REJECT]_ `attestation.data.index < 2`.
-- _[REJECT]_ `attestation.data.index == 0` if
-  `block.slot == attestation.data.slot`.
-- _[REJECT]_ If `attestation.data.index == 1` (payload present for a past
-  block), the execution payload for `block` passes validation.
-- _[IGNORE]_ When `attestation.data.index == 1` (payload present for a past
-  block), the execution payload for `block` has been seen (a client MAY queue
-  attestations for processing once the payload is retrieved and SHOULD request
-  the payload envelope via `ExecutionPayloadEnvelopesByRoot` using
-  `attestation.data.beacon_block_root`).
-
-The following validations are removed:
-
-- _[REJECT]_ `attestation.data.index == 0`.
 
 ### The Req/Resp domain
 

--- a/specs/gloas/partial-columns/p2p-interface.md
+++ b/specs/gloas/partial-columns/p2p-interface.md
@@ -10,7 +10,7 @@
     - [Modified `PartialDataColumnSidecar`](#modified-partialdatacolumnsidecar)
     - [New `PartialDataColumnGroupID`](#new-partialdatacolumngroupid)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
-    - [Partial Messages on `data_column_sidecar_{subnet_id}`](#partial-messages-on-data_column_sidecar_subnet_id)
+    - [Modified `data_column_sidecar_{subnet_id}` (partial messages)](#modified-data_column_sidecar_subnet_id-partial-messages)
 
 <!-- mdformat-toc end -->
 
@@ -50,7 +50,7 @@ class PartialDataColumnGroupID(Container):
 
 ### The gossip domain: gossipsub
 
-#### Partial Messages on `data_column_sidecar_{subnet_id}`
+#### Modified `data_column_sidecar_{subnet_id}` (partial messages)
 
 *[Modified in Gloas:EIP7732]*
 

--- a/specs/gloas/partial-columns/p2p-interface.md
+++ b/specs/gloas/partial-columns/p2p-interface.md
@@ -10,7 +10,8 @@
     - [Modified `PartialDataColumnSidecar`](#modified-partialdatacolumnsidecar)
     - [New `PartialDataColumnGroupID`](#new-partialdatacolumngroupid)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
-    - [Modified `data_column_sidecar_{subnet_id}` (partial messages)](#modified-data_column_sidecar_subnet_id-partial-messages)
+    - [Blob subnets](#blob-subnets)
+      - [Modified `data_column_sidecar_{subnet_id}` (partial messages)](#modified-data_column_sidecar_subnet_id-partial-messages)
 
 <!-- mdformat-toc end -->
 
@@ -50,7 +51,9 @@ class PartialDataColumnGroupID(Container):
 
 ### The gossip domain: gossipsub
 
-#### Modified `data_column_sidecar_{subnet_id}` (partial messages)
+#### Blob subnets
+
+##### Modified `data_column_sidecar_{subnet_id}` (partial messages)
 
 *[Modified in Gloas:EIP7732]*
 

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -12,7 +12,7 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
-        - [`inclusion_list`](#inclusion_list)
+        - [New `inclusion_list`](#new-inclusion_list)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
       - [InclusionListByCommitteeIndices v1](#inclusionlistbycommitteeindices-v1)
@@ -78,7 +78,7 @@ are given in this table:
 
 Heze introduces a new global topic for inclusion lists.
 
-###### `inclusion_list`
+###### New `inclusion_list`
 
 This topic is used to propagate signed inclusion list as `SignedInclusionList`.
 The following validations MUST pass before forwarding the `inclusion_list` on


### PR DESCRIPTION
The lack of these annotations ("new" or "modified") in post-Altair specs has been of nit of mine for a while. I find these helpful when determining what is new. I believe others will find them useful too.