### PR TITLE
Pass only signed bid to `process_execution_payload_bid`

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -1111,7 +1111,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     # [Modified in Gloas:EIP7732]
     # Removed `process_execution_payload`
     # [New in Gloas:EIP7732]
-    process_execution_payload_bid(state, block)
+    process_execution_payload_bid(state, block.body.signed_execution_payload_bid)
     process_randao(state, block.body)
     process_eth1_data(state, block.body)
     # [Modified in Gloas:EIP7732]
@@ -1440,8 +1440,9 @@ def verify_execution_payload_bid_signature(
 ##### New `process_execution_payload_bid`
 
 ```python
-def process_execution_payload_bid(state: BeaconState, block: BeaconBlock) -> None:
-    signed_bid = block.body.signed_execution_payload_bid
+def process_execution_payload_bid(
+    state: BeaconState, signed_bid: SignedExecutionPayloadBid
+) -> None:
     bid = signed_bid.message
     builder_index = bid.builder_index
     amount = bid.value
@@ -1465,10 +1466,11 @@ def process_execution_payload_bid(state: BeaconState, block: BeaconBlock) -> Non
     )
 
     # Verify that the bid is for the current slot
-    assert bid.slot == block.slot
+    assert bid.slot == state.slot
+    assert state.slot > GENESIS_SLOT
     # Verify that the bid is for the right parent block
     assert bid.parent_block_hash == state.latest_block_hash
-    assert bid.parent_block_root == block.parent_root
+    assert bid.parent_block_root == get_block_root_at_slot(state, Slot(state.slot - 1))
     assert bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
 
     # Record the pending payment if there is some payment

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
@@ -602,9 +602,10 @@ def test_process_execution_payload_bid_wrong_slot(spec, state):
         spec,
         state,
         builder_index=spec.BUILDER_INDEX_SELF_BUILD,
-        slot=block.slot + 1,  # Wrong slot
+        slot=block.slot,
         parent_block_root=block.parent_root,
     )
+    signed_bid.message.slot = signed_bid.message.slot + 1  # Wrong slot
 
     block.body.signed_execution_payload_bid = signed_bid
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload_bid.py
@@ -7,19 +7,20 @@ def run_execution_payload_bid_processing(spec, state, block, valid=True):
     """
     Run ``process_execution_payload_bid``, yielding:
     - pre-state ('pre')
-    - block ('block')
+    - execution payload bid ('execution_payload_bid')
     - post-state ('post').
     If ``valid == False``, run expecting ``AssertionError``
     """
+    signed_bid = block.body.signed_execution_payload_bid
     yield "pre", state
-    yield "block", block
+    yield "execution_payload_bid", signed_bid
 
     if not valid:
-        expect_assertion_error(lambda: spec.process_execution_payload_bid(state, block))
+        expect_assertion_error(lambda: spec.process_execution_payload_bid(state, signed_bid))
         yield "post", None
         return
 
-    spec.process_execution_payload_bid(state, block)
+    spec.process_execution_payload_bid(state, signed_bid)
     yield "post", state
 
 

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -49,7 +49,7 @@ Operations:
 | `deposit_request`          | `DepositRequest`             | `deposit_request`       | `process_deposit_request(state, deposit_request)` (new in Electra)             |
 | `withdrawal_request`       | `WithdrawalRequest`          | `withdrawal_request`    | `process_withdrawal_request(state, withdrawal_request)` (new in Electra)       |
 | `consolidation_request`    | `ConsolidationRequest`       | `consolidation_request` | `process_consolidation_request(state, consolidation_request)` (new in Electra) |
-| `execution_payload_bid`    | `BeaconBlock`                | **`block`**             | `process_execution_payload_bid(state, block)` (new in Gloas)                   |
+| `execution_payload_bid`    | `SignedExecutionPayloadBid`  | `execution_payload_bid` | `process_execution_payload_bid(state, execution_payload_bid)` (new in Gloas)   |
 | `parent_execution_payload` | `BeaconBlock`                | **`block`**             | `process_parent_execution_payload(state, block)` (new in Gloas)                |
 | `payload_attestation`      | `PayloadAttestation`         | `payload_attestation`   | `process_payload_attestation(state, payload_attestation)` (new in Gloas)       |
 


### PR DESCRIPTION
Most operation processors take the minimum amount of information that's needed for validation, e.g., process_sync_aggregate solely takes the sync aggregate. For process_execution_payload_bid, the full block is passed instead, while at the same time requiring in validator.md that the verification checks in process_execution_payload_bid have to be run in order to construct a bid.

Clean that up by only taking the SignedExecutionPayloadBid, so that the verification checks no longer depend on the existence of a BeaconBlock.
