### PR TITLE
Document new `parent_slot` param in `process_attestation`

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/attestations.py
@@ -18,11 +18,15 @@ from eth_consensus_specs.utils import bls
 from eth_consensus_specs.utils.ssz.ssz_typing import BitList
 
 
+def get_parent_slot(state):
+    # Outside of block processing, the bid in the state is still the
+    # parent block's bid, so its slot is the parent block's slot.
+    return state.latest_execution_payload_bid.slot
+
+
 def process_attestation(spec, state, attestation):
     if is_post_gloas(spec):
-        # Outside of block processing, the bid in the state is still the
-        # parent block's bid, so its slot is the parent block's slot.
-        spec.process_attestation(state, attestation, state.latest_execution_payload_bid.slot)
+        spec.process_attestation(state, attestation, get_parent_slot(state))
     else:
         spec.process_attestation(state, attestation)
 
@@ -32,6 +36,7 @@ def run_attestation_processing(spec, state, attestation, valid=True):
     Run ``process_attestation``, yielding:
       - pre-state ('pre')
       - attestation ('attestation')
+      - parent slot ('parent_slot' in meta, Gloas and later)
       - post-state ('post').
     If ``valid == False``, run expecting ``AssertionError``
     """
@@ -39,6 +44,10 @@ def run_attestation_processing(spec, state, attestation, valid=True):
     yield "pre", state
 
     yield "attestation", attestation
+
+    # Gloas takes the parent block's slot as an extra input.
+    if is_post_gloas(spec):
+        yield "parent_slot", "meta", int(get_parent_slot(state))
 
     # If the attestation is invalid, processing is aborted, and there is no post-state.
     if not valid:

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -11,6 +11,8 @@ test handlers.
 description: string    -- Optional description of test case, purely for debugging purposes.
                           Tests should use the directory name of the test case as identifier, not the description.
 bls_setting: int       -- see general test-format spec.
+parent_slot: int       -- Only for the `attestation` handler in Gloas and later.
+                          The slot of the parent block, an extra input to `process_attestation`.
 ```
 
 ### `pre.ssz_snappy`
@@ -36,7 +38,7 @@ Operations:
 
 | *`operation-name`*         | *`operation-object`*         | *`input name`*            | *`processing call`*                                                              |
 | -------------------------- | ---------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
-| `attestation`              | `Attestation`                | `attestation`             | `process_attestation(state, attestation)`                                        |
+| `attestation`              | `Attestation`                | `attestation`             | `process_attestation(state, attestation)` (`parent_slot` added in Gloas)         |
 | `attester_slashing`        | `AttesterSlashing`           | `attester_slashing`       | `process_attester_slashing(state, attester_slashing)`                            |
 | `block_header`             | `BeaconBlock`                | **`block`**               | `process_block_header(state, block)`                                             |
 | `deposit`                  | `Deposit`                    | `deposit`                 | `process_deposit(state, deposit)` (removed in Fulu)                              |


### PR DESCRIPTION
Follow up to following. I forgot to update the test format & yield `parent_slot` in attestation tests.

* https://github.com/ethereum/consensus-specs/pull/5473