### PR TITLE
Fix missing KZG trusted setup when generating compliance tests

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/utils/kzg.py
+++ b/tests/core/pyspec/eth_consensus_specs/utils/kzg.py
@@ -27,9 +27,6 @@ def load_trusted_setup(precompute: int = 0):
     Load and cache the trusted setup. The JSON file (with g1_monomial,
     g1_lagrange, g2_monomial hex arrays) is converted to the text format that
     ckzg.load_trusted_setup expects.
-
-    Every helper below calls this, so the setup is loaded on first use no matter
-    which entry point imports this module.
     """
     global trusted_setup
     if trusted_setup is not None:
@@ -57,16 +54,14 @@ def load_trusted_setup(precompute: int = 0):
 
 def blob_to_kzg_commitment(blob):
     try:
-        return ckzg.blob_to_kzg_commitment(bytes(blob), load_trusted_setup())
+        return ckzg.blob_to_kzg_commitment(bytes(blob), trusted_setup)
     except Exception as e:
         raise AssertionError(str(e)) from e
 
 
 def compute_blob_kzg_proof(blob, commitment_bytes):
     try:
-        return ckzg.compute_blob_kzg_proof(
-            bytes(blob), bytes(commitment_bytes), load_trusted_setup()
-        )
+        return ckzg.compute_blob_kzg_proof(bytes(blob), bytes(commitment_bytes), trusted_setup)
     except Exception as e:
         raise AssertionError(str(e)) from e
 
@@ -77,7 +72,7 @@ def verify_blob_kzg_proof(blob, commitment_bytes, proof_bytes):
             bytes(blob),
             bytes(commitment_bytes),
             bytes(proof_bytes),
-            load_trusted_setup(),
+            trusted_setup,
         )
     except Exception as e:
         raise AssertionError(str(e)) from e
@@ -89,7 +84,7 @@ def verify_blob_kzg_proof_batch(blobs, commitments_bytes, proofs_bytes):
             b"".join(bytes(blob) for blob in blobs),
             b"".join(bytes(commitment) for commitment in commitments_bytes),
             b"".join(bytes(proof) for proof in proofs_bytes),
-            load_trusted_setup(),
+            trusted_setup,
         )
     except Exception as e:
         raise AssertionError(str(e)) from e
@@ -97,14 +92,14 @@ def verify_blob_kzg_proof_batch(blobs, commitments_bytes, proofs_bytes):
 
 def compute_cells(blob):
     try:
-        return ckzg.compute_cells(bytes(blob), load_trusted_setup())
+        return ckzg.compute_cells(bytes(blob), trusted_setup)
     except Exception as e:
         raise AssertionError(str(e)) from e
 
 
 def compute_cells_and_kzg_proofs(blob):
     try:
-        return ckzg.compute_cells_and_kzg_proofs(bytes(blob), load_trusted_setup())
+        return ckzg.compute_cells_and_kzg_proofs(bytes(blob), trusted_setup)
     except Exception as e:
         raise AssertionError(str(e)) from e
 
@@ -116,7 +111,7 @@ def verify_cell_kzg_proof_batch(commitments_bytes, cell_indices, cells, proofs_b
             [int(cell_index) for cell_index in cell_indices],
             [bytes(cell) for cell in cells],
             [bytes(proof) for proof in proofs_bytes],
-            load_trusted_setup(),
+            trusted_setup,
         )
     except Exception as e:
         raise AssertionError(str(e)) from e
@@ -127,7 +122,7 @@ def recover_cells_and_kzg_proofs(cell_indices, cells):
         return ckzg.recover_cells_and_kzg_proofs(
             [int(cell_index) for cell_index in cell_indices],
             [bytes(cell) for cell in cells],
-            load_trusted_setup(),
+            trusted_setup,
         )
     except Exception as e:
         raise AssertionError(str(e)) from e

--- a/tests/core/pyspec/eth_consensus_specs/utils/kzg.py
+++ b/tests/core/pyspec/eth_consensus_specs/utils/kzg.py
@@ -27,6 +27,9 @@ def load_trusted_setup(precompute: int = 0):
     Load and cache the trusted setup. The JSON file (with g1_monomial,
     g1_lagrange, g2_monomial hex arrays) is converted to the text format that
     ckzg.load_trusted_setup expects.
+
+    Every helper below calls this, so the setup is loaded on first use no matter
+    which entry point imports this module.
     """
     global trusted_setup
     if trusted_setup is not None:
