### PR TITLE
Use `MAX_REQUEST_PAYLOADS` in `EnvelopesByRange`

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -594,7 +594,7 @@ Response Content:
 
 ```
 (
-  List[SignedExecutionPayloadEnvelope, MAX_REQUEST_BLOCKS_DENEB]
+  List[SignedExecutionPayloadEnvelope, MAX_REQUEST_PAYLOADS]
 )
 ```
 


### PR DESCRIPTION
For some reason, we're still using `MAX_REQUEST_BLOCKS_DENEB` in `ExecutionPayloadEnvelopesByRange`. I believe we forgot to update this when adding the new config a while back. This would mirror `ExecutionPayloadEnvelopesByRoot`:

https://github.com/ethereum/consensus-specs/blob/7d5f3348d7b947851861745be9ce0ba30e526531/specs/gloas/p2p-interface.md?plain=1#L618-L649