### PR TITLE
ci: pass workflow/composite inputs via env before shell

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -29,10 +29,13 @@ runs:
 
     - name: Archive tests
       shell: bash
+      env:
+        SOURCE_PATH: ${{ inputs.source-path }}
+        ARCHIVE_NAME: ${{ inputs.name }}
       run: |
         # Ensure source-path exists so tar succeeds even when zero artifacts
         # were downloaded (e.g. presets with no per-fork reftests).
-        mkdir -p ${{ inputs.source-path }}
+        mkdir -p "$SOURCE_PATH"
         tar --sort=name \
             --owner=0 \
             --group=0 \
@@ -41,18 +44,21 @@ runs:
             --format=gnu \
             --use-compress-program='gzip --no-name' \
             --create \
-            --file=${{ inputs.name }}.tar.gz \
-            ${{ inputs.source-path }}
+            --file="${ARCHIVE_NAME}.tar.gz" \
+            "$SOURCE_PATH"
 
     - name: Delete intermediate artifacts
       shell: bash
-      run: |
-        gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-          --paginate --jq '.artifacts[]
-            | select(.name | startswith("${{ inputs.artifact-prefix }}-${{ inputs.name }}-"))
-            | .id' | while read id; do
-          gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
-        done
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         GH_REPO: ${{ github.repository }}
+        ARTIFACT_PREFIX: ${{ inputs.artifact-prefix }}
+        ARTIFACT_NAME: ${{ inputs.name }}
+      run: |
+        PREFIX="${ARTIFACT_PREFIX}-${ARTIFACT_NAME}-"
+        gh api "repos/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+          --paginate \
+          --jq --arg p "$PREFIX" '.artifacts[] | select(.name | startswith($p)) | .id' \
+          | while read -r id; do
+              gh api -X DELETE "repos/${GH_REPO}/actions/artifacts/$id"
+            done

--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -85,22 +85,39 @@ jobs:
     steps:
       - name: Resolve configuration
         id: config
+        env:
+          INPUT_REPO: ${{ inputs.repo }}
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_RELEASE: ${{ inputs.release }}
+          INPUT_SEED: ${{ inputs.seed }}
+          INPUT_ALTAIR: ${{ inputs.altair }}
+          INPUT_BELLATRIX: ${{ inputs.bellatrix }}
+          INPUT_CAPELLA: ${{ inputs.capella }}
+          INPUT_DENEB: ${{ inputs.deneb }}
+          INPUT_ELECTRA: ${{ inputs.electra }}
+          INPUT_FULU: ${{ inputs.fulu }}
+          INPUT_GLOAS: ${{ inputs.gloas }}
+          INPUT_TINY: ${{ inputs.tiny }}
+          INPUT_SMALL: ${{ inputs.small }}
+          INPUT_STANDARD: ${{ inputs.standard }}
+          THIS_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # Repo
-          repo="${{ inputs.repo || github.repository }}"
+          repo="${INPUT_REPO:-$THIS_REPO}"
           echo "repo=$repo" >> "$GITHUB_OUTPUT"
 
           # Ref
-          ref="${{ inputs.ref }}"
+          ref="$INPUT_REF"
           if [[ -n "$ref" ]]; then
             echo "ref=$ref" >> "$GITHUB_OUTPUT"
           fi
 
           # Release tag
-          release="${{ inputs.release }}"
+          release="$INPUT_RELEASE"
           if [[ -n "$release" ]]; then
-            if [[ "$repo" != "${{ github.repository }}" ]]; then
-              echo "Release-tagged compliance runs must use ${{ github.repository }} as the repository." >&2
+            if [[ "$repo" != "$THIS_REPO" ]]; then
+              echo "Release-tagged compliance runs must use ${THIS_REPO} as the repository." >&2
               exit 1
             fi
             if [[ "$ref" != "$release" ]]; then
@@ -115,17 +132,17 @@ jobs:
           echo "presets=$presets" >> "$GITHUB_OUTPUT"
 
           # Forks
-          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+          if [[ "$EVENT_NAME" == "schedule" ]]; then
             forks='["fulu","gloas"]'
           else
             selected=()
-            [[ "${{ inputs.altair }}" == "true" ]] && selected+=("altair")
-            [[ "${{ inputs.bellatrix }}" == "true" ]] && selected+=("bellatrix")
-            [[ "${{ inputs.capella }}" == "true" ]] && selected+=("capella")
-            [[ "${{ inputs.deneb }}" == "true" ]] && selected+=("deneb")
-            [[ "${{ inputs.electra }}" == "true" ]] && selected+=("electra")
-            [[ "${{ inputs.fulu }}" == "true" ]] && selected+=("fulu")
-            [[ "${{ inputs.gloas }}" == "true" ]] && selected+=("gloas")
+            [[ "$INPUT_ALTAIR" == "true" ]] && selected+=("altair")
+            [[ "$INPUT_BELLATRIX" == "true" ]] && selected+=("bellatrix")
+            [[ "$INPUT_CAPELLA" == "true" ]] && selected+=("capella")
+            [[ "$INPUT_DENEB" == "true" ]] && selected+=("deneb")
+            [[ "$INPUT_ELECTRA" == "true" ]] && selected+=("electra")
+            [[ "$INPUT_FULU" == "true" ]] && selected+=("fulu")
+            [[ "$INPUT_GLOAS" == "true" ]] && selected+=("gloas")
 
             if [[ ${#selected[@]} -eq 0 ]]; then
               echo "No forks selected." >&2
@@ -138,13 +155,13 @@ jobs:
           echo "forks=$forks" >> "$GITHUB_OUTPUT"
 
           # Configs
-          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+          if [[ "$EVENT_NAME" == "schedule" ]]; then
             configs='["small"]'
           else
             selected=()
-            [[ "${{ inputs.tiny }}" == "true" ]] && selected+=("tiny")
-            [[ "${{ inputs.small }}" == "true" ]] && selected+=("small")
-            [[ "${{ inputs.standard }}" == "true" ]] && selected+=("standard")
+            [[ "$INPUT_TINY" == "true" ]] && selected+=("tiny")
+            [[ "$INPUT_SMALL" == "true" ]] && selected+=("small")
+            [[ "$INPUT_STANDARD" == "true" ]] && selected+=("standard")
 
             if [[ ${#selected[@]} -eq 0 ]]; then
               echo "No generator configs selected." >&2
@@ -157,7 +174,7 @@ jobs:
           echo "configs=$configs" >> "$GITHUB_OUTPUT"
 
           # Seed
-          seed_input="${{ inputs.seed }}"
+          seed_input="$INPUT_SEED"
           if [[ -z "$seed_input" ]]; then
             seed=$(shuf -i 1-2147483647 -n 1)
           elif [[ "$seed_input" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
`comptests.yml` Resolve configuration and the `package` composite action interpolated several free-string inputs directly into `run:` scripts (`repo`/`ref`/`release`/`seed`/fork flags, `source-path`, archive name, artifact prefix). Move those values into `env:` and expand shell variables instead.

## Test plan
- [ ] Manual/dispatch comptest config resolve still emits repo/ref/forks/configs/seed/matrix
- [ ] Package action still archives downloaded intermediates and deletes matching artifacts


Made with [Cursor](https://cursor.com)