### PR TITLE
Rename `byte` to `Byte`

### DIFF
--- a/pysetup/helpers.py
+++ b/pysetup/helpers.py
@@ -273,7 +273,7 @@ ignored_dependencies = [
     "Bitlist",
     "Bitvector",
     "Boolean",
-    "byte",
+    "Byte",
     "ByteList",
     "bytes",
     "Bytes1",

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1227,7 +1227,7 @@ The `ErrorMessage` schema is:
 
 ```
 (
-  error_message: List[byte, 256]
+  error_message: List[Byte, 256]
 )
 ```
 

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -42,7 +42,7 @@
 ### Basic types
 
 - `uintN`: `N`-bit unsigned integer (where `N in [8, 16, 32, 64, 128, 256]`)
-- `byte`: 8-bit opaque data container, equivalent in serialization and hashing
+- `Byte`: 8-bit opaque data container, equivalent in serialization and hashing
   to `uint8`
 - `Boolean`: `True` or `False`
 
@@ -107,16 +107,16 @@ types that contain a variable-size type. All other types are said to be
 
 ### Byte
 
-Although the SSZ serialization of `byte` is equivalent to that of `uint8`, the
+Although the SSZ serialization of `Byte` is equivalent to that of `uint8`, the
 former is used for opaque data while the latter is intended as a number.
 
 ### Aliases
 
 For convenience we alias:
 
-- `BytesN` and `ByteVector[N]` to `Vector[byte, N]` (this is *not* a basic type)
-- `ByteList[N]` to `List[byte, N]`
-- `ProgressiveByteList` to `ProgressiveList[byte]`
+- `BytesN` and `ByteVector[N]` to `Vector[Byte, N]` (this is *not* a basic type)
+- `ByteList[N]` to `List[Byte, N]`
+- `ProgressiveByteList` to `ProgressiveList[Byte]`
 
 Aliases are semantically equivalent to their underlying type and therefore share
 canonical representations both in SSZ and in related formats.
@@ -168,7 +168,7 @@ is equal to the default value for that type.
 #### Compatible Merkleization
 
 - Types are compatible with themselves.
-- `byte` is compatible with `uint8` and vice versa.
+- `Byte` is compatible with `uint8` and vice versa.
 - `Bitlist[N]` are compatible if they share the same capacity `N`.
 - `Bitvector[N]` are compatible if they share the same capacity `N`.
 - `List[type, N]` are compatible if `type` is compatible and they share the same
@@ -460,17 +460,17 @@ value. Parsers may ignore additional JSON fields.
 | SSZ                                   | JSON            | Example                                  |
 | ------------------------------------- | --------------- | ---------------------------------------- |
 | `uintN`                               | string          | `"0"`                                    |
-| `byte`                                | hex-byte-string | `"0x00"`                                 |
+| `Byte`                                | hex-byte-string | `"0x00"`                                 |
 | `Boolean`                             | bool            | `false`                                  |
 | `Container`                           | object          | `{ "field": ... }`                       |
 | `ProgressiveContainer(active_fields)` | object          | `{ "field": ... }`                       |
 | `Vector[type, N]`                     | array           | `[element, ...]`                         |
-| `Vector[byte, N]`                     | hex-byte-string | `"0x1122"`                               |
+| `Vector[Byte, N]`                     | hex-byte-string | `"0x1122"`                               |
 | `Bitvector[N]`                        | hex-byte-string | `"0x1122"`                               |
 | `List[type, N]`                       | array           | `[element, ...]`                         |
-| `List[byte, N]`                       | hex-byte-string | `"0x1122"`                               |
+| `List[Byte, N]`                       | hex-byte-string | `"0x1122"`                               |
 | `ProgressiveList[type]`               | array           | `[element, ...]`                         |
-| `ProgressiveList[byte]`               | hex-byte-string | `"0x1122"`                               |
+| `ProgressiveList[Byte]`               | hex-byte-string | `"0x1122"`                               |
 | `Bitlist[N]`                          | hex-byte-string | `"0x1122"`                               |
 | `ProgressiveBitlist`                  | hex-byte-string | `"0x1122"`                               |
 | `Union[type_0, type_1, ...]`          | selector-object | `{ "selector": string, "data": type_N }` |
@@ -483,7 +483,7 @@ Aliases are encoded as their underlying type.
 `hex-byte-string` is a `0x`-prefixed hex encoding of byte data, as it would
 appear in an SSZ stream.
 
-`List`, `ProgressiveList`, and `Vector` of `byte` (and aliases thereof) are
+`List`, `ProgressiveList`, and `Vector` of `Byte` (and aliases thereof) are
 encoded as `hex-byte-string`. `Bitlist`, `ProgressiveBitlist`, and `Bitvector`
 similarly map their SSZ-byte encodings to a `hex-byte-string`.
 

--- a/tests/core/pyspec/eth_consensus_specs/debug/decode.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/decode.py
@@ -5,7 +5,7 @@ from eth_consensus_specs.utils.ssz.ssz_typing import (
     Bitlist,
     Bitvector,
     Boolean,
-    byte,
+    Byte,
     ByteList,
     ByteVector,
     Container,
@@ -23,7 +23,7 @@ def decode(data: Any, typ):
     if issubclass(typ, uint | Boolean):
         return typ(data)
     elif issubclass(typ, Bitlist | ProgressiveBitlist | Bitvector) or (
-        issubclass(typ, ProgressiveList) and issubclass(typ.element_cls(), byte)
+        issubclass(typ, ProgressiveList) and issubclass(typ.element_cls(), Byte)
     ):
         return deserialize(typ, bytes.fromhex(data[2:]))
     elif issubclass(typ, List | ProgressiveList | Vector):

--- a/tests/core/pyspec/eth_consensus_specs/debug/encode.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/encode.py
@@ -3,7 +3,7 @@ from eth_consensus_specs.utils.ssz.ssz_typing import (
     Bitlist,
     Bitvector,
     Boolean,
-    byte,
+    Byte,
     CompatibleUnion,
     Container,
     List,
@@ -25,7 +25,7 @@ def encode(value, include_hash_tree_roots=False):
     elif isinstance(value, Boolean):
         return value == 1
     elif isinstance(value, Bitlist | ProgressiveBitlist | Bitvector) or (
-        isinstance(value, ProgressiveList) and issubclass(value.element_cls(), byte)
+        isinstance(value, ProgressiveList) and issubclass(value.element_cls(), Byte)
     ):
         return "0x" + serialize(value).hex()
     elif isinstance(value, (list, List | ProgressiveList | Vector)):  # normal python lists

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_container.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_container.py
@@ -7,7 +7,7 @@ from eth_consensus_specs.utils.ssz.ssz_impl import deserialize, serialize
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     Bitlist,
     Bitvector,
-    byte,
+    Byte,
     ByteList,
     Container,
     List,
@@ -25,7 +25,7 @@ from .ssz_test_case import invalid_test_case, valid_test_case
 
 
 class SingleFieldTestStruct(Container):
-    A: byte
+    A: Byte
 
 
 class SmallTestStruct(Container):
@@ -56,7 +56,7 @@ class ComplexTestStruct(Container):
 
 
 class ProgressiveTestStruct(Container):
-    A: ProgressiveList[byte]
+    A: ProgressiveList[Byte]
     B: ProgressiveList[uint64]
     C: ProgressiveList[SmallTestStruct]
     D: ProgressiveList[ProgressiveList[VarTestStruct]]

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_progressive_container.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_progressive_container.py
@@ -5,7 +5,7 @@ from eth_consensus_specs.debug.random_value import RandomizationMode
 from eth_consensus_specs.test.exceptions import SkippedTest
 from eth_consensus_specs.utils.ssz.ssz_impl import deserialize, serialize
 from eth_consensus_specs.utils.ssz.ssz_typing import (
-    byte,
+    Byte,
     List,
     ProgressiveBitlist,
     ProgressiveContainer,
@@ -26,7 +26,7 @@ from .ssz_test_case import invalid_test_case
 
 
 class ProgressiveSingleFieldContainerTestStruct(ProgressiveContainer(active_fields=[1])):
-    A: byte
+    A: Byte
 
 
 class ProgressiveSingleListContainerTestStruct(ProgressiveContainer(active_fields=[0, 0, 0, 0, 1])):
@@ -34,7 +34,7 @@ class ProgressiveSingleListContainerTestStruct(ProgressiveContainer(active_field
 
 
 class ProgressiveVarTestStruct(ProgressiveContainer(active_fields=[1, 0, 1, 0, 1])):
-    A: byte
+    A: Byte
     B: List[uint16, 123]
     C: ProgressiveBitlist
 
@@ -44,7 +44,7 @@ class ProgressiveComplexTestStruct(
         active_fields=[1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1]
     )
 ):
-    A: byte
+    A: Byte
     B: List[uint16, 123]
     C: ProgressiveBitlist
     D: ProgressiveList[uint64]
@@ -55,18 +55,18 @@ class ProgressiveComplexTestStruct(
 
 
 class ModifiedTestStruct1(ProgressiveContainer(active_fields=[1, 1])):
-    A: byte
-    X: byte
+    A: Byte
+    X: Byte
 
 
 class ModifiedTestStruct2(ProgressiveContainer(active_fields=[1, 0, 1])):
-    A: byte
+    A: Byte
     B: List[uint16, 123]
 
 
 class ModifiedTestStruct3(ProgressiveContainer(active_fields=[1, 1, 1])):
-    A: byte
-    X: byte
+    A: Byte
+    X: Byte
     B: List[uint16, 123]
 
 
@@ -76,20 +76,20 @@ class ModifiedTestStruct4(ProgressiveContainer(active_fields=[0, 0, 1, 0, 1])):
 
 
 class ModifiedTestStruct5(ProgressiveContainer(active_fields=[1, 0, 0, 0, 1])):
-    A: byte
+    A: Byte
     C: ProgressiveBitlist
 
 
 class ModifiedTestStruct6(ProgressiveContainer(active_fields=[1, 1, 1, 0, 1, 0, 0, 0, 1])):
-    A: byte
-    X: byte
+    A: Byte
+    X: Byte
     B: List[uint16, 123]
     C: ProgressiveBitlist
     D: ProgressiveList[uint64]
 
 
 class ModifiedTestStruct7(ProgressiveContainer(active_fields=[1, 0, 1, 0, 0, 0, 0, 0, 1])):
-    A: byte
+    A: Byte
     B: List[uint16, 123]
     D: ProgressiveList[uint64]
 
@@ -99,8 +99,8 @@ class ModifiedTestStruct8(
         active_fields=[1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1]
     )
 ):
-    A: byte
-    X: byte
+    A: Byte
+    X: Byte
     B: List[uint16, 123]
     C: ProgressiveBitlist
     D: ProgressiveList[uint64]
@@ -115,7 +115,7 @@ class ModifiedTestStruct9(
         active_fields=[1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1]
     )
 ):
-    A: byte
+    A: Byte
     B: List[uint16, 123]
     C: ProgressiveBitlist
     D: ProgressiveList[uint64]

--- a/tests/core/pyspec/eth_consensus_specs/utils/ssz/ssz_typing.py
+++ b/tests/core/pyspec/eth_consensus_specs/utils/ssz/ssz_typing.py
@@ -2,7 +2,7 @@
 
 from remerkleable.basic import (
     boolean as Boolean,
-    byte,
+    byte as Byte,
     uint,
     uint8,
     uint16,

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -192,7 +192,7 @@ Data:
 
 ```python
 class SingleFieldTestStruct(Container):
-    A: byte
+    A: Byte
 
 
 class SmallTestStruct(Container):
@@ -223,7 +223,7 @@ class ComplexTestStruct(Container):
 
 
 class ProgressiveTestStruct(Container):
-    A: ProgressiveList[byte]
+    A: ProgressiveList[Byte]
     B: ProgressiveList[uint64]
     C: ProgressiveList[SmallTestStruct]
     D: ProgressiveList[ProgressiveList[VarTestStruct]]
@@ -270,7 +270,7 @@ Data:
 
 ```python
 class ProgressiveSingleFieldContainerTestStruct(ProgressiveContainer(active_fields=[1])):
-    A: byte
+    A: Byte
 
 
 class ProgressiveSingleListContainerTestStruct(ProgressiveContainer(active_fields=[0, 0, 0, 0, 1])):
@@ -278,7 +278,7 @@ class ProgressiveSingleListContainerTestStruct(ProgressiveContainer(active_field
 
 
 class ProgressiveVarTestStruct(ProgressiveContainer(active_fields=[1, 0, 1, 0, 1])):
-    A: byte
+    A: Byte
     B: List[uint16, 123]
     C: ProgressiveBitlist
 
@@ -288,7 +288,7 @@ class ProgressiveComplexTestStruct(
         active_fields=[1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1]
     )
 ):
-    A: byte
+    A: Byte
     B: List[uint16, 123]
     C: ProgressiveBitlist
     D: ProgressiveList[uint64]


### PR DESCRIPTION
`Byte` is part of the SSZ spec but it's not actually used in consensus-specs. Still, we should rename it to be consistent with #5466. When we replace remerkleable with another SSZ library, the specs/imports/tests will be removed .