### PR TITLE
Change IL store's keys to (slot, dependent root)

### DIFF
--- a/pysetup/spec_builders/heze.py
+++ b/pysetup/spec_builders/heze.py
@@ -16,7 +16,10 @@ from eth_consensus_specs.gloas import {preset_name} as gloas
     def sundry_functions(cls) -> str:
         return """
 def cached_or_new_inclusion_list_store() -> InclusionListStore:
-    return InclusionListStore()
+    return InclusionListStore(
+        inclusion_lists=defaultdict(dict),
+        equivocators=defaultdict(set),
+    )
 """
 
     @classmethod

--- a/specs/heze/builder.md
+++ b/specs/heze/builder.md
@@ -24,4 +24,7 @@ builder" to implement Heze.
 comprises all valid and non-equivocating inclusion lists they have observed.
 
 1. Set `bid.inclusion_list_bits` to
-   `get_inclusion_list_bits(get_inclusion_list_store(), state, Slot(bid.slot - 1), only_timely=False)`.
+   `get_inclusion_list_bits(get_inclusion_list_store(), state, slot, dependent_root, only_timely=False)`,
+   where `slot` is `bid.slot - Slot(1)` and `dependent_root` is
+   `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`
+   and `store` is the fork choice store.

--- a/specs/heze/builder.md
+++ b/specs/heze/builder.md
@@ -24,7 +24,9 @@ builder" to implement Heze.
 comprises all valid and non-equivocating inclusion lists they have observed.
 
 1. Set `bid.inclusion_list_bits` to
-   `get_inclusion_list_bits(get_inclusion_list_store(), state, slot, dependent_root, only_timely=False)`,
-   where `slot` is `bid.slot - Slot(1)` and `dependent_root` is
-   `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`
+   `get_inclusion_list_bits(get_inclusion_list_store(), inclusion_list_committee, slot, dependent_root, only_timely=False)`,
+   where `inclusion_list_committee` is
+   `get_inclusion_list_committee(state, slot)`, `slot` is `bid.slot - Slot(1)`,
+   `dependent_root` is
+   `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`,
    and `store` is the fork choice store.

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -185,13 +185,14 @@ constraints remains valid, but fork choice does not extend it.
 ```python
 def record_payload_inclusion_list_satisfaction(
     store: Store,
-    state: BeaconState,
     root: Root,
     payload: ExecutionPayload,
     execution_engine: ExecutionEngine,
 ) -> None:
+    slot = store.blocks[root].slot - Slot(1)
+    dependent_root = get_shuffling_dependent_root(store, root, compute_epoch_at_slot(slot))
     inclusion_list_transactions = get_inclusion_list_transactions(
-        get_inclusion_list_store(), state, Slot(state.slot - 1), only_timely=True
+        get_inclusion_list_store(), slot, dependent_root, only_timely=True
     )
     is_inclusion_list_satisfied = execution_engine.is_inclusion_list_satisfied(
         payload, inclusion_list_transactions
@@ -294,12 +295,7 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     is_timely = is_current_slot and time_into_slot_ms < get_inclusion_list_due_ms()
 
     # Process the inclusion list
-    process_inclusion_list(
-        get_inclusion_list_store(),
-        signed_inclusion_list,
-        hash_tree_root(committee),
-        is_timely,
-    )
+    process_inclusion_list(get_inclusion_list_store(), signed_inclusion_list, is_timely)
 ```
 
 ### Modified `on_execution_payload_envelope`
