### PR TITLE
Only allow bids compatible with the head view

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -421,9 +421,9 @@ follows the node's payload status. For a *full* node from the previous slot, it
 considers the PTC view on both payload timeliness and data availability.
 
 ```python
-def should_build_on_full(store: Store, head: ForkChoiceNode) -> bool:
+def should_build_on_full(store: Store, head: ForkChoiceNode, slot: Slot) -> bool:
     assert head.payload_status != PAYLOAD_STATUS_PENDING
-    if store.blocks[head.root].slot + 1 != get_current_slot(store):
+    if store.blocks[head.root].slot + 1 != slot:
         return head.payload_status == PAYLOAD_STATUS_FULL
     if head.payload_status == PAYLOAD_STATUS_EMPTY:
         return False

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -428,7 +428,8 @@ where `store` is the fork choice store, and the alias
   limitation defined in the consensus layer -- i.e. validate that
   `len(bid.blob_kzg_commitments) <= get_blob_parameters(compute_epoch_at_slot(bid.slot)).max_blobs_per_block`.
 - _[IGNORE]_ this is the first signed bid seen with a valid signature from the
-  given builder for this slot.
+  given builder for the tuple 
+  `(bid.slot, bid.parent_block_hash, bid.parent_block_root)`.
 - _[IGNORE]_ this bid is the highest value bid seen for the tuple
   `(bid.slot, bid.parent_block_hash, bid.parent_block_root)`.
 - _[IGNORE]_ `bid.value` is less or equal than the builder's excess balance --
@@ -438,8 +439,8 @@ where `store` is the fork choice store, and the alias
   `is_gas_limit_target_compatible(parent_gas_limit, bid.gas_limit, proposer_preferences.target_gas_limit)`
   is `True` where `parent_gas_limit` is the `gas_limit` of that execution
   payload.
-- _[IGNORE]_ `bid.parent_block_root` is the hash tree root of a known beacon
-  block in fork choice.
+- _[IGNORE]_The bid mimicks what this node would propose for, i.e.
+   `is_bid_on_current_head(store, bid)` returns `True`. 
 - _[REJECT]_ The bid is for a higher slot than its parent block -- i.e. validate
   that `bid.slot` is greater than the slot of the block with root
   `bid.parent_block_root`.
@@ -467,6 +468,45 @@ def is_gas_limit_target_compatible(
     return gas_limit == min_gas_limit
 ```
 
+```python
+def is_bid_on_current_head(store: Store, bid: ExecutionPayloadBid) -> bool:
+    """ 
+    Check if ``bid`` has the same parent information as this node would propose.
+    """
+    head_node = get_head(store)
+    head_block = store.blocks[head_node.root]
+    parent_root = head_block.parent_root
+    parent_block = store.blocks[parent_root]
+    parent_payload_status = get_parent_payload_status(store, head_block)
+    parent_node = ForkChoiceNode(root=parent_root, payload_status=parent_payload_status)
+
+    head_late = is_head_late(store, head_node.root)
+    ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
+    finalization_ok = is_finalization_ok(store, slot)
+    parent_slot_ok = parent_block.slot + 1 == head_block.slot
+    single_slot_reorg = head_block.slot + 1 == bid.slot
+    head_weak = is_head_weak(store, head_node.root)
+    parent_strong = is_parent_strong(store, head_node.root)
+    bid_on_parent = bid.parent_block_root == parent_root and 
+        bid.parent_block_hash == head_block.body.signed_execution_payload_bid.message.parent_block_hash
+    if all([
+        head_late,
+        ffg_competitive,
+        finalization_ok,
+        single_slot_reorg,
+        head_weak,
+        parent_strong,
+    ]):
+        return bid_on_parent
+    if bid.parent_block_root != head_node.root: 
+        return false
+    if should_build_on_full(store, head_node):
+        return bid.parent_block_hash == head_bock.body.signed_execution_payload_bid.message.block_hash 
+    else:
+        return bid.parent_block_hash == head_bock.body.signed_execution_payload_bid.message.parent_block_hash 
+```
+
+ 
 *Note*: Implementations SHOULD include DoS prevention measures to mitigate spam
 from malicious builders submitting numerous bids with minimal value increments.
 Possible strategies include: (1) only forwarding bids that exceed the current

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -501,7 +501,7 @@ def is_bid_on_current_head(store: Store, bid: ExecutionPayloadBid) -> bool:
         return bid_on_parent
     if bid.parent_block_root != head_node.root:
         return False
