### PR TITLE
Run filtered tests in parallel by default

### DIFF
--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -21,6 +21,11 @@ directly to pytest with `-k` and therefore supports its features, such as
 boolean operators (`and`, `or`, `not`). For example,
 `make test k="gossip and valid"` is valid.
 
+## Debug mode
+
+`print()` output can be made visible with the `debug=true` flag. These messages
+are not shown when tests run in parallel.
+
 ## Filter by fork
 
 Tests can be limited to a single fork via the `fork=<fork>` flag. It is not

--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,14 @@ help-verbose:
 	@echo ""
 	@echo "  Output:"
 	@echo "    verbose=true       Enable verbose pytest output"
+	@echo "    debug=true         Enable print() output; disables parallelism"
 	@echo "    reftests=true      Generate reference test vectors"
 	@echo "    coverage=true      Enable code coverage tracking"
 	@echo ""
 	@echo "  Examples:"
 	@echo "    make test"
 	@echo "    make test k=test_compute_fork_digest"
+	@echo "    make test k=test_compute_fork_digest debug=true"
 	@echo "    make test fork=deneb"
 	@echo "    make test preset=mainnet"
 	@echo "    make test preset=mainnet fork=deneb k=test_compute_fork_digest"
@@ -195,8 +197,8 @@ COV_REPORT_DIR = $(PYSPEC_DIR)/.htmlcov
 test: MAYBE_TEST := $(if $(k),-k "$(k)")
 test: MAYBE_FORK := $(if $(fork),--fork=$(fork))
 test: PRESET := $(if $(preset),--preset=$(preset),)
-# Disable parallelism when running a specific test. Makes debugging difficult (print doesn't work).
-test: MAYBE_PARALLEL := $(if $(k),,-n logical --dist=worksteal)
+# Disable parallelism when debugging so print() output is visible (xdist swallows it).
+test: MAYBE_PARALLEL := $(if $(filter true,$(debug)),,-n logical --dist=worksteal)
 # Output
 test: MAYBE_VERBOSE := $(if $(filter true,$(verbose)),-v)
 test: MAYBE_REFTESTS := $(if $(filter true,$(reftests)),--reftests --reftests-output=$(REFTESTS_DIR))


### PR DESCRIPTION
Previously, `k=` forced single-threaded execution so `print()` output was visible. Keep parallel runs for filtered tests and introduce `debug=true` when that output is needed.