@@ -328,7 +324,7 @@ def on_execution_payload_envelope(
     # Check if this payload satisfies the inclusion list constraints
     # If not, add this payload to the store as inclusion list constraints unsatisfied
     record_payload_inclusion_list_satisfaction(
-        store, state, envelope.beacon_block_root, envelope.payload, EXECUTION_ENGINE
+        store, envelope.beacon_block_root, envelope.payload, EXECUTION_ENGINE
     )
 
     # Add execution payload envelope to the store

--- a/specs/heze/inclusion-list.md
+++ b/specs/heze/inclusion-list.md
@@ -101,8 +101,9 @@ they MAY be pruned.
 def get_inclusion_list_transactions(
     store: InclusionListStore, slot: Slot, dependent_root: Root, only_timely: bool = True
 ) -> Sequence[Transaction]:
-    inclusion_lists = store.inclusion_lists[(slot, dependent_root)]
-    equivocators = store.equivocators[(slot, dependent_root)]
+    key = (slot, dependent_root)
+    inclusion_lists = store.inclusion_lists[key]
+    equivocators = store.equivocators[key]
 
     transactions: list[Transaction] = []
     for validator_index, inclusion_list in inclusion_lists.items():
@@ -130,8 +131,9 @@ def get_inclusion_list_bits(
     dependent_root: Root,
     only_timely: bool = True,
 ) -> InclusionListBits:
-    inclusion_lists = store.inclusion_lists[(slot, dependent_root)]
-    equivocators = store.equivocators[(slot, dependent_root)]
+    key = (slot, dependent_root)
+    inclusion_lists = store.inclusion_lists[key]
+    equivocators = store.equivocators[key]
 
     validator_indices = []
     for validator_index, inclusion_list in inclusion_lists.items():

--- a/specs/heze/inclusion-list.md
+++ b/specs/heze/inclusion-list.md
@@ -66,21 +66,20 @@ def process_inclusion_list(
 ) -> None:
     inclusion_list = signed_inclusion_list.message
     validator_index = inclusion_list.validator_index
+    key = (inclusion_list.slot, inclusion_list.dependent_root)
 
-    inclusion_lists = store.inclusion_lists[(inclusion_list.slot, inclusion_list.dependent_root)]
-    equivocators = store.equivocators[(inclusion_list.slot, inclusion_list.dependent_root)]
-
-    if validator_index in inclusion_lists:
+    if validator_index in store.inclusion_lists[key]:
         # Mark the validator as an equivocator if it published a different inclusion list
-        stored_inclusion_list = inclusion_lists[validator_index].signed_inclusion_list.message
+        stored_entry = store.inclusion_lists[key][validator_index]
+        stored_inclusion_list = stored_entry.signed_inclusion_list.message
         if stored_inclusion_list != inclusion_list:
-            equivocators.add(validator_index)
+            store.equivocators[key].add(validator_index)
 
         # Ignore an inclusion list that has already been processed
         return
 
     # Store the signed inclusion list and its timeliness
-    inclusion_lists[validator_index] = InclusionListEntry(
+    store.inclusion_lists[key][validator_index] = InclusionListEntry(
         signed_inclusion_list=signed_inclusion_list,
         timely=timely,
     )

--- a/specs/heze/inclusion-list.md
+++ b/specs/heze/inclusion-list.md
@@ -126,7 +126,7 @@ def get_inclusion_list_transactions(
 ```python
 def get_inclusion_list_bits(
     store: InclusionListStore,
-    state: BeaconState,
+    committee: InclusionListCommittee,
     slot: Slot,
     dependent_root: Root,
     only_timely: bool = True,
@@ -147,7 +147,6 @@ def get_inclusion_list_bits(
 
         validator_indices.append(validator_index)
 
-    committee = get_inclusion_list_committee(state, slot)
     return InclusionListBits(validator_index in validator_indices for validator_index in committee)
 ```
 
@@ -156,14 +155,14 @@ def get_inclusion_list_bits(
 ```python
 def is_inclusion_list_bits_inclusive(
     store: InclusionListStore,
-    state: BeaconState,
+    committee: InclusionListCommittee,
     slot: Slot,
     dependent_root: Root,
     inclusion_list_bits: InclusionListBits,
     only_timely: bool = True,
 ) -> bool:
     local_inclusion_list_bits = get_inclusion_list_bits(
-        store, state, slot, dependent_root, only_timely
+        store, committee, slot, dependent_root, only_timely
     )
 
     for i in range(INCLUSION_LIST_COMMITTEE_SIZE):

--- a/specs/heze/inclusion-list.md
+++ b/specs/heze/inclusion-list.md
@@ -32,7 +32,7 @@ These are the inclusion list specifications to implement Heze.
 @dataclass(eq=True, frozen=True)
 class InclusionListEntry:
     signed_inclusion_list: SignedInclusionList
-    is_timely: Boolean
+    timely: Boolean
 ```
 
 #### `InclusionListStore`
@@ -40,12 +40,8 @@ class InclusionListEntry:
 ```python
 @dataclass
 class InclusionListStore:
-    inclusion_lists: DefaultDict[Root, Dict[Root, InclusionListEntry]] = field(
-        default_factory=lambda: defaultdict(dict)
-    )
-    equivocators: DefaultDict[Root, Set[ValidatorIndex]] = field(
-        default_factory=lambda: defaultdict(set)
-    )
+    inclusion_lists: DefaultDict[Tuple[Slot, Root], Dict[ValidatorIndex, InclusionListEntry]]
+    equivocators: DefaultDict[Tuple[Slot, Root], Set[ValidatorIndex]]
 ```
 
 ## Helpers
@@ -66,45 +62,37 @@ def get_inclusion_list_store() -> InclusionListStore:
 
 ```python
 def process_inclusion_list(
-    store: InclusionListStore,
-    signed_inclusion_list: SignedInclusionList,
-    inclusion_list_committee_root: Root,
-    is_timely: bool,
+    store: InclusionListStore, signed_inclusion_list: SignedInclusionList, timely: bool
 ) -> None:
     inclusion_list = signed_inclusion_list.message
-    key = inclusion_list_committee_root
+    validator_index = inclusion_list.validator_index
 
-    # Ignore an inclusion list that has already been stored
-    inclusion_list_root = hash_tree_root(inclusion_list)
-    if inclusion_list_root in store.inclusion_lists[key]:
+    inclusion_lists = store.inclusion_lists[(inclusion_list.slot, inclusion_list.dependent_root)]
+    equivocators = store.equivocators[(inclusion_list.slot, inclusion_list.dependent_root)]
+
+    if validator_index in inclusion_lists:
+        # Mark the validator as an equivocator if it published a different inclusion list
+        stored_inclusion_list = inclusion_lists[validator_index].signed_inclusion_list.message
+        if stored_inclusion_list != inclusion_list:
+            equivocators.add(validator_index)
+
+        # Ignore an inclusion list that has already been processed
         return
-
-    # Ignore inclusion lists from equivocators
-    if inclusion_list.validator_index in store.equivocators[key]:
-        return
-
-    # Mark the validator as an equivocator if it published a different inclusion list
-    for inclusion_list_entry in store.inclusion_lists[key].values():
-        stored_message = inclusion_list_entry.signed_inclusion_list.message
-        if stored_message.validator_index == inclusion_list.validator_index:
-            store.equivocators[key].add(inclusion_list.validator_index)
-            return
 
     # Store the signed inclusion list and its timeliness
-    store.inclusion_lists[key][inclusion_list_root] = InclusionListEntry(
+    inclusion_lists[validator_index] = InclusionListEntry(
         signed_inclusion_list=signed_inclusion_list,
-        is_timely=is_timely,
+        timely=timely,
     )
 ```
 
 ### New `get_inclusion_list_transactions`
 
 *Note*: `get_inclusion_list_transactions` returns a list of unique transactions
-from all valid and non-equivocating `InclusionList`s for the given slot and for
-which the `inclusion_list_committee_root` compatible with the `dependent_root`
-in the `InclusionList` matches the one calculated from the given `state`. When
-`only_timely` is `True`, only `InclusionList`s received in a timely manner on
-the p2p network are considered; otherwise, timeliness is not considered.
+from all valid and non-equivocating `InclusionList`s for the given `slot` and
+`dependent_root`. When `only_timely` is `True`, only `InclusionList`s received
+in a timely manner on the p2p network are considered; otherwise, timeliness is
+not considered.
 
 *Note*: Inclusion lists MUST be retained for at least
 `MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS` slots beyond their slot, after which
@@ -112,27 +100,22 @@ they MAY be pruned.
 
 ```python
 def get_inclusion_list_transactions(
-    store: InclusionListStore, state: BeaconState, slot: Slot, only_timely: bool = True
+    store: InclusionListStore, slot: Slot, dependent_root: Root, only_timely: bool = True
 ) -> Sequence[Transaction]:
-    committee = get_inclusion_list_committee(state, slot)
-    key = hash_tree_root(committee)
-
-    inclusion_lists = store.inclusion_lists[key]
-    equivocators = store.equivocators[key]
+    inclusion_lists = store.inclusion_lists[(slot, dependent_root)]
+    equivocators = store.equivocators[(slot, dependent_root)]
 
     transactions: list[Transaction] = []
-    for inclusion_list_entry in inclusion_lists.values():
-        inclusion_list = inclusion_list_entry.signed_inclusion_list.message
-
+    for validator_index, inclusion_list in inclusion_lists.items():
         # Ignore inclusion lists from equivocators
-        if inclusion_list.validator_index in equivocators:
+        if validator_index in equivocators:
             continue
 
         # Ignore untimely inclusion lists if only timely ones are requested
-        if only_timely and not inclusion_list_entry.is_timely:
+        if only_timely and not inclusion_list.timely:
             continue
 
-        transactions.extend(inclusion_list.transactions)
+        transactions.extend(inclusion_list.signed_inclusion_list.message.transactions)
 
     # Deduplicate inclusion list transactions. Order does not need to be preserved.
     return list(set(transactions))
@@ -142,32 +125,28 @@ def get_inclusion_list_transactions(
 
 ```python
 def get_inclusion_list_bits(
-    store: InclusionListStore, state: BeaconState, slot: Slot, only_timely: bool = True
+    store: InclusionListStore,
+    state: BeaconState,
+    slot: Slot,
+    dependent_root: Root,
+    only_timely: bool = True,
 ) -> InclusionListBits:
-    """
-    Return a ``BitVector`` over inclusion list committee indices with bits set
-    for those who provided valid, non-equivocating inclusion lists for the given ``slot``.
-    """
-    committee = get_inclusion_list_committee(state, slot)
-    key = hash_tree_root(committee)
-
-    inclusion_lists = store.inclusion_lists[key]
-    equivocators = store.equivocators[key]
+    inclusion_lists = store.inclusion_lists[(slot, dependent_root)]
+    equivocators = store.equivocators[(slot, dependent_root)]
 
     validator_indices = []
-    for inclusion_list_entry in inclusion_lists.values():
-        inclusion_list = inclusion_list_entry.signed_inclusion_list.message
-
+    for validator_index, inclusion_list in inclusion_lists.items():
         # Ignore inclusion lists from equivocators
-        if inclusion_list.validator_index in equivocators:
+        if validator_index in equivocators:
             continue
 
         # Ignore untimely inclusion lists if only timely ones are requested
-        if only_timely and not inclusion_list_entry.is_timely:
+        if only_timely and not inclusion_list.timely:
             continue
 
-        validator_indices.append(inclusion_list.validator_index)
+        validator_indices.append(validator_index)
 
+    committee = get_inclusion_list_committee(state, slot)
     return InclusionListBits(validator_index in validator_indices for validator_index in committee)
 ```
 
@@ -178,14 +157,13 @@ def is_inclusion_list_bits_inclusive(
     store: InclusionListStore,
     state: BeaconState,
     slot: Slot,
+    dependent_root: Root,
     inclusion_list_bits: InclusionListBits,
     only_timely: bool = True,
 ) -> bool:
-    """
-    Return ``True`` if and only if ``inclusion_list_bits`` has a bit set for
-    every bit set in the local inclusion list bits for the given ``slot``.
-    """
-    local_inclusion_list_bits = get_inclusion_list_bits(store, state, slot, only_timely)
+    local_inclusion_list_bits = get_inclusion_list_bits(
+        store, state, slot, dependent_root, only_timely
+    )
 
     for i in range(INCLUSION_LIST_COMMITTEE_SIZE):
         if local_inclusion_list_bits[i] and not inclusion_list_bits[i]:

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -111,9 +111,11 @@ The following validations are added, assuming the alias
 
 - _[IGNORE]_ `bid.inclusion_list_bits` is inclusive of the node's view of
   inclusion lists for the slot preceding the bid's slot -- i.e.
-  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), state, slot, dependent_root, bid.inclusion_list_bits, only_timely=True)`
-  returns `True`, where `slot` is `bid.slot - Slot(1)` and `dependent_root` is
-  `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`
+  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), inclusion_list_committee, slot, dependent_root, bid.inclusion_list_bits, only_timely=True)`
+  returns `True`, where `inclusion_list_committee` is
+  `get_inclusion_list_committee(state, slot)`, `slot` is `bid.slot - Slot(1)`,
+  `dependent_root` is
+  `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`,
   and `store` is the fork choice store.
 
 ##### New `inclusion_list`

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -111,9 +111,10 @@ The following validations are added, assuming the alias
 
 - _[IGNORE]_ `bid.inclusion_list_bits` is inclusive of the node's view of
   inclusion lists for the slot preceding the bid's slot -- i.e.
-  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), state, Slot(bid.slot - 1), bid.inclusion_list_bits, only_timely=True)`
-  returns `True`, where `state` is the head state corresponding to processing
-  the block up to the current slot as determined by the fork choice.
+  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), state, slot, dependent_root, bid.inclusion_list_bits, only_timely=True)`
+  returns `True`, where `slot` is `bid.slot - Slot(1)` and `dependent_root` is
+  `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`
+  and `store` is the fork choice store.
 
 ##### New `inclusion_list`
 

--- a/specs/heze/validator.md
+++ b/specs/heze/validator.md
@@ -116,9 +116,11 @@ with respect to the proposer's inclusion list view, which comprises all valid
 and non-equivocating inclusion lists they have observed.
 
 - The `bid.inclusion_list_bits` must satisfy
-  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), state, slot, dependent_root, bid.inclusion_list_bits, only_timely=False)`,
-  where `slot` is `bid.slot - Slot(1)` and `dependent_root` is
-  `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`
+  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), inclusion_list_committee, slot, dependent_root, bid.inclusion_list_bits, only_timely=False)`,
+  where `inclusion_list_committee` is
+  `get_inclusion_list_committee(state, slot)`, `slot` is `bid.slot - Slot(1)`,
+  `dependent_root` is
+  `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`,
   and `store` is the fork choice store.
 
 ##### ExecutionPayload

--- a/specs/heze/validator.md
+++ b/specs/heze/validator.md
@@ -116,7 +116,10 @@ with respect to the proposer's inclusion list view, which comprises all valid
 and non-equivocating inclusion lists they have observed.
 
 - The `bid.inclusion_list_bits` must satisfy
-  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), state, slot - 1, bid.inclusion_list_bits, only_timely=False)`.
+  `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), state, slot, dependent_root, bid.inclusion_list_bits, only_timely=False)`,
+  where `slot` is `bid.slot - Slot(1)` and `dependent_root` is
+  `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`
+  and `store` is the fork choice store.
 
 ##### ExecutionPayload
 
