### PR TITLE
Set `BUILDER_WITHDRAWAL_PREFIX` to 0xB0

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -182,7 +182,7 @@ future validator withdrawal prefix may reuse this value.
 
 | Name                        | Value            |
 | --------------------------- | ---------------- |
-| `BUILDER_WITHDRAWAL_PREFIX` | `Bytes1('0x03')` |
+| `BUILDER_WITHDRAWAL_PREFIX` | `Bytes1('0xB0')` |
 
 ### Builder versions
 

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -51,11 +51,12 @@ must include:
   under `DOMAIN_BUILDER_DEPOSIT`.
 
 *Note*: Builders may be onboarded at the fork by submitting a deposit to the
-validator deposit contract with a `0x03` withdrawal credential. This must be
-done late enough that the deposit is still pending at the fork, but early enough
-that the slot in which the deposit is added to the pending deposit queue is
-finalized so that the builder is considered active. Such a deposit signs over
-`DepositMessage` under `DOMAIN_DEPOSIT`, with withdrawal credentials of the form
+validator deposit contract with a `BUILDER_WITHDRAWAL_PREFIX` withdrawal
+credential. This must be done late enough that the deposit is still pending at
+the fork, but early enough that the slot in which the deposit is added to the
+pending deposit queue is finalized so that the builder is considered active.
+Such a deposit signs over `DepositMessage` under `DOMAIN_DEPOSIT`, with
+withdrawal credentials of the form
 `BUILDER_WITHDRAWAL_PREFIX + b"\x00" * 11 + execution_address`.
 
 ### Process deposit

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_builder_deposit_request.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_builder_deposit_request.py
@@ -275,7 +275,7 @@ def test_process_builder_deposit_request__top_up(spec, state):
 
     Input State Configured:
         - Existing builder pubkey
-        - Builder withdrawal credentials (0x03 prefix)
+        - Builder withdrawal credentials
 
     Output State Verified:
         - Builder balance increased (top-up)

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_deposit_request.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_deposit_request.py
@@ -21,14 +21,14 @@ def test_process_deposit_request__builder_credentials_queued(spec, state):
 
     Input State Configured:
         - New pubkey (not an existing validator or builder)
-        - Builder withdrawal credentials (0x03 prefix)
+        - Builder withdrawal credentials
 
     Output State Verified:
         - Pending deposit added to the validator queue
         - No builder created (builder count unchanged)
     """
     amount = spec.MIN_DEPOSIT_AMOUNT
-    # Builder withdrawal credentials (0x03 prefix) on an otherwise ordinary deposit
+    # Builder withdrawal credentials on an otherwise ordinary deposit
     withdrawal_credentials = spec.BUILDER_WITHDRAWAL_PREFIX + b"\x00" * 11 + b"\x59" * 20
     deposit_request = prepare_process_deposit_request(
         spec,
@@ -60,14 +60,14 @@ def test_process_deposit_request__builder_pubkey_queued(spec, state):
 
     Input State Configured:
         - Existing builder pubkey
-        - Builder withdrawal credentials (0x03 prefix)
+        - Builder withdrawal credentials
 
     Output State Verified:
         - Pending deposit added to the validator queue
         - Builder unchanged (no top-up)
     """
     amount = spec.MIN_DEPOSIT_AMOUNT
