### PR TITLE
Use FCR store in `get_safe_execution_block_hash` call

### DIFF
--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -132,7 +132,8 @@ To obtain an execution payload, a block proposer building a block on top of a
    - `state` is the state object after applying `process_slots(state, slot)`
      transition to the resulting state of the parent block processing
    - `safe_block_hash` is the return value of the
-     `get_safe_execution_block_hash(fcr_store: FastConfirmationStore)` function call
+     `get_safe_execution_block_hash(fcr_store: FastConfirmationStore)` function
+      call
    - `finalized_block_hash` is the block hash of the latest finalized execution
      payload (`Hash32()` if none yet finalized)
    - `suggested_fee_recipient` is the value suggested to be used for the

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -132,7 +132,7 @@ To obtain an execution payload, a block proposer building a block on top of a
    - `state` is the state object after applying `process_slots(state, slot)`
      transition to the resulting state of the parent block processing
    - `safe_block_hash` is the return value of the
-     `get_safe_execution_block_hash(store: Store)` function call
+     `get_safe_execution_block_hash(fcr_store: FastConfirmationStore)` function call
    - `finalized_block_hash` is the block hash of the latest finalized execution
      payload (`Hash32()` if none yet finalized)
    - `suggested_fee_recipient` is the value suggested to be used for the

--- a/specs/bellatrix/validator.md
+++ b/specs/bellatrix/validator.md
@@ -133,7 +133,7 @@ To obtain an execution payload, a block proposer building a block on top of a
      transition to the resulting state of the parent block processing
    - `safe_block_hash` is the return value of the
      `get_safe_execution_block_hash(fcr_store: FastConfirmationStore)` function
-      call
+     call
    - `finalized_block_hash` is the block hash of the latest finalized execution
      payload (`Hash32()` if none yet finalized)
    - `suggested_fee_recipient` is the value suggested to be used for the


### PR DESCRIPTION
This is in regards to [FCR in Bellatrix](https://github.com/ethereum/consensus-specs/blob/master/specs/bellatrix/fast-confirmation.md#new-get_safe_execution_block_hash)

The function no longer takes a fork choice `Store`.