### PR TITLE
Introduce `get_set_bit_count` helper

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -622,10 +622,10 @@ def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) ->
     # Verify sync committee aggregate signature signing over the previous slot block root
     committee_pubkeys = state.current_sync_committee.pubkeys
     committee_bits = sync_aggregate.sync_committee_bits
-    if sum(committee_bits) == SYNC_COMMITTEE_SIZE:
+    if get_set_bit_count(committee_bits) == SYNC_COMMITTEE_SIZE:
         # All members participated - use precomputed aggregate key
         participant_pubkeys = [state.current_sync_committee.aggregate_pubkey]
-    elif sum(committee_bits) > SYNC_COMMITTEE_SIZE // 2:
+    elif get_set_bit_count(committee_bits) > SYNC_COMMITTEE_SIZE // 2:
         # More than half participated - subtract non-participant keys.
         # First determine nonparticipating members
         non_participant_pubkeys = [

--- a/specs/altair/light-client/full-node.md
+++ b/specs/altair/light-client/full-node.md
@@ -115,7 +115,7 @@ def create_light_client_update(
 ) -> LightClientUpdate:
     assert compute_epoch_at_slot(attested_state.slot) >= ALTAIR_FORK_EPOCH
     assert (
-        sum(block.message.body.sync_aggregate.sync_committee_bits)
+        get_set_bit_count(block.message.body.sync_aggregate.sync_committee_bits)
         >= MIN_SYNC_COMMITTEE_PARTICIPANTS
     )
 

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -245,8 +245,8 @@ def is_finality_update(update: LightClientUpdate) -> bool:
 def is_better_update(new_update: LightClientUpdate, old_update: LightClientUpdate) -> bool:
     # Compare supermajority (> 2/3) sync committee participation
     max_active_participants = len(new_update.sync_aggregate.sync_committee_bits)
-    new_num_active_participants = sum(new_update.sync_aggregate.sync_committee_bits)
-    old_num_active_participants = sum(old_update.sync_aggregate.sync_committee_bits)
+    new_num_active_participants = get_set_bit_count(new_update.sync_aggregate.sync_committee_bits)
+    old_num_active_participants = get_set_bit_count(old_update.sync_aggregate.sync_committee_bits)
     new_has_supermajority = new_num_active_participants * 3 >= max_active_participants * 2
     old_has_supermajority = old_num_active_participants * 3 >= max_active_participants * 2
     if new_has_supermajority != old_has_supermajority:
@@ -405,7 +405,7 @@ def validate_light_client_update(
 ) -> None:
     # Verify sync committee has sufficient participants
     sync_aggregate = update.sync_aggregate
-    assert sum(sync_aggregate.sync_committee_bits) >= MIN_SYNC_COMMITTEE_PARTICIPANTS
+    assert get_set_bit_count(sync_aggregate.sync_committee_bits) >= MIN_SYNC_COMMITTEE_PARTICIPANTS
 
     # Verify update does not skip a sync committee period
     assert is_valid_light_client_header(update.attested_header)
@@ -545,12 +545,12 @@ def process_light_client_update(
     # Track the maximum number of active participants in the committee signatures
     store.current_max_active_participants = max(
         store.current_max_active_participants,
-        sum(sync_committee_bits),
+        get_set_bit_count(sync_committee_bits),
     )
 
     # Update the optimistic header
     if (
-        sum(sync_committee_bits) > get_safety_threshold(store)
+        get_set_bit_count(sync_committee_bits) > get_safety_threshold(store)
         and update.attested_header.beacon.slot > store.optimistic_header.beacon.slot
     ):
         store.optimistic_header = update.attested_header
@@ -565,7 +565,7 @@ def process_light_client_update(
             == compute_sync_committee_period_at_slot(update.attested_header.beacon.slot)
         )
     )
-    if sum(sync_committee_bits) * 3 >= len(sync_committee_bits) * 2 and (
+    if get_set_bit_count(sync_committee_bits) * 3 >= len(sync_committee_bits) * 2 and (
         update.finalized_header.beacon.slot > store.finalized_header.beacon.slot
         or update_has_finalized_next_sync_committee
     ):

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -628,7 +628,7 @@ def validate_beacon_attestation_gossip(
         raise GossipReject("attestation epoch does not match target epoch")
 
     # [REJECT] The attestation is unaggregated (exactly one bit set)
-    num_bits_set = sum(1 for bit in aggregation_bits if bit)
+    num_bits_set = get_set_bit_count(aggregation_bits)
     if num_bits_set != 1:
         raise GossipReject("attestation is not unaggregated")
 

--- a/specs/fulu/partial-columns/p2p-interface.md
+++ b/specs/fulu/partial-columns/p2p-interface.md
@@ -234,7 +234,7 @@ def validate_partial_data_column_sidecar_gossip(
     Raises GossipIgnore or GossipReject on validation failure.
     """
     has_header = len(sidecar.header) == 1
-    num_cells_present = sum(1 for b in sidecar.cells_present_bitmap if b)
+    num_cells_present = get_set_bit_count(sidecar.cells_present_bitmap)
     has_cells = num_cells_present > 0
 
     # [REJECT] A header and/or cells are present in the message

--- a/specs/gloas/partial-columns/p2p-interface.md
+++ b/specs/gloas/partial-columns/p2p-interface.md
@@ -119,7 +119,7 @@ def validate_partial_data_column_sidecar_gossip(
     Validate a PartialDataColumnSidecar for gossip propagation on a subnet.
     Raises GossipIgnore or GossipReject on validation failure.
     """
-    num_cells_present = sum(1 for b in sidecar.cells_present_bitmap if b)
+    num_cells_present = get_set_bit_count(sidecar.cells_present_bitmap)
 
     # [Modified in Gloas:EIP7732]
     # [REJECT] The message contains at least one cell

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -84,6 +84,7 @@
     - [`SignedBeaconBlockHeader`](#signedbeaconblockheader)
 - [Helpers](#helpers)
   - [Math](#math)
+    - [`get_set_bit_count`](#get_set_bit_count)
     - [`integer_squareroot`](#integer_squareroot)
     - [`xor`](#xor)
     - [`uint_to_bytes`](#uint_to_bytes)
@@ -928,6 +929,16 @@ class SignedBeaconBlockHeader(Container):
 necessarily optimal implementations.
 
 ### Math
+
+#### `get_set_bit_count`
+
+```python
+def get_set_bit_count(bits: Sequence[Boolean]) -> Uint64:
+    """
+    Return the number of bits that are set in ``bits``.
+    """
+    return Uint64(sum(1 for bit in bits if bit))
+```
 
 #### `integer_squareroot`
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1030,7 +1030,7 @@ def validate_beacon_attestation_gossip(
         raise GossipReject("attestation epoch does not match target epoch")
 
     # [REJECT] The attestation is unaggregated (exactly one bit set)
-    num_bits_set = sum(1 for bit in aggregation_bits if bit)
+    num_bits_set = get_set_bit_count(aggregation_bits)
     if num_bits_set != 1:
         raise GossipReject("attestation is not unaggregated")
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_data_collection.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/light_client_data_collection.py
@@ -386,7 +386,7 @@ def _create_lc_update(test, spec, state, block, parent_bid):
 
     # If sync committee does not have sufficient participants, do not bump latest
     sync_aggregate = block.message.body.sync_aggregate
-    num_active_participants = sum(sync_aggregate.sync_committee_bits)
+    num_active_participants = spec.get_set_bit_count(sync_aggregate.sync_committee_bits)
     if num_active_participants < spec.MIN_SYNC_COMMITTEE_PARTICIPANTS:
         latest_signature_slot = attested_data.latest_signature_slot
     else:
@@ -474,7 +474,7 @@ def _process_head_change_for_light_client(test, spec, head_bid, old_finalized_bi
         best = _get_light_client_data(test.lc_data_store, bid).current_period_best_update
         if (
             best.spec is None
-            or sum(best.data.sync_aggregate.sync_committee_bits)
+            or spec.get_set_bit_count(best.data.sync_aggregate.sync_committee_bits)
             < spec.MIN_SYNC_COMMITTEE_PARTICIPANTS
         ):
             test.lc_data_store.db.best_updates.pop(period, None)

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/sync_committee.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/sync_committee.py
@@ -82,7 +82,7 @@ def compute_sync_committee_participant_reward_and_penalty(
 def compute_sync_committee_proposer_reward(spec, state, committee_indices, committee_bits):
     proposer_reward_denominator = spec.WEIGHT_DENOMINATOR - spec.PROPOSER_WEIGHT
     inclusion_reward = compute_sync_committee_inclusion_reward(spec, state)
-    participant_number = committee_bits.count(True)
+    participant_number = spec.get_set_bit_count(committee_bits)
     participant_reward = inclusion_reward * spec.PROPOSER_WEIGHT // proposer_reward_denominator
     return spec.Gwei(participant_reward * participant_number)
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_ex_ante.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_ex_ante.py
@@ -90,7 +90,7 @@ def test_ex_ante_vanilla(spec, state):
         filter_participant_set=_filter_participant_set,
     )
     attestation.data.beacon_block_root = signed_block_b.message.hash_tree_root()
-    assert len([i for i in attestation.aggregation_bits if i == 1]) == 1
+    assert spec.get_set_bit_count(attestation.aggregation_bits) == 1
     sign_attestation(spec, state_b, attestation)
 
     # Block C received at N+2 — C is head
@@ -203,7 +203,7 @@ def test_ex_ante_attestations_is_greater_than_proposer_boost_with_boost(spec, st
         filter_participant_set=_filter_participant_set,
     )
     attestation.data.beacon_block_root = signed_block_b.message.hash_tree_root()
-    assert len([i for i in attestation.aggregation_bits if i == 1]) == participant_num
+    assert spec.get_set_bit_count(attestation.aggregation_bits) == participant_num
     sign_attestation(spec, state_b, attestation)
 
     # Attestation_set_1 received at N+2 — B is head because B's attestation_score > C's proposer_score.
@@ -331,7 +331,7 @@ def test_ex_ante_sandwich_with_honest_attestation(spec, state):
         filter_participant_set=_filter_participant_set,
     )
     attestation.data.beacon_block_root = signed_block_c.message.hash_tree_root()
-    assert len([i for i in attestation.aggregation_bits if i == 1]) == 1
+    assert spec.get_set_bit_count(attestation.aggregation_bits) == 1
     sign_attestation(spec, state_c, attestation)
 
     # Block D at slot `N + 3`, parent is B
@@ -438,7 +438,7 @@ def test_ex_ante_sandwich_with_boost_not_sufficient(spec, state):
         filter_participant_set=_filter_participant_set,
     )
     attestation.data.beacon_block_root = signed_block_c.message.hash_tree_root()
-    assert len([i for i in attestation.aggregation_bits if i == 1]) == participant_num
+    assert spec.get_set_bit_count(attestation.aggregation_bits) == participant_num
     sign_attestation(spec, state_c, attestation)
 
     # Attestation_1 received at N+3 — B is head because B's attestation_score > C's proposer_score.


### PR DESCRIPTION
The new SSZ library (see #5520) does not currently provide a way to `sum()` set bits. Instead of replicating this functionality in `eth-ssz-specs`, I think we should introduce a new helper function for this. Using `sum()` here is a bit too pythonic and a new reader might not understand what it's doing. An explicit helper function would clear that up.