-    if should_build_on_full(store, head_node):
+    if should_build_on_full(store, head_node, bid.slot):
         return bid.parent_block_hash == head_bid.block_hash
     else:
         return bid.parent_block_hash == head_bid.parent_block_hash

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -428,7 +428,7 @@ where `store` is the fork choice store, and the alias
   limitation defined in the consensus layer -- i.e. validate that
   `len(bid.blob_kzg_commitments) <= get_blob_parameters(compute_epoch_at_slot(bid.slot)).max_blobs_per_block`.
 - _[IGNORE]_ this is the first signed bid seen with a valid signature from the
-  given builder for the tuple 
+  given builder for the tuple
   `(bid.slot, bid.parent_block_hash, bid.parent_block_root)`.
 - _[IGNORE]_ this bid is the highest value bid seen for the tuple
   `(bid.slot, bid.parent_block_hash, bid.parent_block_root)`.
@@ -439,8 +439,8 @@ where `store` is the fork choice store, and the alias
   `is_gas_limit_target_compatible(parent_gas_limit, bid.gas_limit, proposer_preferences.target_gas_limit)`
   is `True` where `parent_gas_limit` is the `gas_limit` of that execution
   payload.
-- _[IGNORE]_The bid mimicks what this node would propose for, i.e.
-   `is_bid_on_current_head(store, bid)` returns `True`. 
+- _[IGNORE]_ The bid mimics what this node would propose for, i.e.
+  `is_bid_on_current_head(store, bid)` returns `True`.
 - _[REJECT]_ The bid is for a higher slot than its parent block -- i.e. validate
   that `bid.slot` is greater than the slot of the block with root
   `bid.parent_block_root`.
