### PR TITLE
Only clear builder payment if the slashed validator is the proposer

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -226,6 +226,7 @@ class Builder(Container):
 class BuilderPendingPayment(Container):
     weight: Gwei
     withdrawal: BuilderPendingWithdrawal
+    proposer_index: ValidatorIndex
 ```
 
 #### `BuilderPendingWithdrawal`
@@ -1480,6 +1481,7 @@ def process_execution_payload_bid(state: BeaconState, block: BeaconBlock) -> Non
                 amount=amount,
                 builder_index=builder_index,
             ),
+            proposer_index=block.proposer_index,
         )
         state.builder_pending_payments[SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH] = (
             pending_payment
@@ -1811,16 +1813,22 @@ def process_proposer_slashing(state: BeaconState, proposer_slashing: ProposerSla
         assert bls.Verify(proposer.pubkey, signing_root, signed_header.signature)
 
     # [New in Gloas:EIP7732]
-    # Remove the BuilderPendingPayment corresponding to
-    # this proposal if it is still in the 2-epoch window.
+    # Remove the BuilderPendingPayment corresponding to this proposal if it is
+    # still in the 2-epoch window. Only clear it when the slashed validator is
+    # the proposer that armed the payment; otherwise an unrelated same-slot
+    # equivocation could grief an honest proposer's payment.
     slot = header_1.slot
     proposal_epoch = compute_epoch_at_slot(slot)
     if proposal_epoch == get_current_epoch(state):
         payment_index = SLOTS_PER_EPOCH + slot % SLOTS_PER_EPOCH
-        state.builder_pending_payments[payment_index] = BuilderPendingPayment()
+        payment = state.builder_pending_payments[payment_index]
+        if payment.proposer_index == header_1.proposer_index:
+            state.builder_pending_payments[payment_index] = BuilderPendingPayment()
     elif proposal_epoch == get_previous_epoch(state):
         payment_index = slot % SLOTS_PER_EPOCH
-        state.builder_pending_payments[payment_index] = BuilderPendingPayment()
+        payment = state.builder_pending_payments[payment_index]
+        if payment.proposer_index == header_1.proposer_index:
+            state.builder_pending_payments[payment_index] = BuilderPendingPayment()
 
     slash_validator(state, header_1.proposer_index)
 ```

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -1815,7 +1815,7 @@ def process_proposer_slashing(state: BeaconState, proposer_slashing: ProposerSla
     # [New in Gloas:EIP7732]
     # Remove the BuilderPendingPayment corresponding to this proposal if it is
     # still in the 2-epoch window. Only clear it when the slashed validator is
-    # the proposer that armed the payment; otherwise an unrelated same-slot
+    # the proposer associated with the payment; otherwise an unrelated same-slot
     # equivocation could grief an honest proposer's payment.
     slot = header_1.slot
     proposal_epoch = compute_epoch_at_slot(slot)

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_proposer_slashing.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_proposer_slashing.py
@@ -423,3 +423,55 @@ def test_builder_payment_deletion_previous_epoch_last_slot(spec, state):
         pre_state,
         proposer_slashing,
     )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_payment_not_deleted_foreign_equivocation(spec, state):
+    """
+    Test that a proposer slashing does NOT delete a builder pending payment recorded for
+    a different proposer. This guards against a griefing vector: the clear is keyed only
+    by header slot, so without the proposer check any validator equivocating on a slot
+    could clear an honest proposer's payment for that slot.
+
+    Input State Configured:
+        - builder_pending_payments: current-epoch entry recorded for the payment proposer
+        - proposer_slashing: valid slashing of a different validator for the same slot,
+          within the 2-epoch window
+
+    Output State Verified:
+        - validators[slashed_index].slashed: True
+        - builder_pending_payments: entry left intact (slashed validator is not the
+          payment's proposer)
+    """
+    active = spec.get_active_validator_indices(state, spec.get_current_epoch(state))
+    payment_proposer = active[0]  # the payment is recorded for this proposer
+    slashed_proposer = active[-1]  # equivocates on the slot, not the payment's proposer
+    assert payment_proposer != slashed_proposer
+
+    proposer_slashing, _ = prepare_process_proposer_slashing(
+        spec,
+        state,
+        advance_epochs=2,
+        slot_offset=Random(2024).randrange(spec.SLOTS_PER_EPOCH),
+        proposer_index=slashed_proposer,
+        parent_root_2=b"\x99" * 32,  # Make headers different
+        builder_payment_amount=spec.MIN_ACTIVATION_BALANCE,
+        builder_payment_fee_recipient=b"\x42" * 20,
+        builder_payment_weight=1000,
+        builder_payment_proposer_index=payment_proposer,
+    )
+
+    slashed_slot = proposer_slashing.signed_header_1.message.slot
+    assert spec.compute_epoch_at_slot(slashed_slot) == spec.get_current_epoch(state)
+
+    pre_state = state.copy()
+
+    yield from run_proposer_slashing_processing(spec, state, proposer_slashing)
+
+    assert_process_proposer_slashing(
+        spec,
+        state,
+        pre_state,
+        proposer_slashing,
+    )

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/proposer_slashings.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/proposer_slashings.py
@@ -52,7 +52,9 @@ def check_proposer_slashing_effect(
         - slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] incremented by effective_balance
         - balances[slashed_index] decreased by slash penalty
         - balances[proposer_index] increased by whistleblower reward
