### PR TITLE
Fix broken links

### DIFF
--- a/specs/altair/light-client/p2p-interface.md
+++ b/specs/altair/light-client/p2p-interface.md
@@ -334,7 +334,7 @@ supports processing `LightClientFinalityUpdate` and
 Light clients MAY also collect historic light client data and make it available
 to other peers. If they do, they SHOULD advertise supported message endpoints in
 [the Req/Resp domain](#the-reqresp-domain), and MAY also update the contents of
-their [`Status`](../../phase0/p2p-interface.md#status) message to reflect the
+their [`Status`](../../phase0/p2p-interface.md#status-v1) message to reflect the
 locally available light client data.
 
 If only limited light client data is locally available, the light client SHOULD

--- a/specs/bellatrix/fork-choice.md
+++ b/specs/bellatrix/fork-choice.md
@@ -91,7 +91,7 @@ MUST be set to the hash of a terminal PoW block in this case.
 ##### `safe_block_hash`
 
 The `safe_block_hash` parameter MUST be set to return value of
-[`get_safe_execution_block_hash(fcr_store)`](./fast-confirmation.md#get_safe_execution_block_hash)
+[`get_safe_execution_block_hash(fcr_store)`](./fast-confirmation.md#new-get_safe_execution_block_hash)
 function.
 
 ## Helpers

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -105,7 +105,7 @@ Where:
 - `finalized_block_bid = finalized_block.body.signed_execution_payload_bid.message`.
 
 *Note*: `get_safe_execution_block_hash` is modified in Gloas, see
-[Fast Confirmation](./fast-confirmation.md#get_safe_execution_block_hash).
+[Fast Confirmation](./fast-confirmation.md#modified-get_safe_execution_block_hash).
 
 ## Helpers
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -476,7 +476,7 @@ data being sent on the topic and how the data field of the message is encoded.
   - `epoch` is the context epoch of the message to be sent on the topic
 - `Name` - see table below
 - `Encoding` - the encoding strategy describes a specific representation of
-  bytes that will be transmitted over the wire. See the [Encodings](#Encodings)
+  bytes that will be transmitted over the wire. See the [Encodings](#encodings)
   section for further details.
 
 Clients MUST reject messages with an unknown topic.
@@ -1096,7 +1096,7 @@ With:
   versioned to facilitate backward and forward-compatibility when possible.
 - `Encoding` - while the schema defines the data types in more abstract terms,
   the encoding strategy describes a specific representation of bytes that will
-  be transmitted over the wire. See the [Encodings](#Encoding-strategies)
+  be transmitted over the wire. See the [Encodings](#encoding-strategies)
   section for further details.
 
 This protocol segregation allows libp2p `multistream-select 1.0` /

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -32,7 +32,7 @@ into a SSZ type:
 - ProgressiveContainer
   - [`progressive_containers`](#progressive_containers)
 - CompatibleUnion
-  - [`compatible_unions`](#compatible_uniosn)
+  - [`compatible_unions`](#compatible_unions)
 
 ## Format
 


### PR DESCRIPTION
Several links pointed at anchors that do not exist. The `Status` link referred to `#status` rather than `#status-v1`, and the two links to `get_safe_execution_block_hash` omitted the prefix that its heading carries, which differs per fork: it is new in Bellatrix and modified in Gloas. Two links to the encoding sections of the phase0 networking specification were capitalized, but anchors are lowercase, and a link in the SSZ generic test format had a typo in the anchor.