### PR TITLE
Fix order of asserts in `test_incentives`

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/test_config_invariants.py
@@ -56,14 +56,14 @@ def test_hysteresis_quotient(spec, state):
 @spec_state_test
 def test_incentives(spec, state):
     # Ensure no ETH is minted in slash_validator
-    if is_post_bellatrix(spec):
-        assert spec.MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX <= spec.WHISTLEBLOWER_REWARD_QUOTIENT
-    elif is_post_altair(spec):
-        assert spec.MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR <= spec.WHISTLEBLOWER_REWARD_QUOTIENT
-    elif is_post_electra(spec):
+    if is_post_electra(spec):
         assert (
             spec.MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA <= spec.WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA
         )
+    elif is_post_bellatrix(spec):
+        assert spec.MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX <= spec.WHISTLEBLOWER_REWARD_QUOTIENT
+    elif is_post_altair(spec):
+        assert spec.MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR <= spec.WHISTLEBLOWER_REWARD_QUOTIENT
     else:
         assert spec.MIN_SLASHING_PENALTY_QUOTIENT <= spec.WHISTLEBLOWER_REWARD_QUOTIENT
 


### PR DESCRIPTION
The order of these asserts are wrong. The electra case was added at the bottom instead of the top, so its values were never properly checked. When using `is_post_<fork>` we must order them from latest to oldest.