-    # Deposit for a pubkey that is already a builder, with builder (0x03) credentials
+    # Deposit for a pubkey that is already a builder, with builder credentials
     builder_pubkey = state.builders[0].pubkey
     withdrawal_credentials = spec.BUILDER_WITHDRAWAL_PREFIX + b"\x00" * 11 + b"\x59" * 20
     deposit_request = prepare_process_deposit_request(

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
@@ -398,8 +398,8 @@ def test_fork_builder_deposit_with_existing_validator_pubkey_builder_creds(spec,
 def test_fork_builder_deposit_followed_by_non_builder_credentials(spec, phases, state):
     """
     Test fork with two deposits for the same builder pubkey:
-    - First deposit has builder credentials (0x03)
-    - Second deposit has non-builder credentials (0x02)
+    - First deposit has builder credentials
+    - Second deposit has non-builder credentials
     Both should be applied to the builder.
     """
     post_spec = phases[GLOAS]
@@ -408,7 +408,7 @@ def test_fork_builder_deposit_followed_by_non_builder_credentials(spec, phases, 
     builder_pubkey = builder_pubkeys[0]
     privkey = builder_pubkey_to_privkey[builder_pubkey]
 
-    # First deposit: builder credentials (0x03)
+    # First deposit: builder credentials
     builder_deposit = create_pending_deposit_for_builder(post_spec, builder_pubkey, amount)
 
     # Second deposit: compounding credentials (0x02) for the same pubkey
@@ -453,8 +453,8 @@ def test_fork_builder_deposit_followed_by_non_builder_credentials(spec, phases, 
 def test_fork_validator_deposit_followed_by_builder_credentials(spec, phases, state):
     """
     Test fork with two deposits for the same pubkey:
-    - First deposit has validator credentials (0x02)
-    - Second deposit has builder credentials (0x03)
+    - First deposit has validator credentials
+    - Second deposit has builder credentials
     Both deposits should stay in pending (no builder created).
     """
     post_spec = phases[GLOAS]
@@ -483,7 +483,7 @@ def test_fork_validator_deposit_followed_by_builder_credentials(spec, phases, st
         slot=post_spec.GENESIS_SLOT,
     )
 
-    # Second deposit: builder credentials (0x03) for the same pubkey
+    # Second deposit: builder credentials for the same pubkey
     builder_deposit = create_pending_deposit_for_builder(post_spec, builder_pubkey, amount)
 
     state.pending_deposits = [validator_deposit, builder_deposit]
@@ -513,8 +513,8 @@ def test_fork_validator_deposit_followed_by_builder_credentials(spec, phases, st
 def test_fork_invalid_validator_deposit_followed_by_builder_credentials(spec, phases, state):
     """
     Test fork with two deposits for the same pubkey:
-    - First deposit has validator credentials (0x02) but INVALID signature
-    - Second deposit has builder credentials (0x03) with valid signature
+    - First deposit has validator credentials but INVALID signature
+    - Second deposit has builder credentials with valid signature
     The invalid validator deposit should not block the builder deposit.
     """
     post_spec = phases[GLOAS]
@@ -534,7 +534,7 @@ def test_fork_invalid_validator_deposit_followed_by_builder_credentials(spec, ph
         slot=post_spec.GENESIS_SLOT,
     )
 
-    # Second deposit: builder credentials (0x03) with valid signature
+    # Second deposit: builder credentials with valid signature
     builder_deposit = create_pending_deposit_for_builder(post_spec, builder_pubkey, amount)
 
     state.pending_deposits = [invalid_validator_deposit, builder_deposit]
@@ -561,8 +561,8 @@ def test_fork_invalid_validator_deposit_followed_by_builder_credentials(spec, ph
 def test_fork_invalid_builder_deposit_followed_by_valid_builder_deposit(spec, phases, state):
     """
     Test fork with two builder deposits for the same pubkey:
-    - First deposit has builder credentials (0x03) but INVALID signature
-    - Second deposit has builder credentials (0x03) with valid signature
+    - First deposit has builder credentials but INVALID signature
+    - Second deposit has builder credentials with valid signature
     The valid second deposit should create the builder.
     """
     post_spec = phases[GLOAS]
@@ -571,7 +571,7 @@ def test_fork_invalid_builder_deposit_followed_by_valid_builder_deposit(spec, ph
     builder_pubkey = builder_pubkeys[0]
     builder_withdrawal_credentials = get_builder_withdrawal_credentials(post_spec, builder_pubkey)
 
-    # First deposit: builder credentials (0x03) with INVALID signature
+    # First deposit: builder credentials with INVALID signature
     invalid_builder_deposit = post_spec.PendingDeposit(
         pubkey=builder_pubkey,
         withdrawal_credentials=builder_withdrawal_credentials,
@@ -580,7 +580,7 @@ def test_fork_invalid_builder_deposit_followed_by_valid_builder_deposit(spec, ph
         slot=post_spec.GENESIS_SLOT,
     )
 
-    # Second deposit: builder credentials (0x03) with valid signature
+    # Second deposit: builder credentials with valid signature
     valid_builder_deposit = create_pending_deposit_for_builder(post_spec, builder_pubkey, amount)
 
     state.pending_deposits = [invalid_builder_deposit, valid_builder_deposit]
@@ -604,8 +604,8 @@ def test_fork_invalid_builder_deposit_followed_by_valid_builder_deposit(spec, ph
 def test_fork_valid_builder_deposit_followed_by_invalid_builder_deposit(spec, phases, state):
     """
     Test fork with two builder deposits for the same pubkey:
-    - First deposit has builder credentials (0x03) with valid signature
-    - Second deposit has builder credentials (0x03) but INVALID signature
+    - First deposit has builder credentials with valid signature
+    - Second deposit has builder credentials but INVALID signature
     The valid first deposit should create the builder, second adds to balance.
     """
     post_spec = phases[GLOAS]
@@ -614,10 +614,10 @@ def test_fork_valid_builder_deposit_followed_by_invalid_builder_deposit(spec, ph
     builder_pubkey = builder_pubkeys[0]
     builder_withdrawal_credentials = get_builder_withdrawal_credentials(post_spec, builder_pubkey)
 
-    # First deposit: builder credentials (0x03) with valid signature
+    # First deposit: builder credentials with valid signature
     valid_builder_deposit = create_pending_deposit_for_builder(post_spec, builder_pubkey, amount)
 
-    # Second deposit: builder credentials (0x03) with INVALID signature
+    # Second deposit: builder credentials with INVALID signature
     invalid_builder_deposit = post_spec.PendingDeposit(
         pubkey=builder_pubkey,
         withdrawal_credentials=builder_withdrawal_credentials,


### PR DESCRIPTION
This changes the (temporary) withdrawal prefix used onboard builders at the Gloas fork from 0x03 to 0xB0. The rationale for this change is that it's further away from a realistic value which may be used in the future. This was a popular change and I'm unaware of anyone that is against it.

* https://github.com/ethereum/consensus-specs/pull/5359#discussion_r3442172938

<img width="879" height="1001" alt="image" src="https://github.com/user-attachments/assets/2dbac657-7193-48cf-a633-0a411b2f4008" />