@@ -54,14 +57,16 @@ def load_trusted_setup(precompute: int = 0):
 
 def blob_to_kzg_commitment(blob):
     try:
-        return ckzg.blob_to_kzg_commitment(bytes(blob), trusted_setup)
+        return ckzg.blob_to_kzg_commitment(bytes(blob), load_trusted_setup())
     except Exception as e:
         raise AssertionError(str(e)) from e
 
 
 def compute_blob_kzg_proof(blob, commitment_bytes):
     try:
-        return ckzg.compute_blob_kzg_proof(bytes(blob), bytes(commitment_bytes), trusted_setup)
+        return ckzg.compute_blob_kzg_proof(
+            bytes(blob), bytes(commitment_bytes), load_trusted_setup()
+        )
     except Exception as e:
         raise AssertionError(str(e)) from e
 
@@ -72,7 +77,7 @@ def verify_blob_kzg_proof(blob, commitment_bytes, proof_bytes):
             bytes(blob),
             bytes(commitment_bytes),
             bytes(proof_bytes),
-            trusted_setup,
+            load_trusted_setup(),
         )
     except Exception as e:
         raise AssertionError(str(e)) from e
@@ -84,7 +89,7 @@ def verify_blob_kzg_proof_batch(blobs, commitments_bytes, proofs_bytes):
             b"".join(bytes(blob) for blob in blobs),
             b"".join(bytes(commitment) for commitment in commitments_bytes),
             b"".join(bytes(proof) for proof in proofs_bytes),
-            trusted_setup,
+            load_trusted_setup(),
         )
     except Exception as e:
         raise AssertionError(str(e)) from e
@@ -92,14 +97,14 @@ def verify_blob_kzg_proof_batch(blobs, commitments_bytes, proofs_bytes):
 
 def compute_cells(blob):
     try:
-        return ckzg.compute_cells(bytes(blob), trusted_setup)
+        return ckzg.compute_cells(bytes(blob), load_trusted_setup())
     except Exception as e:
         raise AssertionError(str(e)) from e
 
 
 def compute_cells_and_kzg_proofs(blob):
     try:
-        return ckzg.compute_cells_and_kzg_proofs(bytes(blob), trusted_setup)
+        return ckzg.compute_cells_and_kzg_proofs(bytes(blob), load_trusted_setup())
     except Exception as e:
         raise AssertionError(str(e)) from e
 
@@ -111,7 +116,7 @@ def verify_cell_kzg_proof_batch(commitments_bytes, cell_indices, cells, proofs_b
             [int(cell_index) for cell_index in cell_indices],
             [bytes(cell) for cell in cells],
             [bytes(proof) for proof in proofs_bytes],
-            trusted_setup,
+            load_trusted_setup(),
         )
     except Exception as e:
         raise AssertionError(str(e)) from e
@@ -122,7 +127,7 @@ def recover_cells_and_kzg_proofs(cell_indices, cells):
         return ckzg.recover_cells_and_kzg_proofs(
             [int(cell_index) for cell_index in cell_indices],
             [bytes(cell) for cell in cells],
-            trusted_setup,
+            load_trusted_setup(),
         )
     except Exception as e:
         raise AssertionError(str(e)) from e

--- a/tests/generators/compliance_runners/fork_choice/conftest.py
+++ b/tests/generators/compliance_runners/fork_choice/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from eth_consensus_specs.test.helpers.constants import ELECTRA, MINIMAL
+from eth_consensus_specs.utils.kzg import load_trusted_setup
 from tests.generators.compliance_runners.gen_base.pytest_support import (
     add_comptests_pytest_options,
     configure_generator_context,
@@ -34,6 +35,11 @@ def pytest_generate_tests(metafunc):
         enumerate_groups=enumerate_test_groups,
         base_dir=str(Path(__file__).parent),
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def trusted_setup():
+    load_trusted_setup()
 
 
 @pytest.fixture


### PR DESCRIPTION
Seems like generating compliance tests is [broken](https://github.com/ethereum/consensus-specs/actions/runs/30653186747) since https://github.com/ethereum/consensus-specs/pull/5398. Not sure this is the right fix for it, but it does seem to work and AI is telling me calling `load_trusted_setup()` adds an overhead of ~96 ns which seems negligible.