### PR TITLE
Fix `viable_for_head_roots_and_weights` runner

### DIFF
--- a/tests/generators/compliance_runners/fork_choice/runner/test_run.py
+++ b/tests/generators/compliance_runners/fork_choice/runner/test_run.py
@@ -172,7 +172,7 @@ def run_test(test_info):
                 elif check == "viable_for_head_roots_and_weights":
                     actual = value
                     expected = get_viable_for_head_checks(spec, store)
-                    assert {frozenset(e) for e in actual} == {frozenset(e) for e in expected}
+                    assert {e["root"]: e for e in actual} == {e["root"]: e for e in expected}
                 elif check in ("payload_timeliness_vote", "payload_data_availability_vote"):
                     target_root = spec.Root(decode_hex(value["block_root"]))
                     assert list(getattr(store, check)[target_root]) == value["votes"]


### PR DESCRIPTION
# Description

The `viable_for_head_roots_and_weights` compliance runner check compares entries by their dict keys instead of their values, so mismatched roots and weights are undetected.