### PR TITLE
Remove links that do not resolve on the documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,33 +14,34 @@ specifications can be made through pull requests.
 ## Specifications
 
 Core specifications for Ethereum proof-of-stake clients can be found in
-[specs](specs). These are divided into features. Features are researched and
-developed in parallel, and then consolidated into sequential upgrades when
-ready.
+[specs](specs). These are divided into [features](specs/_features). Features are
+researched and developed in parallel, and then consolidated into sequential
+upgrades when ready.
 
 ### Stable specifications
 
-| Seq. | Code Name     | Fork Epoch | Link                               |
-| ---- | ------------- | ---------- | ---------------------------------- |
-| 0    | **Phase0**    | `0`        | [specs/phase0](specs/phase0)       |
-| 1    | **Altair**    | `74240`    | [specs/altair](specs/altair)       |
-| 2    | **Bellatrix** | `144896`   | [specs/bellatrix](specs/bellatrix) |
-| 3    | **Capella**   | `194048`   | [specs/capella](specs/capella)     |
-| 4    | **Deneb**     | `269568`   | [specs/deneb](specs/deneb)         |
-| 5    | **Electra**   | `364032`   | [specs/electra](specs/electra)     |
-| 6    | **Fulu**      | `411392`   | [specs/fulu](specs/fulu)           |
+| Seq. | Code Name     | Fork Epoch | Link                    |
+| ---- | ------------- | ---------- | ----------------------- |
+| 0    | **Phase0**    | `0`        | [Spec](specs/phase0)    |
+| 1    | **Altair**    | `74240`    | [Spec](specs/altair)    |
+| 2    | **Bellatrix** | `144896`   | [Spec](specs/bellatrix) |
+| 3    | **Capella**   | `194048`   | [Spec](specs/capella)   |
+| 4    | **Deneb**     | `269568`   | [Spec](specs/deneb)     |
+| 5    | **Electra**   | `364032`   | [Spec](specs/electra)   |
+| 6    | **Fulu**      | `411392`   | [Spec](specs/fulu)      |
 
 ### Unstable specifications
 
-| Seq. | Code Name | Fork Epoch | Link                       |
-| ---- | --------- | ---------- | -------------------------- |
-| 7    | **Gloas** | TBD        | [specs/gloas](specs/gloas) |
-| 8    | **Heze**  | TBD        | [specs/heze](specs/heze)   |
+| Seq. | Code Name | Fork Epoch | Link                |
+| ---- | --------- | ---------- | ------------------- |
+| 7    | **Gloas** | TBD        | [Spec](specs/gloas) |
+| 8    | **Heze**  | TBD        | [Spec](specs/heze)  |
 
 ### Accompanying documents
 
-- [SimpleSerialize (SSZ) spec](ssz/simple-serialize.md)
-- [Merkle proof formats](ssz/merkle-proofs.md)
+- [Merkle Proofs](ssz/merkle-proofs.md)
+- [SimpleSerialize (SSZ)](ssz/simple-serialize.md)
+- [Optimistic Sync](sync/optimistic.md)
 
 ### External specifications
 

--- a/README.md
+++ b/README.md
@@ -20,28 +20,27 @@ ready.
 
 ### Stable specifications
 
