### PR TITLE
Change `BUILDER_INDEX_FLAG` to 2^63

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -146,7 +146,7 @@ Gloas is a consensus-layer upgrade containing a number of features. Including:
 
 | Name                 | Value           | Description                                                                                |
 | -------------------- | --------------- | ------------------------------------------------------------------------------------------ |
-| `BUILDER_INDEX_FLAG` | `uint64(2**40)` | Bitwise flag which indicates that a `ValidatorIndex` should be treated as a `BuilderIndex` |
+| `BUILDER_INDEX_FLAG` | `uint64(2**63)` | Bitwise flag which indicates that a `ValidatorIndex` should be treated as a `BuilderIndex` |
 
 ### Domains
 


### PR DESCRIPTION
The `BUILDER_INDEX_FLAG` tries to communicate an unreachable value, i.e. indices above that index represent builders, those below it validators.

2^40 was likely chosen as that is the Fulu validator registry limit. However, EIP-7688 (currently slated for devnet-7) drops that limit by replacing the validators list from a triangle to a smaller structure that grows based on actual demand.

That doesn't make 2^40 reachable (in fact, the current practical limit is 2^32 because the deposit contract runs out of slots at that count). But I got asked about 2^40 still being safe, so it is clear that 2^40 doesn't naturally indicate "unreachable" without extra thoughts about why it's specifically that value and not something else.

Other argument was 2^52 to be below JavaScript Number.MAX_SAFE_INTEGER. It is not relevant in this context, checked with Lodestar.

Therefore, proposing 2^63, it's the highest bit and clearly associated with it being just a flag, not reachable in any circumstance. Clarity.
