### PR TITLE
Add the IL bitlist to bid

### DIFF
--- a/specs/heze/beacon-chain.md
+++ b/specs/heze/beacon-chain.md
@@ -13,6 +13,10 @@
   - [New containers](#new-containers)
     - [`InclusionList`](#inclusionlist)
     - [`SignedInclusionList`](#signedinclusionlist)
+  - [Modified containers](#modified-containers)
+    - [`ExecutionPayloadBid`](#executionpayloadbid)
+    - [`SignedExecutionPayloadBid`](#signedexecutionpayloadbid)
+    - [`BeaconState`](#beaconstate)
 - [Helpers](#helpers)
   - [Predicates](#predicates)
     - [New `is_valid_inclusion_list_signature`](#new-is_valid_inclusion_list_signature)
@@ -68,6 +72,90 @@ class InclusionList(Container):
 class SignedInclusionList(Container):
     message: InclusionList
     signature: BLSSignature
+```
+
+### Modified containers
+
+#### `ExecutionPayloadBid`
+
+```python
+class ExecutionPayloadBid(Container):
+    parent_block_hash: Hash32
+    parent_block_root: Root
+    block_hash: Hash32
+    prev_randao: Bytes32
+    fee_recipient: ExecutionAddress
+    gas_limit: uint64
+    builder_index: BuilderIndex
+    slot: Slot
+    value: Gwei
+    execution_payment: Gwei
+    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    execution_requests_root: Root
+    # [New in Heze:EIP7805]
+    inclusion_list_bits: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]
+```
+
+#### `SignedExecutionPayloadBid`
+
+```python
+class SignedExecutionPayloadBid(Container):
+    # [Modified in Heze:EIP7805]
+    message: ExecutionPayloadBid
+    signature: BLSSignature
+```
+
+#### `BeaconState`
+
+```python
+class BeaconState(Container):
+    genesis_time: uint64
+    genesis_validators_root: Root
+    slot: Slot
+    fork: Fork
+    latest_block_header: BeaconBlockHeader
+    block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
+    state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
+    historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+    eth1_data: Eth1Data
+    eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+    eth1_deposit_index: uint64
+    validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
+    balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
+    randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
+    slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
+    previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+    current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    previous_justified_checkpoint: Checkpoint
+    current_justified_checkpoint: Checkpoint
+    finalized_checkpoint: Checkpoint
+    inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+    current_sync_committee: SyncCommittee
+    next_sync_committee: SyncCommittee
+    latest_block_hash: Hash32
+    next_withdrawal_index: WithdrawalIndex
+    next_withdrawal_validator_index: ValidatorIndex
+    historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+    deposit_requests_start_index: uint64
+    deposit_balance_to_consume: Gwei
+    exit_balance_to_consume: Gwei
+    earliest_exit_epoch: Epoch
+    consolidation_balance_to_consume: Gwei
+    earliest_consolidation_epoch: Epoch
+    pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
+    pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
+    pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
+    proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
+    builders: List[Builder, BUILDER_REGISTRY_LIMIT]
+    next_withdrawal_builder_index: BuilderIndex
+    execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
+    builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
+    builder_pending_withdrawals: List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
+    # [Modified in Heze:EIP7805]
+    latest_execution_payload_bid: ExecutionPayloadBid
+    payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
 ```
 
 ## Helpers

--- a/specs/heze/builder.md
+++ b/specs/heze/builder.md
@@ -1,0 +1,27 @@
+# Heze -- Honest Builder
+
+*Note*: This document is a work-in-progress for researchers and implementers.
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
+
+- [Introduction](#introduction)
+- [Builder activities](#builder-activities)
+  - [Constructing the `SignedExecutionPayloadBid`](#constructing-the-signedexecutionpayloadbid)
+
+<!-- mdformat-toc end -->
+
+## Introduction
+
+This document represents the changes to be made in the code of an "honest
+builder" to implement Heze.
+
+## Builder activities
+
+### Constructing the `SignedExecutionPayloadBid`
+
+*Note*: The only change made to `SignedExecutionPayloadBid` is to set
+`bid.inclusion_list_bits` based on the builder's inclusion list view, which
+comprises all valid and non-equivocating inclusion lists they have observed.
+
+1. Set `bid.inclusion_list_bits` to
+   `get_inclusion_list_bits(get_inclusion_list_store(), state, Slot(bid.slot - 1), only_timely=False)`.

--- a/specs/heze/fork.md
+++ b/specs/heze/fork.md
@@ -35,6 +35,22 @@ change is made to upgrade to Heze.
 ```python
 def upgrade_to_heze(pre: gloas.BeaconState) -> BeaconState:
     epoch = gloas.get_current_epoch(pre)
+    latest_execution_payload_bid = ExecutionPayloadBid(
+        parent_block_hash=pre.latest_execution_payload_bid.parent_block_hash,
+        parent_block_root=pre.latest_execution_payload_bid.parent_block_root,
+        block_hash=pre.latest_execution_payload_bid.block_hash,
+        prev_randao=pre.latest_execution_payload_bid.prev_randao,
+        fee_recipient=pre.latest_execution_payload_bid.fee_recipient,
+        gas_limit=pre.latest_execution_payload_bid.gas_limit,
+        builder_index=pre.latest_execution_payload_bid.builder_index,
+        slot=pre.latest_execution_payload_bid.slot,
+        value=pre.latest_execution_payload_bid.value,
+        execution_payment=pre.latest_execution_payload_bid.execution_payment,
+        blob_kzg_commitments=pre.latest_execution_payload_bid.blob_kzg_commitments,
+        execution_requests_root=pre.latest_execution_payload_bid.execution_requests_root,
+        # [New in Heze:EIP7805]
+        inclusion_list_bits=Bitvector[INCLUSION_LIST_COMMITTEE_SIZE](),
+    )
 
     post = BeaconState(
         genesis_time=pre.genesis_time,
@@ -85,7 +101,8 @@ def upgrade_to_heze(pre: gloas.BeaconState) -> BeaconState:
         execution_payload_availability=pre.execution_payload_availability,
         builder_pending_payments=pre.builder_pending_payments,
         builder_pending_withdrawals=pre.builder_pending_withdrawals,
-        latest_execution_payload_bid=pre.latest_execution_payload_bid,
+        # [Modified in Heze:EIP7805]
+        latest_execution_payload_bid=latest_execution_payload_bid,
         payload_expected_withdrawals=pre.payload_expected_withdrawals,
         ptc_window=pre.ptc_window,
     )

--- a/specs/heze/inclusion-list.md
+++ b/specs/heze/inclusion-list.md
@@ -161,8 +161,8 @@ def is_inclusion_list_bits_inclusive(
     """
     local_inclusion_list_bits = get_inclusion_list_bits(store, state, slot, only_timely)
 
-    return all(
-        inclusion_bit or not local_inclusion_bit
+    return not any(
+        local_inclusion_bit and not inclusion_bit
         for inclusion_bit, local_inclusion_bit in zip(
             inclusion_list_bits, local_inclusion_list_bits, strict=True
         )

--- a/specs/heze/inclusion-list.md
+++ b/specs/heze/inclusion-list.md
@@ -124,7 +124,7 @@ def get_inclusion_list_bits(
 ) -> Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]:
     """
     Return a ``Bitvector`` over inclusion list committee indices with bits set
-    for valid and non-equivocating inclusion list submissions for the given ``slot``.
+    for those who provided valid, non-equivocating inclusion lists for the given ``slot``.
     """
     committee = get_inclusion_list_committee(state, slot)
     key = hash_tree_root(committee)
@@ -156,8 +156,8 @@ def is_inclusion_list_bits_inclusive(
     only_timely: bool = True,
 ) -> bool:
     """
-    Return ``True`` if and only if ``inclusion_list_bits`` is a superset of
-    the locally observed inclusion list bits for the given ``slot``.
+    Return ``True`` if and only if ``inclusion_list_bits`` has a bit set for
+    every bit set in the local inclusion list bits for the given ``slot``.
     """
     local_inclusion_list_bits = get_inclusion_list_bits(store, state, slot, only_timely)
 

--- a/specs/heze/inclusion-list.md
+++ b/specs/heze/inclusion-list.md
@@ -12,6 +12,8 @@
   - [New `get_inclusion_list_store`](#new-get_inclusion_list_store)
   - [New `process_inclusion_list`](#new-process_inclusion_list)
   - [New `get_inclusion_list_transactions`](#new-get_inclusion_list_transactions)
+  - [New `get_inclusion_list_bits`](#new-get_inclusion_list_bits)
+  - [New `is_inclusion_list_bits_inclusive`](#new-is_inclusion_list_bits_inclusive)
 
 <!-- mdformat-toc end -->
 
@@ -112,4 +114,57 @@ def get_inclusion_list_transactions(
 
     # Deduplicate inclusion list transactions. Order does not need to be preserved.
     return list(set(transactions))
+```
+
+### New `get_inclusion_list_bits`
+
+```python
+def get_inclusion_list_bits(
+    store: InclusionListStore, state: BeaconState, slot: Slot, only_timely: bool = True
+) -> Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]:
+    """
+    Return a ``Bitvector`` over inclusion list committee indices with bits set
+    for valid and non-equivocating inclusion list submissions for the given ``slot``.
+    """
+    committee = get_inclusion_list_committee(state, slot)
+    key = hash_tree_root(committee)
+
+    inclusion_lists = store.inclusion_lists[key]
+    equivocators = store.equivocators[key]
+    timeliness = store.inclusion_list_timeliness
+
+    validator_indices = [
+        inclusion_lists[inclusion_list_root].validator_index
+        for inclusion_list_root in inclusion_lists
+        if inclusion_lists[inclusion_list_root].validator_index not in equivocators
+        if not only_timely or timeliness[inclusion_list_root]
+    ]
+
+    return Bitvector[INCLUSION_LIST_COMMITTEE_SIZE](
+        validator_index in validator_indices for validator_index in committee
+    )
+```
+
+### New `is_inclusion_list_bits_inclusive`
+
+```python
+def is_inclusion_list_bits_inclusive(
+    store: InclusionListStore,
+    state: BeaconState,
+    slot: Slot,
+    inclusion_list_bits: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE],
+    only_timely: bool = True,
+) -> bool:
+    """
+    Return ``True`` if and only if ``inclusion_list_bits`` is a superset of
+    the locally observed inclusion list bits for the given ``slot``.
+    """
+    local_inclusion_list_bits = get_inclusion_list_bits(store, state, slot, only_timely)
+
+    return all(
+        inclusion_bit or not local_inclusion_bit
+        for inclusion_bit, local_inclusion_bit in zip(
+            inclusion_list_bits, local_inclusion_list_bits, strict=True
+        )
+    )
 ```

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -15,6 +15,8 @@
         - [New `inclusion_list`](#new-inclusion_list)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
+      - [BeaconBlocksByRange v2](#beaconblocksbyrange-v2)
+      - [BeaconBlocksByRoot v2](#beaconblocksbyroot-v2)
       - [InclusionListByCommitteeIndices v1](#inclusionlistbycommitteeindices-v1)
 
 <!-- mdformat-toc end -->
@@ -103,6 +105,48 @@ the network, assuming the alias `message = signed_inclusion_list.message`:
 ### The Req/Resp domain
 
 #### Messages
+
+##### BeaconBlocksByRange v2
+
+**Protocol ID:** `/eth2/beacon_chain/req/beacon_blocks_by_range/2/`
+
+The Heze fork-digest is introduced to the `context` enum to specify Heze beacon
+block type.
+
+<!-- eth_consensus_specs: skip -->
+
+| `fork_version`           | Chunk SSZ type                |
+| ------------------------ | ----------------------------- |
+| `GENESIS_FORK_VERSION`   | `phase0.SignedBeaconBlock`    |
+| `ALTAIR_FORK_VERSION`    | `altair.SignedBeaconBlock`    |
+| `BELLATRIX_FORK_VERSION` | `bellatrix.SignedBeaconBlock` |
+| `CAPELLA_FORK_VERSION`   | `capella.SignedBeaconBlock`   |
+| `DENEB_FORK_VERSION`     | `deneb.SignedBeaconBlock`     |
+| `ELECTRA_FORK_VERSION`   | `electra.SignedBeaconBlock`   |
+| `FULU_FORK_VERSION`      | `fulu.SignedBeaconBlock`      |
+| `GLOAS_FORK_VERSION`     | `gloas.SignedBeaconBlock`     |
+| `HEZE_FORK_VERSION`      | `heze.SignedBeaconBlock`      |
+
+##### BeaconBlocksByRoot v2
+
+**Protocol ID:** `/eth2/beacon_chain/req/beacon_blocks_by_root/2/`
+
+The Heze fork-digest is introduced to the `context` enum to specify Heze beacon
+block type.
+
+<!-- eth_consensus_specs: skip -->
+
+| `fork_version`           | Chunk SSZ type                |
+| ------------------------ | ----------------------------- |
+| `GENESIS_FORK_VERSION`   | `phase0.SignedBeaconBlock`    |
+| `ALTAIR_FORK_VERSION`    | `altair.SignedBeaconBlock`    |
+| `BELLATRIX_FORK_VERSION` | `bellatrix.SignedBeaconBlock` |
+| `CAPELLA_FORK_VERSION`   | `capella.SignedBeaconBlock`   |
+| `DENEB_FORK_VERSION`     | `deneb.SignedBeaconBlock`     |
+| `ELECTRA_FORK_VERSION`   | `electra.SignedBeaconBlock`   |
+| `FULU_FORK_VERSION`      | `fulu.SignedBeaconBlock`      |
+| `GLOAS_FORK_VERSION`     | `gloas.SignedBeaconBlock`     |
+| `HEZE_FORK_VERSION`      | `heze.SignedBeaconBlock`      |
 
 ##### InclusionListByCommitteeIndices v1
 

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -12,6 +12,7 @@
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
+        - [Modified `execution_payload_bid`](#modified-execution_payload_bid)
         - [New `inclusion_list`](#new-inclusion_list)
   - [The Req/Resp domain](#the-reqresp-domain)
     - [Messages](#messages)
@@ -69,6 +70,10 @@ def compute_fork_version(epoch: Epoch) -> Version:
 
 #### Topics and messages
 
+Topics follow the same specification as in prior upgrades.
+
+The `execution_payload_bid` topic is updated to support the modified type
+
 The new topics along with the type of the `data` field of a gossipsub message
 are given in this table:
 
@@ -78,7 +83,16 @@ are given in this table:
 
 ##### Global topics
 
-Heze introduces a new global topic for inclusion lists.
+###### Modified `execution_payload_bid`
+
+The following validations are added, assuming the alias
+`bid = signed_execution_payload_bid.message`:
+
+- _[IGNORE]_ `bid.inclusion_list_bits` is inclusive of the node's view of
+  inclusion lists for the slot preceding the bid's slot -- i.e.
+  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), state, Slot(bid.slot - 1), bid.inclusion_list_bits, only_timely=False)`
+  returns `True`, where `state` is the head state corresponding to processing
+  the block up to the current slot as determined by the fork choice.
 
 ###### New `inclusion_list`
 

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -70,9 +70,7 @@ def compute_fork_version(epoch: Epoch) -> Version:
 
 #### Topics and messages
 
-Topics follow the same specification as in prior upgrades.
-
-The `execution_payload_bid` topic is updated to support the modified type
+The `execution_payload_bid` topic is modified to support Heze bids.
 
 The new topics along with the type of the `data` field of a gossipsub message
 are given in this table:

--- a/specs/heze/validator.md
+++ b/specs/heze/validator.md
@@ -17,6 +17,7 @@
     - [Lookahead](#lookahead)
   - [Block and sidecar proposal](#block-and-sidecar-proposal)
     - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
+      - [Signed execution payload bid](#signed-execution-payload-bid)
       - [ExecutionPayload](#executionpayload)
   - [Inclusion list proposal](#inclusion-list-proposal)
     - [Constructing the `SignedInclusionList`](#constructing-the-signedinclusionlist)
@@ -106,6 +107,16 @@ list committee slot.
 ### Block and sidecar proposal
 
 #### Constructing the `BeaconBlockBody`
+
+##### Signed execution payload bid
+
+*Note*: The only change made to `signed_execution_payload_bid` is to require
+that `bid.inclusion_list_bits` must satisfy `is_inclusion_list_bits_inclusive()`
+with respect to the proposer's inclusion list view, which comprises all valid
+and non-equivocating inclusion lists they have observed.
+
+- The `bid.inclusion_list_bits` must satisfy
+  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), state, slot - 1, bid.inclusion_list_bits, only_timely=False)`.
 
 ##### ExecutionPayload
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload_bid.py
@@ -1,4 +1,5 @@
 from eth_consensus_specs.test.context import expect_assertion_error
+from eth_consensus_specs.test.helpers.forks import is_post_heze
 from eth_consensus_specs.test.helpers.keys import builder_privkeys
 
 
@@ -36,6 +37,7 @@ def prepare_signed_execution_payload_bid(
     block_hash=None,
     blob_kzg_commitments=None,
     prev_randao=None,
+    inclusion_list_bits=None,
     valid_signature=True,
     valid_amount=True,
 ):
@@ -93,6 +95,9 @@ def prepare_signed_execution_payload_bid(
         "value": value,
         "blob_kzg_commitments": blob_kzg_commitments,
     }
+    if is_post_heze(spec) and inclusion_list_bits is not None:
+        bid_kwargs["inclusion_list_bits"] = inclusion_list_bits
+
     bid = spec.ExecutionPayloadBid(**bid_kwargs)
 
     if valid_signature:

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/block_processing/test_process_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/block_processing/test_process_execution_payload_bid.py
@@ -1,0 +1,51 @@
+from eth_consensus_specs.test.context import (
+    always_bls,
+    spec_state_test,
+    with_heze_and_later,
+)
+from eth_consensus_specs.test.gloas.block_processing.test_process_execution_payload_bid import (
+    prepare_block_with_non_proposer_builder,
+)
+from eth_consensus_specs.test.helpers.execution_payload_bid import (
+    prepare_signed_execution_payload_bid,
+    run_execution_payload_bid_processing,
+)
+from eth_consensus_specs.test.helpers.state import next_epoch_with_full_participation
+
+
+@with_heze_and_later
+@spec_state_test
+@always_bls
+def test_process_execution_payload_bid_valid_builder_with_non_default_inclusion_list_bits(
+    spec, state
+):
+    """
+    Test valid builder bid with non-default ``inclusion_list_bits``.
+    """
+    next_epoch_with_full_participation(spec, state)
+    next_epoch_with_full_participation(spec, state)
+    next_epoch_with_full_participation(spec, state)
+    next_epoch_with_full_participation(spec, state)
+    assert state.finalized_checkpoint.epoch == 2
+
+    block, builder_index = prepare_block_with_non_proposer_builder(spec, state)
+    assert spec.is_active_builder(state, builder_index) is True
+
+    inclusion_list_bits = spec.Bitvector[spec.INCLUSION_LIST_COMMITTEE_SIZE]()
+    inclusion_list_bits[0] = True
+
+    signed_bid = prepare_signed_execution_payload_bid(
+        spec,
+        state,
+        builder_index=builder_index,
+        value=spec.Gwei(1000000),
+        slot=block.slot,
+        parent_block_root=block.parent_root,
+        inclusion_list_bits=inclusion_list_bits,
+    )
+
+    block.body.signed_execution_payload_bid = signed_bid
+
+    yield from run_execution_payload_bid_processing(spec, state, block)
+
+    assert state.latest_execution_payload_bid == signed_bid.message


### PR DESCRIPTION
This PR adds the IL bitlist back to bid according to the breakout 37's discussion. This essentially reverts #5371.

On top of that, this PR adds blocks ByRoot and ByRange because this bitlist addition changes the beacon block in Heze.