@@ -470,25 +470,26 @@ def is_gas_limit_target_compatible(
 
 ```python
 def is_bid_on_current_head(store: Store, bid: ExecutionPayloadBid) -> bool:
-    """ 
+    """
     Check if ``bid`` has the same parent information as this node would propose.
     """
     head_node = get_head(store)
     head_block = store.blocks[head_node.root]
+    head_bid = head_block.body.signed_execution_payload_bid.message
     parent_root = head_block.parent_root
     parent_block = store.blocks[parent_root]
-    parent_payload_status = get_parent_payload_status(store, head_block)
-    parent_node = ForkChoiceNode(root=parent_root, payload_status=parent_payload_status)
 
     head_late = is_head_late(store, head_node.root)
     ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
-    finalization_ok = is_finalization_ok(store, slot)
+    finalization_ok = is_finalization_ok(store, bid.slot)
     parent_slot_ok = parent_block.slot + 1 == head_block.slot
-    single_slot_reorg = head_block.slot + 1 == bid.slot
+    current_time_ok = head_block.slot + 1 == bid.slot
+    single_slot_reorg = parent_slot_ok and current_time_ok
     head_weak = is_head_weak(store, head_node.root)
     parent_strong = is_parent_strong(store, head_node.root)
-    bid_on_parent = bid.parent_block_root == parent_root and 
-        bid.parent_block_hash == head_block.body.signed_execution_payload_bid.message.parent_block_hash
+    bid_on_parent = (
+        bid.parent_block_root == parent_root and bid.parent_block_hash == head_bid.parent_block_hash
+    )
     if all([
         head_late,
         ffg_competitive,
@@ -498,15 +499,14 @@ def is_bid_on_current_head(store: Store, bid: ExecutionPayloadBid) -> bool:
         parent_strong,
     ]):
         return bid_on_parent
-    if bid.parent_block_root != head_node.root: 
-        return false
+    if bid.parent_block_root != head_node.root:
+        return False
     if should_build_on_full(store, head_node):
-        return bid.parent_block_hash == head_bock.body.signed_execution_payload_bid.message.block_hash 
+        return bid.parent_block_hash == head_bid.block_hash
     else:
-        return bid.parent_block_hash == head_bock.body.signed_execution_payload_bid.message.parent_block_hash 
+        return bid.parent_block_hash == head_bid.parent_block_hash
 ```
 
- 
 *Note*: Implementations SHOULD include DoS prevention measures to mitigate spam
 from malicious builders submitting numerous bids with minimal value increments.
 Possible strategies include: (1) only forwarding bids that exceed the current

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -469,6 +469,34 @@ def is_gas_limit_target_compatible(
 ```
 
 ```python
+def should_reorg_head(store: Store, head_root: Root, slot: Slot) -> bool:
+    """
+    Check if this node would re-org the head block when proposing at ``slot``.
+    """
+    head_block = store.blocks[head_root]
+    parent_root = head_block.parent_root
+    parent_block = store.blocks[parent_root]
+
+    head_late = is_head_late(store, head_root)
+    ffg_competitive = is_ffg_competitive(store, head_root, parent_root)
+    finalization_ok = is_finalization_ok(store, slot)
+    parent_slot_ok = parent_block.slot + Slot(1) == head_block.slot
+    current_time_ok = head_block.slot + Slot(1) == slot
+    single_slot_reorg = parent_slot_ok and current_time_ok
+    head_weak = is_head_weak(store, head_root)
+    parent_strong = is_parent_strong(store, head_root)
+
+    return all([
+        head_late,
+        ffg_competitive,
+        finalization_ok,
+        single_slot_reorg,
+        head_weak,
+        parent_strong,
+    ])
+```
+
+```python
 def is_bid_on_current_head(store: Store, bid: ExecutionPayloadBid) -> bool:
     """
     Check if ``bid`` has the same parent information as this node would propose.
@@ -476,35 +504,20 @@ def is_bid_on_current_head(store: Store, bid: ExecutionPayloadBid) -> bool:
     head_node = get_head(store)
     head_block = store.blocks[head_node.root]
     head_bid = head_block.body.signed_execution_payload_bid.message
-    parent_root = head_block.parent_root
-    parent_block = store.blocks[parent_root]
 
-    head_late = is_head_late(store, head_node.root)
-    ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
-    finalization_ok = is_finalization_ok(store, bid.slot)
-    parent_slot_ok = parent_block.slot + 1 == head_block.slot
-    current_time_ok = head_block.slot + 1 == bid.slot
-    single_slot_reorg = parent_slot_ok and current_time_ok
-    head_weak = is_head_weak(store, head_node.root)
-    parent_strong = is_parent_strong(store, head_node.root)
-    bid_on_parent = (
-        bid.parent_block_root == parent_root and bid.parent_block_hash == head_bid.parent_block_hash
-    )
-    if all([
-        head_late,
-        ffg_competitive,
-        finalization_ok,
-        single_slot_reorg,
-        head_weak,
-        parent_strong,
-    ]):
-        return bid_on_parent
-    if bid.parent_block_root != head_node.root:
+    builds_on_parent_block = bid.parent_block_root == head_block.parent_root
+    builds_on_parent_payload = bid.parent_block_hash == head_bid.parent_block_hash
+    builds_on_head_block = bid.parent_block_root == head_node.root
+    builds_on_head_payload = bid.parent_block_hash == head_bid.block_hash
+
+    if should_reorg_head(store, head_node.root, bid.slot):
+        return builds_on_parent_block and builds_on_parent_payload
+    if not builds_on_head_block:
         return False
     if should_build_on_full(store, head_node, bid.slot):
-        return bid.parent_block_hash == head_bid.block_hash
-    else:
-        return bid.parent_block_hash == head_bid.parent_block_hash
+        return builds_on_head_payload
+
+    return builds_on_parent_payload
 ```
 
 *Note*: Implementations SHOULD include DoS prevention measures to mitigate spam

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -212,8 +212,8 @@ top of a `state` MUST take the following actions in order to construct the
   - The `bid.slot` is for the proposal block slot.
   - The `bid.parent_block_hash` equals
     `state.latest_execution_payload_bid.block_hash` if
-    `should_build_on_full(store, head)` is true, otherwise
-    `state.latest_execution_payload_bid.parent_block_hash`.
+    `should_build_on_full(store, head, get_current_slot(store))` is true,
+    otherwise `state.latest_execution_payload_bid.parent_block_hash`.
   - The `bid.parent_block_root` equals the current block's `parent_root`.
   - The `bid.prev_randao` equals
     `get_randao_mix(state, get_current_epoch(state))`.
@@ -248,9 +248,9 @@ parent's execution payload. The proposer constructs this field as follows:
 
 - If the parent block is pre-Gloas (first Gloas block), set
   `parent_execution_requests` to an empty `ExecutionRequests()`.
-- If `should_build_on_full(store, head)` returns `True` (the proposer is
-  building on the parent's full payload), set `parent_execution_requests` to
-  `store.payloads[head.root].execution_requests`.
+- If `should_build_on_full(store, head, get_current_slot(store))` returns `True`
+  (the proposer is building on the parent's full payload), set
+  `parent_execution_requests` to `store.payloads[head.root].execution_requests`.
 - Otherwise (the proposer is building on the parent's empty variant), set
   `parent_execution_requests` to an empty `ExecutionRequests()`.
 
@@ -319,10 +319,11 @@ def get_execution_requests(execution_requests_list: Sequence[bytes]) -> Executio
 ##### ExecutionPayload
 
 *Note*: `prepare_execution_payload` is modified to build on the parent's full
-payload or its empty variant, as decided by `should_build_on_full(store, head)`,
-which determines the withdrawals source and the execution head for the new
-payload. When building on a full parent, `apply_parent_execution_payload` is
-called so that withdrawals are computed against the post-processing state.
+payload or its empty variant, as decided by
+`should_build_on_full(store, head, get_current_slot(store))`, which determines
+the withdrawals source and the execution head for the new payload. When building
+on a full parent, `apply_parent_execution_payload` is called so that withdrawals
+are computed against the post-processing state.
 
 ```python
 def prepare_execution_payload(
@@ -340,7 +341,7 @@ def prepare_execution_payload(
 ) -> Optional[PayloadId]:
     # [New in Gloas:EIP7732]
     parent_bid = state.latest_execution_payload_bid
-    if should_build_on_full(store, head):
+    if should_build_on_full(store, head, get_current_slot(store)):
         envelope = store.payloads[head.root]
         # Make a copy of the state to avoid mutability issues
         state = copy(state)

--- a/specs/heze/validator.md
+++ b/specs/heze/validator.md
@@ -145,7 +145,7 @@ def prepare_execution_payload(
     execution_engine: ExecutionEngine,
 ) -> Optional[PayloadId]:
     parent_bid = state.latest_execution_payload_bid
-    if should_build_on_full(store, head):
+    if should_build_on_full(store, head, get_current_slot(store)):
         envelope = store.payloads[head.root]
         # Make a copy of the state to avoid mutability issues
         state = copy(state)


### PR DESCRIPTION
The rationale for this PR is as follows. By allowing bids for branches that are not compatible with the head view, nodes will allow arbitrary messages on a global topic. Filtering by bid price is not useful since the builder can submit bids with arbitrarily large bids as they won't be includable by any honest proposer. 

The alternative is to allow bids for arbitrary branches but restricting the number of bids per builder, it opens that DOS door, but it lacks the complexity of this PR. 

The biggest drawback of this PR is that in order for account for the possibility of honest CL reorgs, the node needs to process attestations before the next slot, every slot, and run forkchoice, something that nodes typically only do when they are proposing. After thinking over this for a while I believe the DOS may be even better than an extra forkchoice run at the end of the slot just for this. 

An alternative would be to only allow for the current head, but that does not cover the situation of proposer boost reorgs. 