### PR TITLE
Modify `on_inclusion_list` to handle ILs from req/resp

### DIFF
--- a/specs/heze/beacon-chain.md
+++ b/specs/heze/beacon-chain.md
@@ -86,7 +86,7 @@ class InclusionListCommittee(Vector[ValidatorIndex, INCLUSION_LIST_COMMITTEE_SIZ
 class InclusionList(Container):
     slot: Slot
     validator_index: ValidatorIndex
-    inclusion_list_committee_root: Root
+    dependent_root: Root
     transactions: Transactions
 ```
 

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -281,7 +281,6 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     dependent_state = copy(store.block_states[inclusion_list.dependent_root])
     if dependent_state.slot < inclusion_list.slot:
         process_slots(dependent_state, inclusion_list.slot)
-
     committee = get_inclusion_list_committee(dependent_state, inclusion_list.slot)
     assert inclusion_list.validator_index in committee
 
@@ -296,7 +295,10 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
 
     # Process the inclusion list
     process_inclusion_list(
-        get_inclusion_list_store(), signed_inclusion_list, hash_tree_root(committee), is_timely
+        get_inclusion_list_store(),
+        signed_inclusion_list,
+        hash_tree_root(committee),
+        is_timely,
     )
 ```
 

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -263,12 +263,22 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     """
     Run ``on_inclusion_list`` upon receiving a new inclusion list.
     """
+    # Verify the validator is in the inclusion list committee
+    dependent_state = copy(store.block_states[inclusion_list.dependent_root])
+    if dependent_state.slot < inclusion_list.slot:
+        process_slots(dependent_state, inclusion_list.slot)
+
+    committee = get_inclusion_list_committee(dependent_state, inclusion_list.slot)
+    assert inclusion_list.validator_index in committee
+
     seconds_since_genesis = store.time - store.genesis_time
     time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
     inclusion_list_due_ms = get_inclusion_list_due_ms()
     is_timely = time_into_slot_ms < inclusion_list_due_ms
 
-    process_inclusion_list(get_inclusion_list_store(), signed_inclusion_list, is_timely)
+    process_inclusion_list(
+        get_inclusion_list_store(), signed_inclusion_list, hash_tree_root(committee), is_timely
+    )
 ```
 
 ### Modified `on_execution_payload_envelope`

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -263,6 +263,20 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     """
     Run ``on_inclusion_list`` upon receiving a new inclusion list.
     """
+    inclusion_list = signed_inclusion_list.message
+    current_slot = get_current_slot(store)
+
+    # The transactions must not exceed the maximum size
+    transactions_size = sum(len(transaction) for transaction in inclusion_list.transactions)
+    assert transactions_size <= MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST
+
+    # The slot must be within the retention window
+    assert inclusion_list.slot <= current_slot
+    assert inclusion_list.slot + MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS >= current_slot
+
+    # The dependent block must be known
+    assert inclusion_list.dependent_root in store.block_states
+
     # Verify the validator is in the inclusion list committee
     dependent_state = copy(store.block_states[inclusion_list.dependent_root])
     if dependent_state.slot < inclusion_list.slot:
@@ -271,11 +285,16 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     committee = get_inclusion_list_committee(dependent_state, inclusion_list.slot)
     assert inclusion_list.validator_index in committee
 
+    # Verify the signature
+    assert is_valid_inclusion_list_signature(dependent_state, signed_inclusion_list)
+
+    # The inclusion list is timely if it arrives in its slot before the deadline
     seconds_since_genesis = store.time - store.genesis_time
     time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-    inclusion_list_due_ms = get_inclusion_list_due_ms()
-    is_timely = time_into_slot_ms < inclusion_list_due_ms
+    is_current_slot = inclusion_list.slot == current_slot
+    is_timely = is_current_slot and time_into_slot_ms < get_inclusion_list_due_ms()
 
+    # Process the inclusion list
     process_inclusion_list(
         get_inclusion_list_store(), signed_inclusion_list, hash_tree_root(committee), is_timely
     )

--- a/specs/heze/inclusion-list.md
+++ b/specs/heze/inclusion-list.md
@@ -59,10 +59,11 @@ def get_inclusion_list_store() -> InclusionListStore:
 def process_inclusion_list(
     store: InclusionListStore,
     signed_inclusion_list: SignedInclusionList,
+    inclusion_list_committee_root: Root,
     is_timely: bool,
 ) -> None:
     inclusion_list = signed_inclusion_list.message
-    key = inclusion_list.inclusion_list_committee_root
+    key = inclusion_list_committee_root
 
     # Ignore an inclusion list that has already been stored
     inclusion_list_root = hash_tree_root(inclusion_list)
@@ -88,10 +89,10 @@ def process_inclusion_list(
 
 *Note*: `get_inclusion_list_transactions` returns a list of unique transactions
 from all valid and non-equivocating `InclusionList`s for the given slot and for
-which the `inclusion_list_committee_root` in the `InclusionList` matches the one
-calculated based on the current state. When `only_timely` is `True`, only
-`InclusionList`s received in a timely manner on the p2p network are considered;
-otherwise, timeliness is not considered.
+which the `inclusion_list_committee_root` compatible with the `dependent_root`
+in the `InclusionList` matches the one calculated from the given `state`. When
+`only_timely` is `True`, only `InclusionList`s received in a timely manner on
+the p2p network are considered; otherwise, timeliness is not considered.
 
 *Note*: Inclusion lists MUST be retained for at least
 `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS` slots beyond their slot, after which

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -217,7 +217,7 @@ Response Content:
 )
 ```
 
-Requests inclusion lists by `slot`, `dependent_root` and inclusion list
+Requests inclusion lists by `slot`, `dependent_root`, and inclusion list
 committee `indices`. The `indices` field is interpreted with respect to
 `get_inclusion_list_committee(state, slot)`, where `state` is the state
 corresponding to processing the block with root `dependent_root` up to the slot

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -131,12 +131,19 @@ the network, assuming the alias `message = signed_inclusion_list.message`:
   `message.slot == current_slot`.
 - _[IGNORE]_ The `message` is either the first or second valid message received
   from the validator with index `message.validator_index`.
+- _[IGNORE]_ The block with root `message.dependent_root` has been seen (via
+  gossip or non-gossip sources) (a client MAY queue the message for processing
+  once the block is retrieved).
+- _[REJECT]_ The slot of the block with root `message.dependent_root` is
+  strictly less than
+  `compute_start_slot_at_epoch(compute_epoch_at_slot(message.slot) - MIN_SEED_LOOKAHEAD)`.
+- _[IGNORE]_ `is_valid_dependent_root(store, message.dependent_root, epoch)`
+  returns `True`, where `store` is the fork choice store and `epoch` is
+  `compute_epoch_at_slot(message.slot) - MIN_SEED_LOOKAHEAD`.
 - _[REJECT]_ The message's validator index is in
-  `get_inclusion_list_committee(state, message.slot)`, where `state` is the head
-  state corresponding to processing the block up to the current slot as
-  determined by the fork choice.
-- _[REJECT]_ The `message.inclusion_list_committee_root` is equal to
-  `hash_tree_root(get_inclusion_list_committee(state, message.slot))`.
+  `get_inclusion_list_committee(state, message.slot)`, where `state` is the
+  state corresponding to processing the block with root `message.dependent_root`
+  up to the slot `message.slot`.
 - _[REJECT]_ The signature of `signed_inclusion_list.signature` is valid with
   respect to the validator's public key.
 
@@ -197,7 +204,7 @@ Request Content:
 ```
 (
   slot: Slot
-  inclusion_list_committee_root: Root
+  dependent_root: Root
   indices: InclusionListBits
 )
 ```
@@ -210,11 +217,13 @@ Response Content:
 )
 ```
 
-Requests inclusion lists by `slot`, `inclusion_list_committee_root` and
-inclusion list committee `indices`. The response is a list of
-`SignedInclusionList` whose length is less than or equal to the number of
-requested inclusion lists. It may be less in the case that the responding peer
-is missing inclusion lists.
+Requests inclusion lists by `slot`, `dependent_root` and inclusion list
+committee `indices`. The `indices` field is interpreted with respect to
+`get_inclusion_list_committee(state, slot)`, where `state` is the state
+corresponding to processing the block with root `dependent_root` up to the slot
+`slot`. The response is a list of `SignedInclusionList` whose length is less
+than or equal to the number of requested inclusion lists. It may be less in the
+case that the responding peer is missing inclusion lists.
 
 No more than `MAX_REQUEST_INCLUSION_LIST` may be requested at a time.
 
@@ -240,8 +249,7 @@ MAY limit the number of inclusion lists in the response.
 Clients SHOULD include an inclusion list in the response as soon as it passes
 the gossip validation rules. Clients SHOULD NOT respond with inclusion lists
 that fail the gossip validation rules. Clients SHOULD NOT respond with inclusion
-lists from equivocators for the requested `slot` and
-`inclusion_list_committee_root`.
+lists from equivocators for the requested `slot` and `dependent_root`.
 
 For each successful `response_chunk`, the `ForkDigest` context epoch is
 determined by `compute_epoch_at_slot(signed_inclusion_list.message.slot)`.

--- a/specs/heze/validator.md
+++ b/specs/heze/validator.md
@@ -195,19 +195,11 @@ head, or against the local head returned by `get_head()` otherwise.
 
 #### Constructing the `SignedInclusionList`
 
-The validator creates the `signed_inclusion_list` as follows:
-
-- First, the validator creates the `inclusion_list`.
-- Set `inclusion_list.slot` to the assigned slot returned by
-  `get_inclusion_list_committee_assignment`.
-- Set `inclusion_list.validator_index` to the validator's index.
-- Set `inclusion_list.inclusion_list_committee_root` to the hash tree root of
-  the committee that the validator is a member of.
-- Set `inclusion_list.transactions` using the response from `ExecutionEngine`
-  via `get_inclusion_list`.
-
-After building the `inclusion_list`, the validator obtains a `signature` of the
-inclusion list by using:
+A validator constructs the `signed_inclusion_list` with
+`get_signed_inclusion_list` for the assigned `slot` returned by
+`get_inclusion_list_committee_assignment`. Let `head_root` be the validator's
+current head root and `inclusion_list_transactions` be the inclusion list
+transactions obtained from `ExecutionEngine` via `get_inclusion_list`.
 
 ```python
 def get_inclusion_list_signature(
@@ -220,6 +212,23 @@ def get_inclusion_list_signature(
     return bls.Sign(privkey, signing_root)
 ```
 
-Then the validator assembles
-`signed_inclusion_list = SignedInclusionList(message=inclusion_list, signature=signature)`
-and broadcasts it on the `inclusion_list` global gossip topic.
+```python
+def get_signed_inclusion_list(
+    store: Store,
+    state: BeaconState,
+    head_root: Root,
+    slot: Slot,
+    validator_index: ValidatorIndex,
+    inclusion_list_transactions: Sequence[Transaction],
+    privkey: int,
+) -> SignedInclusionList:
+    dependent_root = get_shuffling_dependent_root(store, head_root, compute_epoch_at_slot(slot))
+    inclusion_list = InclusionList(
+        slot=slot,
+        validator_index=validator_index,
+        dependent_root=dependent_root,
+        transactions=inclusion_list_transactions,
+    )
+    signature = get_inclusion_list_signature(state, inclusion_list, privkey)
+    return SignedInclusionList(message=inclusion_list, signature=signature)
+```

--- a/specs/heze/validator.md
+++ b/specs/heze/validator.md
@@ -222,11 +222,10 @@ def get_signed_inclusion_list(
     inclusion_list_transactions: Sequence[Transaction],
     privkey: int,
 ) -> SignedInclusionList:
-    dependent_root = get_shuffling_dependent_root(store, head_root, compute_epoch_at_slot(slot))
     inclusion_list = InclusionList(
         slot=slot,
         validator_index=validator_index,
-        dependent_root=dependent_root,
+        dependent_root=get_shuffling_dependent_root(store, head_root, compute_epoch_at_slot(slot)),
         transactions=inclusion_list_transactions,
     )
     signature = get_inclusion_list_signature(state, inclusion_list, privkey)

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/inclusion_list.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/inclusion_list.py
@@ -2,11 +2,9 @@ from functools import lru_cache
 from random import randbytes
 
 from eth_consensus_specs.test.helpers.keys import privkeys
-from eth_consensus_specs.utils.ssz.ssz_impl import hash_tree_root
-from eth_consensus_specs.utils.ssz.ssz_typing import Vector
 
 
-def get_empty_inclusion_list(spec, state, slot=None, validator_index=None):
+def get_empty_inclusion_list(spec, store, state, slot=None, validator_index=None):
     """
     Build an empty inclusion list for ``slot``. Slot must be greater than or equal to the current slot in ``state``.
     """
@@ -16,8 +14,9 @@ def get_empty_inclusion_list(spec, state, slot=None, validator_index=None):
         raise Exception("get_empty_inclusion_list cannot build inclusion lists for past slots")
 
     committee = spec.get_inclusion_list_committee(state, slot)
-    committee_root = hash_tree_root(
-        Vector[spec.ValidatorIndex, spec.INCLUSION_LIST_COMMITTEE_SIZE](*committee)
+    head_root = spec.get_head(store).root
+    dependent_root = spec.get_shuffling_dependent_root(
+        store, head_root, spec.compute_epoch_at_slot(slot)
     )
 
     if validator_index is None:
@@ -28,7 +27,7 @@ def get_empty_inclusion_list(spec, state, slot=None, validator_index=None):
     empty_inclusion_list = spec.InclusionList()
     empty_inclusion_list.slot = slot
     empty_inclusion_list.validator_index = validator_index
-    empty_inclusion_list.inclusion_list_committee_root = committee_root
+    empty_inclusion_list.dependent_root = dependent_root
     empty_inclusion_list.transactions = []
 
     return empty_inclusion_list
@@ -36,6 +35,7 @@ def get_empty_inclusion_list(spec, state, slot=None, validator_index=None):
 
 def get_empty_signed_inclusion_list(
     spec,
+    store,
     state,
     slot=None,
     validator_index=None,
@@ -43,7 +43,7 @@ def get_empty_signed_inclusion_list(
     """
     Build an empty signed inclusion list for ``slot``. Slot must be greater than or equal to the current slot in ``state``.
     """
-    empty_inclusion_list = get_empty_inclusion_list(spec, state, slot, validator_index)
+    empty_inclusion_list = get_empty_inclusion_list(spec, store, state, slot, validator_index)
     signed_inclusion_list = sign_inclusion_list(spec, state, empty_inclusion_list)
 
     return signed_inclusion_list
@@ -51,6 +51,7 @@ def get_empty_signed_inclusion_list(
 
 def get_sample_inclusion_list(
     spec,
+    store,
     state,
     slot=None,
     validator_index=None,
@@ -62,7 +63,7 @@ def get_sample_inclusion_list(
     Build a sample inclusion list for ``slot``. Slot must be greater than or equal to the current slot in ``state``.
     When ``transactions`` is provided, ``max_transaction_size`` and ``max_transaction_count`` are ignored.
     """
-    inclusion_list = get_empty_inclusion_list(spec, state, slot, validator_index)
+    inclusion_list = get_empty_inclusion_list(spec, store, state, slot, validator_index)
     inclusion_list.transactions = (
         get_sample_transactions(spec, max_transaction_size, max_transaction_count)
         if transactions is None
@@ -74,6 +75,7 @@ def get_sample_inclusion_list(
 
 def get_sample_signed_inclusion_list(
     spec,
+    store,
     state,
     slot=None,
     validator_index=None,
@@ -87,6 +89,7 @@ def get_sample_signed_inclusion_list(
     """
     sample_inclusion_list = get_sample_inclusion_list(
         spec,
+        store,
         state,
         slot,
         validator_index,

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
@@ -97,7 +97,7 @@ def build_max_size_signed_inclusion_list(spec):
     inclusion_list = spec.InclusionList(
         slot=spec.Slot(0),
         validator_index=spec.ValidatorIndex(0),
-        inclusion_list_committee_root=spec.Root(),
+        dependent_root=spec.Root(),
         transactions=transactions,
     )
     return spec.SignedInclusionList(message=inclusion_list, signature=spec.BLSSignature())

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
@@ -6,7 +6,11 @@ from eth_consensus_specs.test.context import (
     with_custom_state,
     with_heze_and_later,
 )
-from eth_consensus_specs.test.helpers.fork_choice import get_genesis_forkchoice_store
+from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
+from eth_consensus_specs.test.helpers.fork_choice import (
+    get_genesis_forkchoice_store,
+    run_on_block,
+)
 from eth_consensus_specs.test.helpers.inclusion_list import (
     get_empty_signed_inclusion_list,
     get_sample_inclusion_list,
@@ -15,7 +19,19 @@ from eth_consensus_specs.test.helpers.inclusion_list import (
     run_with_inclusion_list_store,
     sign_inclusion_list,
 )
-from tests.core.pyspec.eth_consensus_specs.utils.hash_function import ZERO_BYTES32
+from eth_consensus_specs.test.helpers.state import state_transition_and_sign_block
+
+
+def advance_to_epoch_with_known_dependent_root(spec, state, forkchoice_store):
+    """
+    Advance ``state`` and the ``forkchoice_store`` clock past the genesis epochs,
+    so that inclusion lists built for the current slot have a dependent root that
+    resolves to a known block.
+    """
+    slot = spec.compute_start_slot_at_epoch(spec.MIN_SEED_LOOKAHEAD + 1)
+    spec.process_slots(state, slot)
+    time = state.genesis_time + slot * spec.config.SLOT_DURATION_MS // 1000
+    spec.on_tick(forkchoice_store, time)
 
 
 @with_heze_and_later
@@ -23,6 +39,7 @@ from tests.core.pyspec.eth_consensus_specs.utils.hash_function import ZERO_BYTES
 def test_inclusion_list_store_transaction_uniqueness(spec, state):
     def run_func():
         forkchoice_store = get_genesis_forkchoice_store(spec, state)
+        advance_to_epoch_with_known_dependent_root(spec, state, forkchoice_store)
         inclusion_list_store = spec.get_inclusion_list_store()
         inclusion_list_committee = spec.get_inclusion_list_committee(state, state.slot)
 
@@ -31,7 +48,7 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         # An empty IL.
         signed_inclusion_lists.append(
             get_empty_signed_inclusion_list(
-                spec, state, validator_index=inclusion_list_committee[0]
+                spec, forkchoice_store, state, validator_index=inclusion_list_committee[0]
             )
         )
 
@@ -39,6 +56,7 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         signed_inclusion_lists.append(
             get_sample_signed_inclusion_list(
                 spec,
+                forkchoice_store,
                 state,
                 validator_index=inclusion_list_committee[1],
                 max_transaction_size=0,
@@ -51,6 +69,7 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         signed_inclusion_lists.append(
             get_sample_signed_inclusion_list(
                 spec,
+                forkchoice_store,
                 state,
                 validator_index=inclusion_list_committee[2],
                 transactions=transactions,
@@ -59,6 +78,7 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         signed_inclusion_lists.append(
             get_sample_signed_inclusion_list(
                 spec,
+                forkchoice_store,
                 state,
                 validator_index=inclusion_list_committee[3],
                 transactions=transactions,
@@ -69,6 +89,7 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         signed_inclusion_lists.append(
             get_sample_signed_inclusion_list(
                 spec,
+                forkchoice_store,
                 state,
                 validator_index=inclusion_list_committee[4],
             )
@@ -78,6 +99,7 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         signed_inclusion_lists.append(
             get_sample_signed_inclusion_list(
                 spec,
+                forkchoice_store,
                 state,
                 validator_index=inclusion_list_committee[5],
                 max_transaction_size=spec.config.MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST,
@@ -89,6 +111,7 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         signed_inclusion_lists.append(
             get_sample_signed_inclusion_list(
                 spec,
+                forkchoice_store,
                 state,
                 validator_index=inclusion_list_committee[6],
                 max_transaction_size=spec.config.MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST // 16,
@@ -100,6 +123,7 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         signed_inclusion_lists.append(
             get_sample_signed_inclusion_list(
                 spec,
+                forkchoice_store,
                 state,
                 validator_index=inclusion_list_committee[7],
                 max_transaction_size=1,
@@ -125,12 +149,15 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
 
 @with_heze_and_later
 @spec_state_test
-def test_inclusion_list_store_by_slot_and_committee_root__empty_slot(spec, state):
+def test_inclusion_list_store_by_slot_and_dependent_root__empty_slot(spec, state):
     def run_func():
         forkchoice_store = get_genesis_forkchoice_store(spec, state)
+        advance_to_epoch_with_known_dependent_root(spec, state, forkchoice_store)
         inclusion_list_store = spec.get_inclusion_list_store()
 
-        signed_inclusion_list_slot_0 = get_sample_signed_inclusion_list(spec, state)
+        signed_inclusion_list_slot_0 = get_sample_signed_inclusion_list(
+            spec, forkchoice_store, state
+        )
 
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_slot_0)
 
@@ -151,41 +178,66 @@ def test_inclusion_list_store_by_slot_and_committee_root__empty_slot(spec, state
 
 @with_heze_and_later
 @spec_state_test
-def test_inclusion_list_store_by_slot_and_committee_root__different_committee_root(spec, state):
+def test_inclusion_list_store_by_slot_and_dependent_root__different_dependent_root(spec, state):
     def run_func():
         forkchoice_store = get_genesis_forkchoice_store(spec, state)
+        advance_to_epoch_with_known_dependent_root(spec, state, forkchoice_store)
         inclusion_list_store = spec.get_inclusion_list_store()
         inclusion_list_committee = spec.get_inclusion_list_committee(state, state.slot)
 
+        # Build IL0 against the canonical branch.
         transactions = get_sample_transactions(spec, max_transaction_count=1)
         inclusion_list_0 = get_sample_inclusion_list(
             spec,
+            forkchoice_store,
             state,
             validator_index=inclusion_list_committee[0],
             transactions=transactions,
         )
+        signed_inclusion_list_0 = sign_inclusion_list(spec, state, inclusion_list_0)
+
+        # Make a fork branch off the head.
+        head_root = spec.get_head(forkchoice_store).root
+        fork_state = forkchoice_store.block_states[head_root].copy()
+        block = build_empty_block_for_next_slot(spec, fork_state)
+        signed_block = state_transition_and_sign_block(spec, fork_state, block)
+        run_on_block(spec, forkchoice_store, signed_block)
+
+        # Build IL1 against the fork branch.
+        spec.process_slots(fork_state, state.slot)
+        fork_inclusion_list_committee = spec.get_inclusion_list_committee(
+            fork_state, fork_state.slot
+        )
         inclusion_list_1 = get_sample_inclusion_list(
             spec,
-            state,
-            validator_index=inclusion_list_committee[1],
+            forkchoice_store,
+            fork_state,
+            validator_index=fork_inclusion_list_committee[0],
             # Reverse transaction bytes to ensure IL0 and IL1 have different transactions.
-            transactions=[transaction[::-1] for transaction in transactions],
+            transactions=[
+                spec.Transaction(transaction.encode_bytes()[::-1]) for transaction in transactions
+            ],
         )
+        signed_inclusion_list_1 = sign_inclusion_list(spec, fork_state, inclusion_list_1)
 
-        # Make IL1 have a different committee root.
-        inclusion_list_1.inclusion_list_committee_root = ZERO_BYTES32
-
-        signed_inclusion_list_0 = sign_inclusion_list(spec, state, inclusion_list_0)
-        signed_inclusion_list_1 = sign_inclusion_list(spec, state, inclusion_list_1)
-
+        # Both inclusion lists are valid, with different dependent roots.
+        assert inclusion_list_0.dependent_root != inclusion_list_1.dependent_root
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_0)
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_1)
 
+        # Only the inclusion list whose dependent root is compatible with the
+        # given state is returned.
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
             inclusion_list_store, state, state.slot
         )
-
         assert set(inclusion_list_transactions) == set(signed_inclusion_list_0.message.transactions)
+
+        fork_inclusion_list_transactions = spec.get_inclusion_list_transactions(
+            inclusion_list_store, fork_state, fork_state.slot
+        )
+        assert set(fork_inclusion_list_transactions) == set(
+            signed_inclusion_list_1.message.transactions
+        )
 
     run_with_inclusion_list_store(spec, run_func)
 
@@ -195,20 +247,21 @@ def test_inclusion_list_store_by_slot_and_committee_root__different_committee_ro
 def test_inclusion_list_store_equivocation(spec, state):
     def run_func():
         forkchoice_store = get_genesis_forkchoice_store(spec, state)
+        advance_to_epoch_with_known_dependent_root(spec, state, forkchoice_store)
         inclusion_list_store = spec.get_inclusion_list_store()
         inclusion_list_committee = spec.get_inclusion_list_committee(state, state.slot)
 
         signed_inclusion_list_1 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=inclusion_list_committee[0]
+            spec, forkchoice_store, state, validator_index=inclusion_list_committee[0]
         )
         signed_inclusion_list_2 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=inclusion_list_committee[0]
+            spec, forkchoice_store, state, validator_index=inclusion_list_committee[0]
         )
         signed_inclusion_list_3 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=inclusion_list_committee[0]
+            spec, forkchoice_store, state, validator_index=inclusion_list_committee[0]
         )
         signed_inclusion_list_4 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=inclusion_list_committee[1]
+            spec, forkchoice_store, state, validator_index=inclusion_list_committee[1]
         )
 
         # The first IL from an IL committee member should be stored successfully.
@@ -260,16 +313,16 @@ def test_inclusion_list_store_equivocation(spec, state):
 def test_inclusion_list_store_equivocation_scope(spec, state):
     def run_func():
         forkchoice_store = get_genesis_forkchoice_store(spec, state)
+        advance_to_epoch_with_known_dependent_root(spec, state, forkchoice_store)
         inclusion_list_store = spec.get_inclusion_list_store()
         inclusion_list_committee = spec.get_inclusion_list_committee(state, state.slot)
-        inclusion_list_committee_root = spec.hash_tree_root(inclusion_list_committee)
         validator_index = inclusion_list_committee[0]
 
         signed_inclusion_list_1 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=validator_index
+            spec, forkchoice_store, state, validator_index=validator_index
         )
         signed_inclusion_list_2 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=validator_index
+            spec, forkchoice_store, state, validator_index=validator_index
         )
 
         # An IL committee member equivocates.
@@ -282,20 +335,23 @@ def test_inclusion_list_store_equivocation_scope(spec, state):
 
         assert inclusion_list_transactions == []
 
-        # Find a later slot where the equivocator rejoins under a different committee root.
-        found_different_committee = False
+        # Find a later slot where the equivocator becomes an IL committee member again.
+        found_later_assignment = False
         for _ in range(spec.SLOTS_PER_EPOCH * 2):
             spec.process_slots(state, state.slot + 1)
             committee = spec.get_inclusion_list_committee(state, state.slot)
-            committee_root = spec.hash_tree_root(committee)
-            if validator_index in committee and inclusion_list_committee_root != committee_root:
-                found_different_committee = True
+            if validator_index in committee:
+                found_later_assignment = True
                 break
-        assert found_different_committee
+        assert found_later_assignment
+
+        # Advance the fork choice store clock to the new slot.
+        time = state.genesis_time + state.slot * spec.config.SLOT_DURATION_MS // 1000
+        spec.on_tick(forkchoice_store, time)
 
         # After the equivocated slot, the IL committee member should be able to participate successfully.
         signed_inclusion_list_3 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=validator_index
+            spec, forkchoice_store, state, validator_index=validator_index
         )
 
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_3)
@@ -314,17 +370,18 @@ def test_inclusion_list_store_equivocation_scope(spec, state):
 def test_inclusion_list_store_inclusion_list_due(spec, state):
     def run_func():
         forkchoice_store = get_genesis_forkchoice_store(spec, state)
+        advance_to_epoch_with_known_dependent_root(spec, state, forkchoice_store)
         inclusion_list_store = spec.get_inclusion_list_store()
         inclusion_list_committee = spec.get_inclusion_list_committee(state, state.slot)
 
         signed_inclusion_list_1 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=inclusion_list_committee[0]
+            spec, forkchoice_store, state, validator_index=inclusion_list_committee[0]
         )
         signed_inclusion_list_2 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=inclusion_list_committee[0]
+            spec, forkchoice_store, state, validator_index=inclusion_list_committee[0]
         )
         signed_inclusion_list_3 = get_sample_signed_inclusion_list(
-            spec, state, validator_index=inclusion_list_committee[1]
+            spec, forkchoice_store, state, validator_index=inclusion_list_committee[1]
         )
 
         # An IL received before the inclusion list due should be stored successfully.

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/validator/test_validator.py
@@ -9,6 +9,7 @@ from eth_consensus_specs.test.context import (
     with_custom_state,
     with_heze_and_later,
 )
+from eth_consensus_specs.test.helpers.fork_choice import get_genesis_forkchoice_store
 from eth_consensus_specs.test.helpers.inclusion_list import get_empty_inclusion_list
 from eth_consensus_specs.test.helpers.keys import privkeys, pubkeys
 from eth_consensus_specs.test.phase0.unittests.validator.test_validator_unittest import (
@@ -85,7 +86,8 @@ def test_get_inclusion_committee_assignment_out_bound_epoch(spec, state):
 @spec_state_test
 @always_bls
 def test_get_inclusion_list_signature(spec, state):
-    inclusion_list = get_empty_inclusion_list(spec, state)
+    forkchoice_store = get_genesis_forkchoice_store(spec, state)
+    inclusion_list = get_empty_inclusion_list(spec, forkchoice_store, state)
     domain = spec.get_domain(
         state, spec.DOMAIN_INCLUSION_LIST_COMMITTEE, spec.compute_epoch_at_slot(inclusion_list.slot)
     )


### PR DESCRIPTION
Following #5460, this PR modifies `on_inclusion_list` to handle ILs from req/resp. Since ILs can be obtained from the p2p network or via req/resp, `on_inclusion_list` should perform some sanity checks.

Additionally, ILs might come from nodes from different branches. Even when the network is healthy, two branches can have different dependent roots. (For instance, when the latest finalized epoch is N, current epoch is N+2 and a fork happened in epoch N.) To make it easier to check whether the validator is an includer, `inclusion_list_committee_root` field is replaced with `dependent_root`.

It's worth to mention that `get_shuffling_dependent_root` returns `Root()` for the first two epochs since Heze genesis. Strictly following this will produce ILs that will be dropped for the first two epochs. However, proposer preferences have the exact same issue and clients handle this by using the genesis root, instead of `Root()`. I think inclusion lists can follow the same approach, or we can change `get_shuffling_dependent_root` to return the genesis root when epoch <= MIN_SEED_LOOKAHEAD. This PR doesn't aim to address the issue.

Special thanks to @ensi321 for spotting the req/resp-related issues.