### PR TITLE
Link EIPs with github permalinks for unstable specs

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -123,15 +123,20 @@
 
 Gloas is a consensus-layer upgrade containing a number of features. Including:
 
-- [EIP-7732](https://eips.ethereum.org/EIPS/eip-7732): Enshrined
-  Proposer-Builder Separation
-- [EIP-7843](https://eips.ethereum.org/EIPS/eip-7843): SLOTNUM opcode
-- [EIP-8045](https://eips.ethereum.org/EIPS/eip-8045): Exclude slashed
-  validators from proposing
-- [EIP-8061](https://eips.ethereum.org/EIPS/eip-8061): Increase exit and
-  consolidation churn
-- [EIP-8282](https://eips.ethereum.org/EIPS/eip-8282): Builder Execution
-  Requests
+- [EIP-7732](https://github.com/ethereum/EIPs/blob/c36a2e58a4496ed21bef6b1c97505b03fd159f0a/EIPS/eip-7732.md):
+  Enshrined Proposer-Builder Separation
+- [EIP-7843](https://github.com/ethereum/EIPs/blob/c3bfd4ba41cf0fcbfe8c404f33ba89f5174971e0/EIPS/eip-7843.md):
+  SLOTNUM opcode
+- [EIP-8045](https://github.com/ethereum/EIPs/blob/414a8404198c5afaa3cfed10a385a9aae1dfaae3/EIPS/eip-8045.md):
+  Exclude slashed validators from proposing
+- [EIP-8061](https://github.com/ethereum/EIPs/blob/01f15c37c64114c478cb1136e0a6966084e4db14/EIPS/eip-8061.md):
+  Increase exit and consolidation churn
+- [EIP-8282](https://github.com/wemeetagain/EIPs/blob/9753e62c5bcfd69ec557600252dcdbdcb317bb6e/EIPS/eip-8282.md):
+  Builder Execution Requests
+
+*Note*: These EIPs are in draft and may change or be removed. Each link above
+points to the specific version targeted by this specification, which may differ
+from the latest published version of the EIPs.
 
 ## Types
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -38,8 +38,8 @@ builders.
 ### Submit deposit
 
 Builders are created by submitting a builder deposit request to the builder
-deposit contract on the execution layer, as defined in
-[EIP-8282](https://eips.ethereum.org/EIPS/eip-8282). The request must include:
+deposit contract on the execution layer, as defined in EIP-8282. The request
+must include:
 
 - `pubkey`: The builder's BLS public key.
 - `withdrawal_credentials`: The withdrawal credentials, where the first byte is
@@ -85,10 +85,9 @@ finalized at the fork, the builder will be immediately active. See
 ### Exiting
 
 A builder exits by submitting a builder exit request to the builder exit
-contract on the execution layer, as defined in
-[EIP-8282](https://eips.ethereum.org/EIPS/eip-8282). The request contains the
-builder's `pubkey` and is authorized by the builder's `execution_address` (the
-transaction sender), not the BLS key.
+contract on the execution layer, as defined in EIP-8282. The request contains
+the builder's `pubkey` and is authorized by the builder's `execution_address`
+(the transaction sender), not the BLS key.
 
 The consensus layer initiates the exit only if the builder is active, the
 request's `source_address` matches the builder's `execution_address`, and the

--- a/specs/heze/beacon-chain.md
+++ b/specs/heze/beacon-chain.md
@@ -25,8 +25,12 @@
 
 Heze is a consensus-layer upgrade containing a number of features. Including:
 
-- [EIP-7805](https://eips.ethereum.org/EIPS/eip-7805): Fork-choice enforced
-  Inclusion Lists (FOCIL)
+- [EIP-7805](https://github.com/ethereum/EIPs/blob/9a345f96c2295a678b0ce33e94d41276ddb3fdef/EIPS/eip-7805.md):
+  Fork-choice enforced Inclusion Lists (FOCIL)
+
+*Note*: These EIPs are in draft and may change or be removed. Each link above
+points to the specific version targeted by this specification, which may differ
+from the latest published version of the EIPs.
 
 ## Constants
 


### PR DESCRIPTION
This is a requested change by @parithosh. Linking EIPs with permalinks for Gloas & Heze make it clear which version of the EIP is being targeted. When specifications for an upgrade are changed to stable, we will revert these back to `eip.ethereum.org` links.

<img width="636" height="703" alt="image" src="https://github.com/user-attachments/assets/e4b073fc-51d5-4733-aae9-b10ac8cf2aae" />