### PR TITLE
Add allowed and reserved list of builder versions

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -186,10 +186,10 @@ future validator withdrawal prefix may reuse this value.
 
 ### Builder versions
 
-| Name                               | Value        |
-| ---------------------------------- | ------------ |
-| `PAYLOAD_BUILDER_ALLOWED_VERSION`  | `uint8(8)`   |
-| `PAYLOAD_BUILDER_RESERVED_VERSION` | `uint8(128)` |
+| Name                               | Value         |
+| ---------------------------------- | ------------- |
+| `PAYLOAD_BUILDER_ALLOWED_VERSION`  | `uint8(0xB1)` |
+| `PAYLOAD_BUILDER_RESERVED_VERSION` | `uint8(0xB0)` |
 
 ### Execution-layer triggered requests
 
@@ -1696,7 +1696,7 @@ def process_builder_deposit_request(state: BeaconState, request: BuilderDepositR
     builder_pubkeys = [b.pubkey for b in state.builders]
     if request.pubkey not in builder_pubkeys:
         version = uint8(request.withdrawal_credentials[0])
-        is_valid_version = version <= PAYLOAD_BUILDER_RESERVED_VERSION
+        is_valid_version = version >= PAYLOAD_BUILDER_RESERVED_VERSION
         if is_valid_builder_deposit_signature(request) and is_valid_version:
             add_builder_to_registry(
                 state,

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -186,10 +186,10 @@ future validator withdrawal prefix may reuse this value.
 
 ### Builder versions
 
-| Name                               | Value         |
-| ---------------------------------- | ------------- |
-| `PAYLOAD_BUILDER_ALLOWED_VERSION`  | `uint8(0xB1)` |
-| `PAYLOAD_BUILDER_RESERVED_VERSION` | `uint8(0xB0)` |
+| Name                            | Value         |
+| ------------------------------- | ------------- |
+| `BUILDER_MAX_VERSION`           | `uint8(1)`    |
+| `BUILDER_MIN_WITHDRAWAL_PREFIX` | `uint8(0xB0)` |
 
 ### Execution-layer triggered requests
 
@@ -1554,7 +1554,7 @@ def process_execution_payload_bid(
         # Verify that the builder is active
         assert is_active_builder(state, builder_index)
         # Verify that the builder is a payload builder
-        assert state.builders[builder_index].version <= PAYLOAD_BUILDER_ALLOWED_VERSION
+        assert state.builders[builder_index].version <= BUILDER_MAX_VERSION
         # Verify that the builder has funds to cover the bid
         assert can_builder_cover_bid(state, builder_index, amount)
         # Verify that the bid signature is valid
@@ -1695,8 +1695,9 @@ caching should account for this behavior.
 def process_builder_deposit_request(state: BeaconState, request: BuilderDepositRequest) -> None:
     builder_pubkeys = [b.pubkey for b in state.builders]
     if request.pubkey not in builder_pubkeys:
-        version = uint8(request.withdrawal_credentials[0])
-        is_valid_version = version >= PAYLOAD_BUILDER_RESERVED_VERSION
+        prefix = uint8(request.withdrawal_credentials[0])
+        is_valid_version = prefix >= BUILDER_MIN_WITHDRAWAL_PREFIX
+        version = prefix - BUILDER_MIN_WITHDRAWAL_PREFIX
         if is_valid_builder_deposit_signature(request) and is_valid_version:
             add_builder_to_registry(
                 state,

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -188,7 +188,7 @@ future validator withdrawal prefix may reuse this value.
 
 | Name                               | Value        |
 | ---------------------------------- | ------------ |
-| `PAYLOAD_BUILDER_ALLOWED_VERSION`  | `uint8(1)`   |
+| `PAYLOAD_BUILDER_ALLOWED_VERSION`  | `uint8(8)`   |
 | `PAYLOAD_BUILDER_RESERVED_VERSION` | `uint8(128)` |
 
 ### Execution-layer triggered requests

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -186,9 +186,10 @@ future validator withdrawal prefix may reuse this value.
 
 ### Builder versions
 
-| Name                      | Value      |
-| ------------------------- | ---------- |
-| `PAYLOAD_BUILDER_VERSION` | `uint8(0)` |
+| Name                               | Value        |
+| ---------------------------------- | ------------ |
+| `PAYLOAD_BUILDER_ALLOWED_VERSION`  | `uint8(1)`   |
+| `PAYLOAD_BUILDER_RESERVED_VERSION` | `uint8(128)` |
 
 ### Execution-layer triggered requests
 
@@ -1553,7 +1554,7 @@ def process_execution_payload_bid(
         # Verify that the builder is active
         assert is_active_builder(state, builder_index)
         # Verify that the builder is a payload builder
-        assert state.builders[builder_index].version == PAYLOAD_BUILDER_VERSION
+        assert state.builders[builder_index].version <= PAYLOAD_BUILDER_ALLOWED_VERSION
         # Verify that the builder has funds to cover the bid
         assert can_builder_cover_bid(state, builder_index, amount)
         # Verify that the bid signature is valid
@@ -1694,11 +1695,13 @@ caching should account for this behavior.
 def process_builder_deposit_request(state: BeaconState, request: BuilderDepositRequest) -> None:
     builder_pubkeys = [b.pubkey for b in state.builders]
     if request.pubkey not in builder_pubkeys:
-        if is_valid_builder_deposit_signature(request):
+        version = uint8(request.withdrawal_credentials[0])
+        is_valid_version = version <= PAYLOAD_BUILDER_RESERVED_VERSION
+        if is_valid_builder_deposit_signature(request) and is_valid_version:
             add_builder_to_registry(
                 state,
                 request.pubkey,
-                uint8(request.withdrawal_credentials[0]),
+                version,
                 ExecutionAddress(request.withdrawal_credentials[12:]),
                 request.amount,
                 state.slot,

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -45,7 +45,7 @@ must include:
 - `withdrawal_credentials`: The withdrawal credentials, where the first byte is
   the builder version and the last 20 bytes are the execution-layer address that
   will receive withdrawals. For the version, execution payload builders should
-  use `PAYLOAD_BUILDER_VERSION`.
+  use a version lower or equal than `PAYLOAD_BUILDER_ALLOWED_VERSION`.
 - `amount`: At least `MIN_DEPOSIT_AMOUNT` gwei.
 - `signature`: BLS proof of possession over the corresponding `DepositMessage`
   under `DOMAIN_BUILDER_DEPOSIT`.

--- a/specs/gloas/builder.md
+++ b/specs/gloas/builder.md
@@ -45,7 +45,7 @@ must include:
 - `withdrawal_credentials`: The withdrawal credentials, where the first byte is
   the builder version and the last 20 bytes are the execution-layer address that
   will receive withdrawals. For the version, execution payload builders should
-  use a version lower or equal than `PAYLOAD_BUILDER_ALLOWED_VERSION`.
+  use a version lower or equal than `BUILDER_MAX_VERSION`.
 - `amount`: At least `MIN_DEPOSIT_AMOUNT` gwei.
 - `signature`: BLS proof of possession over the corresponding `DepositMessage`
   under `DOMAIN_BUILDER_DEPOSIT`.

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -106,7 +106,7 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
             add_builder_to_registry(
                 state,
                 deposit.pubkey,
-                uint8(0),
+                uint8(PAYLOAD_BUILDER_RESERVED_VERSION),
                 ExecutionAddress(deposit.withdrawal_credentials[12:]),
                 deposit.amount,
                 deposit.slot,

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -106,7 +106,7 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
             add_builder_to_registry(
                 state,
                 deposit.pubkey,
-                PAYLOAD_BUILDER_VERSION,
+                uint8(0),
                 ExecutionAddress(deposit.withdrawal_credentials[12:]),
                 deposit.amount,
                 deposit.slot,

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -106,7 +106,7 @@ def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
             add_builder_to_registry(
                 state,
                 deposit.pubkey,
-                uint8(PAYLOAD_BUILDER_RESERVED_VERSION),
+                uint8(0),
                 ExecutionAddress(deposit.withdrawal_credentials[12:]),
                 deposit.amount,
                 deposit.slot,

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -369,8 +369,8 @@ where `store` is the fork choice store, and the alias
 - _[IGNORE]_ The matching `signed_proposer_preferences` has been seen.
 - _[REJECT]_ `bid.builder_index` is a valid/active builder index -- i.e.
   `is_active_builder(state, bid.builder_index)` returns `True`.
-- _[REJECT]_ The builder version is `PAYLOAD_BUILDER_VERSION` -- i.e.
-  `state.builders[bid.builder_index].version == PAYLOAD_BUILDER_VERSION`.
+- _[REJECT]_
+  `state.builders[bid.builder_index].version <= PAYLOAD_BUILDER_ALLOWED_VERSION`.
 - _[REJECT]_ `bid.execution_payment == 0`.
 - _[REJECT]_ `bid.fee_recipient == proposer_preferences.fee_recipient`.
 - _[REJECT]_ The length of KZG commitments is less than or equal to the

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -369,8 +369,7 @@ where `store` is the fork choice store, and the alias
 - _[IGNORE]_ The matching `signed_proposer_preferences` has been seen.
 - _[REJECT]_ `bid.builder_index` is a valid/active builder index -- i.e.
   `is_active_builder(state, bid.builder_index)` returns `True`.
-- _[REJECT]_
-  `state.builders[bid.builder_index].version <= PAYLOAD_BUILDER_ALLOWED_VERSION`.
+- _[REJECT]_ `state.builders[bid.builder_index].version <= BUILDER_MAX_VERSION`.
 - _[REJECT]_ `bid.execution_payment == 0`.
 - _[REJECT]_ `bid.fee_recipient == proposer_preferences.fee_recipient`.
 - _[REJECT]_ The length of KZG commitments is less than or equal to the

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
@@ -272,7 +272,7 @@ def test_process_execution_payload_bid_inactive_builder_exiting(spec, state):
 @spec_state_test
 def test_process_execution_payload_bid_non_payload_builder_version(spec, state):
     """
-    Test that a bid from a builder whose version is not PAYLOAD_BUILDER_VERSION fails.
+    Test that a bid from a builder whose version is bigger than PAYLOAD_BUILDER_ALLOWED_VERSION fails.
     """
     next_epoch_with_full_participation(spec, state)
     next_epoch_with_full_participation(spec, state)
@@ -284,8 +284,7 @@ def test_process_execution_payload_bid_non_payload_builder_version(spec, state):
     assert spec.is_active_builder(state, builder_index)
 
     # Mark the builder as a non-payload builder, leaving every other condition valid
-    state.builders[builder_index].version = spec.uint8(spec.PAYLOAD_BUILDER_VERSION + 1)
-    assert state.builders[builder_index].version != spec.PAYLOAD_BUILDER_VERSION
+    state.builders[builder_index].version = spec.uint8(spec.PAYLOAD_BUILDER_ALLOWED_VERSION + 1)
 
     # The builder can cover the bid, so the version check is the only failing condition
     value = spec.Gwei(1000000)  # 0.001 ETH

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
@@ -272,7 +272,7 @@ def test_process_execution_payload_bid_inactive_builder_exiting(spec, state):
 @spec_state_test
 def test_process_execution_payload_bid_non_payload_builder_version(spec, state):
     """
-    Test that a bid from a builder whose version is bigger than PAYLOAD_BUILDER_ALLOWED_VERSION fails.
+    Test that a bid from a builder whose version is bigger than BUILDER_MAX_VERSION fails.
     """
     next_epoch_with_full_participation(spec, state)
     next_epoch_with_full_participation(spec, state)
@@ -284,7 +284,7 @@ def test_process_execution_payload_bid_non_payload_builder_version(spec, state):
     assert spec.is_active_builder(state, builder_index)
 
     # Mark the builder as a non-payload builder, leaving every other condition valid
-    state.builders[builder_index].version = spec.uint8(spec.PAYLOAD_BUILDER_ALLOWED_VERSION + 1)
+    state.builders[builder_index].version = spec.uint8(spec.BUILDER_MAX_VERSION + 1)
 
     # The builder can cover the bid, so the version check is the only failing condition
     value = spec.Gwei(1000000)  # 0.001 ETH

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
@@ -141,7 +141,7 @@ def test_fork_builder_deposit_version(spec, phases, state):
     # The onboarded builder is registered with the payload builder version
     assert len(post_state.builders) == 1
     assert post_state.builders[0].pubkey == builder_pubkey
-    assert post_state.builders[0].version == spec.uint8(0)
+    assert post_state.builders[0].version == spec.uint8(spec.PAYLOAD_BUILDERS_RESERVED_VERSION)
 
 
 @with_phases(phases=[FULU], other_phases=[GLOAS])

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_onboard_builders.py
@@ -141,7 +141,7 @@ def test_fork_builder_deposit_version(spec, phases, state):
     # The onboarded builder is registered with the payload builder version
     assert len(post_state.builders) == 1
     assert post_state.builders[0].pubkey == builder_pubkey
-    assert post_state.builders[0].version == post_spec.PAYLOAD_BUILDER_VERSION
+    assert post_state.builders[0].version == spec.uint8(0)
 
 
 @with_phases(phases=[FULU], other_phases=[GLOAS])


### PR DESCRIPTION
This PR adds two different lists. A list of *allowed* builder versions and a list of *reserved* builder versions. 

Any builder deposit for a version that is reserved is ignored at deposit processing time. This means that a builder that sends a version that is larger than `PAYLOAD_BUILDER_RESERVED_VERSION` will lose its deposit. 

Any builder with a version that is above `PAYLOAD_BUILDER_ALLOWED_VERSION` will not be able to land bids on chain. Their bids are ignored over P2P and blocks that include such bids are invalid. 

## Rationale for the *reserved* list:

It allows the protocol to make certain that no builder with version larger than `PAYLOAD_BUILDER_RESERVED_VERSION` exists on state, thus, if in future forks we want to create a special type of builder that requires that no such builder existed, we still have this option.  

## Rationale for the *allowed* list. 

It allows the protocol to onboard builders with different versions that are able to send bids during the current fork. Thus, if we ever want to create some custom type of builders in the future that requires at fork  N + 1 to have had landed a bid on fork N, this can be achieved. 

## Rationale for these lists to be different

We want *allowed* to be a strict subset of *not reserved* to

- Allow builders to desposit with whatever version they want at the current fork as long as it's not reserved, potentially allowing some offchain mechanisms that would otherwise be forbidden.
- Allow the protocol to create new builders for fork N+1 that can be deposited during fork N but that are required to **never have landed** a bid onchain before the fork. 

Protocols that prove against beacon block roots have guarantees that the bid's builder version lives on each of the above lists because of these features and because all these lists are separated: 

- Builders onboarded at Gloas are guaranteed to have version 0. 
- Builders onboarded after the Gloas fork are guaranteed to not be reserved
- Builders that landed a block during Gloas are guaranteed to be allowed. 
