### PR TITLE
Fix typo in pending deposit comments

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/electra/epoch_processing/pending_deposits/test_apply_pending_deposit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/epoch_processing/pending_deposits/test_apply_pending_deposit.py
@@ -190,7 +190,7 @@ def test_apply_pending_deposit_non_versioned_withdrawal_credentials(spec, state)
     # fresh deposit = next validator index = validator appended to registry
     validator_index = len(state.validators)
     withdrawal_credentials = (
-        b"\xff" + b"\x02" * 31  # Non specified withdrawal credentials version  # Garabage bytes
+        b"\xff" + b"\x02" * 31  # Non specified withdrawal credentials version  # Garbage bytes
     )
     amount = spec.MIN_ACTIVATION_BALANCE
     pending_deposit = prepare_pending_deposit(
@@ -212,7 +212,7 @@ def test_apply_pending_deposit_non_versioned_withdrawal_credentials_over_min_act
     # fresh deposit = next validator index = validator appended to registry
     validator_index = len(state.validators)
     withdrawal_credentials = (
-        b"\xff" + b"\x02" * 31  # Non specified withdrawal credentials version  # Garabage bytes
+        b"\xff" + b"\x02" * 31  # Non specified withdrawal credentials version  # Garbage bytes
     )
     # just 1 over the limit, effective balance should be set MIN_ACTIVATION_BALANCE during processing
     amount = spec.MIN_ACTIVATION_BALANCE + 1


### PR DESCRIPTION
<!-- Description
Provide at least one paragraph that clearly and succinctly explains:
* What this PR does (but not how it does it)
* Why this PR is necessary, including context
-->

Corrects two comment typos in pending deposit tests:

- `Garabage bytes` -> `Garbage bytes`

This is comment-only and does not change test behavior or consensus logic.



<!-- Checklist
Ensure the following tasks have been done prior to submitting the PR:
* Update documentation (if applicable)
* Add tests for new functionality (if applicable)
* Run `make lint` to check formatting
* Run `make test` to check tests
-->

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->
