### PR TITLE
spec(eip8025): contain invalid proof gossip

### DIFF
--- a/specs/_features/eip8025/p2p-interface.md
+++ b/specs/_features/eip8025/p2p-interface.md
@@ -97,6 +97,9 @@ The following validations MUST pass before forwarding the
   `(proof.public_input.new_payload_request_root, proof.proof_type, signed_execution_proof.validator_index)`
   -- i.e. the first *valid or invalid* proof for `proof.proof_type` from
   `signed_execution_proof.validator_index`.
+- _[IGNORE]_ The validator has not previously signed an invalid execution proof
+  -- i.e. `signed_execution_proof.validator_index` is not in the local set of
+  invalid execution proof signers.
 - _[REJECT]_ The validator with index `signed_execution_proof.validator_index`
   is an active validator -- i.e.
   `is_active_validator(state.validators[signed_execution_proof.validator_index], get_current_epoch(state))`
@@ -110,6 +113,28 @@ The following validations MUST pass before forwarding the
 - _[IGNORE]_ No *valid* proof has already been received for the tuple
   `(proof.public_input.new_payload_request_root, proof.proof_type)` -- i.e. no
   *valid* proof for `proof.proof_type` from any prover has been received.
+
+Clients MUST add `signed_execution_proof.validator_index` to the local set of
+invalid execution proof signers when its signature is valid and a subsequent
+_[REJECT]_ condition fails. A failure before signature validation MUST NOT mark
+the claimed validator because the message is not yet authenticated. Clients MUST
+retain entries across restarts while the corresponding validator remains active.
+
+The invalid-signer suppression applies only to unsolicited `execution_proof`
+gossip. It MUST NOT be applied to execution proofs returned in direct response
+to a locally initiated `ExecutionProofsByRange` or `ExecutionProofsByRoot`
+request. Requested proofs are bounded by the request limits and MUST be
+validated normally. A valid requested proof remains eligible for local use and
+for serving through req/resp regardless of whether its signer is suppressed from
+gossip. Invalid responses MAY cause the responding peer to be descored or
+disconnected.
+
+*Note*: Gossip _[REJECT]_ still penalizes the peer that forwarded an invalid
+proof. Tracking the authenticated validator additionally prevents peer identity
+rotation from repeatedly imposing expensive proof verification. This bounds such
+verification to one authenticated invalid proof per validator for each client.
+Restricting that tracking to gossip preserves proof recovery through the bounded
+req/resp protocols without requiring validators to re-sign proofs.
 
 ## The Req/Resp domain
 

--- a/specs/_features/eip8025/prover.md
+++ b/specs/_features/eip8025/prover.md
@@ -65,6 +65,9 @@ proofs for a `SignedExecutionPayloadEnvelope` performs the following steps:
 3. Upon receiving a proof completion event for a tracked
    `new_payload_request_root`:
    - Fetch the completed `ExecutionProof` from the proof engine.
+   - Verify the proof using `proof_engine.verify_execution_proof(proof)`. Abort
+     processing if verification fails. An honest prover MUST NOT sign or gossip
+     an execution proof that it has not verified.
    - Let `validator_index` be the prover's validator index.
    - Let
      `signature = get_execution_proof_signature(state, proof, prover_privkey)`.


### PR DESCRIPTION
## Summary

EIP-8025 allows any active validator to sign an execution proof. Existing gossip validation rejects invalid proofs and can penalize the forwarding peer, but a malicious validator can rotate inexpensive peer identities while continuing to sign proofs that require expensive proof-engine verification.

This change adds authenticated validator-level containment for unsolicited execution-proof gossip without reintroducing proof re-signing.

## Proposed solution

- Ignore future `execution_proof` gossip signed by a validator that has already authenticated an invalid execution proof.
- Record the validator only after its BLS signature passes and a later rejection condition fails. Messages with invalid signatures cannot frame another validator.
- Retain the invalid-signer record across restarts while the validator remains active.
- Limit signer suppression to unsolicited gossip.
- Continue validating proofs returned by locally initiated `ExecutionProofsByRange` and `ExecutionProofsByRoot` requests.
- Keep valid requested proofs eligible for local use and request and response serving even when their signer is suppressed from gossip.
- Require honest provers to verify completed proofs before signing and broadcasting them.

## Rationale

Peer scoring remains useful because a gossip rejection penalizes the peer that forwarded the invalid message. It is not sufficient by itself when peer identities can be rotated independently of validator keys.

The authenticated signer record makes the validator key the durable accountability anchor. Each client performs at most one expensive unsolicited invalid-proof verification per validator before suppressing later gossip from that signer.

Applying suppression only to gossip addresses the selective-availability concern raised in the issue. A node that ignored later gossip from a signer can still recover a valid proof through the existing bounded request and response protocols. This removes the need for validators to re-sign every valid proof and avoids the resulting protocol complexity and network amplification.

The mechanism is transitional and does not alter proof containers, signatures, topic encodings, or request limits.

## Validation

- `make lint`
- `make test fork=eip8025`
  - 1,365 passed
  - 6,431 skipped

Fixes #5145.
