### PR TITLE
Fix typos in fork choice compliance runner

### DIFF
--- a/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/block_tree.py
@@ -233,13 +233,13 @@ def _generate_sm_link_tree(
         3. Randomly sample all active validators between a set of forks that are being advanced in the epoch.
            Validator partitions are disjoint and are changing only at the epoch boundary.
            If no new branches are created in the current epoch then partitions from the previous epoch will be used
-           to advahce the state of every fork to the next epoch.
+           to advance the state of every fork to the next epoch.
         4. Advance every fork to the next epoch respecting a validator partition assigned to it in the current epoch.
            Preserve attestations produced but not yet included on chain for potential inclusion in the next epoch.
         5. Justify required checkpoints by moving the majority of validators to the justifying fork,
            this is taken into account by step (3).
 
-    :return: Sequence of signed blocks oredered by a slot number.
+    :return: Sequence of signed blocks ordered by a slot number.
     """
     assert any(sm_links)
 

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -428,7 +428,7 @@ def advance_branch_to_next_epoch(spec, branch_tip, enable_attesting=True):
     target_slot = spec.compute_start_slot_at_epoch(current_epoch + 1)
 
     while state.slot < target_slot:
-        # Produce block if the proposer is among participanting validators
+        # Produce block if the proposer is among participating validators
         proposer = spec.get_beacon_proposer_index(state)
         if state.slot > spec.GENESIS_SLOT and proposer in branch_tip.participants:
             signed_block, state, attestations, _, _ = produce_block(spec, state, attestations)
@@ -652,7 +652,7 @@ def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list
 
     test_steps = []
 
-    def try_add_mesage(runner, message):
+    def try_add_message(runner, message):
         try:
             runner(spec, store, message, valid=True)
             return True
@@ -685,13 +685,13 @@ def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list
         elif event_kind == "attestation":
             _, attestation, valid = event
             if valid is None:
-                valid = try_add_mesage(run_on_attestation, attestation)
+                valid = try_add_message(run_on_attestation, attestation)
             yield from add_attestation(spec, store, attestation, test_steps, valid=valid)
             output_store_checks(spec, store, test_steps)
         elif event_kind == "attester_slashing":
             _, attester_slashing, valid = event
             if valid is None:
-                valid = try_add_mesage(run_on_attester_slashing, attester_slashing)
+                valid = try_add_message(run_on_attester_slashing, attester_slashing)
             yield from add_attester_slashing(
                 spec, store, attester_slashing, test_steps, valid=valid
             )
@@ -699,13 +699,13 @@ def yield_fork_choice_test_events(spec, test_data: FCTestData, test_events: list
         elif event_kind == "execution_payload":
             _, signed_envelope, valid = event
             if valid is None:
-                valid = try_add_mesage(run_on_execution_payload_envelope, signed_envelope)
+                valid = try_add_message(run_on_execution_payload_envelope, signed_envelope)
             yield from add_execution_payload(spec, store, signed_envelope, test_steps, valid=valid)
             output_store_checks(spec, store, test_steps)
         elif event_kind == "payload_attestation":
             _, ptc_message, valid = event
             if valid is None:
-                valid = try_add_mesage(run_on_payload_attestation_message, ptc_message)
+                valid = try_add_message(run_on_payload_attestation_message, ptc_message)
             yield from add_payload_attestation_message(
                 spec, store, ptc_message, test_steps, valid=valid
             )

--- a/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/scheduler.py
@@ -57,7 +57,7 @@ class MessageScheduler:
             root not in self.store.blocks for root in item.dependencies
         )
 
-    def enque_message(self, item: QueueItem):
+    def enqueue_message(self, item: QueueItem):
         self.message_queue.append(item)
 
     def drain_queue(
@@ -72,7 +72,7 @@ class MessageScheduler:
         updated = False
         for item in self.drain_queue():
             if self.is_early_message(item):
-                self.enque_message(item)
+                self.enqueue_message(item)
             elif item.kind == QueueItemKind.ATTESTATION:
                 if self.process_attestation(item.message):
                     applied_events.append(("attestation", item.message, True))
@@ -127,7 +127,7 @@ class MessageScheduler:
         except AssertionError:
             item = QueueItem(attestation, QueueItemKind.ATTESTATION, is_from_block)
             if self.is_early_message(item):
-                self.enque_message(item)
+                self.enqueue_message(item)
             return False
 
     def process_slashing(self, slashing):
@@ -144,7 +144,7 @@ class MessageScheduler:
         except AssertionError:
             item = QueueItem(ptc_message, QueueItemKind.PAYLOAD_ATTESTATION, is_from_block)
             if self.is_early_message(item):
-                self.enque_message(item)
+                self.enqueue_message(item)
             return False
 
     def process_block_messages(self, signed_block):
@@ -170,7 +170,7 @@ class MessageScheduler:
         except AssertionError:
             item = QueueItem(signed_block, QueueItemKind.BLOCK)
             if self.is_early_message(item):
-                self.enque_message(item)
+                self.enqueue_message(item)
             valid = False
         if valid:
             applied_events.extend(self.purge_queue())
@@ -184,5 +184,5 @@ class MessageScheduler:
         except AssertionError:
             item = QueueItem(signed_payload, QueueItemKind.EXECUTION_PAYLOAD)
             if self.is_early_message(item):
-                self.enque_message(item)
+                self.enqueue_message(item)
             return False


### PR DESCRIPTION
<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What this PR does (but not how it does it)
* Why this PR is necessary, including context
-->

Fix a few typos in the fork choice compliance runner comments, docstrings, and internal helper names.

This is a cleanup-only change and does not alter test generation behavior.

<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->
