### PR TITLE
Set slot before using it for object construction

### DIFF
--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -127,22 +127,22 @@ to include. They produce a `SignedExecutionPayloadBid` as follows.
     that is `payload.prev_randao`. This value **MUST** equal
     `get_randao_mix(parent_state, get_current_epoch(parent_state))`, where
     `parent_state` is the post-state of `bid.parent_block_root`.
-06. Set `bid.fee_recipient` to be an execution address to receive the payment.
+06. Set `bid.slot` to be the slot for which this bid is aimed. This slot
+    **MUST** be either the current slot or the next slot.
+07. Set `bid.fee_recipient` to be an execution address to receive the payment.
     The proposer's preferred fee recipient is obtained from the
     `SignedProposerPreferences` whose `message.proposal_slot` matches `bid.slot`
     and whose `message.dependent_root` matches
     `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(bid.slot))`,
     where `store` is the fork choice store.
-07. Set `bid.gas_limit` to be the gas limit of the constructed payload, which
+08. Set `bid.gas_limit` to be the gas limit of the constructed payload, which
     **MUST** satisfy
     `is_gas_limit_target_compatible(parent_gas_limit, bid.gas_limit, target_gas_limit)`,
     where `parent_gas_limit` is the `gas_limit` of the parent execution payload
     and `target_gas_limit` is the `target_gas_limit` in the
-    `SignedProposerPreferences` referenced in step 6.
-08. Set `bid.builder_index` to be the index of the builder performing these
+    `SignedProposerPreferences` referenced in step 7.
+09. Set `bid.builder_index` to be the index of the builder performing these
     actions.
-09. Set `bid.slot` to be the slot for which this bid is aimed. This slot
-    **MUST** be either the current slot or the next slot.
 10. Set `bid.value` to be the value (in gwei) that the builder will pay the
     proposer if the bid is accepted. The builder **MUST** have enough excess
     balance to fulfill this bid and all pending payments.

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -155,11 +155,11 @@ def get_upcoming_proposal_slots(
 To construct each `SignedProposerPreferences`:
 
 1. Instantiate a new `ProposerPreferences` object as `preferences`.
-2. Set `preferences.dependent_root` to
+2. Set `preferences.proposal_slot` to `upcoming_proposal_slots[i]`.
+3. Set `preferences.dependent_root` to
    `get_shuffling_dependent_root(store, head_root, compute_epoch_at_slot(preferences.proposal_slot))`,
    where `store` is the fork choice store and `head_root` is the proposer's
    current head root.
-3. Set `preferences.proposal_slot` to `upcoming_proposal_slots[i]`.
 4. Set `preferences.validator_index` to the validator's index.
 5. Set `preferences.fee_recipient` to the execution address where the validator
    wishes to receive the builder payment.


### PR DESCRIPTION
This PR reorders object constructions for `SignedExecutionPayloadBid` and `SignedProposerPreferences` to set `slot` before using it. The rest remains the same in line with the field declaration of each data structure.