@@ -168,7 +171,12 @@ def prepare_execution_payload(
         target_gas_limit=target_gas_limit,
         # [New in Heze:EIP7805]
         inclusion_list_transactions=get_inclusion_list_transactions(
-            get_inclusion_list_store(), state, Slot(state.slot - 1), only_timely=False
+            get_inclusion_list_store(),
+            state.slot - Slot(1),
+            get_shuffling_dependent_root(
+                store, head.root, compute_epoch_at_slot(state.slot - Slot(1))
+            ),
+            only_timely=False,
         ),
     )
     return execution_engine.notify_forkchoice_updated(

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/inclusion_list.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/inclusion_list.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from functools import lru_cache
 from random import randbytes
 
@@ -142,7 +143,10 @@ def run_with_inclusion_list_store(spec, func):
 
     @lru_cache(maxsize=1)
     def cached_or_new_inclusion_list_store():
-        return spec.InclusionListStore()
+        return spec.InclusionListStore(
+            inclusion_lists=defaultdict(dict),
+            equivocators=defaultdict(set),
+        )
 
     cached_or_new_inclusion_list_store_backup = spec.cached_or_new_inclusion_list_store
     spec.cached_or_new_inclusion_list_store = cached_or_new_inclusion_list_store

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
@@ -134,8 +134,9 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         for signed_inclusion_list in signed_inclusion_lists:
             spec.on_inclusion_list(forkchoice_store, signed_inclusion_list)
 
+        dependent_root = signed_inclusion_lists[0].message.dependent_root
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert set(inclusion_list_transactions) == {
@@ -162,10 +163,14 @@ def test_inclusion_list_store_by_slot_and_dependent_root__empty_slot(spec, state
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_slot_0)
 
         inclusion_list_transactions_slot_0 = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store,
+            state.slot,
+            signed_inclusion_list_slot_0.message.dependent_root,
         )
         inclusion_list_transactions_slot_1 = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot + 1
+            inclusion_list_store,
+            state.slot + 1,
+            signed_inclusion_list_slot_0.message.dependent_root,
         )
 
         assert set(inclusion_list_transactions_slot_0) == set(
@@ -225,15 +230,14 @@ def test_inclusion_list_store_by_slot_and_dependent_root__different_dependent_ro
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_0)
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_1)
 
