### PR TITLE
Fix grammar typo in light client sync protocol docs

### DIFF
--- a/specs/capella/light-client/sync-protocol.md
+++ b/specs/capella/light-client/sync-protocol.md
@@ -26,7 +26,7 @@ as part of the Capella upgrade. It extends the
 The [fork document](./fork.md) explains how to upgrade existing Altair based
 deployments to Capella.
 
-Additional documents describes the impact of the upgrade on certain roles:
+Additional documents describe the impact of the upgrade on certain roles:
 
 - [Full node](./full-node.md)
 - [Networking](./p2p-interface.md)

--- a/specs/deneb/light-client/sync-protocol.md
+++ b/specs/deneb/light-client/sync-protocol.md
@@ -17,7 +17,7 @@ This upgrade updates light client data to include the Deneb changes to the
 The [fork document](./fork.md) explains how to upgrade existing Capella based
 deployments to Deneb.
 
-Additional documents describes the impact of the upgrade on certain roles:
+Additional documents describe the impact of the upgrade on certain roles:
 
 - [Full node](./full-node.md)
 - [Networking](./p2p-interface.md)

--- a/specs/electra/light-client/sync-protocol.md
+++ b/specs/electra/light-client/sync-protocol.md
@@ -22,7 +22,7 @@ generalized indices of [`BeaconState`](../beacon-chain.md). It extends the
 The [fork document](./fork.md) explains how to upgrade existing Deneb based
 deployments to Electra.
 
-Additional documents describes the impact of the upgrade on certain roles:
+Additional documents describe the impact of the upgrade on certain roles:
 
 - [Networking](./p2p-interface.md)
 

--- a/specs/gloas/light-client/sync-protocol.md
+++ b/specs/gloas/light-client/sync-protocol.md
@@ -24,7 +24,7 @@ the
 The [fork document](./fork.md) explains how to upgrade existing Electra based
 deployments to Gloas.
 
-Additional documents describes the impact of the upgrade on certain roles:
+Additional documents describe the impact of the upgrade on certain roles:
 
 - [Full node](./full-node.md)
 - [Networking](./p2p-interface.md)


### PR DESCRIPTION
<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What this PR does (but not how it does it)
* Why this PR is necessary, including context
-->

Fix a repeated grammar typo in the light client sync protocol documentation:

- "Additional documents describes" -> "Additional documents describe"

This is a documentation-only cleanup and does not change protocol behavior or test generation.




<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->


- `git diff --check`
- `codespell specs/capella/light-client/sync-protocol.md specs/deneb/light-client/sync-protocol.md specs/electra/light-client/sync-protocol.md specs/gloas/light-client/sync-protocol.md --quiet-level=2`

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->
