### PR TITLE
Use better types for constants/configs/presets

### DIFF
--- a/pysetup/md_doc_paths.py
+++ b/pysetup/md_doc_paths.py
@@ -31,8 +31,6 @@ PREVIOUS_FORK_OF = {
 
 ALL_FORKS = list(PREVIOUS_FORK_OF.keys())
 
-IGNORE_SPEC_FILES = ["specs/phase0/deposit-contract.md"]
-
 EXTRA_SPEC_FILES = {BELLATRIX: "sync/optimistic.md"}
 
 DEFAULT_ORDER = (
@@ -86,7 +84,7 @@ def get_md_doc_paths(spec_fork: str) -> str:
                     filepath = str(Path(root) / filename)
                     filepaths.append(filepath)
                 for filepath in sorted(filepaths, key=sort_key):
-                    if filepath.endswith(".md") and filepath not in IGNORE_SPEC_FILES:
+                    if filepath.endswith(".md"):
                         md_doc_paths += filepath + "\n"
             # Append extra files if any
             if fork in EXTRA_SPEC_FILES:

--- a/pysetup/spec_builders/bellatrix.py
+++ b/pysetup/spec_builders/bellatrix.py
@@ -11,7 +11,7 @@ class BellatrixSpecBuilder(BaseSpecBuilder):
         return f"""
 from typing import Protocol
 from eth_consensus_specs.altair import {preset_name} as altair
-from eth_consensus_specs.utils.ssz.ssz_typing import Bytes8, Bytes20, ByteList, ByteVector
+from eth_consensus_specs.utils.ssz.ssz_typing import Bytes8, ByteList, ByteVector
 """
 
     @classmethod

--- a/pysetup/spec_builders/phase0.py
+++ b/pysetup/spec_builders/phase0.py
@@ -32,7 +32,7 @@ from typing import (
 from eth_consensus_specs.utils.ssz.ssz_impl import hash_tree_root, copy, uint_to_bytes
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     View, Boolean, Container, List, Vector, Uint8, Uint32, Uint64, Uint256,
-    Bytes1, Bytes4, Bytes32, Bytes48, Bytes96, Bitlist)
+    Bytes1, Bytes4, Bytes20, Bytes32, Bytes48, Bytes96, Bitlist)
 from eth_consensus_specs.utils.ssz.ssz_typing import Bitvector  # noqa: F401
 from eth_consensus_specs.utils import bls
 from eth_consensus_specs.utils.hash_function import hash

--- a/specs/_features/eip6914/beacon-chain.md
+++ b/specs/_features/eip6914/beacon-chain.md
@@ -29,9 +29,9 @@ validator records. Refers to
 
 ### Time parameters
 
-| Name                         | Value                      | Unit   |
-| ---------------------------- | -------------------------- | ------ |
-| `SAFE_EPOCHS_TO_REUSE_INDEX` | `Uint64(2**16)` (= 65,536) | epochs |
+| Name                         | Value                     |
+| ---------------------------- | ------------------------- |
+| `SAFE_EPOCHS_TO_REUSE_INDEX` | `Epoch(2**16)` (= 65,536) |
 
 ## Helpers
 

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -122,7 +122,7 @@ to their final, maximum security values.
 | Name                               | Value                  | Unit       |
 | ---------------------------------- | ---------------------- | ---------- |
 | `SYNC_COMMITTEE_SIZE`              | `Uint64(2**9)` (= 512) | validators |
-| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `Uint64(2**8)` (= 256) | epochs     |
+| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `Epoch(2**8)` (= 256)  | epochs     |
 
 ## Configuration
 

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -119,10 +119,10 @@ to their final, maximum security values.
 
 ### Sync committee
 
-| Name                               | Value                  | Unit       |
-| ---------------------------------- | ---------------------- | ---------- |
-| `SYNC_COMMITTEE_SIZE`              | `Uint64(2**9)` (= 512) | validators |
-| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `Epoch(2**8)` (= 256)  | epochs     |
+| Name                               | Value                  |
+| ---------------------------------- | ---------------------- |
+| `SYNC_COMMITTEE_SIZE`              | `Uint64(2**9)` (= 512) |
+| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `Epoch(2**8)` (= 256)  |
 
 ## Configuration
 

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -71,11 +71,11 @@ Altair is the first beacon-chain upgrade. Its main features are:
 
 ### Participation flag indices
 
-| Name                       | Value |
-| -------------------------- | ----- |
-| `TIMELY_SOURCE_FLAG_INDEX` | `0`   |
-| `TIMELY_TARGET_FLAG_INDEX` | `1`   |
-| `TIMELY_HEAD_FLAG_INDEX`   | `2`   |
+| Name                       | Value       |
+| -------------------------- | ----------- |
+| `TIMELY_SOURCE_FLAG_INDEX` | `Uint64(0)` |
+| `TIMELY_TARGET_FLAG_INDEX` | `Uint64(1)` |
+| `TIMELY_HEAD_FLAG_INDEX`   | `Uint64(2)` |
 
 ### Incentivization weights
 

--- a/specs/altair/light-client/p2p-interface.md
+++ b/specs/altair/light-client/p2p-interface.md
@@ -30,9 +30,9 @@ messages, topics and data to the Req-Resp and Gossip domains.
 
 ### Configuration
 
-| Name                               | Value          | Description                                                         |
-| ---------------------------------- | -------------- | ------------------------------------------------------------------- |
-| `MAX_REQUEST_LIGHT_CLIENT_UPDATES` | `2**7` (= 128) | Maximum number of `LightClientUpdate` instances in a single request |
+| Name                               | Value                  | Description                                                         |
+| ---------------------------------- | ---------------------- | ------------------------------------------------------------------- |
+| `MAX_REQUEST_LIGHT_CLIENT_UPDATES` | `Uint64(2**7)` (= 128) | Maximum number of `LightClientUpdate` instances in a single request |
 
 ### The gossip domain: gossipsub
 

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -77,10 +77,10 @@ Additional documents describe how the light client sync protocol can be used:
 
 ### Misc
 
-| Name                              | Value                                                      | Unit       |
-| --------------------------------- | ---------------------------------------------------------- | ---------- |
-| `MIN_SYNC_COMMITTEE_PARTICIPANTS` | `Uint64(1)`                                                | validators |
-| `UPDATE_TIMEOUT`                  | `Slot(SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD)` | slots      |
+| Name                              | Value                                                      |
+| --------------------------------- | ---------------------------------------------------------- |
+| `MIN_SYNC_COMMITTEE_PARTICIPANTS` | `Uint64(1)`                                                |
+| `UPDATE_TIMEOUT`                  | `Slot(SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD)` |
 
 ## Containers
 

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -79,7 +79,7 @@ Additional documents describe how the light client sync protocol can be used:
 
 | Name                              | Value                                                      | Unit       |
 | --------------------------------- | ---------------------------------------------------------- | ---------- |
-| `MIN_SYNC_COMMITTEE_PARTICIPANTS` | `1`                                                        | validators |
+| `MIN_SYNC_COMMITTEE_PARTICIPANTS` | `Uint64(1)`                                                | validators |
 | `UPDATE_TIMEOUT`                  | `Slot(SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD)` | slots      |
 
 ## Containers

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -77,10 +77,10 @@ Additional documents describe how the light client sync protocol can be used:
 
 ### Misc
 
-| Name                              | Value                                                | Unit       |
-| --------------------------------- | ---------------------------------------------------- | ---------- |
-| `MIN_SYNC_COMMITTEE_PARTICIPANTS` | `1`                                                  | validators |
-| `UPDATE_TIMEOUT`                  | `SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | slots      |
+| Name                              | Value                                                      | Unit       |
+| --------------------------------- | ---------------------------------------------------------- | ---------- |
+| `MIN_SYNC_COMMITTEE_PARTICIPANTS` | `1`                                                        | validators |
+| `UPDATE_TIMEOUT`                  | `Slot(SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD)` | slots      |
 
 ## Containers
 

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -74,19 +74,19 @@ and use as a reference throughout.
 
 ### Misc
 
-| Name                                       | Value                 | Unit       |
-| ------------------------------------------ | --------------------- | ---------- |
-| `TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE` | `Uint64(2**4)` (= 16) | validators |
-| `SYNC_COMMITTEE_SUBNET_COUNT`              | `Uint64(2**2)` (= 4)  | subnets    |
+| Name                                       | Value                 |
+| ------------------------------------------ | --------------------- |
+| `TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE` | `Uint64(2**4)` (= 16) |
+| `SYNC_COMMITTEE_SUBNET_COUNT`              | `Uint64(2**2)` (= 4)  |
 
 ## Configuration
 
 ### Time parameters
 
-| Name                   | Value          | Unit         | Duration                   |
-| ---------------------- | -------------- | ------------ | -------------------------- |
-| `SYNC_MESSAGE_DUE_BPS` | `Uint64(3333)` | basis points | ~33% of `SLOT_DURATION_MS` |
-| `CONTRIBUTION_DUE_BPS` | `Uint64(6667)` | basis points | ~67% of `SLOT_DURATION_MS` |
+| Name                   | Value          | Duration                   |
+| ---------------------- | -------------- | -------------------------- |
+| `SYNC_MESSAGE_DUE_BPS` | `Uint64(3333)` | ~33% of `SLOT_DURATION_MS` |
+| `CONTRIBUTION_DUE_BPS` | `Uint64(6667)` | ~67% of `SLOT_DURATION_MS` |
 
 ## Containers
 

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -54,10 +54,9 @@ Including:
 
 *Note*: The `Transaction` type is a stub which is not final.
 
-| Name               | SSZ equivalent                        | Description                                                                                                                                       |
-| ------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Transaction`      | `ByteList[MAX_BYTES_PER_TRANSACTION]` | Either a [typed transaction envelope](https://eips.ethereum.org/EIPS/eip-2718#opaque-byte-array-rather-than-an-rlp-array) or a legacy transaction |
-| `ExecutionAddress` | `Bytes20`                             | Address of account on the execution layer                                                                                                         |
+| Name          | SSZ equivalent                        | Description                                                                                                                                       |
+| ------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Transaction` | `ByteList[MAX_BYTES_PER_TRANSACTION]` | Either a [typed transaction envelope](https://eips.ethereum.org/EIPS/eip-2718#opaque-byte-array-rather-than-an-rlp-array) or a legacy transaction |
 
 ## Constants
 

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -91,11 +91,11 @@ final, maximum security values.
 
 ### Transition settings
 
-| Name                                   | Value                                                |
-| -------------------------------------- | ---------------------------------------------------- |
-| `TERMINAL_TOTAL_DIFFICULTY`            | `58750000000000000000000` (Estimated: Sept 15, 2022) |
-| `TERMINAL_BLOCK_HASH`                  | `Hash32()`                                           |
-| `TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH` | `FAR_FUTURE_EPOCH`                                   |
+| Name                                   | Value                              |
+| -------------------------------------- | ---------------------------------- |
+| `TERMINAL_TOTAL_DIFFICULTY`            | `Uint256(58750000000000000000000)` |
+| `TERMINAL_BLOCK_HASH`                  | `Hash32()`                         |
+| `TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH` | `Epoch(FAR_FUTURE_EPOCH)`          |
 
 ## Containers
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -60,11 +60,11 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 *[New in Deneb:EIP4844]*
 
-| Name                                    | Value                    | Description                                                    |
-| --------------------------------------- | ------------------------ | -------------------------------------------------------------- |
-| `MAX_REQUEST_BLOCKS_DENEB`              | `2**7` (= 128)           | Maximum number of blocks in a single request                   |
-| `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` | `2**12` (= 4,096 epochs) | Minimum epoch range over which a node must serve blob sidecars |
-| `BLOB_SIDECAR_SUBNET_COUNT`             | `6`                      | Number of blob sidecar subnets used in the gossipsub protocol  |
+| Name                                    | Value                           | Description                                                    |
+| --------------------------------------- | ------------------------------- | -------------------------------------------------------------- |
+| `MAX_REQUEST_BLOCKS_DENEB`              | `2**7` (= 128)                  | Maximum number of blocks in a single request                   |
+| `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` | `Epoch(2**12)` (= 4,096 epochs) | Minimum epoch range over which a node must serve blob sidecars |
+| `BLOB_SIDECAR_SUBNET_COUNT`             | `6`                             | Number of blob sidecar subnets used in the gossipsub protocol  |
 
 ### Containers
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -62,9 +62,9 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 | Name                                    | Value                           | Description                                                    |
 | --------------------------------------- | ------------------------------- | -------------------------------------------------------------- |
-| `MAX_REQUEST_BLOCKS_DENEB`              | `2**7` (= 128)                  | Maximum number of blocks in a single request                   |
+| `MAX_REQUEST_BLOCKS_DENEB`              | `Uint64(2**7)` (= 128)          | Maximum number of blocks in a single request                   |
 | `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` | `Epoch(2**12)` (= 4,096 epochs) | Minimum epoch range over which a node must serve blob sidecars |
-| `BLOB_SIDECAR_SUBNET_COUNT`             | `6`                             | Number of blob sidecar subnets used in the gossipsub protocol  |
+| `BLOB_SIDECAR_SUBNET_COUNT`             | `Uint64(6)`                     | Number of blob sidecar subnets used in the gossipsub protocol  |
 
 ### Containers
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -60,11 +60,11 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 *[New in Deneb:EIP4844]*
 
-| Name                                    | Value                           | Description                                                    |
-| --------------------------------------- | ------------------------------- | -------------------------------------------------------------- |
-| `MAX_REQUEST_BLOCKS_DENEB`              | `Uint64(2**7)` (= 128)          | Maximum number of blocks in a single request                   |
-| `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` | `Epoch(2**12)` (= 4,096 epochs) | Minimum epoch range over which a node must serve blob sidecars |
-| `BLOB_SIDECAR_SUBNET_COUNT`             | `Uint64(6)`                     | Number of blob sidecar subnets used in the gossipsub protocol  |
+| Name                                    | Value                    | Description                                                    |
+| --------------------------------------- | ------------------------ | -------------------------------------------------------------- |
+| `MAX_REQUEST_BLOCKS_DENEB`              | `Uint64(2**7)` (= 128)   | Maximum number of blocks in a single request                   |
+| `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` | `Epoch(2**12)` (= 4,096) | Minimum epoch range over which a node must serve blob sidecars |
+| `BLOB_SIDECAR_SUBNET_COUNT`             | `Uint64(6)`              | Number of blob sidecar subnets used in the gossipsub protocol  |
 
 ### Containers
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -181,11 +181,11 @@ specification.
 
 ### State list lengths
 
-| Name                                | Value                           | Unit                        |
-| ----------------------------------- | ------------------------------- | --------------------------- |
-| `PENDING_DEPOSITS_LIMIT`            | `Uint64(2**27)` (= 134,217,728) | pending deposits            |
-| `PENDING_PARTIAL_WITHDRAWALS_LIMIT` | `Uint64(2**27)` (= 134,217,728) | pending partial withdrawals |
-| `PENDING_CONSOLIDATIONS_LIMIT`      | `Uint64(2**18)` (= 262,144)     | pending consolidations      |
+| Name                                | Value                           |
+| ----------------------------------- | ------------------------------- |
+| `PENDING_DEPOSITS_LIMIT`            | `Uint64(2**27)` (= 134,217,728) |
+| `PENDING_PARTIAL_WITHDRAWALS_LIMIT` | `Uint64(2**27)` (= 134,217,728) |
+| `PENDING_CONSOLIDATIONS_LIMIT`      | `Uint64(2**18)` (= 262,144)     |
 
 ### Max operations per block
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -147,7 +147,7 @@ specification.
 | Name                                 | Value               | Description                                            |
 | ------------------------------------ | ------------------- | ------------------------------------------------------ |
 | `UNSET_DEPOSIT_REQUESTS_START_INDEX` | `Uint64(2**64 - 1)` | Value which indicates no start index has been assigned |
-| `FULL_EXIT_REQUEST_AMOUNT`           | `Uint64(0)`         | Withdrawal amount used to signal a full validator exit |
+| `FULL_EXIT_REQUEST_AMOUNT`           | `Gwei(0)`           | Withdrawal amount used to signal a full validator exit |
 
 ### Withdrawal prefixes
 

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -42,9 +42,9 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 *[New in Electra:EIP7691]*
 
-| Name                                | Value | Description                                                   |
-| ----------------------------------- | ----- | ------------------------------------------------------------- |
-| `BLOB_SIDECAR_SUBNET_COUNT_ELECTRA` | `9`   | Number of blob sidecar subnets used in the gossipsub protocol |
+| Name                                | Value       | Description                                                   |
+| ----------------------------------- | ----------- | ------------------------------------------------------------- |
+| `BLOB_SIDECAR_SUBNET_COUNT_ELECTRA` | `Uint64(9)` | Number of blob sidecar subnets used in the gossipsub protocol |
 
 ### Helpers
 

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -55,9 +55,9 @@ specification.
 
 ### Size parameters
 
-| Name                | Value                        | Description                                   |
-| ------------------- | ---------------------------- | --------------------------------------------- |
-| `NUMBER_OF_COLUMNS` | `CELLS_PER_EXT_BLOB` (= 128) | Number of columns in the extended data matrix |
+| Name                | Value                                | Description                                   |
+| ------------------- | ------------------------------------ | --------------------------------------------- |
+| `NUMBER_OF_COLUMNS` | `Uint64(CELLS_PER_EXT_BLOB)` (= 128) | Number of columns in the extended data matrix |
 
 ## Configuration
 

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -63,10 +63,10 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 *[New in Fulu:EIP7594]*
 
-| Name                                           | Value                     | Description                                                           |
-| ---------------------------------------------- | ------------------------- | --------------------------------------------------------------------- |
-| `DATA_COLUMN_SIDECAR_SUBNET_COUNT`             | `Uint64(2**7)` (= 128)    | Number of data column sidecar subnets used in the gossipsub protocol  |
-| `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` | `Uint64(2**12)` (= 4,096) | Minimum epoch range over which a node must serve data column sidecars |
+| Name                                           | Value                    | Description                                                           |
+| ---------------------------------------------- | ------------------------ | --------------------------------------------------------------------- |
+| `DATA_COLUMN_SIDECAR_SUBNET_COUNT`             | `Uint64(2**7)` (= 128)   | Number of data column sidecar subnets used in the gossipsub protocol  |
+| `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` | `Epoch(2**12)` (= 4,096) | Minimum epoch range over which a node must serve data column sidecars |
 
 ### Containers
 

--- a/specs/fulu/validator.md
+++ b/specs/fulu/validator.md
@@ -47,7 +47,7 @@ document and used throughout.
 
 | Name                                   | Value              | Description                                                                                                |
 | -------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- |
-| `VALIDATOR_CUSTODY_REQUIREMENT`        | `8`                | Minimum number of custody groups an honest node with validators attached custodies and serves samples from |
+| `VALIDATOR_CUSTODY_REQUIREMENT`        | `Uint64(8)`        | Minimum number of custody groups an honest node with validators attached custodies and serves samples from |
 | `BALANCE_PER_ADDITIONAL_CUSTODY_GROUP` | `Gwei(32 * 10**9)` | Effective balance increment corresponding to one additional group to custody                               |
 
 ## Helpers

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -244,9 +244,9 @@ same `Withdrawal` container can be used for validators and builders.
 
 ### Time parameters
 
-| Name                                | Value                | Unit   |
-| ----------------------------------- | -------------------- | ------ |
-| `MIN_BUILDER_WITHDRAWABILITY_DELAY` | `Epoch(2**6)` (= 64) | epochs |
+| Name                                | Value                |
+| ----------------------------------- | -------------------- |
+| `MIN_BUILDER_WITHDRAWABILITY_DELAY` | `Epoch(2**6)` (= 64) |
 
 ## Containers
 

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -244,9 +244,9 @@ same `Withdrawal` container can be used for validators and builders.
 
 ### Time parameters
 
-| Name                                | Value                 | Unit   |
-| ----------------------------------- | --------------------- | ------ |
-| `MIN_BUILDER_WITHDRAWABILITY_DELAY` | `Uint64(2**6)` (= 64) | epochs |
+| Name                                | Value                | Unit   |
+| ----------------------------------- | -------------------- | ------ |
+| `MIN_BUILDER_WITHDRAWABILITY_DELAY` | `Epoch(2**6)` (= 64) | epochs |
 
 ## Containers
 

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -75,16 +75,16 @@ This is the modification of the fork-choice accompanying the Gloas upgrade.
 
 ## Constants
 
-| Name                                 | Value                   |
-| ------------------------------------ | ----------------------- |
-| `PAYLOAD_TIMELY_THRESHOLD`           | `PTC_SIZE // 2` (= 256) |
-| `DATA_AVAILABILITY_TIMELY_THRESHOLD` | `PTC_SIZE // 2` (= 256) |
-| `PAYLOAD_STATUS_EMPTY`               | `PayloadStatus(0)`      |
-| `PAYLOAD_STATUS_FULL`                | `PayloadStatus(1)`      |
-| `PAYLOAD_STATUS_PENDING`             | `PayloadStatus(2)`      |
-| `ATTESTATION_TIMELINESS_INDEX`       | `0`                     |
-| `PTC_TIMELINESS_INDEX`               | `1`                     |
-| `NUM_BLOCK_TIMELINESS_DEADLINES`     | `2`                     |
+| Name                                 | Value                           |
+| ------------------------------------ | ------------------------------- |
+| `PAYLOAD_TIMELY_THRESHOLD`           | `Uint64(PTC_SIZE // 2)` (= 256) |
+| `DATA_AVAILABILITY_TIMELY_THRESHOLD` | `Uint64(PTC_SIZE // 2)` (= 256) |
+| `PAYLOAD_STATUS_EMPTY`               | `PayloadStatus(0)`              |
+| `PAYLOAD_STATUS_FULL`                | `PayloadStatus(1)`              |
+| `PAYLOAD_STATUS_PENDING`             | `PayloadStatus(2)`              |
+| `ATTESTATION_TIMELINESS_INDEX`       | `Uint64(0)`                     |
+| `PTC_TIMELINESS_INDEX`               | `Uint64(1)`                     |
+| `NUM_BLOCK_TIMELINESS_DEADLINES`     | `Uint64(2)`                     |
 
 ## Protocols
 

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -70,9 +70,9 @@ libp2p messages.
 
 ### Configuration
 
-| Name                   | Value          |
-| ---------------------- | -------------- |
-| `MAX_REQUEST_PAYLOADS` | `2**7` (= 128) |
+| Name                   | Value                  |
+| ---------------------- | ---------------------- |
+| `MAX_REQUEST_PAYLOADS` | `Uint64(2**7)` (= 128) |
 
 ### Containers
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -38,14 +38,14 @@ validator" to implement Gloas.
 
 ### Time parameters
 
-| Name                          | Value          | Unit         | Duration                  |
-| ----------------------------- | -------------- | ------------ | ------------------------- |
-| `ATTESTATION_DUE_BPS_GLOAS`   | `Uint64(2500)` | basis points | 25% of `SLOT_DURATION_MS` |
-| `AGGREGATE_DUE_BPS_GLOAS`     | `Uint64(5000)` | basis points | 50% of `SLOT_DURATION_MS` |
-| `SYNC_MESSAGE_DUE_BPS_GLOAS`  | `Uint64(2500)` | basis points | 25% of `SLOT_DURATION_MS` |
-| `CONTRIBUTION_DUE_BPS_GLOAS`  | `Uint64(5000)` | basis points | 50% of `SLOT_DURATION_MS` |
-| `PAYLOAD_DUE_BPS`             | `Uint64(5000)` | basis points | 50% of `SLOT_DURATION_MS` |
-| `PAYLOAD_ATTESTATION_DUE_BPS` | `Uint64(7500)` | basis points | 75% of `SLOT_DURATION_MS` |
+| Name                          | Value          | Duration                  |
+| ----------------------------- | -------------- | ------------------------- |
+| `ATTESTATION_DUE_BPS_GLOAS`   | `Uint64(2500)` | 25% of `SLOT_DURATION_MS` |
+| `AGGREGATE_DUE_BPS_GLOAS`     | `Uint64(5000)` | 50% of `SLOT_DURATION_MS` |
+| `SYNC_MESSAGE_DUE_BPS_GLOAS`  | `Uint64(2500)` | 25% of `SLOT_DURATION_MS` |
+| `CONTRIBUTION_DUE_BPS_GLOAS`  | `Uint64(5000)` | 50% of `SLOT_DURATION_MS` |
+| `PAYLOAD_DUE_BPS`             | `Uint64(5000)` | 50% of `SLOT_DURATION_MS` |
+| `PAYLOAD_ATTESTATION_DUE_BPS` | `Uint64(7500)` | 75% of `SLOT_DURATION_MS` |
 
 ## Validator assignment
 

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -33,9 +33,9 @@ This is the modification of the fork choice accompanying the Heze upgrade.
 
 ### Time parameters
 
-| Name                     | Value          | Unit         | Duration                   |
-| ------------------------ | -------------- | ------------ | -------------------------- |
-| `INCLUSION_LIST_DUE_BPS` | `Uint64(6667)` | basis points | ~67% of `SLOT_DURATION_MS` |
+| Name                     | Value          | Duration                   |
+| ------------------------ | -------------- | -------------------------- |
+| `INCLUSION_LIST_DUE_BPS` | `Uint64(6667)` | ~67% of `SLOT_DURATION_MS` |
 
 ## Protocols
 

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -44,11 +44,11 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 
 ### Configuration
 
-| Name                                     | Value             | Description                                                     |
-| ---------------------------------------- | ----------------- | --------------------------------------------------------------- |
-| `MAX_REQUEST_INCLUSION_LIST`             | `2**4` (= 16)     | Maximum number of inclusion lists in a single request           |
-| `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS` | `Slot(1)`         | Minimum slot range over which a node must serve inclusion lists |
-| `MAX_BYTES_PER_INCLUSION_LIST`           | `2**13` (= 8,192) | Maximum size of the inclusion list's transactions in bytes      |
+| Name                                     | Value                     | Description                                                     |
+| ---------------------------------------- | ------------------------- | --------------------------------------------------------------- |
+| `MAX_REQUEST_INCLUSION_LIST`             | `Uint64(2**4)` (= 16)     | Maximum number of inclusion lists in a single request           |
+| `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS` | `Slot(1)`                 | Minimum slot range over which a node must serve inclusion lists |
+| `MAX_BYTES_PER_INCLUSION_LIST`           | `Uint64(2**13)` (= 8,192) | Maximum size of the inclusion list's transactions in bytes      |
 
 ### Helpers
 

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -47,7 +47,7 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 | Name                                     | Value             | Description                                                     |
 | ---------------------------------------- | ----------------- | --------------------------------------------------------------- |
 | `MAX_REQUEST_INCLUSION_LIST`             | `2**4` (= 16)     | Maximum number of inclusion lists in a single request           |
-| `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS` | `1`               | Minimum slot range over which a node must serve inclusion lists |
+| `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS` | `Slot(1)`         | Minimum slot range over which a node must serve inclusion lists |
 | `MAX_BYTES_PER_INCLUSION_LIST`           | `2**13` (= 8,192) | Maximum size of the inclusion list's transactions in bytes      |
 
 ### Helpers

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -257,24 +257,24 @@ operation, e.g. testing, but not generally between different networks.
 
 ### Time parameters
 
-| Name                               | Value                   | Unit   |
-| ---------------------------------- | ----------------------- | ------ |
-| `MIN_ATTESTATION_INCLUSION_DELAY`  | `Slot(2**0)` (= 1)      | slots  |
-| `SLOTS_PER_EPOCH`                  | `Slot(2**5)` (= 32)     | slots  |
-| `MIN_SEED_LOOKAHEAD`               | `Epoch(2**0)` (= 1)     | epochs |
-| `MAX_SEED_LOOKAHEAD`               | `Epoch(2**2)` (= 4)     | epochs |
-| `MIN_EPOCHS_TO_INACTIVITY_PENALTY` | `Epoch(2**2)` (= 4)     | epochs |
-| `EPOCHS_PER_ETH1_VOTING_PERIOD`    | `Epoch(2**6)` (= 64)    | epochs |
-| `SLOTS_PER_HISTORICAL_ROOT`        | `Slot(2**13)` (= 8,192) | slots  |
+| Name                               | Value                   |
+| ---------------------------------- | ----------------------- |
+| `MIN_ATTESTATION_INCLUSION_DELAY`  | `Slot(2**0)` (= 1)      |
+| `SLOTS_PER_EPOCH`                  | `Slot(2**5)` (= 32)     |
+| `MIN_SEED_LOOKAHEAD`               | `Epoch(2**0)` (= 1)     |
+| `MAX_SEED_LOOKAHEAD`               | `Epoch(2**2)` (= 4)     |
+| `MIN_EPOCHS_TO_INACTIVITY_PENALTY` | `Epoch(2**2)` (= 4)     |
+| `EPOCHS_PER_ETH1_VOTING_PERIOD`    | `Epoch(2**6)` (= 64)    |
+| `SLOTS_PER_HISTORICAL_ROOT`        | `Slot(2**13)` (= 8,192) |
 
 ### State list lengths
 
-| Name                           | Value                                 | Unit             |
-| ------------------------------ | ------------------------------------- | ---------------- |
-| `EPOCHS_PER_HISTORICAL_VECTOR` | `Epoch(2**16)` (= 65,536)             | epochs           |
-| `EPOCHS_PER_SLASHINGS_VECTOR`  | `Epoch(2**13)` (= 8,192)              | epochs           |
-| `HISTORICAL_ROOTS_LIMIT`       | `Uint64(2**24)` (= 16,777,216)        | historical roots |
-| `VALIDATOR_REGISTRY_LIMIT`     | `Uint64(2**40)` (= 1,099,511,627,776) | validators       |
+| Name                           | Value                                 |
+| ------------------------------ | ------------------------------------- |
+| `EPOCHS_PER_HISTORICAL_VECTOR` | `Epoch(2**16)` (= 65,536)             |
+| `EPOCHS_PER_SLASHINGS_VECTOR`  | `Epoch(2**13)` (= 8,192)              |
+| `HISTORICAL_ROOTS_LIMIT`       | `Uint64(2**24)` (= 16,777,216)        |
+| `VALIDATOR_REGISTRY_LIMIT`     | `Uint64(2**40)` (= 1,099,511,627,776) |
 
 ### Rewards and penalties
 
@@ -330,13 +330,13 @@ different configuration.
 
 ### Time parameters
 
-| Name                                  | Value                     | Unit         |
-| ------------------------------------- | ------------------------- | ------------ |
-| `SLOT_DURATION_MS`                    | `Uint64(12000)`           | milliseconds |
-| `SECONDS_PER_ETH1_BLOCK`              | `Uint64(14)`              | seconds      |
-| `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `Epoch(2**8)` (= 256)     | epochs       |
-| `SHARD_COMMITTEE_PERIOD`              | `Epoch(2**8)` (= 256)     | epochs       |
-| `ETH1_FOLLOW_DISTANCE`                | `Uint64(2**11)` (= 2,048) | Eth1 blocks  |
+| Name                                  | Value                     |
+| ------------------------------------- | ------------------------- |
+| `SLOT_DURATION_MS`                    | `Uint64(12000)`           |
+| `SECONDS_PER_ETH1_BLOCK`              | `Uint64(14)`              |
+| `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `Epoch(2**8)` (= 256)     |
+| `SHARD_COMMITTEE_PERIOD`              | `Epoch(2**8)` (= 256)     |
+| `ETH1_FOLLOW_DISTANCE`                | `Uint64(2**11)` (= 2,048) |
 
 ### Validator cycle
 

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -257,22 +257,22 @@ operation, e.g. testing, but not generally between different networks.
 
 ### Time parameters
 
-| Name                               | Value                     | Unit   |
-| ---------------------------------- | ------------------------- | ------ |
-| `MIN_ATTESTATION_INCLUSION_DELAY`  | `Uint64(2**0)` (= 1)      | slots  |
-| `SLOTS_PER_EPOCH`                  | `Uint64(2**5)` (= 32)     | slots  |
-| `MIN_SEED_LOOKAHEAD`               | `Uint64(2**0)` (= 1)      | epochs |
-| `MAX_SEED_LOOKAHEAD`               | `Uint64(2**2)` (= 4)      | epochs |
-| `MIN_EPOCHS_TO_INACTIVITY_PENALTY` | `Uint64(2**2)` (= 4)      | epochs |
-| `EPOCHS_PER_ETH1_VOTING_PERIOD`    | `Uint64(2**6)` (= 64)     | epochs |
-| `SLOTS_PER_HISTORICAL_ROOT`        | `Uint64(2**13)` (= 8,192) | slots  |
+| Name                               | Value                   | Unit   |
+| ---------------------------------- | ----------------------- | ------ |
+| `MIN_ATTESTATION_INCLUSION_DELAY`  | `Slot(2**0)` (= 1)      | slots  |
+| `SLOTS_PER_EPOCH`                  | `Slot(2**5)` (= 32)     | slots  |
+| `MIN_SEED_LOOKAHEAD`               | `Epoch(2**0)` (= 1)     | epochs |
+| `MAX_SEED_LOOKAHEAD`               | `Epoch(2**2)` (= 4)     | epochs |
+| `MIN_EPOCHS_TO_INACTIVITY_PENALTY` | `Epoch(2**2)` (= 4)     | epochs |
+| `EPOCHS_PER_ETH1_VOTING_PERIOD`    | `Epoch(2**6)` (= 64)    | epochs |
+| `SLOTS_PER_HISTORICAL_ROOT`        | `Slot(2**13)` (= 8,192) | slots  |
 
 ### State list lengths
 
 | Name                           | Value                                 | Unit             |
 | ------------------------------ | ------------------------------------- | ---------------- |
-| `EPOCHS_PER_HISTORICAL_VECTOR` | `Uint64(2**16)` (= 65,536)            | epochs           |
-| `EPOCHS_PER_SLASHINGS_VECTOR`  | `Uint64(2**13)` (= 8,192)             | epochs           |
+| `EPOCHS_PER_HISTORICAL_VECTOR` | `Epoch(2**16)` (= 65,536)             | epochs           |
+| `EPOCHS_PER_SLASHINGS_VECTOR`  | `Epoch(2**13)` (= 8,192)              | epochs           |
 | `HISTORICAL_ROOTS_LIMIT`       | `Uint64(2**24)` (= 16,777,216)        | historical roots |
 | `VALIDATOR_REGISTRY_LIMIT`     | `Uint64(2**40)` (= 1,099,511,627,776) | validators       |
 
@@ -334,8 +334,8 @@ different configuration.
 | ------------------------------------- | ------------------------- | ------------ |
 | `SLOT_DURATION_MS`                    | `Uint64(12000)`           | milliseconds |
 | `SECONDS_PER_ETH1_BLOCK`              | `Uint64(14)`              | seconds      |
-| `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `Uint64(2**8)` (= 256)    | epochs       |
-| `SHARD_COMMITTEE_PERIOD`              | `Uint64(2**8)` (= 256)    | epochs       |
+| `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `Epoch(2**8)` (= 256)     | epochs       |
+| `SHARD_COMMITTEE_PERIOD`              | `Epoch(2**8)` (= 256)     | epochs       |
 | `ETH1_FOLLOW_DISTANCE`                | `Uint64(2**11)` (= 2,048) | Eth1 blocks  |
 
 ### Validator cycle

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -183,17 +183,16 @@ specification.
 
 ### Misc
 
-| Name                          | Value                 |
-| ----------------------------- | --------------------- |
-| `UINT64_MAX`                  | `Uint64(2**64 - 1)`   |
-| `UINT64_MAX_SQRT`             | `Uint64(4294967295)`  |
-| `GENESIS_SLOT`                | `Slot(0)`             |
-| `GENESIS_EPOCH`               | `Epoch(0)`            |
-| `FAR_FUTURE_EPOCH`            | `Epoch(2**64 - 1)`    |
-| `BASE_REWARDS_PER_EPOCH`      | `Uint64(4)`           |
-| `DEPOSIT_CONTRACT_TREE_DEPTH` | `Uint64(2**5)` (= 32) |
-| `JUSTIFICATION_BITS_LENGTH`   | `Uint64(4)`           |
-| `ENDIANNESS`                  | `'little'`            |
+| Name                        | Value                |
+| --------------------------- | -------------------- |
+| `UINT64_MAX`                | `Uint64(2**64 - 1)`  |
+| `UINT64_MAX_SQRT`           | `Uint64(4294967295)` |
+| `GENESIS_SLOT`              | `Slot(0)`            |
+| `GENESIS_EPOCH`             | `Epoch(0)`           |
+| `FAR_FUTURE_EPOCH`          | `Epoch(2**64 - 1)`   |
+| `BASE_REWARDS_PER_EPOCH`    | `Uint64(4)`          |
+| `JUSTIFICATION_BITS_LENGTH` | `Uint64(4)`          |
+| `ENDIANNESS`                | `'little'`           |
 
 ### Withdrawal prefixes
 

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -24,9 +24,9 @@ contract, part of Phase 0.
 The following values are (non-configurable) constants used throughout the
 specification.
 
-| Name                          | Value         |
-| ----------------------------- | ------------- |
-| `DEPOSIT_CONTRACT_TREE_DEPTH` | `2**5` (= 32) |
+| Name                          | Value                 |
+| ----------------------------- | --------------------- |
+| `DEPOSIT_CONTRACT_TREE_DEPTH` | `Uint64(2**5)` (= 32) |
 
 ## Configuration
 
@@ -35,8 +35,8 @@ specification-design purposes.
 
 | Name                       | Value                                        |
 | -------------------------- | -------------------------------------------- |
-| `DEPOSIT_CHAIN_ID`         | `1`                                          |
-| `DEPOSIT_NETWORK_ID`       | `1`                                          |
+| `DEPOSIT_CHAIN_ID`         | `Uint64(1)`                                  |
+| `DEPOSIT_NETWORK_ID`       | `Uint64(1)`                                  |
 | `DEPOSIT_CONTRACT_ADDRESS` | `0x00000000219ab540356cBB839Cbe05303d7705Fa` |
 
 ## Staking deposit contract

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -3,6 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
+- [Types](#types)
 - [Constants](#constants)
 - [Configuration](#configuration)
 - [Staking deposit contract](#staking-deposit-contract)
@@ -19,6 +20,12 @@
 This document represents the specification for the beacon-chain deposit
 contract, part of Phase 0.
 
+## Types
+
+| Name               | SSZ equivalent | Description                               |
+| ------------------ | -------------- | ----------------------------------------- |
+| `ExecutionAddress` | `Bytes20`      | Address of account on the execution layer |
+
 ## Constants
 
 The following values are (non-configurable) constants used throughout the
@@ -33,11 +40,11 @@ specification.
 *Note*: The default mainnet configuration values are included here for
 specification-design purposes.
 
-| Name                       | Value                                        |
-| -------------------------- | -------------------------------------------- |
-| `DEPOSIT_CHAIN_ID`         | `Uint64(1)`                                  |
-| `DEPOSIT_NETWORK_ID`       | `Uint64(1)`                                  |
-| `DEPOSIT_CONTRACT_ADDRESS` | `0x00000000219ab540356cBB839Cbe05303d7705Fa` |
+| Name                       | Value                                                            |
+| -------------------------- | ---------------------------------------------------------------- |
+| `DEPOSIT_CHAIN_ID`         | `Uint64(1)`                                                      |
+| `DEPOSIT_NETWORK_ID`       | `Uint64(1)`                                                      |
+| `DEPOSIT_CONTRACT_ADDRESS` | `ExecutionAddress('0x00000000219ab540356cBB839Cbe05303d7705Fa')` |
 
 ## Staking deposit contract
 

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -356,8 +356,8 @@ def is_full_validator_set_covered(start_slot: Slot, end_slot: Slot) -> bool:
     """
     Return ``True`` if the range between ``start_slot`` and ``end_slot`` (inclusive of both) includes an entire epoch.
     """
-    start_full_epoch = compute_epoch_at_slot(start_slot + (SLOTS_PER_EPOCH - 1))
-    end_full_epoch = compute_epoch_at_slot(Slot(end_slot + 1))
+    start_full_epoch = compute_epoch_at_slot(start_slot + SLOTS_PER_EPOCH - Slot(1))
+    end_full_epoch = compute_epoch_at_slot(end_slot + Slot(1))
     return start_full_epoch < end_full_epoch
 ```
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -136,9 +136,9 @@ handlers must not modify `store`.
 
 #### Time parameters
 
-| Name                        | Value          | Unit         | Duration                   |
-| --------------------------- | -------------- | ------------ | -------------------------- |
-| `PROPOSER_REORG_CUTOFF_BPS` | `Uint64(1667)` | basis points | ~17% of `SLOT_DURATION_MS` |
+| Name                        | Value          | Duration                   |
+| --------------------------- | -------------- | -------------------------- |
+| `PROPOSER_REORG_CUTOFF_BPS` | `Uint64(1667)` | ~17% of `SLOT_DURATION_MS` |
 
 ### Helpers
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -222,27 +222,27 @@ We define the following Python custom types for type hinting and readability:
 
 ### Constants
 
-| Name           | Value | Unit                             |
-| -------------- | ----- | -------------------------------- |
-| `NODE_ID_BITS` | `256` | The bit length of Uint256 is 256 |
+| Name           | Value         |
+| -------------- | ------------- |
+| `NODE_ID_BITS` | `Uint64(256)` |
 
 ### Configuration
 
 This section outlines configurations that are used in this specification.
 
-| Name                                 | Value                               | Description                                                                       |
-| ------------------------------------ | ----------------------------------- | --------------------------------------------------------------------------------- |
-| `MAX_PAYLOAD_SIZE`                   | `10 * 2**20` (= 10,485,760, 10 MiB) | Maximum allowed size of uncompressed payload in gossipsub messages and RPC chunks |
-| `MAX_REQUEST_BLOCKS`                 | `2**10` (= 1,024)                   | Maximum number of blocks in a single request                                      |
-| `EPOCHS_PER_SUBNET_SUBSCRIPTION`     | `Epoch(2**8)` (= 256)               | Number of epochs on a subnet subscription                                         |
-| `ATTESTATION_PROPAGATION_SLOT_RANGE` | `Slot(32)`                          | Maximum number of slots during which an attestation can be propagated             |
-| `MAXIMUM_GOSSIP_CLOCK_DISPARITY`     | `500`                               | Maximum **milliseconds** of clock disparity assumed between honest nodes          |
-| `MESSAGE_DOMAIN_INVALID_SNAPPY`      | `DomainType('0x00000000')`          | 4-byte domain for gossip message-id isolation of *invalid* snappy messages        |
-| `MESSAGE_DOMAIN_VALID_SNAPPY`        | `DomainType('0x01000000')`          | 4-byte domain for gossip message-id isolation of *valid* snappy messages          |
-| `SUBNETS_PER_NODE`                   | `2`                                 | Number of long-lived subnets a beacon node should be subscribed to                |
-| `ATTESTATION_SUBNET_COUNT`           | `2**6` (= 64)                       | Number of attestation subnets used in the gossipsub protocol                      |
-| `ATTESTATION_SUBNET_EXTRA_BITS`      | `0`                                 | Number of extra bits of a NodeId to use when mapping to a subscribed subnet       |
-| `MAX_CONCURRENT_REQUESTS`            | `2`                                 | Maximum number of concurrent requests per protocol ID that a client may issue     |
+| Name                                 | Value                                       | Description                                                                       |
+| ------------------------------------ | ------------------------------------------- | --------------------------------------------------------------------------------- |
+| `MAX_PAYLOAD_SIZE`                   | `Uint64(10 * 2**20)` (= 10,485,760, 10 MiB) | Maximum allowed size of uncompressed payload in gossipsub messages and RPC chunks |
+| `MAX_REQUEST_BLOCKS`                 | `Uint64(2**10)` (= 1,024)                   | Maximum number of blocks in a single request                                      |
+| `EPOCHS_PER_SUBNET_SUBSCRIPTION`     | `Epoch(2**8)` (= 256)                       | Number of epochs on a subnet subscription                                         |
+| `ATTESTATION_PROPAGATION_SLOT_RANGE` | `Slot(32)`                                  | Maximum number of slots during which an attestation can be propagated             |
+| `MAXIMUM_GOSSIP_CLOCK_DISPARITY`     | `Uint64(500)`                               | Maximum **milliseconds** of clock disparity assumed between honest nodes          |
+| `MESSAGE_DOMAIN_INVALID_SNAPPY`      | `DomainType('0x00000000')`                  | 4-byte domain for gossip message-id isolation of *invalid* snappy messages        |
+| `MESSAGE_DOMAIN_VALID_SNAPPY`        | `DomainType('0x01000000')`                  | 4-byte domain for gossip message-id isolation of *valid* snappy messages          |
+| `SUBNETS_PER_NODE`                   | `Uint64(2)`                                 | Number of long-lived subnets a beacon node should be subscribed to                |
+| `ATTESTATION_SUBNET_COUNT`           | `Uint64(2**6)` (= 64)                       | Number of attestation subnets used in the gossipsub protocol                      |
+| `ATTESTATION_SUBNET_EXTRA_BITS`      | `Uint64(0)`                                 | Number of extra bits of a NodeId to use when mapping to a subscribed subnet       |
+| `MAX_CONCURRENT_REQUESTS`            | `Uint64(2)`                                 | Maximum number of concurrent requests per protocol ID that a client may issue     |
 
 ### Helpers
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1740,8 +1740,8 @@ should:
 ```python
 def compute_subscribed_subnet(node_id: NodeID, epoch: Epoch, index: int) -> SubnetID:
     prefix_bits = int(compute_attestation_subnet_prefix_bits())
-    node_id_prefix = node_id >> (NODE_ID_BITS - prefix_bits)
-    node_offset = node_id % EPOCHS_PER_SUBNET_SUBSCRIPTION
+    node_id_prefix = node_id >> int(NODE_ID_BITS - prefix_bits)
+    node_offset = Uint64(node_id % Uint256(EPOCHS_PER_SUBNET_SUBSCRIPTION))
     permutation_seed = hash(
         uint_to_bytes(Uint64((epoch + node_offset) // EPOCHS_PER_SUBNET_SUBSCRIPTION))
     )

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -234,8 +234,8 @@ This section outlines configurations that are used in this specification.
 | ------------------------------------ | ----------------------------------- | --------------------------------------------------------------------------------- |
 | `MAX_PAYLOAD_SIZE`                   | `10 * 2**20` (= 10,485,760, 10 MiB) | Maximum allowed size of uncompressed payload in gossipsub messages and RPC chunks |
 | `MAX_REQUEST_BLOCKS`                 | `2**10` (= 1,024)                   | Maximum number of blocks in a single request                                      |
-| `EPOCHS_PER_SUBNET_SUBSCRIPTION`     | `2**8` (= 256)                      | Number of epochs on a subnet subscription                                         |
-| `ATTESTATION_PROPAGATION_SLOT_RANGE` | `32`                                | Maximum number of slots during which an attestation can be propagated             |
+| `EPOCHS_PER_SUBNET_SUBSCRIPTION`     | `Epoch(2**8)` (= 256)               | Number of epochs on a subnet subscription                                         |
+| `ATTESTATION_PROPAGATION_SLOT_RANGE` | `Slot(32)`                          | Maximum number of slots during which an attestation can be propagated             |
 | `MAXIMUM_GOSSIP_CLOCK_DISPARITY`     | `500`                               | Maximum **milliseconds** of clock disparity assumed between honest nodes          |
 | `MESSAGE_DOMAIN_INVALID_SNAPPY`      | `DomainType('0x00000000')`          | 4-byte domain for gossip message-id isolation of *invalid* snappy messages        |
 | `MESSAGE_DOMAIN_VALID_SNAPPY`        | `DomainType('0x01000000')`          | 4-byte domain for gossip message-id isolation of *valid* snappy messages          |

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -100,9 +100,9 @@ specifications before continuing and use as a reference throughout.
 
 ### Misc
 
-| Name                               | Value         | Unit       |
-| ---------------------------------- | ------------- | ---------- |
-| `TARGET_AGGREGATORS_PER_COMMITTEE` | `2**4` (= 16) | validators |
+| Name                               | Value                 | Unit       |
+| ---------------------------------- | --------------------- | ---------- |
+| `TARGET_AGGREGATORS_PER_COMMITTEE` | `Uint64(2**4)` (= 16) | validators |
 
 ## Configuration
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -100,18 +100,18 @@ specifications before continuing and use as a reference throughout.
 
 ### Misc
 
-| Name                               | Value                 | Unit       |
-| ---------------------------------- | --------------------- | ---------- |
-| `TARGET_AGGREGATORS_PER_COMMITTEE` | `Uint64(2**4)` (= 16) | validators |
+| Name                               | Value                 |
+| ---------------------------------- | --------------------- |
+| `TARGET_AGGREGATORS_PER_COMMITTEE` | `Uint64(2**4)` (= 16) |
 
 ## Configuration
 
 ### Time parameters
 
-| Name                  | Value          | Unit         | Duration                   |
-| --------------------- | -------------- | ------------ | -------------------------- |
-| `ATTESTATION_DUE_BPS` | `Uint64(3333)` | basis points | ~33% of `SLOT_DURATION_MS` |
-| `AGGREGATE_DUE_BPS`   | `Uint64(6667)` | basis points | ~67% of `SLOT_DURATION_MS` |
+| Name                  | Value          | Duration                   |
+| --------------------- | -------------- | -------------------------- |
+| `ATTESTATION_DUE_BPS` | `Uint64(3333)` | ~33% of `SLOT_DURATION_MS` |
+| `AGGREGATE_DUE_BPS`   | `Uint64(6667)` | ~67% of `SLOT_DURATION_MS` |
 
 ## Containers
 

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -46,9 +46,9 @@ statelessness).
 
 ## Constants
 
-| Name                                  | Value         | Unit  |
-| ------------------------------------- | ------------- | ----- |
-| `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY` | `Uint64(128)` | slots |
+| Name                                  | Value       |
+| ------------------------------------- | ----------- |
+| `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY` | `Slot(128)` |
 
 *Note: the `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY` must be user-configurable. See
 [Fork Choice Poisoning](#fork-choice-poisoning).*

--- a/sync/optimistic.md
+++ b/sync/optimistic.md
@@ -46,9 +46,9 @@ statelessness).
 
 ## Constants
 
-| Name                                  | Value | Unit  |
-| ------------------------------------- | ----- | ----- |
-| `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY` | `128` | slots |
+| Name                                  | Value         | Unit  |
+| ------------------------------------- | ------------- | ----- |
+| `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY` | `Uint64(128)` | slots |
 
 *Note: the `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY` must be user-configurable. See
 [Fork Choice Poisoning](#fork-choice-poisoning).*

--- a/tests/core/pyspec/eth_consensus_specs/test/bellatrix/unittests/test_validate_merge_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/bellatrix/unittests/test_validate_merge_block.py
@@ -110,7 +110,7 @@ def test_validate_merge_block_fail_after_terminal(spec, state):
 @spec_configured_state_test(
     {
         "TERMINAL_BLOCK_HASH": TERMINAL_BLOCK_HASH_CONFIG_VAR,
-        "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH": "0",
+        "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH": 0,
     }
 )
 def test_validate_merge_block_tbh_override_success(spec, state):
@@ -132,7 +132,7 @@ def test_validate_merge_block_tbh_override_success(spec, state):
 @spec_configured_state_test(
     {
         "TERMINAL_BLOCK_HASH": TERMINAL_BLOCK_HASH_CONFIG_VAR,
-        "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH": "0",
+        "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH": 0,
     }
 )
 def test_validate_merge_block_fail_parent_hash_is_not_tbh(spec, state):
@@ -153,7 +153,7 @@ def test_validate_merge_block_fail_parent_hash_is_not_tbh(spec, state):
 @spec_configured_state_test(
     {
         "TERMINAL_BLOCK_HASH": TERMINAL_BLOCK_HASH_CONFIG_VAR,
-        "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH": "1",
+        "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH": 1,
     }
 )
 def test_validate_merge_block_terminal_block_hash_fail_activation_not_reached(spec, state):
@@ -175,7 +175,7 @@ def test_validate_merge_block_terminal_block_hash_fail_activation_not_reached(sp
 @spec_configured_state_test(
     {
         "TERMINAL_BLOCK_HASH": TERMINAL_BLOCK_HASH_CONFIG_VAR,
-        "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH": "1",
+        "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH": 1,
     }
 )
 def test_validate_merge_block_fail_activation_not_reached_parent_hash_is_not_tbh(spec, state):


### PR DESCRIPTION
With the new SSZ library, operations must be performed on the same types. For example, `Uint64(1) + Uint64(2)` not `Uint64(1) + 2` and not `Uint64(1) + Epoch(2)`. In preparation for that, this PR updates several constants/configs/presets to use more accurate types. It also defines types for items which lacked them. As a result of this, columns for units have been removed as they are no longer that useful.