### PR TITLE
Fix website navigation nits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,10 +241,12 @@ SYNC_DIR = ./sync
 
 # Copy files to the docs directory.
 _copy_docs:
-	@cp -r $(SPEC_DIR) $(DOCS_DIR)
-	@cp -r $(SYNC_DIR) $(DOCS_DIR)
-	@cp -r $(SSZ_DIR) $(DOCS_DIR)
-	@cp $(CURDIR)/README.md $(DOCS_DIR)/README.md
+	@rm -rf $(DOCS_DIR)
+	@mkdir -p $(DOCS_DIR)
+	@cp -r $(SPEC_DIR) $(DOCS_DIR)/specs
+	@cp -r $(SYNC_DIR) $(DOCS_DIR)/sync
+	@cp -r $(SSZ_DIR) $(DOCS_DIR)/ssz
+	@cp $(CURDIR)/README.md $(DOCS_DIR)/index.md
 
 # Start a local documentation server.
 serve_docs: _pyspec _copy_docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,6 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
-    - navigation.tabs
     - search
 markdown_extensions:
   - toc:
@@ -29,6 +28,8 @@ markdown_extensions:
       anchor_linenums: true
   - mdx_truly_sane_lists:
       nested_indent: 4
+hooks:
+  - scripts/mkdocs_hooks.py
 plugins:
   - search
   - awesome-pages

--- a/scripts/gen_spec_indices.py
+++ b/scripts/gen_spec_indices.py
@@ -112,8 +112,12 @@ spec_forks = []
 if os.path.exists("specs"):
     for item in sorted(os.listdir("specs")):
         item_path = os.path.join("specs", item)
-        if os.path.isdir(item_path) and item not in {"_deprecated"}:
+        if os.path.isdir(item_path):
             spec_forks.append(item)
+
+print("  - Generating .pages for the site root")
+with mkdocs_gen_files.open(".pages", "w") as f:
+    f.write("nav:\n  - Specs: specs\n")
 
 
 def generate_pages_recursively(base_path: str) -> None:

--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -1,0 +1,25 @@
+"""
+Hooks for the mkdocs documentation site.
+
+This module is registered through the hooks option in mkdocs.yml.
+"""
+
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.structure.files import Files
+from mkdocs.structure.nav import Navigation
+
+
+def on_nav(nav: Navigation, config: MkDocsConfig, files: Files) -> Navigation:
+    """Show the forks at the top level of the sidebar.
+
+    The specs are copied to docs/specs so that the relative links between the
+    markdown files keep working, which leaves the whole sidebar nested inside a
+    single specs entry. That entry carries no information, so it is unwrapped
+    here and its forks are lifted to the top level.
+    """
+    if len(nav.items) == 1 and nav.items[0].is_section:
+        nav.items[:] = nav.items[0].children
+        for item in nav.items:
+            item.parent = None
+
+    return nav


### PR DESCRIPTION
Issues:

* The navigation tabs are ugly & not scalable.
* The navigation sidebar is useless on the homepage.

*Note*: Links to SSZ and optimistic sync are no longer shown on the navigation sidebar. The SSZ specs are going to move to a new home soon and I intend to integrate the optimistic syncing specs into the normal specs directory.

Before:

<img width="1381" height="686" alt="image" src="https://github.com/user-attachments/assets/fd63eca4-4e0a-4695-9cbd-9c84b073c5d0" />

After:

<img width="1381" height="686" alt="image" src="https://github.com/user-attachments/assets/633364aa-c20d-472e-9336-02f0dd73e960" />