-        - [GLOAS+] builder_pending_payments cleared if header slot within 2-epoch window
+        - [GLOAS+] builder_pending_payments entry cleared if the slashed validator is the
+          payment's proposer and the header slot is within the 2-epoch window; left intact
+          otherwise
     """
     current_epoch = spec.get_current_epoch(state)
     pre_validator = pre_state.validators[slashed_index]
@@ -147,12 +149,23 @@ def check_proposer_slashing_effect(
 
         if proposal_epoch == current_epoch:
             payment_index = spec.SLOTS_PER_EPOCH + header_slot % spec.SLOTS_PER_EPOCH
-            assert state.builder_pending_payments[payment_index] == spec.BuilderPendingPayment()
         elif proposal_epoch == spec.get_previous_epoch(state):
             payment_index = header_slot % spec.SLOTS_PER_EPOCH
+        else:
+            payment_index = None
+
+        if payment_index is None:
+            # Slot is outside the 2-epoch window: payments are untouched
+            assert state.builder_pending_payments == pre_state.builder_pending_payments
+        elif pre_state.builder_pending_payments[payment_index].proposer_index == slashed_index:
+            # The slashed validator is this payment's proposer, so it is cleared
             assert state.builder_pending_payments[payment_index] == spec.BuilderPendingPayment()
         else:
-            assert state.builder_pending_payments == pre_state.builder_pending_payments
+            # This payment has a different proposer, so it is left intact
+            assert (
+                state.builder_pending_payments[payment_index]
+                == pre_state.builder_pending_payments[payment_index]
+            )
 
 
 def get_valid_proposer_slashing(

--- a/tests/infra/helpers/proposer_slashings.py
+++ b/tests/infra/helpers/proposer_slashings.py
@@ -67,6 +67,7 @@ def prepare_process_proposer_slashing(
     builder_payment_fee_recipient=None,  # Fee recipient address (20 bytes)
     builder_payment_weight=None,  # Weight for the pending payment (default: 0)
     builder_payment_builder_index=None,  # Builder index for the payment (default: last builder)
+    builder_payment_proposer_index=None,  # Proposer recorded on the payment (default: slashed proposer)
 ):
     """
     Prepare a proposer slashing operation with configurable headers and state.
@@ -203,9 +204,16 @@ def prepare_process_proposer_slashing(
                 builder_index=builder_index,
             )
 
+            payment_proposer_index = (
+                spec.ValidatorIndex(builder_payment_proposer_index)
+                if builder_payment_proposer_index is not None
+                else effective_proposer_1
+            )
+
             pending_payment = spec.BuilderPendingPayment(
                 weight=spec.Gwei(weight),
                 withdrawal=pending_withdrawal,
+                proposer_index=payment_proposer_index,
             )
 
             state.builder_pending_payments[payment_index] = pending_payment


### PR DESCRIPTION
### Summary

In Gloas, `process_proposer_slashing` clears the `BuilderPendingPayment` IOU for a slot using only the slot number from the slashing evidence (`header_1.slot`), with no check that the slashed validator was that slot's proposer.

https://github.com/ethereum/consensus-specs/blob/5e032ed5512a2fe6a8eb90d83f5b0ff07bbed82c/specs/gloas/beacon-chain.md#L1816-L1823

### The grief vector

`process_proposer_slashing` validates a slashing by checking only that the two headers are consistent with each other — never that the proposer was the one actually assigned to the slot. Because the IOU is then cleared using only `header_1.slot`, the slashed validator does not have to be the slot's proposer for the clear to fire.

Concretely:

1. Honest proposer `P` proposes the canonical block at slot `N` with a positive bid, arming a `BuilderPendingPayment` at slot `N`'s index.
2. A *different* slashable validator `V` signs two distinct block headers that both claim `slot = N`. These are valid slashing evidence (V is equivocating), even though V was never slot `N`'s proposer and the headers point to no real block.
3. That slashing is included while slot `N` is still in the 2-epoch payment window. The clear keys on `header_1.slot = N`, so it zeroes `P`'s IOU.

Result: `P`'s payment is cancelled — the proposer is never credited, the builder is never charged — purely because `V` equivocated on the same slot number.

### Impact

A validator can be sacrificed (one slashing) to cancel an honest proposer's builder payment. It applies to payments not yet settled via an on-chain payload reveal.

### Fix

Bind each IOU to the proposer that armed it, and clear it only on a match:

- Add `proposer_index: ValidatorIndex` to `BuilderPendingPayment`.
- Set it from `block.proposer_index` in `process_execution_payload_bid`.
- In `process_proposer_slashing`, clear the entry only when `payment.proposer_index == header_1.proposer_index`.

The arming proposer can't be recomputed at slashing time for the previous-epoch case (`proposer_lookahead` no longer covers it), so the binding is stored on the entry. `block.proposer_index` is sound to record because `process_block_header` (run before the bid) asserts it equals `get_beacon_proposer_index(state)`.