### PR TITLE
Fix `limit()` calls for `ProgressiveList` operation lists

### DIFF
--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -39,7 +39,7 @@ from eth_consensus_specs.test.helpers.keys import (
 from eth_consensus_specs.test.helpers.state import (
     next_slot,
 )
-from eth_consensus_specs.utils.ssz.ssz_typing import View
+from eth_consensus_specs.utils.ssz.ssz_typing import ProgressiveList, View
 
 from .debug_helpers import print_epoch, print_head
 
@@ -256,6 +256,18 @@ def _compute_pseudo_randao_reveal(spec, proposer_index, epoch):
     return spec.BLSSignature(randao_reveal_bytes)
 
 
+def _max_operations_in_block(list_type, spec_limit):
+    """
+    Return the maximum number of elements the block builder may include for an
+    operation list. Bounded List types carry the cap as their SSZ limit. With EIP-7688,
+    forks use an unbounded ProgressiveList, so the cap enforced by process_operations
+    (spec_limit) applies instead.
+    """
+    if issubclass(list_type, ProgressiveList):
+        return spec_limit
+    return list_type.limit()
+
+
 def produce_block(
     spec,
     state,
@@ -282,7 +294,7 @@ def produce_block(
     )
 
     # Prepare attestations
-    limit = type(block.body.attestations).limit()
+    limit = _max_operations_in_block(type(block.body.attestations), spec.MAX_ATTESTATIONS_ELECTRA)
     attestation_in_block = [
         a
         for a in attestations
@@ -298,7 +310,9 @@ def produce_block(
         block.body.attestations.append(a)
 
     # Add attester slashings
-    limit = type(block.body.attester_slashings).limit()
+    limit = _max_operations_in_block(
+        type(block.body.attester_slashings), spec.MAX_ATTESTER_SLASHINGS_ELECTRA
+    )
     attester_slashings_in_block = attester_slashings[:limit]
     for s in attester_slashings_in_block:
         block.body.attester_slashings.append(s)


### PR DESCRIPTION
I noticed that [the latest compliance tests are failing](https://github.com/ethereum/consensus-specs/actions/runs/28833834030/job/85513345631). EIP-7688 changed the gloas `BeaconBlockBody` operation lists from bounded `List` types to unbounded `ProgressiveList` types. The fork choice compliance block builder decided how many attestations and attester slashings to include via the SSZ type's `limit()`, which `ProgressiveList` does not provide, so every gloas fork choice test failed to generate.

A `ProgressiveList` has no SSZ-level cap, but `process_operations` still enforces `MAX_ATTESTATIONS_ELECTRA` and `MAX_ATTESTER_SLASHINGS_ELECTRA`. The builder now uses those caps for progressive lists and keeps reading the SSZ limit for bounded lists, so it stops over-packing blocks and producing bodies that fail state transition.