-        # Only the inclusion list whose dependent root is compatible with the
-        # given state is returned.
+        # Only the inclusion list stored under the given dependent root is returned.
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, inclusion_list_0.dependent_root
         )
         assert set(inclusion_list_transactions) == set(signed_inclusion_list_0.message.transactions)
 
         fork_inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, fork_state, fork_state.slot
+            inclusion_list_store, fork_state.slot, inclusion_list_1.dependent_root
         )
         assert set(fork_inclusion_list_transactions) == set(
             signed_inclusion_list_1.message.transactions
@@ -263,12 +267,13 @@ def test_inclusion_list_store_equivocation(spec, state):
         signed_inclusion_list_4 = get_sample_signed_inclusion_list(
             spec, forkchoice_store, state, validator_index=inclusion_list_committee[1]
         )
+        dependent_root = signed_inclusion_list_1.message.dependent_root
 
         # The first IL from an IL committee member should be stored successfully.
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_1)
 
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert set(inclusion_list_transactions) == set(signed_inclusion_list_1.message.transactions)
@@ -277,7 +282,7 @@ def test_inclusion_list_store_equivocation(spec, state):
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_2)
 
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert inclusion_list_transactions == []
@@ -286,7 +291,7 @@ def test_inclusion_list_store_equivocation(spec, state):
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_4)
 
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert set(inclusion_list_transactions) == set(signed_inclusion_list_4.message.transactions)
@@ -295,7 +300,7 @@ def test_inclusion_list_store_equivocation(spec, state):
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_3)
 
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert set(inclusion_list_transactions) == set(signed_inclusion_list_4.message.transactions)
@@ -324,13 +329,14 @@ def test_inclusion_list_store_equivocation_scope(spec, state):
         signed_inclusion_list_2 = get_sample_signed_inclusion_list(
             spec, forkchoice_store, state, validator_index=validator_index
         )
