### PR TITLE
Group dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": false,
-  "extends": ["config:recommended", ":semanticCommitsDisabled"],
+  "extends": ["config:recommended", ":semanticCommitsDisabled", "group:all"],
   "labels": ["dependencies"],
   "schedule": ["before 12pm on monday"],
   "packageRules": [
     {
       "matchDepNames": ["python"],
       "enabled": false
-    },
-    {
-      "matchManagers": ["uv"],
-      "groupName": null
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": null
     }
   ]
 }


### PR DESCRIPTION
This was a suggestion from client teams. They subscribe to consensus-specs changes and do not like being spammed with unimportant dependency updates every week.

<img width="505" height="185" alt="image" src="https://github.com/user-attachments/assets/4943481a-4f96-4a26-bccc-5eeb82f1b8b5" />

...

<img width="505" height="304" alt="image" src="https://github.com/user-attachments/assets/80249426-46f2-476b-a280-58bd715cf281" />
