### PR TITLE
Add new `get_min_activation_balance` helper function

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/altair/block_processing/sync_aggregate/test_process_sync_aggregate.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/block_processing/sync_aggregate/test_process_sync_aggregate.py
@@ -11,6 +11,7 @@ from eth_consensus_specs.test.context import (
     with_custom_state,
     with_presets,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
@@ -241,7 +242,7 @@ def _run_sync_committee_selected_twice(
     state.balances[validator_index] = pre_balance
     state.validators[validator_index].effective_balance = min(
         pre_balance - pre_balance % spec.EFFECTIVE_BALANCE_INCREMENT,
-        spec.MAX_EFFECTIVE_BALANCE,
+        get_min_activation_balance(spec),
     )
 
     yield from run_successful_sync_committee_test(
@@ -303,12 +304,12 @@ def test_sync_committee_rewards_duplicate_committee_max_effective_balance_only_p
     validator_index = yield from _run_sync_committee_selected_twice(
         spec,
         state,
-        pre_balance=spec.MAX_EFFECTIVE_BALANCE,
+        pre_balance=get_min_activation_balance(spec),
         participate_first_position=True,
         participate_second_position=False,
     )
 
-    assert state.balances[validator_index] == spec.MAX_EFFECTIVE_BALANCE
+    assert state.balances[validator_index] == get_min_activation_balance(spec)
 
 
 @with_altair_and_later
@@ -320,12 +321,12 @@ def test_sync_committee_rewards_duplicate_committee_max_effective_balance_only_p
     validator_index = yield from _run_sync_committee_selected_twice(
         spec,
         state,
-        pre_balance=spec.MAX_EFFECTIVE_BALANCE,
+        pre_balance=get_min_activation_balance(spec),
         participate_first_position=False,
         participate_second_position=True,
     )
 
-    assert state.balances[validator_index] == spec.MAX_EFFECTIVE_BALANCE
+    assert state.balances[validator_index] == get_min_activation_balance(spec)
 
 
 @with_altair_and_later

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/epoch_processing/test_process_participation_flag_updates.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/epoch_processing/test_process_participation_flag_updates.py
@@ -8,6 +8,7 @@ from eth_consensus_specs.test.context import (
     with_custom_state,
     with_presets,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import MINIMAL
 from eth_consensus_specs.test.helpers.epoch_processing import run_epoch_processing_with
 from eth_consensus_specs.test.helpers.state import next_epoch_via_block
@@ -137,7 +138,7 @@ def custom_validator_count(factor: float):
         num_validators = (
             spec.SLOTS_PER_EPOCH * spec.MAX_COMMITTEES_PER_SLOT * spec.TARGET_COMMITTEE_SIZE
         )
-        return [spec.MAX_EFFECTIVE_BALANCE] * int(float(int(num_validators)) * factor)
+        return [get_min_activation_balance(spec)] * int(float(int(num_validators)) * factor)
 
     return initializer
 

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/fork/test_fork_active_validators.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/fork/test_fork_active_validators.py
@@ -5,6 +5,7 @@ from eth_consensus_specs.test.context import (
     with_phases,
     with_state,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
 from eth_consensus_specs.test.helpers.constants import ELECTRA, FULU, PHASE0
 from eth_consensus_specs.test.helpers.deposits import (
@@ -155,7 +156,7 @@ def _template_test_after_fork_new_validator_active_pre_electra(
     def test_after_fork_new_validator_active(spec, phases, state):
         new_validator_index = len(state.validators)
 
-        amount = spec.MAX_EFFECTIVE_BALANCE
+        amount = get_min_activation_balance(spec)
 
         deposit = prepare_state_and_deposit(spec, state, new_validator_index, amount, signed=True)
 

--- a/tests/core/pyspec/eth_consensus_specs/test/capella/block_processing/test_process_deposit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/capella/block_processing/test_process_deposit.py
@@ -2,6 +2,7 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_all_phases_from_to,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import (
     CAPELLA,
     FULU,
@@ -30,7 +31,7 @@ def test_success_top_up_to_withdrawn_validator(spec, state):
     assert state.validators[validator_index].effective_balance == 0
 
     # Make a top-up balance to validator
-    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    amount = get_min_activation_balance(spec) // 4
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     yield from run_deposit_processing(spec, state, deposit, validator_index)

--- a/tests/core/pyspec/eth_consensus_specs/test/capella/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/capella/block_processing/test_process_withdrawals.py
@@ -6,6 +6,7 @@ from eth_consensus_specs.test.context import (
     with_capella_and_later,
     with_presets,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import (
     CAPELLA,
     GLOAS,
@@ -76,7 +77,7 @@ def test_success_one_partial_withdrawal(spec, state):
     assert len(fully_withdrawable_indices) == 0
     assert len(partial_withdrawals_indices) == 1
     for index in partial_withdrawals_indices:
-        assert state.balances[index] > spec.MAX_EFFECTIVE_BALANCE
+        assert state.balances[index] > get_min_activation_balance(spec)
 
     next_slot(spec, state)
     execution_payload = build_empty_execution_payload(spec, state)
@@ -678,14 +679,15 @@ def test_success_no_max_effective_balance(spec, state):
         state,
         validator_index,
         # Reduce validator's effective balance to make it ineligible for withdrawals
-        effective_balance=spec.MAX_EFFECTIVE_BALANCE - spec.EFFECTIVE_BALANCE_INCREMENT,
+        effective_balance=get_min_activation_balance(spec) - spec.EFFECTIVE_BALANCE_INCREMENT,
         # Give the validator an excess balance, so this isn't the reason it fails
-        balance=spec.MAX_EFFECTIVE_BALANCE + 1,
+        balance=get_min_activation_balance(spec) + 1,
     )
     validator = state.validators[validator_index]
 
     assert (
-        validator.effective_balance == spec.MAX_EFFECTIVE_BALANCE - spec.EFFECTIVE_BALANCE_INCREMENT
+        validator.effective_balance
+        == get_min_activation_balance(spec) - spec.EFFECTIVE_BALANCE_INCREMENT
     )
     assert not check_is_partially_withdrawable_validator(spec, state, validator_index)
 
@@ -706,13 +708,13 @@ def test_success_no_excess_balance(spec, state):
         state,
         validator_index,
         # Ensure validator has the required effective balance, so this isn't the reason it fails
-        effective_balance=spec.MAX_EFFECTIVE_BALANCE,
+        effective_balance=get_min_activation_balance(spec),
         # Remove validator's excess balance to make it ineligible for withdrawals
-        balance=spec.MAX_EFFECTIVE_BALANCE,
+        balance=get_min_activation_balance(spec),
     )
     validator = state.validators[validator_index]
 
-    assert validator.effective_balance == spec.MAX_EFFECTIVE_BALANCE
+    assert validator.effective_balance == get_min_activation_balance(spec)
     assert not check_is_partially_withdrawable_validator(spec, state, validator_index)
 
     execution_payload = build_empty_execution_payload(spec, state)
@@ -730,7 +732,7 @@ def test_success_excess_balance_but_no_max_effective_balance(spec, state):
     validator = state.validators[validator_index]
 
     # To be partially withdrawable, the validator needs both a maxed out effective balance and an excess balance
-    validator.effective_balance = spec.MAX_EFFECTIVE_BALANCE - 1
+    validator.effective_balance = get_min_activation_balance(spec) - 1
 
     assert not check_is_partially_withdrawable_validator(spec, state, validator_index)
 
@@ -951,8 +953,8 @@ def test_partially_withdrawable_validator_legacy_max_plus_one(spec, state):
         spec,
         state,
         validator_index,
-        effective_balance=spec.MAX_EFFECTIVE_BALANCE,
-        balance=spec.MAX_EFFECTIVE_BALANCE + 1,
+        effective_balance=get_min_activation_balance(spec),
+        balance=get_min_activation_balance(spec) + 1,
     )
     assert check_is_partially_withdrawable_validator(spec, state, validator_index)
 
@@ -1001,8 +1003,8 @@ def test_partially_withdrawable_validator_legacy_max_minus_one(spec, state):
         state,
         validator_index,
         # Assume effective balance updates haven't happened yet
-        effective_balance=spec.MAX_EFFECTIVE_BALANCE,
-        balance=spec.MAX_EFFECTIVE_BALANCE - 1,
+        effective_balance=get_min_activation_balance(spec),
+        balance=get_min_activation_balance(spec) - 1,
     )
     assert not check_is_partially_withdrawable_validator(spec, state, validator_index)
 

--- a/tests/core/pyspec/eth_consensus_specs/test/capella/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/capella/sanity/test_blocks.py
@@ -9,6 +9,7 @@ from eth_consensus_specs.test.context import (
 from eth_consensus_specs.test.helpers.attestations import (
     next_epoch_with_attestations,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block,
     build_empty_block_for_next_slot,
@@ -101,7 +102,7 @@ def test_deposit_and_bls_change(spec, state):
     initial_balances_len = len(state.balances)
 
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     signed_address_change = get_signed_address_change(
@@ -260,7 +261,7 @@ def test_partial_withdrawal_in_epoch_transition(spec, state):
 
     assert state.balances[index] < pre_balance
     # Potentially less than due to sync committee penalty
-    assert state.balances[index] <= spec.MAX_EFFECTIVE_BALANCE
+    assert state.balances[index] <= get_min_activation_balance(spec)
     assert len(get_expected_withdrawals(spec, state)) == 0
 
 
@@ -444,12 +445,12 @@ def test_top_up_and_partial_withdrawable_validator(spec, state):
     validator_index = next_withdrawal_validator_index + 1
 
     set_eth1_withdrawal_credential_with_balance(
-        spec, state, validator_index, balance=spec.MAX_EFFECTIVE_BALANCE
+        spec, state, validator_index, balance=get_min_activation_balance(spec)
     )
     assert not check_is_partially_withdrawable_validator(spec, state, validator_index)
 
     # Make a top-up balance to validator
-    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    amount = get_min_activation_balance(spec) // 4
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     yield "pre", state
@@ -499,7 +500,7 @@ def test_top_up_to_fully_withdrawn_validator(spec, state):
     assert state.validators[validator_index].effective_balance == 0
 
     # Make a top-up deposit to validator
-    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    amount = get_min_activation_balance(spec) // 4
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     yield "pre", state
@@ -536,8 +537,8 @@ def test_top_up_to_fully_withdrawn_validator(spec, state):
 def _insert_validator(spec, state, balance):
     effective_balance = (
         balance - balance % spec.EFFECTIVE_BALANCE_INCREMENT
-        if balance < spec.MAX_EFFECTIVE_BALANCE
-        else spec.MAX_EFFECTIVE_BALANCE
+        if balance < get_min_activation_balance(spec)
+        else get_min_activation_balance(spec)
     )
 
     validator_index = len(state.validators)
@@ -582,7 +583,7 @@ def _run_activate_and_partial_withdrawal(spec, state, initial_balance):
         state.validators[validator_index], spec.get_current_epoch(state)
     )
 
-    if initial_balance > spec.MAX_EFFECTIVE_BALANCE:
+    if initial_balance > get_min_activation_balance(spec):
         assert check_is_partially_withdrawable_validator(spec, state, validator_index)
     else:
         assert not check_is_partially_withdrawable_validator(spec, state, validator_index)
@@ -601,7 +602,7 @@ def _run_activate_and_partial_withdrawal(spec, state, initial_balance):
 @spec_state_test
 def test_activate_and_partial_withdrawal_max_effective_balance(spec, state):
     yield from _run_activate_and_partial_withdrawal(
-        spec, state, initial_balance=spec.MAX_EFFECTIVE_BALANCE
+        spec, state, initial_balance=get_min_activation_balance(spec)
     )
 
 
@@ -610,5 +611,5 @@ def test_activate_and_partial_withdrawal_max_effective_balance(spec, state):
 @spec_state_test
 def test_activate_and_partial_withdrawal_overdeposit(spec, state):
     yield from _run_activate_and_partial_withdrawal(
-        spec, state, initial_balance=spec.MAX_EFFECTIVE_BALANCE + 10000000
+        spec, state, initial_balance=get_min_activation_balance(spec) + 10000000
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/epoch_processing/test_process_registry_updates.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/epoch_processing/test_process_registry_updates.py
@@ -8,6 +8,7 @@ from eth_consensus_specs.test.context import (
     with_deneb_and_later,
     with_presets,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import MINIMAL
 from eth_consensus_specs.test.helpers.epoch_processing import run_epoch_processing_with
 from eth_consensus_specs.test.helpers.forks import is_post_electra
@@ -29,7 +30,9 @@ def run_test_activation_churn_limit(spec, state):
 
     validator_count_0 = len(state.validators)
 
-    balance = spec.MIN_ACTIVATION_BALANCE if is_post_electra(spec) else spec.MAX_EFFECTIVE_BALANCE
+    balance = (
+        spec.MIN_ACTIVATION_BALANCE if is_post_electra(spec) else get_min_activation_balance(spec)
+    )
 
     for i in range(mock_activations):
         index = validator_count_0 + i

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/transition/test_transition.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/transition/test_transition.py
@@ -3,6 +3,7 @@ from eth_consensus_specs.test.context import (
     with_fork_metas,
     with_presets,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import (
     AFTER_DENEB_PRE_POST_FORKS,
     MINIMAL,
@@ -29,10 +30,10 @@ def mock_activated_validators(spec, state, mock_activations):
             activation_epoch=spec.FAR_FUTURE_EPOCH,
             exit_epoch=spec.FAR_FUTURE_EPOCH,
             withdrawable_epoch=spec.FAR_FUTURE_EPOCH,
-            effective_balance=spec.MAX_EFFECTIVE_BALANCE,
+            effective_balance=get_min_activation_balance(spec),
         )
         state.validators.append(validator)
-        state.balances.append(spec.MAX_EFFECTIVE_BALANCE)
+        state.balances.append(get_min_activation_balance(spec))
         state.previous_epoch_participation.append(spec.ParticipationFlags(0b0000_0000))
         state.current_epoch_participation.append(spec.ParticipationFlags(0b0000_0000))
         state.inactivity_scores.append(0)

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/block_processing/test_process_consolidation_request.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/block_processing/test_process_consolidation_request.py
@@ -8,6 +8,7 @@ from eth_consensus_specs.test.context import (
     with_electra_and_later,
     with_presets,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import MINIMAL
 from eth_consensus_specs.test.helpers.forks import is_post_gloas
 from eth_consensus_specs.test.helpers.withdrawals import (
@@ -369,7 +370,7 @@ def test_basic_consolidation_source_has_less_than_max_effective_balance(spec, st
     set_eth1_withdrawal_credential_with_balance(spec, state, source_index, address=source_address)
 
     # Lower the source validator's effective balance
-    source_effective_balance = spec.MAX_EFFECTIVE_BALANCE - spec.EFFECTIVE_BALANCE_INCREMENT
+    source_effective_balance = get_min_activation_balance(spec) - spec.EFFECTIVE_BALANCE_INCREMENT
     state.validators[source_index].effective_balance = source_effective_balance
 
     # Make consolidation with source address

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/block_processing/test_process_deposit_request.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/block_processing/test_process_deposit_request.py
@@ -4,6 +4,7 @@ from eth_consensus_specs.test.context import (
     with_electra_and_later,
     with_electra_only,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.deposit_requests import (
     assert_process_deposit_request,
     prepare_process_deposit_request,
@@ -129,8 +130,8 @@ def test_process_deposit_request_top_up_max_effective_balance_compounding(spec, 
         + b"\x59" * 20  # a 20-byte eth1 address
     )
 
-    state.balances[validator_index] = spec.MAX_EFFECTIVE_BALANCE
-    state.validators[validator_index].effective_balance = spec.MAX_EFFECTIVE_BALANCE
+    state.balances[validator_index] = get_min_activation_balance(spec)
+    state.validators[validator_index].effective_balance = get_min_activation_balance(spec)
     state.validators[validator_index].withdrawal_credentials = withdrawal_credentials
 
     deposit_request = prepare_deposit_request(

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/sanity/blocks/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/sanity/blocks/test_blocks.py
@@ -8,6 +8,7 @@ from eth_consensus_specs.test.context import (
     with_custom_state,
     with_presets,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block_for_next_slot,
     transition_unsigned_block,
@@ -287,13 +288,13 @@ def test_withdrawal_and_withdrawal_request_same_validator(spec, state):
     # Give a validator an excess balance
     validator_index = 0
     excess_balance = 200000
-    balance = spec.MAX_EFFECTIVE_BALANCE + excess_balance
+    balance = get_min_activation_balance(spec) + excess_balance
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
         spec,
         state,
         validator_index,
-        effective_balance=spec.MAX_EFFECTIVE_BALANCE,
+        effective_balance=get_min_activation_balance(spec),
         balance=balance,
         address=address,
     )
@@ -331,13 +332,13 @@ def test_withdrawal_and_switch_to_compounding_request_same_validator(spec, state
     # Give a validator an excess balance
     validator_index = 0
     excess_balance = 200000
-    balance = spec.MAX_EFFECTIVE_BALANCE + excess_balance
+    balance = get_min_activation_balance(spec) + excess_balance
     address = b"\x22" * 20
     set_eth1_withdrawal_credential_with_balance(
         spec,
         state,
         validator_index,
-        effective_balance=spec.MAX_EFFECTIVE_BALANCE,
+        effective_balance=get_min_activation_balance(spec),
         balance=balance,
         address=address,
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/sanity/test_blocks.py
@@ -1,4 +1,5 @@
 from eth_consensus_specs.test.context import spec_state_test, with_fulu_and_later
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
 from eth_consensus_specs.test.helpers.deposits import prepare_state_and_deposit
 from eth_consensus_specs.test.helpers.state import state_transition_and_sign_block
@@ -11,7 +12,7 @@ def test_invalid_old_style_deposit_rejected(spec, state):
     # `process_operations` asserts that blocks carry no deposits, so
     # a block with a non-empty `body.deposits` must be rejected.
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     yield "pre", state

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_builder_deposit_request.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_builder_deposit_request.py
@@ -1,4 +1,5 @@
 from eth_consensus_specs.test.context import always_bls, spec_state_test, with_gloas_and_later
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.builder_deposit_requests import (
     assert_process_builder_deposit_request,
     prepare_process_builder_deposit_request,
@@ -181,7 +182,7 @@ def test_process_builder_deposit_request__new_builder_max_minus_one(spec, state)
         - New builder created
         - Builder balance equals MAX_EFFECTIVE_BALANCE - 1
     """
-    amount = spec.MAX_EFFECTIVE_BALANCE - 1
+    amount = get_min_activation_balance(spec) - 1
     builder_deposit_request = prepare_process_builder_deposit_request(
         spec, state, amount=amount, signed=True
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_withdrawals.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_withdrawals.py
@@ -4,6 +4,7 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_gloas_and_later,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.builders import add_builder_to_registry
 from eth_consensus_specs.test.helpers.withdrawals import (
     assert_process_withdrawals,
@@ -297,7 +298,7 @@ def test_pending_withdrawals_processing(spec, state):
     pending_indices = list(range(spec.MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP))
 
     excess_balance = spec.Gwei(1_000_000_000)
-    initial_balance = spec.MAX_EFFECTIVE_BALANCE + excess_balance
+    initial_balance = get_min_activation_balance(spec) + excess_balance
 
     prepare_process_withdrawals(
         spec,
@@ -311,7 +312,7 @@ def test_pending_withdrawals_processing(spec, state):
     pre_state = state.copy()
     yield from run_gloas_withdrawals_processing(spec, state)
 
-    expected_balances = dict.fromkeys(pending_indices, spec.MAX_EFFECTIVE_BALANCE)
+    expected_balances = dict.fromkeys(pending_indices, get_min_activation_balance(spec))
 
     assert_process_withdrawals(
         spec,
@@ -348,7 +349,7 @@ def test_pending_withdrawals_processing_exceeds_limit(spec, state):
     pending_indices = list(range(num_pending))
 
     excess_balance = spec.Gwei(1_000_000_000)
-    initial_balance = spec.MAX_EFFECTIVE_BALANCE + excess_balance
+    initial_balance = get_min_activation_balance(spec) + excess_balance
 
     prepare_process_withdrawals(
         spec,
@@ -364,7 +365,7 @@ def test_pending_withdrawals_processing_exceeds_limit(spec, state):
     pre_state = state.copy()
     yield from run_gloas_withdrawals_processing(spec, state)
 
-    expected_balances = dict.fromkeys(processed_indices, spec.MAX_EFFECTIVE_BALANCE)
+    expected_balances = dict.fromkeys(processed_indices, get_min_activation_balance(spec))
     expected_balances.update(dict.fromkeys(unprocessed_indices, initial_balance))
 
     assert_process_withdrawals(
@@ -495,7 +496,7 @@ def test_builder_payments_exceed_limit_blocks_other_withdrawals(spec, state):
 
     # Cap validator balances to prevent sweep withdrawals
     capped_validator_balances = {
-        i: min(state.balances[i], spec.MAX_EFFECTIVE_BALANCE)
+        i: min(state.balances[i], get_min_activation_balance(spec))
         for i in range(len(state.validators))
         if state.validators[i].withdrawal_credentials[0:1] == spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX
     }
@@ -1066,7 +1067,7 @@ def test_full_builder_payload_reserves_sweep_slot(spec, state):
     # Setup: Cap validator balances to prevent any sweep withdrawals
     for i, validator in enumerate(state.validators):
         if validator.withdrawal_credentials[0:1] == spec.ETH1_ADDRESS_WITHDRAWAL_PREFIX:
-            state.balances[i] = min(state.balances[i], spec.MAX_EFFECTIVE_BALANCE)
+            state.balances[i] = min(state.balances[i], get_min_activation_balance(spec))
 
     # Setup: Simulate parent being FULL so process_withdrawals runs (deferred
     # processing otherwise returns early when parent was EMPTY).

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/balances.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/balances.py
@@ -1,0 +1,12 @@
+from eth_consensus_specs.test.helpers.forks import is_post_electra
+
+
+def get_min_activation_balance(spec):
+    """
+    Returns the minimum activation balance. Electra introduced
+    ``MIN_ACTIVATION_BALANCE``; before Electra the equivalent value was
+    ``MAX_EFFECTIVE_BALANCE``.
+    """
+    if is_post_electra(spec):
+        return spec.MIN_ACTIVATION_BALANCE
+    return spec.MAX_EFFECTIVE_BALANCE

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/deposits.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/deposits.py
@@ -1,6 +1,7 @@
 from random import Random
 
 from eth_consensus_specs.test.context import expect_assertion_error
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.epoch_processing import (
     run_epoch_processing_from,
     run_epoch_processing_to,
@@ -33,7 +34,7 @@ def mock_deposit(spec, state, index):
     assert spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
     state.validators[index].activation_eligibility_epoch = spec.FAR_FUTURE_EPOCH
     state.validators[index].activation_epoch = spec.FAR_FUTURE_EPOCH
-    state.validators[index].effective_balance = spec.MAX_EFFECTIVE_BALANCE
+    state.validators[index].effective_balance = get_min_activation_balance(spec)
     if is_post_altair(spec):
         state.inactivity_scores[index] = 0
     assert not spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
@@ -131,7 +132,7 @@ def prepare_random_genesis_deposits(
     if rng is None:
         rng = Random(3131)
     if max_amount is None:
-        max_amount = spec.MAX_EFFECTIVE_BALANCE
+        max_amount = get_min_activation_balance(spec)
     if min_amount is None:
         min_amount = spec.MIN_DEPOSIT_AMOUNT
     if deposit_data_list is None:
@@ -393,7 +394,7 @@ def run_deposit_processing(spec, state, deposit, validator_index, valid=True, ef
                 # Top-ups do not change effective balance
                 assert state.validators[validator_index].effective_balance == pre_effective_balance
             else:
-                effective_balance = min(spec.MAX_EFFECTIVE_BALANCE, deposit.data.amount)
+                effective_balance = min(get_min_activation_balance(spec), deposit.data.amount)
                 effective_balance -= effective_balance % spec.EFFECTIVE_BALANCE_INCREMENT
                 assert state.validators[validator_index].effective_balance == effective_balance
             assert get_balance(state, validator_index) == pre_balance + deposit.data.amount
@@ -422,7 +423,7 @@ def run_deposit_processing_with_specific_fork_version(
     spec, state, fork_version, valid=True, effective=True
 ):
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
 
     pubkey = pubkeys[validator_index]
     privkey = privkeys[validator_index]

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_transition.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fork_transition.py
@@ -7,6 +7,7 @@ from eth_consensus_specs.test.helpers.attestations import (
 from eth_consensus_specs.test.helpers.attester_slashings import (
     get_valid_attester_slashing_by_indices,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block,
     build_empty_block_for_next_slot,
@@ -381,7 +382,7 @@ def run_transition_with_operation(
     elif operation_type == OperationType.DEPOSIT:
         # create a new deposit
         selected_validator_index = len(state.validators)
-        amount = spec.MAX_EFFECTIVE_BALANCE
+        amount = get_min_activation_balance(spec)
         deposit = prepare_state_and_deposit(
             spec, state, selected_validator_index, amount, signed=True
         )

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -1,5 +1,6 @@
 from hashlib import sha256
 
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import (
     PHASE0,
 )
@@ -55,7 +56,7 @@ def build_mock_validator(spec, i: int, balance: int):
     else:
         # insecurely use pubkey as withdrawal key as well
         withdrawal_credentials = spec.BLS_WITHDRAWAL_PREFIX + spec.hash(withdrawal_pubkey)[1:]
-        max_effective_balance = spec.MAX_EFFECTIVE_BALANCE
+        max_effective_balance = get_min_activation_balance(spec)
 
     validator = spec.Validator(
         pubkey=active_pubkey,

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/multi_operations.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/multi_operations.py
@@ -7,6 +7,7 @@ from eth_consensus_specs.test.helpers.attestations import (
 from eth_consensus_specs.test.helpers.attester_slashings import (
     get_valid_attester_slashing_by_indices,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
@@ -149,7 +150,7 @@ def get_random_deposits(spec, state, rng, num_deposits=None):
             deposit_data_leaves,
             pubkeys[index],
             privkeys[index],
-            spec.MAX_EFFECTIVE_BALANCE,
+            get_min_activation_balance(spec),
             withdrawal_credentials=withdrawal_credentials,
             signed=True,
         )

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/payload_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/payload_attestation.py
@@ -1,6 +1,7 @@
 from eth_consensus_specs.test.gloas.block_processing.test_process_payload_attestation import (
     prepare_signed_payload_attestation,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_signed_execution_payload_envelope,
@@ -52,7 +53,7 @@ def ptc_size_balances(spec):
     """
     Return a balances list sized to PTC_SIZE so each PTC seat can be pinned to a unique validator.
     """
-    return [spec.MAX_EFFECTIVE_BALANCE] * spec.PTC_SIZE
+    return [get_min_activation_balance(spec)] * spec.PTC_SIZE
 
 
 def setup_verified_parent_with_distinct_ptc(spec, state):

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/withdrawals.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/withdrawals.py
@@ -1,5 +1,6 @@
 import pytest
 
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.forks import (
     is_post_eip8148,
     is_post_electra,
@@ -48,13 +49,13 @@ def set_eth1_withdrawal_credential_with_balance(
     spec, state, index, effective_balance=None, balance=None, address=None
 ):
     if balance is None and effective_balance is None:
-        balance = spec.MAX_EFFECTIVE_BALANCE
-        effective_balance = spec.MAX_EFFECTIVE_BALANCE
+        balance = get_min_activation_balance(spec)
+        effective_balance = get_min_activation_balance(spec)
     elif balance is None:
         balance = effective_balance
     elif effective_balance is None:
         effective_balance = min(
-            balance - balance % spec.EFFECTIVE_BALANCE_INCREMENT, spec.MAX_EFFECTIVE_BALANCE
+            balance - balance % spec.EFFECTIVE_BALANCE_INCREMENT, get_min_activation_balance(spec)
         )
 
     if address is None:
@@ -76,8 +77,8 @@ def set_validator_partially_withdrawable(spec, state, index, excess_balance=1000
             spec,
             state,
             index,
-            effective_balance=spec.MAX_EFFECTIVE_BALANCE,
-            balance=spec.MAX_EFFECTIVE_BALANCE + excess_balance,
+            effective_balance=get_min_activation_balance(spec),
+            balance=get_min_activation_balance(spec) + excess_balance,
         )
 
     assert check_is_partially_withdrawable_validator(spec, state, index)

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
@@ -6,6 +6,7 @@ from eth_consensus_specs.test.context import (
     with_custom_state,
     with_heze_and_later,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.fork_choice import get_genesis_forkchoice_store
 from eth_consensus_specs.test.helpers.inclusion_list import (
     get_empty_signed_inclusion_list,
@@ -253,7 +254,7 @@ def test_inclusion_list_store_equivocation(spec, state):
 @with_heze_and_later
 @spec_test
 @with_custom_state(
-    balances_fn=lambda spec: [spec.MAX_EFFECTIVE_BALANCE] * spec.SLOTS_PER_EPOCH * 2,
+    balances_fn=lambda spec: [get_min_activation_balance(spec)] * spec.SLOTS_PER_EPOCH * 2,
     threshold_fn=default_activation_threshold,
 )
 @single_phase

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/validator/test_validator.py
@@ -9,6 +9,7 @@ from eth_consensus_specs.test.context import (
     with_custom_state,
     with_heze_and_later,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.inclusion_list import get_empty_inclusion_list
 from eth_consensus_specs.test.helpers.keys import privkeys, pubkeys
 from eth_consensus_specs.test.phase0.unittests.validator.test_validator_unittest import (
@@ -17,7 +18,11 @@ from eth_consensus_specs.test.phase0.unittests.validator.test_validator_unittest
 
 
 def inclusion_committee_balances(spec):
-    return [spec.MAX_EFFECTIVE_BALANCE] * spec.SLOTS_PER_EPOCH * spec.INCLUSION_LIST_COMMITTEE_SIZE
+    return (
+        [get_min_activation_balance(spec)]
+        * spec.SLOTS_PER_EPOCH
+        * spec.INCLUSION_LIST_COMMITTEE_SIZE
+    )
 
 
 def run_get_inclusion_list_committee_assignments(spec, state, epoch, valid=True):

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/block_processing/test_process_deposit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/block_processing/test_process_deposit.py
@@ -1,4 +1,5 @@
 from eth_consensus_specs.test.context import always_bls, spec_state_test, with_all_phases_from_to
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import FULU, PHASE0
 from eth_consensus_specs.test.helpers.deposits import (
     build_deposit,
@@ -17,7 +18,7 @@ def test_new_deposit_under_max(spec, state):
     # fresh deposit = next validator index = validator appended to registry
     validator_index = len(state.validators)
     # effective balance will be 1 EFFECTIVE_BALANCE_INCREMENT smaller because of this small decrement.
-    amount = spec.MAX_EFFECTIVE_BALANCE - 1
+    amount = get_min_activation_balance(spec) - 1
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     yield from run_deposit_processing(spec, state, deposit, validator_index)
@@ -29,7 +30,7 @@ def test_new_deposit_max(spec, state):
     # fresh deposit = next validator index = validator appended to registry
     validator_index = len(state.validators)
     # effective balance will be exactly the same as balance.
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     yield from run_deposit_processing(spec, state, deposit, validator_index)
@@ -41,7 +42,7 @@ def test_new_deposit_over_max(spec, state):
     # fresh deposit = next validator index = validator appended to registry
     validator_index = len(state.validators)
     # just 1 over the limit, effective balance should be set MAX_EFFECTIVE_BALANCE during processing
-    amount = spec.MAX_EFFECTIVE_BALANCE + 1
+    amount = get_min_activation_balance(spec) + 1
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     yield from run_deposit_processing(spec, state, deposit, validator_index)
@@ -57,7 +58,7 @@ def test_new_deposit_eth1_withdrawal_credentials(spec, state):
         + b"\x00" * 11  # specified 0s
         + b"\x59" * 20  # a 20-byte eth1 address
     )
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     deposit = prepare_state_and_deposit(
         spec,
         state,
@@ -78,7 +79,7 @@ def test_new_deposit_non_versioned_withdrawal_credentials(spec, state):
     withdrawal_credentials = (
         b"\xff" + b"\x02" * 31  # Non specified withdrawal credentials version  # Garbage bytes
     )
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     deposit = prepare_state_and_deposit(
         spec,
         state,
@@ -96,7 +97,7 @@ def test_new_deposit_non_versioned_withdrawal_credentials(spec, state):
 @always_bls
 def test_correct_sig_but_forked_state(spec, state):
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     # deposits will always be valid, regardless of the current fork
     state.fork.current_version = spec.Version("0x1234abcd")
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
@@ -109,7 +110,7 @@ def test_correct_sig_but_forked_state(spec, state):
 def test_incorrect_sig_new_deposit(spec, state):
     # fresh deposit = next validator index = validator appended to registry
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount)
     yield from run_deposit_processing(spec, state, deposit, validator_index, effective=False)
 
@@ -118,28 +119,30 @@ def test_incorrect_sig_new_deposit(spec, state):
 @spec_state_test
 def test_top_up__max_effective_balance(spec, state):
     validator_index = 0
-    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    amount = get_min_activation_balance(spec) // 4
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
-    state.balances[validator_index] = spec.MAX_EFFECTIVE_BALANCE
-    state.validators[validator_index].effective_balance = spec.MAX_EFFECTIVE_BALANCE
+    state.balances[validator_index] = get_min_activation_balance(spec)
+    state.validators[validator_index].effective_balance = get_min_activation_balance(spec)
 
     yield from run_deposit_processing(spec, state, deposit, validator_index)
 
     if not is_post_electra(spec):
-        assert state.balances[validator_index] == spec.MAX_EFFECTIVE_BALANCE + amount
-        assert state.validators[validator_index].effective_balance == spec.MAX_EFFECTIVE_BALANCE
+        assert state.balances[validator_index] == get_min_activation_balance(spec) + amount
+        assert state.validators[validator_index].effective_balance == get_min_activation_balance(
+            spec
+        )
 
 
 @with_all_phases_from_to(PHASE0, FULU)
 @spec_state_test
 def test_top_up__less_effective_balance(spec, state):
     validator_index = 0
-    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    amount = get_min_activation_balance(spec) // 4
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
-    initial_balance = spec.MAX_EFFECTIVE_BALANCE - 1000
-    initial_effective_balance = spec.MAX_EFFECTIVE_BALANCE - spec.EFFECTIVE_BALANCE_INCREMENT
+    initial_balance = get_min_activation_balance(spec) - 1000
+    initial_effective_balance = get_min_activation_balance(spec) - spec.EFFECTIVE_BALANCE_INCREMENT
     state.balances[validator_index] = initial_balance
     state.validators[validator_index].effective_balance = initial_effective_balance
 
@@ -155,7 +158,7 @@ def test_top_up__less_effective_balance(spec, state):
 @spec_state_test
 def test_top_up__zero_balance(spec, state):
     validator_index = 0
-    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    amount = get_min_activation_balance(spec) // 4
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     initial_balance = 0
@@ -176,7 +179,7 @@ def test_top_up__zero_balance(spec, state):
 @always_bls
 def test_incorrect_sig_top_up(spec, state):
     validator_index = 0
-    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    amount = get_min_activation_balance(spec) // 4
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount)
 
     # invalid signatures, in top-ups, are allowed!
@@ -187,7 +190,7 @@ def test_incorrect_sig_top_up(spec, state):
 @spec_state_test
 def test_incorrect_withdrawal_credentials_top_up(spec, state):
     validator_index = 0
-    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    amount = get_min_activation_balance(spec) // 4
     withdrawal_credentials = spec.BLS_WITHDRAWAL_PREFIX + spec.hash(b"junk")[1:]
     deposit = prepare_state_and_deposit(
         spec, state, validator_index, amount, withdrawal_credentials=withdrawal_credentials
@@ -211,7 +214,7 @@ def test_invalid_wrong_deposit_for_deposit_count(spec, state):
         deposit_data_leaves,
         pubkey_1,
         privkey_1,
-        spec.MAX_EFFECTIVE_BALANCE,
+        get_min_activation_balance(spec),
         withdrawal_credentials=b"\x00" * 32,
         signed=True,
     )
@@ -226,7 +229,7 @@ def test_invalid_wrong_deposit_for_deposit_count(spec, state):
         deposit_data_leaves,
         pubkey_2,
         privkey_2,
-        spec.MAX_EFFECTIVE_BALANCE,
+        get_min_activation_balance(spec),
         withdrawal_credentials=b"\x00" * 32,
         signed=True,
     )
@@ -242,7 +245,7 @@ def test_invalid_wrong_deposit_for_deposit_count(spec, state):
 @spec_state_test
 def test_invalid_bad_merkle_proof(spec, state):
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount)
 
     # mess up merkle branch
@@ -257,7 +260,7 @@ def test_invalid_bad_merkle_proof(spec, state):
 @spec_state_test
 def test_key_validate_invalid_subgroup(spec, state):
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
 
     # All-zero pubkey would not pass `bls.KeyValidate`, but `process_deposit` would not throw exception.
     pubkey = b"\x00" * 48
@@ -273,7 +276,7 @@ def test_key_validate_invalid_subgroup(spec, state):
 @spec_state_test
 def test_key_validate_invalid_decompression(spec, state):
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
 
     # `deserialization_fails_infinity_with_true_b_flag` BLS G1 deserialization test case.
     # This pubkey would not pass `bls.KeyValidate`, but `process_deposit` would not throw exception.

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/epoch_processing/test_process_effective_balance_updates.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/epoch_processing/test_process_effective_balance_updates.py
@@ -1,4 +1,5 @@
 from eth_consensus_specs.test.context import spec_state_test, with_all_phases
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.epoch_processing import (
     run_epoch_processing_to,
     run_process_slots_up_to_epoch_boundary,
@@ -27,7 +28,7 @@ def run_test_effective_balance_hysteresis(spec, state, with_compounding_credenti
     max = (
         spec.MAX_EFFECTIVE_BALANCE_ELECTRA
         if with_compounding_credentials
-        else spec.MAX_EFFECTIVE_BALANCE
+        else get_min_activation_balance(spec)
     )
     min = spec.config.EJECTION_BALANCE
     inc = spec.EFFECTIVE_BALANCE_INCREMENT

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
@@ -19,10 +19,9 @@ from eth_consensus_specs.test.helpers.attestations import (
     sign_attestation,
 )
 from eth_consensus_specs.test.helpers.attester_slashings import get_indexed_attestation_participants
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.epoch_processing import run_epoch_processing_with
-from eth_consensus_specs.test.helpers.forks import (
-    is_post_altair,
-)
+from eth_consensus_specs.test.helpers.forks import is_post_altair
 from eth_consensus_specs.test.helpers.rewards import leaking
 from eth_consensus_specs.test.helpers.state import (
     next_epoch,
@@ -141,7 +140,7 @@ def test_full_attestations_random_incorrect_fields(spec, state):
 @with_all_phases
 @spec_test
 @with_custom_state(
-    balances_fn=misc_balances, threshold_fn=lambda spec: spec.MAX_EFFECTIVE_BALANCE // 2
+    balances_fn=misc_balances, threshold_fn=lambda spec: get_min_activation_balance(spec) // 2
 )
 @single_phase
 def test_full_attestations_misc_balances(spec, state):

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/epoch_processing/test_process_slashings.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/epoch_processing/test_process_slashings.py
@@ -1,6 +1,7 @@
 from random import Random
 
 from eth_consensus_specs.test.context import spec_state_test, with_all_phases
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.epoch_processing import (
     run_epoch_processing_to,
     run_epoch_processing_with,
@@ -130,7 +131,7 @@ def test_minimal_penalty(spec, state):
     )
     # All the other validators get the maximum.
     for i in range(1, len(state.validators)):
-        state.validators[i].effective_balance = state.balances[i] = spec.MAX_EFFECTIVE_BALANCE
+        state.validators[i].effective_balance = state.balances[i] = get_min_activation_balance(spec)
 
     out_epoch = spec.get_current_epoch(state) + (spec.EPOCHS_PER_SLASHINGS_VECTOR // 2)
 
@@ -175,11 +176,11 @@ def test_scaled_penalties(spec, state):
 
     # make the balances non-uniform.
     # Otherwise it would just be a simple balance slashing. Test the per-validator scaled penalties.
-    diff = spec.MAX_EFFECTIVE_BALANCE - base
+    diff = get_min_activation_balance(spec) - base
     increments = diff // incr
     for i in range(10):
         state.validators[i].effective_balance = base + (incr * (i % increments))
-        assert state.validators[i].effective_balance <= spec.MAX_EFFECTIVE_BALANCE
+        assert state.validators[i].effective_balance <= get_min_activation_balance(spec)
         # add/remove some, see if balances different than the effective balances are picked up
         state.balances[i] = state.validators[i].effective_balance + i - 5
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/genesis/test_initialization.py
@@ -5,15 +5,13 @@ from eth_consensus_specs.test.context import (
     with_phases,
     with_presets,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import MINIMAL
 from eth_consensus_specs.test.helpers.deposits import (
     prepare_full_genesis_deposits,
     prepare_random_genesis_deposits,
 )
-from eth_consensus_specs.test.helpers.forks import (
-    is_post_altair,
-    is_post_electra,
-)
+from eth_consensus_specs.test.helpers.forks import is_post_altair, is_post_electra
 
 
 def get_post_altair_description(spec):
@@ -41,7 +39,7 @@ def test_initialize_beacon_state_from_eth1(spec):
     deposit_count = spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
     deposits, deposit_root, _ = prepare_full_genesis_deposits(
         spec,
-        spec.MAX_EFFECTIVE_BALANCE,
+        get_min_activation_balance(spec),
         deposit_count,
         signed=True,
     )
@@ -60,7 +58,7 @@ def test_initialize_beacon_state_from_eth1(spec):
     assert state.eth1_data.deposit_root == deposit_root
     assert state.eth1_data.deposit_count == deposit_count
     assert state.eth1_data.block_hash == eth1_block_hash
-    assert spec.get_total_active_balance(state) == deposit_count * spec.MAX_EFFECTIVE_BALANCE
+    assert spec.get_total_active_balance(state) == deposit_count * get_min_activation_balance(spec)
 
     # yield state
     yield "state", state
@@ -77,7 +75,7 @@ def test_initialize_beacon_state_some_small_balances(spec):
     if is_post_electra(spec):
         max_effective_balance = spec.MAX_EFFECTIVE_BALANCE_ELECTRA
     else:
-        max_effective_balance = spec.MAX_EFFECTIVE_BALANCE
+        max_effective_balance = get_min_activation_balance(spec)
 
     main_deposit_count = spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
     main_deposits, _, deposit_data_list = prepare_full_genesis_deposits(
@@ -114,7 +112,9 @@ def test_initialize_beacon_state_some_small_balances(spec):
     # only main deposits participate to the active balance
     # NOTE: they are pre-ELECTRA deposits with BLS_WITHDRAWAL_PREFIX,
     # so `MAX_EFFECTIVE_BALANCE` is used
-    assert spec.get_total_active_balance(state) == main_deposit_count * spec.MAX_EFFECTIVE_BALANCE
+    assert spec.get_total_active_balance(state) == main_deposit_count * get_min_activation_balance(
+        spec
+    )
 
     # yield state
     yield "state", state
@@ -132,7 +132,7 @@ def test_initialize_beacon_state_one_topup_activation(spec):
     main_deposit_count = spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1
     main_deposits, _, deposit_data_list = prepare_full_genesis_deposits(
         spec,
-        spec.MAX_EFFECTIVE_BALANCE,
+        get_min_activation_balance(spec),
         deposit_count=main_deposit_count,
         signed=True,
     )
@@ -140,7 +140,7 @@ def test_initialize_beacon_state_one_topup_activation(spec):
     # Submit last pubkey deposit as MAX_EFFECTIVE_BALANCE - MIN_DEPOSIT_AMOUNT
     partial_deposits, _, deposit_data_list = prepare_full_genesis_deposits(
         spec,
-        spec.MAX_EFFECTIVE_BALANCE - spec.MIN_DEPOSIT_AMOUNT,
+        get_min_activation_balance(spec) - spec.MIN_DEPOSIT_AMOUNT,
         deposit_count=1,
         min_pubkey_index=main_deposit_count,
         signed=True,
@@ -219,7 +219,7 @@ def test_initialize_beacon_state_random_valid_genesis(spec):
     # Then make spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT full deposits
     full_deposits, _, _ = prepare_full_genesis_deposits(
         spec,
-        spec.MAX_EFFECTIVE_BALANCE,
+        get_min_activation_balance(spec),
         deposit_count=spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
         signed=True,
         deposit_data_list=deposit_data_list,

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/genesis/test_validity.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/genesis/test_validity.py
@@ -5,13 +5,12 @@ from eth_consensus_specs.test.context import (
     with_phases,
     with_presets,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import MINIMAL
 from eth_consensus_specs.test.helpers.deposits import (
     prepare_full_genesis_deposits,
 )
-from eth_consensus_specs.test.helpers.forks import (
-    is_post_altair,
-)
+from eth_consensus_specs.test.helpers.forks import is_post_altair
 
 
 def get_post_altair_description(spec):
@@ -22,7 +21,7 @@ def create_valid_beacon_state(spec):
     deposit_count = spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
     deposits, _, _ = prepare_full_genesis_deposits(
         spec,
-        amount=spec.MAX_EFFECTIVE_BALANCE,
+        amount=get_min_activation_balance(spec),
         deposit_count=deposit_count,
         signed=True,
     )
@@ -80,7 +79,7 @@ def test_extra_balance(spec):
         yield "description", "meta", get_post_altair_description(spec)
 
     state = create_valid_beacon_state(spec)
-    state.validators[0].effective_balance = spec.MAX_EFFECTIVE_BALANCE + 1
+    state.validators[0].effective_balance = get_min_activation_balance(spec) + 1
 
     yield from run_is_valid_genesis_state(spec, state)
 
@@ -96,7 +95,7 @@ def test_one_more_validator(spec):
     deposit_count = spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT + 1
     deposits, _, _ = prepare_full_genesis_deposits(
         spec,
-        amount=spec.MAX_EFFECTIVE_BALANCE,
+        amount=get_min_activation_balance(spec),
         deposit_count=deposit_count,
         signed=True,
     )
@@ -119,7 +118,7 @@ def test_invalid_not_enough_validator_count(spec):
     deposit_count = spec.config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1
     deposits, _, _ = prepare_full_genesis_deposits(
         spec,
-        amount=spec.MAX_EFFECTIVE_BALANCE,
+        amount=get_min_activation_balance(spec),
         deposit_count=deposit_count,
         signed=True,
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -12,6 +12,7 @@ from eth_consensus_specs.test.helpers.attestations import (
     get_valid_attestation,
     sign_attestation,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block_for_next_slot,
 )
@@ -48,7 +49,7 @@ def large_validator_balances(spec):
     so that there's a chance of non-aggregators (modulo >= 2).
     """
     num_validators = 32 * spec.SLOTS_PER_EPOCH
-    return [spec.MAX_EFFECTIVE_BALANCE] * num_validators
+    return [get_min_activation_balance(spec)] * num_validators
 
 
 def create_signed_aggregate_and_proof(spec, state, attestation, aggregator_index=None):

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/sanity/test_blocks.py
@@ -21,6 +21,7 @@ from eth_consensus_specs.test.helpers.attester_slashings import (
     get_valid_attester_slashing,
     get_valid_attester_slashing_by_indices,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block,
     build_empty_block_for_next_slot,
@@ -821,7 +822,7 @@ def test_deposit_in_block(spec, state):
     initial_balances_len = len(state.balances)
 
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     yield "pre", state
@@ -840,7 +841,7 @@ def test_deposit_in_block(spec, state):
 
     assert len(state.validators) == initial_registry_len + 1
     assert len(state.balances) == initial_balances_len + 1
-    assert balance == spec.MAX_EFFECTIVE_BALANCE
+    assert balance == get_min_activation_balance(spec)
     assert state.validators[validator_index].pubkey == pubkeys[validator_index]
 
 
@@ -848,7 +849,7 @@ def test_deposit_in_block(spec, state):
 @spec_state_test
 def test_invalid_duplicate_deposit_same_block(spec, state):
     validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount, signed=True)
 
     yield "pre", state
@@ -869,7 +870,7 @@ def test_invalid_duplicate_deposit_same_block(spec, state):
 @spec_state_test
 def test_deposit_top_up(spec, state):
     validator_index = 0
-    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    amount = get_min_activation_balance(spec) // 4
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount)
 
     initial_registry_len = len(state.validators)

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/test_config_invariants.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/test_config_invariants.py
@@ -2,6 +2,7 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_all_phases,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.constants import UINT64_MAX
 from eth_consensus_specs.test.helpers.forks import (
     is_post_altair,
@@ -38,10 +39,10 @@ def test_validators(spec, state):
 @with_all_phases
 @spec_state_test
 def test_balances(spec, state):
-    assert spec.MAX_EFFECTIVE_BALANCE % spec.EFFECTIVE_BALANCE_INCREMENT == 0
+    assert get_min_activation_balance(spec) % spec.EFFECTIVE_BALANCE_INCREMENT == 0
     check_bound(spec.MIN_DEPOSIT_AMOUNT, 1, UINT64_MAX)
-    check_bound(spec.MAX_EFFECTIVE_BALANCE, spec.MIN_DEPOSIT_AMOUNT, UINT64_MAX)
-    check_bound(spec.MAX_EFFECTIVE_BALANCE, spec.EFFECTIVE_BALANCE_INCREMENT, UINT64_MAX)
+    check_bound(get_min_activation_balance(spec), spec.MIN_DEPOSIT_AMOUNT, UINT64_MAX)
+    check_bound(get_min_activation_balance(spec), spec.EFFECTIVE_BALANCE_INCREMENT, UINT64_MAX)
 
 
 @with_all_phases

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/validator/test_validator_unittest.py
@@ -14,6 +14,7 @@ from eth_consensus_specs.test.helpers.attestations import (
     build_attestation_data,
     get_valid_attestation,
 )
+from eth_consensus_specs.test.helpers.balances import get_min_activation_balance
 from eth_consensus_specs.test.helpers.block import build_empty_block
 from eth_consensus_specs.test.helpers.constants import FULU, PHASE0
 from eth_consensus_specs.test.helpers.keys import privkeys, pubkeys
@@ -78,7 +79,7 @@ def test_check_if_validator_active(spec, state):
     active_validator_index = len(state.validators) - 1
     assert spec.check_if_validator_active(state, active_validator_index)
     new_validator_index = len(state.validators)
-    amount = spec.MAX_EFFECTIVE_BALANCE
+    amount = get_min_activation_balance(spec)
     spec.add_validator_to_registry(state, pubkeys[new_validator_index], b"\x00" * 32, amount)
     assert not spec.check_if_validator_active(state, new_validator_index)
 


### PR DESCRIPTION
Technically, `MAX_EFFECTIVE_BALANCE` should not be used post-Electra. But there are many instances where it is used, so I thought I'd make a new helper function which replaces them. That way, we can mark `MAX_EFFECTIVE_BALANCE` as removed in Electra. This will be handled in a different PR.