### PR TITLE
Rename `Bitlist`/`Bitvector` to `BitList`/`BitVector`

### DIFF
--- a/pysetup/helpers.py
+++ b/pysetup/helpers.py
@@ -271,7 +271,7 @@ def combine_dicts(old_dict: dict[str, T], new_dict: dict[str, T]) -> dict[str, T
 
 ignored_dependencies = [
     "BitList",
-    "Bitvector",
+    "BitVector",
     "Boolean",
     "Byte",
     "ByteList",

--- a/pysetup/helpers.py
+++ b/pysetup/helpers.py
@@ -24,7 +24,7 @@ def collect_prev_forks(fork: str) -> list[str]:
 
 def requires_mypy_type_ignore(value: str) -> bool:
     return (
-        value.startswith(("Bitlist", "ByteVector"))
+        value.startswith(("BitList", "ByteVector"))
         or (value.startswith("List") and not re.match(r"^List\[\w+,\s*\w+\]$", value))
         or (value.startswith("Vector") and any(k in value for k in ["ceillog2", "floorlog2"]))
     )
@@ -270,7 +270,7 @@ def combine_dicts(old_dict: dict[str, T], new_dict: dict[str, T]) -> dict[str, T
 
 
 ignored_dependencies = [
-    "Bitlist",
+    "BitList",
     "Bitvector",
     "Boolean",
     "Byte",
@@ -296,7 +296,7 @@ ignored_dependencies = [
     "list",
     "List",
     "Optional",
-    "ProgressiveBitlist",
+    "ProgressiveBitList",
     "ProgressiveByteList",
     "ProgressiveList",
     "Sequence",

--- a/pysetup/md_to_spec.py
+++ b/pysetup/md_to_spec.py
@@ -205,13 +205,13 @@ class MarkdownToSpec:
                 if value.startswith(
                     (
                         "Uint",
-                        "Bitlist",
+                        "BitList",
                         "Bitvector",
                         "ByteList",
                         "ByteVector",
                         "Bytes",
                         "List",
-                        "ProgressiveBitlist",
+                        "ProgressiveBitList",
                         "ProgressiveByteList",
                         "ProgressiveList",
                         "Union",

--- a/pysetup/md_to_spec.py
+++ b/pysetup/md_to_spec.py
@@ -206,7 +206,7 @@ class MarkdownToSpec:
                     (
                         "Uint",
                         "BitList",
-                        "Bitvector",
+                        "BitVector",
                         "ByteList",
                         "ByteVector",
                         "Bytes",

--- a/pysetup/spec_builders/gloas.py
+++ b/pysetup/spec_builders/gloas.py
@@ -9,7 +9,7 @@ class GloasSpecBuilder(BaseSpecBuilder):
     @classmethod
     def imports(cls, preset_name: str):
         return f"""
-from eth_consensus_specs.utils.ssz.ssz_typing import ProgressiveBitlist, ProgressiveByteList, ProgressiveContainer, ProgressiveList
+from eth_consensus_specs.utils.ssz.ssz_typing import ProgressiveBitList, ProgressiveByteList, ProgressiveContainer, ProgressiveList
 
 from eth_consensus_specs.fulu import {preset_name} as fulu
 """

--- a/pysetup/spec_builders/phase0.py
+++ b/pysetup/spec_builders/phase0.py
@@ -33,7 +33,7 @@ from eth_consensus_specs.utils.ssz.ssz_impl import hash_tree_root, copy, uint_to
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     View, Boolean, Container, List, Vector, Uint8, Uint32, Uint64, Uint256,
     Bytes1, Bytes4, Bytes20, Bytes32, Bytes48, Bytes96, BitList)
-from eth_consensus_specs.utils.ssz.ssz_typing import Bitvector  # noqa: F401
+from eth_consensus_specs.utils.ssz.ssz_typing import BitVector  # noqa: F401
 from eth_consensus_specs.utils import bls
 from eth_consensus_specs.utils.hash_function import hash
 """

--- a/pysetup/spec_builders/phase0.py
+++ b/pysetup/spec_builders/phase0.py
@@ -32,7 +32,7 @@ from typing import (
 from eth_consensus_specs.utils.ssz.ssz_impl import hash_tree_root, copy, uint_to_bytes
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     View, Boolean, Container, List, Vector, Uint8, Uint32, Uint64, Uint256,
-    Bytes1, Bytes4, Bytes20, Bytes32, Bytes48, Bytes96, Bitlist)
+    Bytes1, Bytes4, Bytes20, Bytes32, Bytes48, Bytes96, BitList)
 from eth_consensus_specs.utils.ssz.ssz_typing import Bitvector  # noqa: F401
 from eth_consensus_specs.utils import bls
 from eth_consensus_specs.utils.hash_function import hash

--- a/specs/_features/eip8148/beacon-chain.md
+++ b/specs/_features/eip8148/beacon-chain.md
@@ -103,7 +103,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 47)):
     slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
     previous_epoch_participation: ProgressiveList[ParticipationFlags]
     current_epoch_participation: ProgressiveList[ParticipationFlags]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
@@ -126,7 +126,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 47)):
     proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
     builders: ProgressiveList[Builder]
     next_withdrawal_builder_index: BuilderIndex
-    execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
+    execution_payload_availability: BitVector[SLOTS_PER_HISTORICAL_ROOT]
     builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
     builder_pending_withdrawals: ProgressiveList[BuilderPendingWithdrawal]
     latest_execution_payload_bid: ExecutionPayloadBid

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -176,7 +176,7 @@ class BeaconState(Container):
     previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
     # [Modified in Altair]
     current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
@@ -194,7 +194,7 @@ class BeaconState(Container):
 
 ```python
 class SyncAggregate(Container):
-    sync_committee_bits: Bitvector[SYNC_COMMITTEE_SIZE]
+    sync_committee_bits: BitVector[SYNC_COMMITTEE_SIZE]
     sync_committee_signature: BLSSignature
 ```
 

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -125,8 +125,8 @@ communicate the sync committee subnet subscriptions:
 ```
 (
   seq_number: Uint64
-  attnets: Bitvector[ATTESTATION_SUBNET_COUNT]
-  syncnets: Bitvector[SYNC_COMMITTEE_SUBNET_COUNT]
+  attnets: BitVector[ATTESTATION_SUBNET_COUNT]
+  syncnets: BitVector[SYNC_COMMITTEE_SUBNET_COUNT]
 )
 ```
 
@@ -134,7 +134,7 @@ Where
 
 - `seq_number` and `attnets` have the same meaning defined in the Phase 0
   document.
-- `syncnets` is a `Bitvector` representing the node's sync committee subnet
+- `syncnets` is a `BitVector` representing the node's sync committee subnet
   subscriptions. This field should mirror the data in the node's ENR as outlined
   in the [validator guide](./validator.md#sync-committee-subnet-stability).
 
@@ -546,7 +546,7 @@ topic.
 
 | Key        | Value                                        |
 | ---------- | -------------------------------------------- |
-| `syncnets` | SSZ `Bitvector[SYNC_COMMITTEE_SUBNET_COUNT]` |
+| `syncnets` | SSZ `BitVector[SYNC_COMMITTEE_SUBNET_COUNT]` |
 
 See the [validator document](./validator.md#sync-committee-subnet-stability) for
 further details on how the new bits are used.

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -107,7 +107,7 @@ class SyncCommitteeContribution(Container):
     slot: Slot
     beacon_block_root: Root
     subcommittee_index: Uint64
-    aggregation_bits: Bitvector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]
+    aggregation_bits: BitVector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]
     signature: BLSSignature
 ```
 
@@ -257,7 +257,7 @@ select the best contribution seen across all aggregators for each
 subnet/subcommittee. A contribution with more valid signatures is better than a
 contribution with fewer signatures.
 
-Recall `block.body.sync_aggregate.sync_committee_bits` is a `Bitvector` where
+Recall `block.body.sync_aggregate.sync_committee_bits` is a `BitVector` where
 the `i`th bit is `True` if the corresponding validator in the sync committee has
 produced a valid signature, and that
 `block.body.sync_aggregate.sync_committee_signature` is the aggregate BLS
@@ -477,8 +477,8 @@ the `subnet_id` used to derive the topic name.
 ###### Aggregation bits
 
 Let `contribution.aggregation_bits` be a
-`Bitvector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]`, where the
-`index`th bit is set in the `Bitvector` for each corresponding validator
+`BitVector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]`, where the
+`index`th bit is set in the `BitVector` for each corresponding validator
 included in this aggregate from the corresponding subcommittee. An aggregator
 finds the index in the sync committee (as determined by a reverse pubkey lookup
 on `state.current_sync_committee.pubkeys`) for a given validator referenced by
@@ -488,7 +488,7 @@ index within the subcommittee is set in `contribution.aggregation_bits`.
 
 For example, if a validator with index `2044` is pseudo-randomly sampled to sync
 committee index `135`. This sync committee index maps to `subcommittee_index`
-`1` with position `7` in the `Bitvector` for the contribution.
+`1` with position `7` in the `BitVector` for the contribution.
 
 *Note*: A validator **could be included multiple times** in a given subcommittee
 such that multiple bits are set for a single `SyncCommitteeMessage`.

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -138,7 +138,7 @@ class BeaconState(Container):
     slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
     previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
     current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -230,7 +230,7 @@ class BeaconState(Container):
     slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
     previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
     current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -206,7 +206,7 @@ class BeaconState(Container):
     slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
     previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
     current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -131,7 +131,7 @@ Electra is a consensus-layer upgrade containing a number of features. Including:
 
 | Name                    | SSZ equivalent                                                                 | Description                                                       |
 | ----------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| `AggregationBits`       | `Bitlist[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]`              | Combined participation info for all participating committees      |
+| `AggregationBits`       | `BitList[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]`              | Combined participation info for all participating committees      |
 | `AttestingIndices`      | `List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]` | List of attesting validator indices                               |
 | `DepositRequests`       | `List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]`                       | List of deposit requests pertaining to an execution payload       |
 | `WithdrawalRequests`    | `List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]`                 | List of withdrawal requests pertaining to an execution payload    |

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -367,7 +367,7 @@ class Attestation(Container):
     data: AttestationData
     signature: BLSSignature
     # [New in Electra:EIP7549]
-    committee_bits: Bitvector[MAX_COMMITTEES_PER_SLOT]
+    committee_bits: BitVector[MAX_COMMITTEES_PER_SLOT]
 ```
 
 #### `IndexedAttestation`
@@ -401,7 +401,7 @@ class BeaconState(Container):
     slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
     previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
     current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
@@ -594,7 +594,7 @@ def is_eligible_for_partial_withdrawals(validator: Validator, balance: Gwei) -> 
 #### New `get_committee_indices`
 
 ```python
-def get_committee_indices(committee_bits: Bitvector) -> Sequence[CommitteeIndex]:
+def get_committee_indices(committee_bits: BitVector) -> Sequence[CommitteeIndex]:
     return [CommitteeIndex(index) for index, bit in enumerate(committee_bits) if bit]
 ```
 

--- a/specs/electra/validator.md
+++ b/specs/electra/validator.md
@@ -133,7 +133,7 @@ def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Att
 
     committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
     committee_flags = [(index in committee_indices) for index in range(MAX_COMMITTEES_PER_SLOT)]
-    committee_bits = Bitvector[MAX_COMMITTEES_PER_SLOT](committee_flags)
+    committee_bits = BitVector[MAX_COMMITTEES_PER_SLOT](committee_flags)
 
     return Attestation(
         aggregation_bits=aggregation_bits,
@@ -291,5 +291,5 @@ updated field assignments:
   `len(committee)` with the bits corresponding to the `attester_index` of each
   `SingleAttestation` input set to `0b1`.
 - Set `aggregate_attestation.committee_bits` to a
-  `Bitvector[MAX_COMMITTEES_PER_SLOT]` with the single bit corresponding to the
+  `BitVector[MAX_COMMITTEES_PER_SLOT]` with the single bit corresponding to the
   shared `committee_index` across all `SingleAttestation` inputs set to `0b1`.

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -222,7 +222,7 @@ class BeaconState(Container):
     slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
     previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
     current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -234,8 +234,8 @@ communicate the custody group count.
 ```
 (
   seq_number: Uint64
-  attnets: Bitvector[ATTESTATION_SUBNET_COUNT]
-  syncnets: Bitvector[SYNC_COMMITTEE_SUBNET_COUNT]
+  attnets: BitVector[ATTESTATION_SUBNET_COUNT]
+  syncnets: BitVector[SYNC_COMMITTEE_SUBNET_COUNT]
   custody_group_count: Uint64 # cgc
 )
 ```

--- a/specs/fulu/partial-columns/p2p-interface.md
+++ b/specs/fulu/partial-columns/p2p-interface.md
@@ -51,7 +51,7 @@ except that only the cells and proofs identified by the bitmap are present.
 
 ```python
 class PartialDataColumnSidecar(Container):
-    cells_present_bitmap: Bitlist[MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    cells_present_bitmap: BitList[MAX_BLOB_COMMITMENTS_PER_BLOCK]
     partial_column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     # Optional header, only sent on eager pushes
@@ -71,8 +71,8 @@ This is encoded as the following SSZ container:
 
 ```python
 class PartialDataColumnPartsMetadata(Container):
-    available: Bitlist[MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    requests: Bitlist[MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    available: BitList[MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    requests: BitList[MAX_BLOB_COMMITMENTS_PER_BLOCK]
 ```
 
 This means that for each cell there are two bits of state. Where the first bit

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -146,7 +146,7 @@ from the latest published version of the EIPs.
 
 | Name                     | SSZ equivalent                           |
 | ------------------------ | ---------------------------------------- |
-| `AggregationBits`        | `ProgressiveBitlist`                     |
+| `AggregationBits`        | `ProgressiveBitList`                     |
 | `AttestingIndices`       | `ProgressiveList[ValidatorIndex]`        |
 | `Transaction`            | `ProgressiveByteList`                    |
 | `DepositRequests`        | `ProgressiveList[DepositRequest]`        |

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -314,7 +314,7 @@ class PayloadAttestationData(Container):
 
 ```python
 class PayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):
-    aggregation_bits: Bitvector[PTC_SIZE]
+    aggregation_bits: BitVector[PTC_SIZE]
     data: PayloadAttestationData
     signature: BLSSignature
 ```
@@ -392,7 +392,7 @@ class Attestation(ProgressiveContainer(active_fields=[1] * 4)):
     aggregation_bits: AggregationBits
     data: AttestationData
     signature: BLSSignature
-    committee_bits: Bitvector[MAX_COMMITTEES_PER_SLOT]
+    committee_bits: BitVector[MAX_COMMITTEES_PER_SLOT]
 ```
 
 #### `IndexedAttestation`
@@ -469,7 +469,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):
     previous_epoch_participation: ProgressiveList[ParticipationFlags]
     # [Modified in Gloas:EIP7688]
     current_epoch_participation: ProgressiveList[ParticipationFlags]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
@@ -502,7 +502,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):
     # [New in Gloas:EIP7732]
     next_withdrawal_builder_index: BuilderIndex
     # [New in Gloas:EIP7732]
-    execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
+    execution_payload_availability: BitVector[SLOTS_PER_HISTORICAL_ROOT]
     # [New in Gloas:EIP7732]
     builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
     # [New in Gloas:EIP7732]

--- a/specs/gloas/partial-columns/p2p-interface.md
+++ b/specs/gloas/partial-columns/p2p-interface.md
@@ -46,7 +46,7 @@ and the [Gloas networking specification](../p2p-interface.md).
 
 ```python
 class PartialDataColumnSidecar(Container):
-    cells_present_bitmap: ProgressiveBitlist
+    cells_present_bitmap: ProgressiveBitList
     partial_column: ProgressiveList[Cell]
     kzg_proofs: ProgressiveList[KZGProof]
     # [Modified in Gloas:EIP7732]

--- a/specs/heze/beacon-chain.md
+++ b/specs/heze/beacon-chain.md
@@ -93,7 +93,7 @@ class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 13)):
     blob_kzg_commitments: ProgressiveList[KZGCommitment]
     execution_requests_root: Root
     # [New in Heze:EIP7805]
-    inclusion_list_bits: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]
+    inclusion_list_bits: BitVector[INCLUSION_LIST_COMMITTEE_SIZE]
 ```
 
 #### `SignedExecutionPayloadBid`
@@ -126,7 +126,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):
     slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
     previous_epoch_participation: ProgressiveList[ParticipationFlags]
     current_epoch_participation: ProgressiveList[ParticipationFlags]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
@@ -149,7 +149,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):
     proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
     builders: ProgressiveList[Builder]
     next_withdrawal_builder_index: BuilderIndex
-    execution_payload_availability: Bitvector[SLOTS_PER_HISTORICAL_ROOT]
+    execution_payload_availability: BitVector[SLOTS_PER_HISTORICAL_ROOT]
     builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
     builder_pending_withdrawals: ProgressiveList[BuilderPendingWithdrawal]
     # [Modified in Heze:EIP7805]

--- a/specs/heze/fork.md
+++ b/specs/heze/fork.md
@@ -49,7 +49,7 @@ def upgrade_to_heze(pre: gloas.BeaconState) -> BeaconState:
         blob_kzg_commitments=pre.latest_execution_payload_bid.blob_kzg_commitments,
         execution_requests_root=pre.latest_execution_payload_bid.execution_requests_root,
         # [New in Heze:EIP7805]
-        inclusion_list_bits=Bitvector[INCLUSION_LIST_COMMITTEE_SIZE](),
+        inclusion_list_bits=BitVector[INCLUSION_LIST_COMMITTEE_SIZE](),
     )
 
     post = BeaconState(

--- a/specs/heze/inclusion-list.md
+++ b/specs/heze/inclusion-list.md
@@ -125,9 +125,9 @@ def get_inclusion_list_transactions(
 ```python
 def get_inclusion_list_bits(
     store: InclusionListStore, state: BeaconState, slot: Slot, only_timely: bool = True
-) -> Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]:
+) -> BitVector[INCLUSION_LIST_COMMITTEE_SIZE]:
     """
-    Return a ``Bitvector`` over inclusion list committee indices with bits set
+    Return a ``BitVector`` over inclusion list committee indices with bits set
     for those who provided valid, non-equivocating inclusion lists for the given ``slot``.
     """
     committee = get_inclusion_list_committee(state, slot)
@@ -144,7 +144,7 @@ def get_inclusion_list_bits(
         if not only_timely or timeliness[inclusion_list_root]
     ]
 
-    return Bitvector[INCLUSION_LIST_COMMITTEE_SIZE](
+    return BitVector[INCLUSION_LIST_COMMITTEE_SIZE](
         validator_index in validator_indices for validator_index in committee
     )
 ```
@@ -156,7 +156,7 @@ def is_inclusion_list_bits_inclusive(
     store: InclusionListStore,
     state: BeaconState,
     slot: Slot,
-    inclusion_list_bits: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE],
+    inclusion_list_bits: BitVector[INCLUSION_LIST_COMMITTEE_SIZE],
     only_timely: bool = True,
 ) -> bool:
     """

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -184,7 +184,7 @@ Request Content:
 (
   slot: Slot
   inclusion_list_committee_root: Root
-  indices: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]
+  indices: BitVector[INCLUSION_LIST_COMMITTEE_SIZE]
 )
 ```
 

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -578,7 +578,7 @@ class BeaconState(Container):
     slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
     previous_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
     current_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
-    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]
+    justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
     previous_justified_checkpoint: Checkpoint
     current_justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -420,7 +420,7 @@ class IndexedAttestation(Container):
 
 ```python
 class PendingAttestation(Container):
-    aggregation_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE]
+    aggregation_bits: BitList[MAX_VALIDATORS_PER_COMMITTEE]
     data: AttestationData
     inclusion_delay: Slot
     proposer_index: ValidatorIndex
@@ -505,7 +505,7 @@ class AttesterSlashing(Container):
 
 ```python
 class Attestation(Container):
-    aggregation_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE]
+    aggregation_bits: BitList[MAX_VALIDATORS_PER_COMMITTEE]
     data: AttestationData
     signature: BLSSignature
 ```

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -390,7 +390,7 @@ Clients MUST locally store the following `MetaData`:
 ```
 (
   seq_number: Uint64
-  attnets: Bitvector[ATTESTATION_SUBNET_COUNT]
+  attnets: BitVector[ATTESTATION_SUBNET_COUNT]
 )
 ```
 
@@ -399,7 +399,7 @@ Where
 - `seq_number` is a `Uint64` starting at `0` used to version the node's
   metadata. If any other field in the local `MetaData` changes, the node MUST
   increment `seq_number` by 1.
-- `attnets` is a `Bitvector` representing the node's persistent attestation
+- `attnets` is a `BitVector` representing the node's persistent attestation
   subnet subscriptions.
 
 *Note*: `MetaData.seq_number` is used for versioning of the node's metadata, is
@@ -1661,7 +1661,7 @@ attestation gossip subnets.
 
 | Key       | Value                                     |
 | --------- | ----------------------------------------- |
-| `attnets` | SSZ `Bitvector[ATTESTATION_SUBNET_COUNT]` |
+| `attnets` | SSZ `BitVector[ATTESTATION_SUBNET_COUNT]` |
 
 If a node's `MetaData.attnets` has any non-zero bit, the ENR MUST include the
 `attnets` entry with the same value as `MetaData.attnets`.

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -666,7 +666,7 @@ Set `attestation.data = attestation_data` where `attestation_data` is the
 ##### Aggregation bits
 
 - Let `attestation.aggregation_bits` be a
-  `Bitlist[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where the
+  `BitList[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where the
   bit of the index of the validator in the `committee` is set to `0b1`.
 
 *Note*: Calling `get_attesting_indices(state, attestation)` should return a list
@@ -757,7 +757,7 @@ being aggregated.
 ##### Aggregation bits
 
 Let `aggregate_attestation.aggregation_bits` be a
-`Bitlist[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where each
+`BitList[MAX_VALIDATORS_PER_COMMITTEE]` of length `len(committee)`, where each
 bit set from each individual attestation is set to `0b1`.
 
 ##### Aggregate signature

--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -64,7 +64,7 @@ def merkle_tree(leaves: Sequence[Bytes32]) -> Sequence[Bytes32]:
 ```
 
 We define a custom type `GeneralizedIndex` as a Python integer type in this
-document. It can be represented as a Bitvector/Bitlist object as well.
+document. It can be represented as a Bitvector/BitList object as well.
 
 We will define Merkle proofs in terms of generalized indices.
 

--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -64,7 +64,7 @@ def merkle_tree(leaves: Sequence[Bytes32]) -> Sequence[Bytes32]:
 ```
 
 We define a custom type `GeneralizedIndex` as a Python integer type in this
-document. It can be represented as a Bitvector/BitList object as well.
+document. It can be represented as a BitVector/BitList object as well.
 
 We will define Merkle proofs in terms of generalized indices.
 

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -17,7 +17,7 @@
   - [`UintN`](#uintn)
   - [`Boolean`](#boolean)
   - [`Bitvector[N]`](#bitvectorn)
-  - [`Bitlist[N]`, `ProgressiveBitlist`](#bitlistn-progressivebitlist)
+  - [`BitList[N]`, `ProgressiveBitList`](#bitlistn-progressivebitlist)
   - [Vectors, containers, progressive containers, lists, progressive lists](#vectors-containers-progressive-containers-lists-progressive-lists)
   - [Union](#union)
   - [Compatible unions](#compatible-unions)
@@ -81,10 +81,10 @@
   - notation `Bitvector[N]`
 - **bitlist**: ordered variable-length collection of `Boolean` values, limited
   to `N` bits
-  - notation `Bitlist[N]`
+  - notation `BitList[N]`
 - **progressive bitlist** _[EIP-7916]_: ordered variable-length collection of
   `Boolean` values, without limit
-  - notation `ProgressiveBitlist`
+  - notation `ProgressiveBitList`
 - **union**: union type containing one of the given subtypes
   - notation `Union[type_0, type_1, ...]`, e.g. `union[None, Uint64, Uint32]`
 - **compatible union** _[EIP-8016, currently unused]_: union type containing one
@@ -94,8 +94,8 @@
 
 *Note*: Both `Vector[Boolean, N]` and `Bitvector[N]` are valid, yet distinct due
 to their different serialization requirements. Similarly, both
-`List[Boolean, N]` and `Bitlist[N]` are valid, yet distinct. Generally
-`Bitvector[N]`/`Bitlist[N]` are preferred because of their serialization
+`List[Boolean, N]` and `BitList[N]` are valid, yet distinct. Generally
+`Bitvector[N]`/`BitList[N]` are preferred because of their serialization
 efficiencies.
 
 ### Variable-size and fixed-size
@@ -136,8 +136,8 @@ Assuming a helper function `default(type)` which returns the default value for
 | `Bitvector[N]`                        | `[False] * N`                                       |
 | `List[type, N]`                       | `[]`                                                |
 | `ProgressiveList[type]`               | `[]`                                                |
-| `Bitlist[N]`                          | `[]`                                                |
-| `ProgressiveBitlist`                  | `[]`                                                |
+| `BitList[N]`                          | `[]`                                                |
+| `ProgressiveBitList`                  | `[]`                                                |
 | `Union[type_0, type_1, ...]`          | `default(type_0)`                                   |
 | `CompatibleUnion({selector: type})`   | n/a (error)                                         |
 
@@ -169,7 +169,7 @@ is equal to the default value for that type.
 
 - Types are compatible with themselves.
 - `Byte` is compatible with `Uint8` and vice versa.
-- `Bitlist[N]` are compatible if they share the same capacity `N`.
+- `BitList[N]` are compatible if they share the same capacity `N`.
 - `Bitvector[N]` are compatible if they share the same capacity `N`.
 - `List[type, N]` are compatible if `type` is compatible and they share the same
   capacity `N`.
@@ -216,7 +216,7 @@ for i in range(N):
 return bytes(array)
 ```
 
-### `Bitlist[N]`, `ProgressiveBitlist`
+### `BitList[N]`, `ProgressiveBitList`
 
 Note that from the offset coding, the length (in bytes) of the bitlist is known.
 An additional `1` bit is added to the end, at index `e` where `e` is the length
@@ -348,7 +348,7 @@ We first define helper functions:
 - `chunk_count(type)`: calculate the amount of leaves for merkleization of the
   type.
   - all basic types: `1`
-  - `Bitlist[N]` and `Bitvector[N]`: `(N + 255) // 256` (dividing by chunk size,
+  - `BitList[N]` and `Bitvector[N]`: `(N + 255) // 256` (dividing by chunk size,
     rounding up)
   - `List[B, N]` and `Vector[B, N]`, where `B` is a basic type:
     `(N * size_of(B) + 31) // 32` (dividing by chunk size, rounding up)
@@ -471,8 +471,8 @@ value. Parsers may ignore additional JSON fields.
 | `List[Byte, N]`                       | hex-byte-string | `"0x1122"`                               |
 | `ProgressiveList[type]`               | array           | `[element, ...]`                         |
 | `ProgressiveList[Byte]`               | hex-byte-string | `"0x1122"`                               |
-| `Bitlist[N]`                          | hex-byte-string | `"0x1122"`                               |
-| `ProgressiveBitlist`                  | hex-byte-string | `"0x1122"`                               |
+| `BitList[N]`                          | hex-byte-string | `"0x1122"`                               |
+| `ProgressiveBitList`                  | hex-byte-string | `"0x1122"`                               |
 | `Union[type_0, type_1, ...]`          | selector-object | `{ "selector": string, "data": type_N }` |
 | `CompatibleUnion({selector: type})`   | selector-object | `{ "selector": string, "data": type }`   |
 
@@ -484,7 +484,7 @@ Aliases are encoded as their underlying type.
 appear in an SSZ stream.
 
 `List`, `ProgressiveList`, and `Vector` of `Byte` (and aliases thereof) are
-encoded as `hex-byte-string`. `Bitlist`, `ProgressiveBitlist`, and `Bitvector`
+encoded as `hex-byte-string`. `BitList`, `ProgressiveBitList`, and `Bitvector`
 similarly map their SSZ-byte encodings to a `hex-byte-string`.
 
 `Union` and `CompatibleUnion` are encoded as an object with a `selector` and

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -16,7 +16,7 @@
 - [Serialization](#serialization)
   - [`UintN`](#uintn)
   - [`Boolean`](#boolean)
-  - [`Bitvector[N]`](#bitvectorn)
+  - [`BitVector[N]`](#bitvectorn)
   - [`BitList[N]`, `ProgressiveBitList`](#bitlistn-progressivebitlist)
   - [Vectors, containers, progressive containers, lists, progressive lists](#vectors-containers-progressive-containers-lists-progressive-lists)
   - [Union](#union)
@@ -78,7 +78,7 @@
   - notation `ProgressiveList[type]`, e.g. `ProgressiveList[Uint64]`
 - **bitvector**: ordered fixed-length collection of `Boolean` values, with `N`
   bits
-  - notation `Bitvector[N]`
+  - notation `BitVector[N]`
 - **bitlist**: ordered variable-length collection of `Boolean` values, limited
   to `N` bits
   - notation `BitList[N]`
@@ -92,10 +92,10 @@
   - notation `CompatibleUnion({selector: type})`, e.g.
     `CompatibleUnion({1: Square, 2: Circle})`
 
-*Note*: Both `Vector[Boolean, N]` and `Bitvector[N]` are valid, yet distinct due
+*Note*: Both `Vector[Boolean, N]` and `BitVector[N]` are valid, yet distinct due
 to their different serialization requirements. Similarly, both
 `List[Boolean, N]` and `BitList[N]` are valid, yet distinct. Generally
-`Bitvector[N]`/`BitList[N]` are preferred because of their serialization
+`BitVector[N]`/`BitList[N]` are preferred because of their serialization
 efficiencies.
 
 ### Variable-size and fixed-size
@@ -133,7 +133,7 @@ Assuming a helper function `default(type)` which returns the default value for
 | `Container`                           | `[default(type) for type in container]`             |
 | `ProgressiveContainer(active_fields)` | `[default(type) for type in progressive_container]` |
 | `Vector[type, N]`                     | `[default(type)] * N`                               |
-| `Bitvector[N]`                        | `[False] * N`                                       |
+| `BitVector[N]`                        | `[False] * N`                                       |
 | `List[type, N]`                       | `[]`                                                |
 | `ProgressiveList[type]`               | `[]`                                                |
 | `BitList[N]`                          | `[]`                                                |
@@ -148,7 +148,7 @@ is equal to the default value for that type.
 
 ### Illegal types
 
-- Empty vector types (`Vector[type, 0]`, `Bitvector[0]`) are illegal.
+- Empty vector types (`Vector[type, 0]`, `BitVector[0]`) are illegal.
 - Containers with no fields are illegal.
 - `ProgressiveContainer` with no fields are illegal.
 - `ProgressiveContainer` with an `active_fields` configuration of more than 256
@@ -170,7 +170,7 @@ is equal to the default value for that type.
 - Types are compatible with themselves.
 - `Byte` is compatible with `Uint8` and vice versa.
 - `BitList[N]` are compatible if they share the same capacity `N`.
-- `Bitvector[N]` are compatible if they share the same capacity `N`.
+- `BitVector[N]` are compatible if they share the same capacity `N`.
 - `List[type, N]` are compatible if `type` is compatible and they share the same
   capacity `N`.
 - `Vector[type, N]` are compatible if `type` is compatible and they share the
@@ -207,7 +207,7 @@ assert value in (True, False)
 return b"\x01" if value is True else b"\x00"
 ```
 
-### `Bitvector[N]`
+### `BitVector[N]`
 
 ```python
 array = [0] * ((N + 7) // 8)
@@ -348,7 +348,7 @@ We first define helper functions:
 - `chunk_count(type)`: calculate the amount of leaves for merkleization of the
   type.
   - all basic types: `1`
-  - `BitList[N]` and `Bitvector[N]`: `(N + 255) // 256` (dividing by chunk size,
+  - `BitList[N]` and `BitVector[N]`: `(N + 255) // 256` (dividing by chunk size,
     rounding up)
   - `List[B, N]` and `Vector[B, N]`, where `B` is a basic type:
     `(N * size_of(B) + 31) // 32` (dividing by chunk size, rounding up)
@@ -466,7 +466,7 @@ value. Parsers may ignore additional JSON fields.
 | `ProgressiveContainer(active_fields)` | object          | `{ "field": ... }`                       |
 | `Vector[type, N]`                     | array           | `[element, ...]`                         |
 | `Vector[Byte, N]`                     | hex-byte-string | `"0x1122"`                               |
-| `Bitvector[N]`                        | hex-byte-string | `"0x1122"`                               |
+| `BitVector[N]`                        | hex-byte-string | `"0x1122"`                               |
 | `List[type, N]`                       | array           | `[element, ...]`                         |
 | `List[Byte, N]`                       | hex-byte-string | `"0x1122"`                               |
 | `ProgressiveList[type]`               | array           | `[element, ...]`                         |
@@ -484,7 +484,7 @@ Aliases are encoded as their underlying type.
 appear in an SSZ stream.
 
 `List`, `ProgressiveList`, and `Vector` of `Byte` (and aliases thereof) are
-encoded as `hex-byte-string`. `BitList`, `ProgressiveBitList`, and `Bitvector`
+encoded as `hex-byte-string`. `BitList`, `ProgressiveBitList`, and `BitVector`
 similarly map their SSZ-byte encodings to a `hex-byte-string`.
 
 `Union` and `CompatibleUnion` are encoded as an object with a `selector` and

--- a/tests/core/pyspec/eth_consensus_specs/debug/decode.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/decode.py
@@ -3,7 +3,7 @@ from typing import Any
 from eth_consensus_specs.utils.ssz.ssz_impl import deserialize, hash_tree_root
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     BitList,
-    Bitvector,
+    BitVector,
     Boolean,
     Byte,
     ByteList,
@@ -22,7 +22,7 @@ from eth_consensus_specs.utils.ssz.ssz_typing import (
 def decode(data: Any, typ):
     if issubclass(typ, Uint | Boolean):
         return typ(data)
-    elif issubclass(typ, BitList | ProgressiveBitList | Bitvector) or (
+    elif issubclass(typ, BitList | ProgressiveBitList | BitVector) or (
         issubclass(typ, ProgressiveList) and issubclass(typ.element_cls(), Byte)
     ):
         return deserialize(typ, bytes.fromhex(data[2:]))

--- a/tests/core/pyspec/eth_consensus_specs/debug/decode.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/decode.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from eth_consensus_specs.utils.ssz.ssz_impl import deserialize, hash_tree_root
 from eth_consensus_specs.utils.ssz.ssz_typing import (
-    Bitlist,
+    BitList,
     Bitvector,
     Boolean,
     Byte,
@@ -10,7 +10,7 @@ from eth_consensus_specs.utils.ssz.ssz_typing import (
     ByteVector,
     Container,
     List,
-    ProgressiveBitlist,
+    ProgressiveBitList,
     ProgressiveList,
     Uint,
     Union,
@@ -22,7 +22,7 @@ from eth_consensus_specs.utils.ssz.ssz_typing import (
 def decode(data: Any, typ):
     if issubclass(typ, Uint | Boolean):
         return typ(data)
-    elif issubclass(typ, Bitlist | ProgressiveBitlist | Bitvector) or (
+    elif issubclass(typ, BitList | ProgressiveBitList | Bitvector) or (
         issubclass(typ, ProgressiveList) and issubclass(typ.element_cls(), Byte)
     ):
         return deserialize(typ, bytes.fromhex(data[2:]))

--- a/tests/core/pyspec/eth_consensus_specs/debug/encode.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/encode.py
@@ -1,7 +1,7 @@
 from eth_consensus_specs.utils.ssz.ssz_impl import hash_tree_root, serialize
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     BitList,
-    Bitvector,
+    BitVector,
     Boolean,
     Byte,
     CompatibleUnion,
@@ -24,7 +24,7 @@ def encode(value, include_hash_tree_roots=False):
         return int(value)
     elif isinstance(value, Boolean):
         return value == 1
-    elif isinstance(value, BitList | ProgressiveBitList | Bitvector) or (
+    elif isinstance(value, BitList | ProgressiveBitList | BitVector) or (
         isinstance(value, ProgressiveList) and issubclass(value.element_cls(), Byte)
     ):
         return "0x" + serialize(value).hex()

--- a/tests/core/pyspec/eth_consensus_specs/debug/encode.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/encode.py
@@ -1,13 +1,13 @@
 from eth_consensus_specs.utils.ssz.ssz_impl import hash_tree_root, serialize
 from eth_consensus_specs.utils.ssz.ssz_typing import (
-    Bitlist,
+    BitList,
     Bitvector,
     Boolean,
     Byte,
     CompatibleUnion,
     Container,
     List,
-    ProgressiveBitlist,
+    ProgressiveBitList,
     ProgressiveContainer,
     ProgressiveList,
     Uint,
@@ -24,7 +24,7 @@ def encode(value, include_hash_tree_roots=False):
         return int(value)
     elif isinstance(value, Boolean):
         return value == 1
-    elif isinstance(value, Bitlist | ProgressiveBitlist | Bitvector) or (
+    elif isinstance(value, BitList | ProgressiveBitList | Bitvector) or (
         isinstance(value, ProgressiveList) and issubclass(value.element_cls(), Byte)
     ):
         return "0x" + serialize(value).hex()

--- a/tests/core/pyspec/eth_consensus_specs/debug/random_value.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/random_value.py
@@ -4,7 +4,7 @@ from random import Random
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     BasicView,
     BitList,
-    Bitvector,
+    BitVector,
     Boolean,
     ByteList,
     ByteVector,
@@ -101,7 +101,7 @@ def get_random_ssz_object(
             return get_max_basic_value(typ)
         else:
             return get_random_basic_value(rng, typ)
-    elif issubclass(typ, Vector | Bitvector):
+    elif issubclass(typ, Vector | BitVector):
         elem_type = typ.element_cls() if issubclass(typ, Vector) else Boolean
         return typ(
             get_random_ssz_object(rng, elem_type, max_bytes_length, max_list_length, mode, chaos)

--- a/tests/core/pyspec/eth_consensus_specs/debug/random_value.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/random_value.py
@@ -3,7 +3,7 @@ from random import Random
 
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     BasicView,
-    Bitlist,
+    BitList,
     Bitvector,
     Boolean,
     ByteList,
@@ -11,7 +11,7 @@ from eth_consensus_specs.utils.ssz.ssz_typing import (
     CompatibleUnion,
     Container,
     List,
-    ProgressiveBitlist,
+    ProgressiveBitList,
     ProgressiveContainer,
     ProgressiveList,
     Uint,
@@ -107,10 +107,10 @@ def get_random_ssz_object(
             get_random_ssz_object(rng, elem_type, max_bytes_length, max_list_length, mode, chaos)
             for _ in range(typ.vector_length())
         )
-    elif issubclass(typ, List | ProgressiveList | Bitlist | ProgressiveBitlist):
+    elif issubclass(typ, List | ProgressiveList | BitList | ProgressiveBitList):
         limit = max_list_length
         # SSZ imposes a hard limit on lists, we can't put in more than that
-        if not issubclass(typ, ProgressiveList | ProgressiveBitlist) and typ.limit() < limit:
+        if not issubclass(typ, ProgressiveList | ProgressiveBitList) and typ.limit() < limit:
             limit = typ.limit()
 
         length = rng.randint(0, limit)
@@ -121,7 +121,7 @@ def get_random_ssz_object(
         elif mode == RandomizationMode.mode_nil_count:
             length = 0
 
-        elem_type = Boolean if issubclass(typ, Bitlist | ProgressiveBitlist) else typ.element_cls()
+        elem_type = Boolean if issubclass(typ, BitList | ProgressiveBitList) else typ.element_cls()
         max_list_length = 1 << (max_list_length.bit_length() >> 1)
         return typ(
             get_random_ssz_object(rng, elem_type, max_bytes_length, max_list_length, mode, chaos)

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/unittests/validator/test_validator.py
@@ -16,7 +16,7 @@ from eth_consensus_specs.test.helpers.keys import privkeys, pubkey_to_privkey, p
 from eth_consensus_specs.test.helpers.state import transition_to
 from eth_consensus_specs.test.helpers.sync_committee import compute_sync_committee_signature
 from eth_consensus_specs.utils import bls
-from eth_consensus_specs.utils.ssz.ssz_typing import Bitvector
+from eth_consensus_specs.utils.ssz.ssz_typing import BitVector
 
 rng = random.Random(1337)
 
@@ -97,7 +97,7 @@ def test_process_sync_committee_contributions(spec, state):
     block = build_empty_block(spec, state)
     previous_slot = state.slot - 1
     target_block_root = spec.get_block_root_at_slot(state, previous_slot)
-    aggregation_bits = Bitvector[spec.SYNC_COMMITTEE_SIZE // spec.SYNC_COMMITTEE_SUBNET_COUNT]()
+    aggregation_bits = BitVector[spec.SYNC_COMMITTEE_SIZE // spec.SYNC_COMMITTEE_SUBNET_COUNT]()
     aggregation_index = 0
     aggregation_bits[aggregation_index] = True
 
@@ -276,7 +276,7 @@ def test_get_contribution_and_proof(spec, state):
         slot=10,
         beacon_block_root=b"\x12" * 32,
         subcommittee_index=1,
-        aggregation_bits=spec.Bitvector[
+        aggregation_bits=spec.BitVector[
             spec.SYNC_COMMITTEE_SIZE // spec.SYNC_COMMITTEE_SUBNET_COUNT
         ](),
         signature=b"\x32" * 96,
@@ -313,7 +313,7 @@ def test_get_contribution_and_proof_signature(spec, state):
             slot=10,
             beacon_block_root=b"\x12" * 32,
             subcommittee_index=1,
-            aggregation_bits=spec.Bitvector[
+            aggregation_bits=spec.BitVector[
                 spec.SYNC_COMMITTEE_SIZE // spec.SYNC_COMMITTEE_SUBNET_COUNT
             ](),
             signature=b"\x34" * 96,

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_attestation.py
@@ -40,7 +40,7 @@ def build_unaggregated_attestation(spec, state, beacon_block_root):
     committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
     single_bit = [False] * len(committee)
     single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+    attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
     attestation.signature = spec.get_attestation_signature(
         state, attestation.data, privkeys[committee[0]]
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/electra/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -198,7 +198,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_zero_committees(spec, state):
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
     # Clear all committee bits.
-    signed_agg.message.aggregate.committee_bits = spec.Bitvector[spec.MAX_COMMITTEES_PER_SLOT]()
+    signed_agg.message.aggregate.committee_bits = spec.BitVector[spec.MAX_COMMITTEES_PER_SLOT]()
 
     yield get_filename(signed_agg), signed_agg
 
@@ -250,7 +250,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_multiple_committees(spec, sta
     bits = [False] * spec.MAX_COMMITTEES_PER_SLOT
     bits[0] = True
     bits[1] = True
-    signed_agg.message.aggregate.committee_bits = spec.Bitvector[spec.MAX_COMMITTEES_PER_SLOT](
+    signed_agg.message.aggregate.committee_bits = spec.BitVector[spec.MAX_COMMITTEES_PER_SLOT](
         *bits
     )
 

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_partial_data_column_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_partial_data_column_sidecar.py
@@ -1575,8 +1575,8 @@ def test_gossip_partial_data_column_sidecar__reject_bitmap_length_mismatch(spec,
     header_msg = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     cells_msg = make_partial_sidecar(spec, sidecar, blob_indices=[0], include_header=False)
     # Stretch the bitmap so its length exceeds the corresponding header's commitments.
-    Bitlist = type(cells_msg.cells_present_bitmap)
-    cells_msg.cells_present_bitmap = Bitlist(list(cells_msg.cells_present_bitmap) + [False, False])
+    BitList = type(cells_msg.cells_present_bitmap)
+    cells_msg.cells_present_bitmap = BitList(list(cells_msg.cells_present_bitmap) + [False, False])
 
     yield get_filename(header_msg), header_msg
     yield get_filename(cells_msg), cells_msg

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_payload_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_payload_attestation.py
@@ -14,7 +14,7 @@ from eth_consensus_specs.test.helpers.constants import MINIMAL
 from eth_consensus_specs.test.helpers.gloas.state import initialize_ptc_window
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import next_epoch
-from eth_consensus_specs.utils.ssz.ssz_typing import Bitvector
+from eth_consensus_specs.utils.ssz.ssz_typing import BitVector
 
 
 def run_payload_attestation_processing(spec, state, payload_attestation, valid=True):
@@ -72,7 +72,7 @@ def prepare_signed_payload_attestation(
     # to deal with duplicates indices in the PTC.
     unset_indices = list(attesting_indices)
 
-    aggregation_bits = Bitvector[spec.PTC_SIZE]()
+    aggregation_bits = BitVector[spec.PTC_SIZE]()
     for i, validator_index in enumerate(ptc):
         if validator_index in unset_indices:
             aggregation_bits[i] = True

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_payload_attestation_message.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork_choice/test_on_payload_attestation_message.py
@@ -364,7 +364,7 @@ def test_on_payload_attestation_message_from_block(spec, state):
         )
 
     # Build the PayloadAttestation aggregate
-    aggregation_bits = spec.Bitvector[spec.PTC_SIZE]()
+    aggregation_bits = spec.BitVector[spec.PTC_SIZE]()
     for i, validator_index in enumerate(ptc_list):
         if validator_index in voter_set:
             aggregation_bits[i] = True

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/attestations.py
@@ -15,7 +15,7 @@ from eth_consensus_specs.test.helpers.state import (
     state_transition_and_sign_block,
 )
 from eth_consensus_specs.utils import bls
-from eth_consensus_specs.utils.ssz.ssz_typing import Bitlist
+from eth_consensus_specs.utils.ssz.ssz_typing import BitList
 
 
 def process_attestation(spec, state, attestation):
@@ -237,7 +237,7 @@ def fill_aggregate_attestation(
         )
     else:
         committee_size = len(beacon_committee)
-        attestation.aggregation_bits = Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](
+        attestation.aggregation_bits = BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](
             *([0] * committee_size)
         )
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
@@ -9,7 +9,7 @@ def build_max_size_attestation(spec):
         aggregation_bits=aggregation_bits,
         data=spec.AttestationData(),
         signature=spec.BLSSignature(),
-        committee_bits=spec.Bitvector[spec.MAX_COMMITTEES_PER_SLOT](),
+        committee_bits=spec.BitVector[spec.MAX_COMMITTEES_PER_SLOT](),
     )
 
 
@@ -27,7 +27,7 @@ def build_max_size_indexed_attestation(spec):
 
 def build_max_size_payload_attestation(spec):
     return spec.PayloadAttestation(
-        aggregation_bits=spec.Bitvector[spec.PTC_SIZE]([True] * spec.PTC_SIZE),
+        aggregation_bits=spec.BitVector[spec.PTC_SIZE]([True] * spec.PTC_SIZE),
         data=spec.PayloadAttestationData(),
         signature=spec.BLSSignature(),
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
@@ -75,7 +75,7 @@ def build_max_size_data_column_sidecar(spec):
 
 
 def build_max_size_partial_data_column_sidecar(spec):
-    cells_present_bitmap = spec.ProgressiveBitlist([True] * spec.MAX_BLOB_COMMITMENTS_PER_BLOCK)
+    cells_present_bitmap = spec.ProgressiveBitList([True] * spec.MAX_BLOB_COMMITMENTS_PER_BLOCK)
     partial_column = spec.ProgressiveList[spec.Cell](
         [spec.Cell()] * spec.MAX_BLOB_COMMITMENTS_PER_BLOCK
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/block_processing/test_process_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/block_processing/test_process_execution_payload_bid.py
@@ -31,7 +31,7 @@ def test_process_execution_payload_bid_valid_builder_with_non_default_inclusion_
     block, builder_index = prepare_block_with_non_proposer_builder(spec, state)
     assert spec.is_active_builder(state, builder_index) is True
 
-    inclusion_list_bits = spec.Bitvector[spec.INCLUSION_LIST_COMMITTEE_SIZE]()
+    inclusion_list_bits = spec.BitVector[spec.INCLUSION_LIST_COMMITTEE_SIZE]()
     inclusion_list_bits[0] = True
 
     signed_bid = prepare_signed_execution_payload_bid(

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/block_processing/test_process_attestation.py
@@ -20,7 +20,7 @@ from eth_consensus_specs.test.helpers.state import (
     next_slots,
     transition_to_slot_via_block,
 )
-from eth_consensus_specs.utils.ssz.ssz_typing import Bitlist
+from eth_consensus_specs.utils.ssz.ssz_typing import BitList
 
 
 @with_all_phases
@@ -367,7 +367,7 @@ def test_invalid_too_few_aggregation_bits(spec, state):
     attestation = get_valid_attestation(spec, state)
     next_slots(spec, state, spec.MIN_ATTESTATION_INCLUSION_DELAY)
 
-    attestation.aggregation_bits = Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](
+    attestation.aggregation_bits = BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](
         *([0b1] + [0b0] * (len(attestation.aggregation_bits) - 1))
     )
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/epoch_processing/test_process_justification_and_finalization.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/epoch_processing/test_process_justification_and_finalization.py
@@ -131,7 +131,7 @@ def finalize_on_234(spec, state, epoch, sufficient_support):
     old_finalized = state.finalized_checkpoint
     state.previous_justified_checkpoint = c4
     state.current_justified_checkpoint = c3
-    state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
+    state.justification_bits = spec.BitVector[spec.JUSTIFICATION_BITS_LENGTH]()
     state.justification_bits[1:3] = [
         1,
         1,
@@ -168,7 +168,7 @@ def finalize_on_23(spec, state, epoch, sufficient_support):
     old_finalized = state.finalized_checkpoint
     state.previous_justified_checkpoint = c3
     state.current_justified_checkpoint = c3
-    state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
+    state.justification_bits = spec.BitVector[spec.JUSTIFICATION_BITS_LENGTH]()
     state.justification_bits[1] = 1  # mock 3rd latest epoch as justified (index is pre-shift)
     # mock the 2nd latest epoch as justifiable, with 3rd as source
     add_mock_attestations(
@@ -202,7 +202,7 @@ def finalize_on_123(spec, state, epoch, sufficient_support):
     old_finalized = state.finalized_checkpoint
     state.previous_justified_checkpoint = c5
     state.current_justified_checkpoint = c3
-    state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
+    state.justification_bits = spec.BitVector[spec.JUSTIFICATION_BITS_LENGTH]()
     state.justification_bits[1] = 1  # mock 3rd latest epochs as justified (index is pre-shift)
     # mock the 2nd latest epoch as justifiable, with 5th as source
     add_mock_attestations(
@@ -240,7 +240,7 @@ def finalize_on_12(spec, state, epoch, sufficient_support, messed_up_target):
     old_finalized = state.finalized_checkpoint
     state.previous_justified_checkpoint = c2
     state.current_justified_checkpoint = c2
-    state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
+    state.justification_bits = spec.BitVector[spec.JUSTIFICATION_BITS_LENGTH]()
     state.justification_bits[0] = 1  # mock 2nd latest epoch as justified (this is pre-shift)
     # mock the 1st latest epoch as justifiable, with 2nd as source
     add_mock_attestations(

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -158,7 +158,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_committee_index_out_of_range(
         # at the smallest position that is both out-of-range and inside the bitvector.
         assert committee_count < spec.MAX_COMMITTEES_PER_SLOT
         oob_index = committee_count
-        signed_agg.message.aggregate.committee_bits = spec.Bitvector[spec.MAX_COMMITTEES_PER_SLOT](
+        signed_agg.message.aggregate.committee_bits = spec.BitVector[spec.MAX_COMMITTEES_PER_SLOT](
             *[i == oob_index for i in range(spec.MAX_COMMITTEES_PER_SLOT)]
         )
     else:

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_aggregate_and_proof.py
@@ -489,7 +489,7 @@ def test_gossip_beacon_aggregate_and_proof__ignore_same_data_root_without_supers
         # ``MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT`` and includes
         # ``committee_bits``; preserve both from the first aggregate.
         aggregate_2 = spec.Attestation(
-            aggregation_bits=spec.Bitlist[
+            aggregation_bits=spec.BitList[
                 spec.MAX_VALIDATORS_PER_COMMITTEE * spec.MAX_COMMITTEES_PER_SLOT
             ](*modified_bits),
             data=signed_agg_1.message.aggregate.data,
@@ -498,7 +498,7 @@ def test_gossip_beacon_aggregate_and_proof__ignore_same_data_root_without_supers
         )
     else:
         aggregate_2 = spec.Attestation(
-            aggregation_bits=spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*modified_bits),
+            aggregation_bits=spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*modified_bits),
             data=signed_agg_1.message.aggregate.data,
             signature=signed_agg_1.message.aggregate.signature,
         )
@@ -718,7 +718,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_aggregation_bits_size_mismatc
     wrong_size = len(committee) + 5
     wrong_bits = [False] * wrong_size
     wrong_bits[0] = True
-    signed_agg.message.aggregate.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](
+    signed_agg.message.aggregate.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](
         *wrong_bits
     )
 
@@ -778,7 +778,7 @@ def test_gossip_beacon_aggregate_and_proof__reject_no_participants(spec, state):
     # Set all aggregation bits to False (no participants)
     committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
     empty_bits = [False] * len(committee)
-    signed_agg.message.aggregate.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](
+    signed_agg.message.aggregate.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](
         *empty_bits
     )
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_beacon_attestation.py
@@ -78,7 +78,7 @@ def test_gossip_beacon_attestation__valid(spec, state):
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
-        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
         attestation.signature = spec.get_attestation_signature(
             state, attestation.data, privkeys[committee[0]]
         )
@@ -264,7 +264,7 @@ def test_gossip_beacon_attestation__ignore_slot_not_in_range(spec, state):
     committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
     single_bit = [False] * len(committee)
     single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+    attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
     attestation.signature = spec.get_attestation_signature(
         state, attestation.data, privkeys[committee[0]]
     )
@@ -334,7 +334,7 @@ def test_gossip_beacon_attestation__valid_within_clock_disparity(spec, state):
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
-        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
         attestation.signature = spec.get_attestation_signature(
             state, attestation.data, privkeys[committee[0]]
         )
@@ -400,7 +400,7 @@ def test_gossip_beacon_attestation__valid_within_clock_disparity_old(spec, state
     committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
     single_bit = [False] * len(committee)
     single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+    attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
     attestation.signature = spec.get_attestation_signature(
         state, attestation.data, privkeys[committee[0]]
     )
@@ -468,7 +468,7 @@ def test_gossip_beacon_attestation__ignore_slot_too_old(spec, state):
     committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
     single_bit = [False] * len(committee)
     single_bit[0] = True
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+    attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
     attestation.signature = spec.get_attestation_signature(
         state, attestation.data, privkeys[committee[0]]
     )
@@ -600,7 +600,7 @@ def test_gossip_beacon_attestation__reject_not_unaggregated(spec, state):
         multi_bits = [False] * len(committee)
         multi_bits[0] = True
         multi_bits[1] = True
-        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*multi_bits)
+        attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*multi_bits)
 
     yield get_filename(attestation), attestation
 
@@ -662,7 +662,7 @@ def test_gossip_beacon_attestation__reject_aggregation_bits_size_mismatch(spec, 
     wrong_size = len(committee) + 5
     wrong_bits = [False] * wrong_size
     wrong_bits[0] = True  # Single bit set (unaggregated)
-    attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*wrong_bits)
+    attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*wrong_bits)
 
     yield get_filename(attestation), attestation
 
@@ -728,7 +728,7 @@ def test_gossip_beacon_attestation__ignore_already_seen(spec, state):
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
-        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
         attestation.signature = spec.get_attestation_signature(
             state, attestation.data, privkeys[committee[0]]
         )
@@ -818,7 +818,7 @@ def test_gossip_beacon_attestation__ignore_block_not_seen(spec, state):
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
-        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
         attestation.signature = spec.get_attestation_signature(
             state, attestation.data, privkeys[committee[0]]
         )
@@ -902,7 +902,7 @@ def test_gossip_beacon_attestation__reject_block_failed_validation(spec, state):
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
-        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
         attestation.signature = spec.get_attestation_signature(
             state, attestation.data, privkeys[committee[0]]
         )
@@ -971,7 +971,7 @@ def test_gossip_beacon_attestation__reject_invalid_signature(spec, state):
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
-        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
     # Invalid signature (zeros)
     attestation.signature = spec.BLSSignature(b"\x00" * 96)
 
@@ -1040,7 +1040,7 @@ def test_gossip_beacon_attestation__reject_target_not_ancestor(spec, state):
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
-        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
         # Sign with the modified data
         attestation.signature = spec.get_attestation_signature(
             state, attestation.data, privkeys[committee[0]]
@@ -1126,7 +1126,7 @@ def test_gossip_beacon_attestation__ignore_finalized_not_ancestor(spec, state):
         committee = spec.get_beacon_committee(state, attestation.data.slot, attestation.data.index)
         single_bit = [False] * len(committee)
         single_bit[0] = True
-        attestation.aggregation_bits = spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
+        attestation.aggregation_bits = spec.BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*single_bit)
         attestation.signature = spec.get_attestation_signature(
             state, attestation.data, privkeys[committee[0]]
         )

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_bitlist.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_bitlist.py
@@ -2,7 +2,7 @@ from random import Random
 
 from eth_consensus_specs.debug.random_value import get_random_ssz_object, RandomizationMode
 from eth_consensus_specs.utils.ssz.ssz_impl import serialize
-from eth_consensus_specs.utils.ssz.ssz_typing import Bitlist
+from eth_consensus_specs.utils.ssz.ssz_typing import BitList
 
 from .ssz_test_case import invalid_test_case, valid_test_case
 
@@ -18,7 +18,7 @@ def bitlist_case_fn(
 ):
     bits = get_random_ssz_object(
         rng,
-        Bitlist[limit],
+        BitList[limit],
         max_bytes_length=(limit // 8) + 1,
         max_list_length=limit,
         mode=mode,
@@ -72,12 +72,12 @@ def invalid_cases():
         for description, data in INVALID_BITLIST_CASES:
             yield (
                 f"bitlist_{typ_limit}_{description}",
-                invalid_test_case(Bitlist[typ_limit], lambda data=data: data),
+                invalid_test_case(BitList[typ_limit], lambda data=data: data),
             )
         yield (
             f"bitlist_{typ_limit}_but_{test_limit}",
             invalid_test_case(
-                Bitlist[typ_limit],
+                BitList[typ_limit],
                 lambda rng, test_limit=test_limit: serialize(
                     bitlist_case_fn(rng, RandomizationMode.mode_max_count, test_limit)
                 ),

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_bitvector.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_bitvector.py
@@ -2,7 +2,7 @@ from random import Random
 
 from eth_consensus_specs.debug.random_value import get_random_ssz_object, RandomizationMode
 from eth_consensus_specs.utils.ssz.ssz_impl import serialize
-from eth_consensus_specs.utils.ssz.ssz_typing import Bitvector
+from eth_consensus_specs.utils.ssz.ssz_typing import BitVector
 
 from .ssz_test_case import invalid_test_case, valid_test_case
 
@@ -12,7 +12,7 @@ def bitvector_case_fn(
 ):
     bits = get_random_ssz_object(
         rng,
-        Bitvector[size],
+        BitVector[size],
         max_bytes_length=(size + 7) // 8,
         max_list_length=size,
         mode=mode,
@@ -47,7 +47,7 @@ def valid_cases():
 
 def invalid_cases():
     # zero length bitvecors are illegal
-    yield "bitvec_0", invalid_test_case(Bitvector[1], lambda: b"")
+    yield "bitvec_0", invalid_test_case(BitVector[1], lambda: b"")
     rng = Random(1234)
     # Create a vector with test_size bits, but make the type typ_size instead,
     # which is invalid when used with the given type size
@@ -72,7 +72,7 @@ def invalid_cases():
             yield (
                 f"bitvec_{typ_size}_{mode.to_name()}_{test_size}",
                 invalid_test_case(
-                    Bitvector[typ_size],
+                    BitVector[typ_size],
                     lambda rng, mode=mode, test_size=test_size, typ_size=typ_size: serialize(
                         bitvector_case_fn(rng, mode, test_size, invalid_making_pos=typ_size)
                     ),

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_container.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_container.py
@@ -5,13 +5,13 @@ from eth_consensus_specs.debug.random_value import get_random_ssz_object, Random
 from eth_consensus_specs.test.exceptions import SkippedTest
 from eth_consensus_specs.utils.ssz.ssz_impl import deserialize, serialize
 from eth_consensus_specs.utils.ssz.ssz_typing import (
-    Bitlist,
+    BitList,
     Bitvector,
     Byte,
     ByteList,
     Container,
     List,
-    ProgressiveBitlist,
+    ProgressiveBitList,
     ProgressiveList,
     Uint8,
     Uint16,
@@ -63,26 +63,26 @@ class ProgressiveTestStruct(Container):
 
 
 class BitsStruct(Container):
-    A: Bitlist[5]
+    A: BitList[5]
     B: Bitvector[2]
     C: Bitvector[1]
-    D: Bitlist[6]
+    D: BitList[6]
     E: Bitvector[8]
 
 
 class ProgressiveBitsStruct(Container):
     A: Bitvector[256]
-    B: Bitlist[256]
-    C: ProgressiveBitlist
+    B: BitList[256]
+    C: ProgressiveBitList
     D: Bitvector[257]
-    E: Bitlist[257]
-    F: ProgressiveBitlist
+    E: BitList[257]
+    F: ProgressiveBitList
     G: Bitvector[1280]
-    H: Bitlist[1280]
-    I: ProgressiveBitlist
+    H: BitList[1280]
+    I: ProgressiveBitList
     J: Bitvector[1281]
-    K: Bitlist[1281]
-    L: ProgressiveBitlist
+    K: BitList[1281]
+    L: ProgressiveBitList
 
 
 def container_case_fn(rng: Random, mode: RandomizationMode, typ: type[View], chaos: bool = False):

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_container.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_container.py
@@ -6,7 +6,7 @@ from eth_consensus_specs.test.exceptions import SkippedTest
 from eth_consensus_specs.utils.ssz.ssz_impl import deserialize, serialize
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     BitList,
-    Bitvector,
+    BitVector,
     Byte,
     ByteList,
     Container,
@@ -64,23 +64,23 @@ class ProgressiveTestStruct(Container):
 
 class BitsStruct(Container):
     A: BitList[5]
-    B: Bitvector[2]
-    C: Bitvector[1]
+    B: BitVector[2]
+    C: BitVector[1]
     D: BitList[6]
-    E: Bitvector[8]
+    E: BitVector[8]
 
 
 class ProgressiveBitsStruct(Container):
-    A: Bitvector[256]
+    A: BitVector[256]
     B: BitList[256]
     C: ProgressiveBitList
-    D: Bitvector[257]
+    D: BitVector[257]
     E: BitList[257]
     F: ProgressiveBitList
-    G: Bitvector[1280]
+    G: BitVector[1280]
     H: BitList[1280]
     I: ProgressiveBitList
-    J: Bitvector[1281]
+    J: BitVector[1281]
     K: BitList[1281]
     L: ProgressiveBitList
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_progressive_bitlist.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_progressive_bitlist.py
@@ -1,7 +1,7 @@
 from random import Random
 
 from eth_consensus_specs.debug.random_value import get_random_ssz_object, RandomizationMode
-from eth_consensus_specs.utils.ssz.ssz_typing import ProgressiveBitlist
+from eth_consensus_specs.utils.ssz.ssz_typing import ProgressiveBitList
 
 from .ssz_bitlist import INVALID_BITLIST_CASES
 from .ssz_test_case import invalid_test_case, valid_test_case
@@ -12,7 +12,7 @@ def progressive_bitlist_case_fn(
 ):
     bits = get_random_ssz_object(
         rng,
-        ProgressiveBitlist,
+        ProgressiveBitList,
         max_bytes_length=(length // 8) + 1,
         max_list_length=length,
         mode=mode,
@@ -84,5 +84,5 @@ def invalid_cases():
     for description, data in INVALID_BITLIST_CASES:
         yield (
             f"progbitlist_{description}",
-            invalid_test_case(ProgressiveBitlist, lambda data=data: data),
+            invalid_test_case(ProgressiveBitList, lambda data=data: data),
         )

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_progressive_container.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/ssz_generic/ssz_generic_cases/ssz_progressive_container.py
@@ -7,7 +7,7 @@ from eth_consensus_specs.utils.ssz.ssz_impl import deserialize, serialize
 from eth_consensus_specs.utils.ssz.ssz_typing import (
     Byte,
     List,
-    ProgressiveBitlist,
+    ProgressiveBitList,
     ProgressiveContainer,
     ProgressiveList,
     Uint16,
@@ -30,13 +30,13 @@ class ProgressiveSingleFieldContainerTestStruct(ProgressiveContainer(active_fiel
 
 
 class ProgressiveSingleListContainerTestStruct(ProgressiveContainer(active_fields=[0, 0, 0, 0, 1])):
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
 
 
 class ProgressiveVarTestStruct(ProgressiveContainer(active_fields=[1, 0, 1, 0, 1])):
     A: Byte
     B: List[Uint16, 123]
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
 
 
 class ProgressiveComplexTestStruct(
@@ -46,7 +46,7 @@ class ProgressiveComplexTestStruct(
 ):
     A: Byte
     B: List[Uint16, 123]
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
     D: ProgressiveList[Uint64]
     E: ProgressiveList[SmallTestStruct]
     F: ProgressiveList[ProgressiveList[VarTestStruct]]
@@ -72,19 +72,19 @@ class ModifiedTestStruct3(ProgressiveContainer(active_fields=[1, 1, 1])):
 
 class ModifiedTestStruct4(ProgressiveContainer(active_fields=[0, 0, 1, 0, 1])):
     B: List[Uint16, 123]
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
 
 
 class ModifiedTestStruct5(ProgressiveContainer(active_fields=[1, 0, 0, 0, 1])):
     A: Byte
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
 
 
 class ModifiedTestStruct6(ProgressiveContainer(active_fields=[1, 1, 1, 0, 1, 0, 0, 0, 1])):
     A: Byte
     X: Byte
     B: List[Uint16, 123]
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
     D: ProgressiveList[Uint64]
 
 
@@ -102,7 +102,7 @@ class ModifiedTestStruct8(
     A: Byte
     X: Byte
     B: List[Uint16, 123]
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
     D: ProgressiveList[Uint64]
     E: ProgressiveList[SmallTestStruct]
     F: ProgressiveList[ProgressiveList[VarTestStruct]]
@@ -117,7 +117,7 @@ class ModifiedTestStruct9(
 ):
     A: Byte
     B: List[Uint16, 123]
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
     D: ProgressiveList[Uint64]
     F: ProgressiveList[ProgressiveList[VarTestStruct]]
     G: List[ProgressiveSingleFieldContainerTestStruct, 10]

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/fork_choice/test_on_attestation.py
@@ -339,7 +339,7 @@ def test_on_attestation_invalid_attestation(spec, state):
     attestation = get_valid_attestation(spec, state, slot=block.slot, signed=True)
     # make invalid by using an invalid committee index
     if is_post_electra(spec):
-        attestation.committee_bits = spec.Bitvector[spec.MAX_COMMITTEES_PER_SLOT]()
+        attestation.committee_bits = spec.BitVector[spec.MAX_COMMITTEES_PER_SLOT]()
     else:
         attestation.data.index = spec.MAX_COMMITTEES_PER_SLOT * spec.SLOTS_PER_EPOCH
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/unittests/validator/test_validator_unittest.py
@@ -19,7 +19,7 @@ from eth_consensus_specs.test.helpers.constants import FULU, PHASE0
 from eth_consensus_specs.test.helpers.keys import privkeys, pubkeys
 from eth_consensus_specs.test.helpers.state import next_epoch
 from eth_consensus_specs.utils import bls
-from eth_consensus_specs.utils.ssz.ssz_typing import Bitlist
+from eth_consensus_specs.utils.ssz.ssz_typing import BitList
 
 
 def run_get_signature_test(
@@ -460,7 +460,7 @@ def test_get_aggregate_signature(spec, state):
         attestation_data.index,
     )
     committee_size = len(beacon_committee)
-    aggregation_bits = Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](*([0] * committee_size))
+    aggregation_bits = BitList[spec.MAX_VALIDATORS_PER_COMMITTEE](*([0] * committee_size))
     for i, validator_index in enumerate(beacon_committee):
         bits = aggregation_bits.copy()
         bits[i] = True

--- a/tests/core/pyspec/eth_consensus_specs/utils/ssz/ssz_typing.py
+++ b/tests/core/pyspec/eth_consensus_specs/utils/ssz/ssz_typing.py
@@ -13,7 +13,7 @@ from remerkleable.basic import (
 )
 from remerkleable.bitfields import (
     Bitlist as BitList,
-    Bitvector,
+    Bitvector as BitVector,
 )
 from remerkleable.byte_arrays import (
     ByteList,

--- a/tests/core/pyspec/eth_consensus_specs/utils/ssz/ssz_typing.py
+++ b/tests/core/pyspec/eth_consensus_specs/utils/ssz/ssz_typing.py
@@ -11,7 +11,10 @@ from remerkleable.basic import (
     uint128 as Uint128,
     uint256 as Uint256,
 )
-from remerkleable.bitfields import Bitlist, Bitvector
+from remerkleable.bitfields import (
+    Bitlist as BitList,
+    Bitvector,
+)
 from remerkleable.byte_arrays import (
     ByteList,
     Bytes1,
@@ -26,7 +29,7 @@ from remerkleable.complex import Container, List, Vector
 from remerkleable.core import BasicView, Path, View
 from remerkleable.progressive import (
     CompatibleUnion,
-    ProgressiveBitlist,
+    ProgressiveBitlist as ProgressiveBitList,
     ProgressiveByteList,
     ProgressiveContainer,
     ProgressiveList,

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -231,23 +231,23 @@ class ProgressiveTestStruct(Container):
 
 class BitsStruct(Container):
     A: BitList[5]
-    B: Bitvector[2]
-    C: Bitvector[1]
+    B: BitVector[2]
+    C: BitVector[1]
     D: BitList[6]
-    E: Bitvector[8]
+    E: BitVector[8]
 
 
 class ProgressiveBitsStruct(Container):
-    A: Bitvector[256]
+    A: BitVector[256]
     B: BitList[256]
     C: ProgressiveBitList
-    D: Bitvector[257]
+    D: BitVector[257]
     E: BitList[257]
     F: ProgressiveBitList
-    G: Bitvector[1280]
+    G: BitVector[1280]
     H: BitList[1280]
     I: ProgressiveBitList
-    J: Bitvector[1281]
+    J: BitVector[1281]
     K: BitList[1281]
     L: ProgressiveBitList
 ```

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -22,7 +22,7 @@ into a SSZ type:
 - Bitfields
   - [`bitvector`](#bitvector)
   - [`bitlist`](#bitlist)
-- ProgressiveBitlist
+- ProgressiveBitList
   - [`progressive_bitlist`](#progressive_bitlist)
 - Basic types
   - [`boolean`](#boolean)
@@ -230,26 +230,26 @@ class ProgressiveTestStruct(Container):
 
 
 class BitsStruct(Container):
-    A: Bitlist[5]
+    A: BitList[5]
     B: Bitvector[2]
     C: Bitvector[1]
-    D: Bitlist[6]
+    D: BitList[6]
     E: Bitvector[8]
 
 
 class ProgressiveBitsStruct(Container):
     A: Bitvector[256]
-    B: Bitlist[256]
-    C: ProgressiveBitlist
+    B: BitList[256]
+    C: ProgressiveBitList
     D: Bitvector[257]
-    E: Bitlist[257]
-    F: ProgressiveBitlist
+    E: BitList[257]
+    F: ProgressiveBitList
     G: Bitvector[1280]
-    H: Bitlist[1280]
-    I: ProgressiveBitlist
+    H: BitList[1280]
+    I: ProgressiveBitList
     J: Bitvector[1281]
-    K: Bitlist[1281]
-    L: ProgressiveBitlist
+    K: BitList[1281]
+    L: ProgressiveBitList
 ```
 
 ### `progressive_containers`
@@ -274,13 +274,13 @@ class ProgressiveSingleFieldContainerTestStruct(ProgressiveContainer(active_fiel
 
 
 class ProgressiveSingleListContainerTestStruct(ProgressiveContainer(active_fields=[0, 0, 0, 0, 1])):
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
 
 
 class ProgressiveVarTestStruct(ProgressiveContainer(active_fields=[1, 0, 1, 0, 1])):
     A: Byte
     B: List[Uint16, 123]
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
 
 
 class ProgressiveComplexTestStruct(
@@ -290,7 +290,7 @@ class ProgressiveComplexTestStruct(
 ):
     A: Byte
     B: List[Uint16, 123]
-    C: ProgressiveBitlist
+    C: ProgressiveBitList
     D: ProgressiveList[Uint64]
     E: ProgressiveList[SmallTestStruct]
     F: ProgressiveList[ProgressiveList[VarTestStruct]]

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -208,7 +208,7 @@ def messages_to_payload_attestations(spec, state, messages):
     for data, attesting_indices in groups.values():
         ptc = spec.get_ptc(state, data.slot)
         index_set = set(attesting_indices)
-        aggregation_bits = spec.Bitvector[spec.PTC_SIZE]()
+        aggregation_bits = spec.BitVector[spec.PTC_SIZE]()
         for i, validator_index in enumerate(ptc):
             if validator_index in index_set:
                 aggregation_bits[i] = True


### PR DESCRIPTION
In the new SSZ library, we use `BitList`/`BitVector` instead for consistency with `ByteList`/`ByteVector`. In preparation for that, alias the import and replace all instances of these with the new style.