-| Seq. | Code Name     | Fork Epoch | Links                                                                                   |
-| ---- | ------------- | ---------- | --------------------------------------------------------------------------------------- |
-| 0    | **Phase0**    | `0`        | [Specs](specs/phase0), [Tests](tests/core/pyspec/eth_consensus_specs/test/phase0)       |
-| 1    | **Altair**    | `74240`    | [Specs](specs/altair), [Tests](tests/core/pyspec/eth_consensus_specs/test/altair)       |
-| 2    | **Bellatrix** | `144896`   | [Specs](specs/bellatrix), [Tests](tests/core/pyspec/eth_consensus_specs/test/bellatrix) |
-| 3    | **Capella**   | `194048`   | [Specs](specs/capella), [Tests](tests/core/pyspec/eth_consensus_specs/test/capella)     |
-| 4    | **Deneb**     | `269568`   | [Specs](specs/deneb), [Tests](tests/core/pyspec/eth_consensus_specs/test/deneb)         |
-| 5    | **Electra**   | `364032`   | [Specs](specs/electra), [Tests](tests/core/pyspec/eth_consensus_specs/test/electra)     |
-| 6    | **Fulu**      | `411392`   | [Specs](specs/fulu), [Tests](tests/core/pyspec/eth_consensus_specs/test/fulu)           |
+| Seq. | Code Name     | Fork Epoch | Link                               |
+| ---- | ------------- | ---------- | ---------------------------------- |
+| 0    | **Phase0**    | `0`        | [specs/phase0](specs/phase0)       |
+| 1    | **Altair**    | `74240`    | [specs/altair](specs/altair)       |
+| 2    | **Bellatrix** | `144896`   | [specs/bellatrix](specs/bellatrix) |
+| 3    | **Capella**   | `194048`   | [specs/capella](specs/capella)     |
+| 4    | **Deneb**     | `269568`   | [specs/deneb](specs/deneb)         |
+| 5    | **Electra**   | `364032`   | [specs/electra](specs/electra)     |
+| 6    | **Fulu**      | `411392`   | [specs/fulu](specs/fulu)           |
 
 ### Unstable specifications
 
-| Seq. | Code Name | Fork Epoch | Links                                                                           |
-| ---- | --------- | ---------- | ------------------------------------------------------------------------------- |
-| 7    | **Gloas** | TBD        | [Specs](specs/gloas), [Tests](tests/core/pyspec/eth_consensus_specs/test/gloas) |
-| 8    | **Heze**  | TBD        | [Specs](specs/heze), [Tests](tests/core/pyspec/eth_consensus_specs/test/heze)   |
+| Seq. | Code Name | Fork Epoch | Link                       |
+| ---- | --------- | ---------- | -------------------------- |
+| 7    | **Gloas** | TBD        | [specs/gloas](specs/gloas) |
+| 8    | **Heze**  | TBD        | [specs/heze](specs/heze)   |
 
 ### Accompanying documents
 
 - [SimpleSerialize (SSZ) spec](ssz/simple-serialize.md)
 - [Merkle proof formats](ssz/merkle-proofs.md)
-- [General test format](tests/formats/README.md)
 
 ### External specifications
 
@@ -110,4 +109,3 @@ consensus specifications:
 - [Specifications viewer (mkdocs)](https://ethereum.github.io/consensus-specs/)
 - [Specifications viewer (jtraglia)](https://jtraglia.github.io/eth-spec-viewer/)
 - [The Eth2 Book](https://eth2book.info)
-- [PySpec Tests](tests/core/pyspec/README.md)

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -226,8 +226,6 @@ consensus-layer specifications **MUST** be zero.
 *Note*: The below configuration is bundled as a preset: a bundle of
 configuration variables which are expected to differ between different modes of
 operation, e.g. testing, but not generally between different networks.
-Additional preset configurations can be found in the [`configs`](../../configs)
-directory.
 
 ### Misc
 
@@ -318,8 +316,8 @@ directory.
 
 *Note*: The default mainnet configuration values are included here for
 illustrative purposes. Defaults for this more dynamic type of configuration are
-available with the presets in the [`configs`](../../configs) directory. Testnets
-and other types of chain instances may use a different configuration.
+available with presets. Testnets and other types of chain instances may use a
+different configuration.
 
 ### Genesis settings
 

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -31,10 +31,7 @@ specification.
 ## Configuration
 
 *Note*: The default mainnet configuration values are included here for
-specification-design purposes. The different configurations for mainnet,
-testnets, and YAML-based testing can be found in the
-[`configs/constant_presets`](../../configs) directory. These configurations are
-updated for releases and may be out of sync during `dev` changes.
+specification-design purposes.
 
 | Name                       | Value                                        |
 | -------------------------- | -------------------------------------------- |


### PR DESCRIPTION
The readme and two phase0 specifications linked to directories and files that live outside the published documentation. These links resolve on GitHub but return a 404 on the documentation site, which publishes only the specifications. Most of them went unnoticed because a link naming a directory rather than a markdown file is not checked when the site is built, so only two of the eleven were ever reported. One also referred to `configs/constant_presets`, which does not exist. The links are dropped rather than rewritten, since the values and documents they pointed at add little beyond what each section already states, and an absolute URL would stop working for readers browsing a fork or a branch.