+        dependent_root = signed_inclusion_list_1.message.dependent_root
 
         # An IL committee member equivocates.
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_1)
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_2)
 
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert inclusion_list_transactions == []
@@ -353,11 +359,12 @@ def test_inclusion_list_store_equivocation_scope(spec, state):
         signed_inclusion_list_3 = get_sample_signed_inclusion_list(
             spec, forkchoice_store, state, validator_index=validator_index
         )
+        dependent_root = signed_inclusion_list_3.message.dependent_root
 
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_3)
 
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert set(inclusion_list_transactions) == set(signed_inclusion_list_3.message.transactions)
@@ -383,12 +390,13 @@ def test_inclusion_list_store_inclusion_list_due(spec, state):
         signed_inclusion_list_3 = get_sample_signed_inclusion_list(
             spec, forkchoice_store, state, validator_index=inclusion_list_committee[1]
         )
+        dependent_root = signed_inclusion_list_1.message.dependent_root
 
         # An IL received before the inclusion list due should be stored successfully.
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_1)
 
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert set(inclusion_list_transactions) == set(signed_inclusion_list_1.message.transactions)
@@ -405,7 +413,7 @@ def test_inclusion_list_store_inclusion_list_due(spec, state):
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_3)
 
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert set(inclusion_list_transactions) == set(signed_inclusion_list_1.message.transactions)
@@ -414,7 +422,7 @@ def test_inclusion_list_store_inclusion_list_due(spec, state):
         spec.on_inclusion_list(forkchoice_store, signed_inclusion_list_2)
 
         inclusion_list_transactions = spec.get_inclusion_list_transactions(
-            inclusion_list_store, state, state.slot
+            inclusion_list_store, state.slot, dependent_root
         )
 
         assert inclusion_list_transactions == []


### PR DESCRIPTION
This PR changes the IL store's keys from the IL committee root to (slot, dependent_root). It still pins ILs to a specific IL committee while avoiding the root calculation, which was only used for the key and felt somewhat awkward. Another possible key is [slot][dependent_root] although the type declaration becomes a bit lengthier. No strong preference from the author; we can change it if people want. Lastly, some refactors were also introduced.