### PR TITLE
Use the genesis root as a dependent root for the first two epochs

### DIFF
--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -912,16 +912,12 @@ def record_block_timeliness(store: Store, root: Root) -> None:
 
 ```python
 def get_shuffling_dependent_root(store: Store, root: Root, epoch: Epoch) -> Root:
-    if epoch <= MIN_SEED_LOOKAHEAD:
-        # Genesis block parent
-        return Root()
-
     # [Modified in Gloas:EIP7732]
     node = ForkChoiceNode(
         root=root,
         payload_status=PAYLOAD_STATUS_PENDING,
     )
-    dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+    dependent_slot = compute_shuffling_dependent_slot(epoch)
     return get_ancestor(store, node, dependent_slot).root
 ```
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -59,6 +59,7 @@
       - [`update_latest_messages`](#update_latest_messages)
     - [`on_block` helpers](#on_block-helpers)
       - [`record_block_timeliness`](#record_block_timeliness)
+      - [`compute_shuffling_dependent_slot`](#compute_shuffling_dependent_slot)
       - [`get_shuffling_dependent_root`](#get_shuffling_dependent_root)
       - [`update_proposer_boost_root`](#update_proposer_boost_root)
   - [Handlers](#handlers)
@@ -879,16 +880,21 @@ def record_block_timeliness(store: Store, root: Root) -> None:
     store.block_timeliness[root] = is_timely
 ```
 
+##### `compute_shuffling_dependent_slot`
+
+```python
+def compute_shuffling_dependent_slot(epoch: Epoch) -> Slot:
+    if epoch <= MIN_SEED_LOOKAHEAD:
+        return GENESIS_SLOT
+    return Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+```
+
 ##### `get_shuffling_dependent_root`
 
 ```python
 def get_shuffling_dependent_root(store: Store, root: Root, epoch: Epoch) -> Root:
-    if epoch <= MIN_SEED_LOOKAHEAD:
-        # Genesis block parent
-        return Root()
-
     node = ForkChoiceNode(root=root)
-    dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+    dependent_slot = compute_shuffling_dependent_slot(epoch)
     return get_ancestor(store, node, dependent_slot).root
 ```
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -886,7 +886,7 @@ def record_block_timeliness(store: Store, root: Root) -> None:
 def compute_shuffling_dependent_slot(epoch: Epoch) -> Slot:
     if epoch <= MIN_SEED_LOOKAHEAD:
         return GENESIS_SLOT
-    return Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+    return compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - Slot(1)
 ```
 
 ##### `get_shuffling_dependent_root`

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_proposer_preferences.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_proposer_preferences.py
@@ -800,14 +800,11 @@ def test_gossip_proposer_preferences__ignore_slot_from_past_epoch(spec, state):
     # Pick a proposal slot whose epoch is strictly less than the current epoch.
     past_slot = spec.Slot(0)
     _, validator_index = find_upcoming_proposal_slot(spec, state)
-    # The dependent_root for the genesis epoch is unreachable, use a placeholder
-    # since this check fires before the dependent_root lookup.
     signed_prefs = build_signed_proposer_preferences(
         spec,
         state,
         proposal_slot=past_slot,
         validator_index=validator_index,
-        dependent_root=spec.Root(),
     )
     yield get_filename(signed_prefs), signed_prefs
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/proposer_preferences.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/proposer_preferences.py
@@ -31,8 +31,7 @@ def build_signed_proposer_preferences(
 
     if dependent_root is None:
         proposal_epoch = spec.compute_epoch_at_slot(proposal_slot)
-        lookahead_epoch = spec.Epoch(proposal_epoch - spec.MIN_SEED_LOOKAHEAD)
-        dependent_slot = spec.Slot(spec.compute_start_slot_at_epoch(lookahead_epoch) - 1)
+        dependent_slot = spec.compute_shuffling_dependent_slot(proposal_epoch)
         dependent_root = spec.get_block_root_at_slot(state, dependent_slot)
 
     if fee_recipient is None:

--- a/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
+++ b/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py
@@ -234,16 +234,8 @@ def is_attestation_eligible_for_block(spec, state, attestation) -> bool:
 
 def get_dependent_root(spec, state, slot):
     epoch = spec.compute_epoch_at_slot(slot)
-    if epoch <= spec.MIN_SEED_LOOKAHEAD:
-        dependent_slot = spec.GENESIS_SLOT
-    else:
-        dependent_slot = spec.compute_start_slot_at_epoch(epoch - spec.MIN_SEED_LOOKAHEAD) - 1
-
-    if dependent_slot > spec.GENESIS_SLOT:
-        return spec.get_block_root_at_slot(state, dependent_slot)
-    else:
-        # Default genesis block value
-        return spec.Root()
+    dependent_slot = spec.compute_shuffling_dependent_slot(epoch)
+    return spec.get_block_root_at_slot(state, dependent_slot)
 
 
 def get_voting_source(spec, state, target):


### PR DESCRIPTION
Previously, `get_shuffling_dependent_root` returned Root(), which causes some discrepancy between the spec and clients. The genesis block is the dependent block for the first two epochs and it seems all CL clients but Grandine use the genesis block root as a dependent root for the first two epochs. This PR modifies `get_shuffling_dependent_root` to return the genesis block root for epoch <= MIN_SEED_LOOKAHEAD.