### PR TITLE
Fix builder payment weight double-count under target equivocation

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -2328,8 +2328,8 @@ def process_attestation(
     proposer_reward_numerator = 0
     for index in get_attesting_indices(state, attestation):
         # [New in Gloas:EIP7732]
-        # For same-slot attestations, check if we are setting any new flags.
-        # If we are, this validator has not contributed to this slot's quorum yet.
+        # Captured before the flag loop below, to credit each validator at most once.
+        had_no_participation = epoch_participation[index] == ParticipationFlags(0b0000_0000)
         will_set_new_flag = False
 
         for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):
@@ -2342,10 +2342,10 @@ def process_attestation(
                 will_set_new_flag = True
 
         # [New in Gloas:EIP7732]
-        # Add weight for same-slot attestations when any new flag is set.
-        # This ensures each validator contributes exactly once per slot.
+        # Add same-slot weight on the validator's first flag-setting inclusion only.
         if (
             will_set_new_flag
+            and had_no_participation
             and is_attestation_same_slot(state, data)
             and payment.withdrawal.amount > 0
         ):

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -2328,7 +2328,6 @@ def process_attestation(
     proposer_reward_numerator = 0
     for index in get_attesting_indices(state, attestation):
         # [New in Gloas:EIP7732]
-        # Captured before the flag loop below, to credit each validator at most once.
         had_no_participation = epoch_participation[index] == ParticipationFlags(0b0000_0000)
         will_set_new_flag = False
 
@@ -2342,7 +2341,6 @@ def process_attestation(
                 will_set_new_flag = True
 
         # [New in Gloas:EIP7732]
-        # Add same-slot weight on the validator's first flag-setting inclusion only.
         if (
             will_set_new_flag
             and had_no_participation

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/sanity/test_blocks.py
@@ -13,6 +13,7 @@ from eth_consensus_specs.test.gloas.block_processing.test_process_payload_attest
 from eth_consensus_specs.test.helpers.attestations import (
     get_max_attestations,
     get_valid_attestation,
+    sign_attestation,
 )
 from eth_consensus_specs.test.helpers.attester_slashings import (
     get_max_attester_slashings,
@@ -39,6 +40,7 @@ from eth_consensus_specs.test.helpers.state import (
     next_epoch_with_full_participation,
     next_slots,
     state_transition_and_sign_block,
+    transition_to_slot_via_block,
 )
 from eth_consensus_specs.test.helpers.voluntary_exits import prepare_signed_exits
 from eth_consensus_specs.test.helpers.withdrawals import (
@@ -1016,3 +1018,68 @@ def test_proposer_lookahead_excludes_slashed_validators(spec, state):
     # The newly appended lookahead epoch matches the Gloas selection
     last_epoch_start = len(state.proposer_lookahead) - spec.SLOTS_PER_EPOCH
     assert list(state.proposer_lookahead[last_epoch_start:]) == list(proposers_in_gloas)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_builder_payment_weight_no_double_counting_target_equivocation(spec, state):
+    """
+    A validator that equivocates on the attestation target (same source, different
+    target roots) is credited to the builder payment weight at most once, even when
+    both attestations land in the same block.
+    """
+    # Block at slot 1, then advance so slot 1's block root is retrievable from state.
+    transition_to_slot_via_block(spec, state, 1)
+    next_slots(spec, state, 1)
+
+    attestation_slot = spec.Slot(1)
+    committee = spec.get_beacon_committee(state, attestation_slot, 0)
+    attester = committee[0]
+    # A block was proposed at the attestation slot, so these are same-slot attestations.
+    head_root = spec.get_block_root_at_slot(state, attestation_slot)
+
+    def build(wrong_target):
+        attestation = get_valid_attestation(
+            spec,
+            state,
+            slot=attestation_slot,
+            index=0,
+            payload_index=0,
+            beacon_block_root=head_root,
+            filter_participant_set=lambda _: {attester},
+        )
+        if wrong_target:
+            attestation.data.target.root = spec.Root(b"\x11" * 32)
+        sign_attestation(spec, state, attestation)
+        assert spec.is_attestation_same_slot(state, attestation.data)
+        return attestation
+
+    attestation_wrong_target = build(wrong_target=True)
+    attestation_right_target = build(wrong_target=False)
+    assert attestation_wrong_target.data.target.root != attestation_right_target.data.target.root
+
+    # Give slot 1 a builder payment to accrue weight against.
+    payment_index = spec.SLOTS_PER_EPOCH + attestation_slot % spec.SLOTS_PER_EPOCH
+    state.builder_pending_payments[payment_index] = spec.BuilderPendingPayment(
+        weight=spec.Gwei(0),
+        withdrawal=spec.BuilderPendingWithdrawal(
+            fee_recipient=spec.ExecutionAddress(),
+            amount=spec.Gwei(1000000000),
+            builder_index=0,
+        ),
+    )
+
+    yield "pre", state
+
+    block = build_empty_block_for_next_slot(spec, state)
+    block.body.attestations = [attestation_wrong_target, attestation_right_target]
+    signed_block = state_transition_and_sign_block(spec, state, block)
+
+    yield "blocks", [signed_block]
+    yield "post", state
+
+    # Credited once, not once per flag set.
+    assert (
+        state.builder_pending_payments[payment_index].weight
+        == state.validators[attester].effective_balance
+    )


### PR DESCRIPTION
`process_attestation` credits `payment.weight` whenever an attestation sets a new participation flag (`will_set_new_flag`). Because `TIMELY_SOURCE` and `TIMELY_TARGET` are separate flags, a validator that equivocates on the target (same source, conflicting target roots) is credited twice: `TIMELY_SOURCE` on a wrong-target same-slot attestation, then `TIMELY_TARGET` on a right-target one. This contradicts the function's own comment — "This ensures each validator contributes exactly once per slot" — and lets one equivocating validator count for 2× its effective balance toward the builder-payment quorum (payment.weight >= get_builder_payment_quorum_threshold(...), checked in process_builder_pending_payments at the epoch boundary). The double vote is slashable, but no path decrements `payment.weight`, so the extra credit persists.

Gate the credit on the validator having had no participation flag for the slot before this attestation, so it is taken only on the first flag-setting inclusion. Reuses existing state; honest validators are unaffected (a single attestation still credits once, and a late same-slot attestation still credits on its first inclusion).

Add a regression test: same validator, two same-slot attestations with conflicting targets, asserting the weight is credited once. It fails on the unpatched spec (weight = 2x effective balance) and passes with the fix.
