### PR TITLE
Get proposer index via `get_beacon_proposer_index`

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -1483,7 +1483,7 @@ def process_execution_payload_bid(
                 amount=amount,
                 builder_index=builder_index,
             ),
-            proposer_index=block.proposer_index,
+            proposer_index=get_beacon_proposer_index(state),
         )
         state.builder_pending_payments[SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH] = (
             pending_payment


### PR DESCRIPTION
Related to:

* https://github.com/ethereum/consensus-specs/pull/5364
* https://github.com/ethereum/consensus-specs/pull/5365

I merged these back-to-back without pulling in updates from master & didn't realize that they conflicted. The first removes block as a parameter which the second uses to get the proposer index. Thankfully, the fix is simple; we can use `get_beacon_proposer_index` for this. It's worth mentioning that `process_block_header` checks that these are the same, so this change is safe.