### PR TITLE
Remove the `bit` type

### DIFF
--- a/pysetup/helpers.py
+++ b/pysetup/helpers.py
@@ -270,7 +270,6 @@ def combine_dicts(old_dict: dict[str, T], new_dict: dict[str, T]) -> dict[str, T
 
 
 ignored_dependencies = [
-    "bit",
     "Bitlist",
     "Bitvector",
     "boolean",

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -114,7 +114,6 @@ former is used for opaque data while the latter is intended as a number.
 
 For convenience we alias:
 
-- `bit` to `boolean`
 - `BytesN` and `ByteVector[N]` to `Vector[byte, N]` (this is *not* a basic type)
 - `ByteList[N]` to `List[byte, N]`
 - `ProgressiveByteList` to `ProgressiveList[byte]`

--- a/tests/core/pyspec/eth_consensus_specs/utils/ssz/ssz_typing.py
+++ b/tests/core/pyspec/eth_consensus_specs/utils/ssz/ssz_typing.py
@@ -1,7 +1,6 @@
 # ruff: noqa: F401
 
 from remerkleable.basic import (
-    bit,
     boolean,
     byte,
     uint,


### PR DESCRIPTION
The SSZ `bit` type is completely unused in the specs. Let's remove it.