### PR TITLE
Allow epoch boundary reorgs in Fulu

### DIFF
--- a/pysetup/spec_builders/fulu.py
+++ b/pysetup/spec_builders/fulu.py
@@ -30,6 +30,7 @@ from eth_consensus_specs.electra import {preset_name} as electra
             "get_blob_sidecars",
             "get_eth1_pending_deposit_count",
             "get_eth1_vote",
+            "is_shuffling_stable",
             "process_deposit",
             "upgrade_to_electra",
             "validate_blob_sidecar_gossip",

--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -4,6 +4,7 @@
 
 - [Introduction](#introduction)
 - [Helpers](#helpers)
+  - [Modified `get_proposer_head`](#modified-get_proposer_head)
   - [Modified `is_data_available`](#modified-is_data_available)
 - [Handlers](#handlers)
   - [Modified `on_block`](#modified-on_block)
@@ -15,6 +16,67 @@
 This is the modification of the fork choice accompanying Fulu.
 
 ## Helpers
+
+### Modified `get_proposer_head`
+
+*Note*: The function is modified to allow proposer re-orgs at epoch boundaries.
+The proposer lookahead introduced in Fulu fixes proposer assignments before the
+epoch boundary, so a re-org of a late block at the end of the previous epoch
+cannot change the current slot's proposer.
+
+```python
+def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
+    head_block = store.blocks[head_node.root]
+    parent_root = head_block.parent_root
+    parent_block = store.blocks[parent_root]
+    parent_node = ForkChoiceNode(root=parent_root)
+
+    # Only re-org the head block if it arrived later than the attestation deadline.
+    head_late = is_head_late(store, head_node.root)
+
+    # [Modified in Fulu:EIP7917]
+    # Proposer re-orgs are allowed at epoch boundaries.
+
+    # Ensure that the FFG information of the new head will be competitive with the current head.
+    ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
+
+    # Do not re-org if the chain is not finalizing with acceptable frequency.
+    finalization_ok = is_finalization_ok(store, slot)
+
+    # Only re-org if we are proposing on-time.
+    proposing_on_time = is_proposing_on_time(store)
+
+    # Only re-org a single slot at most.
+    parent_slot_ok = parent_block.slot + 1 == head_block.slot
+    current_time_ok = head_block.slot + 1 == slot
+    single_slot_reorg = parent_slot_ok and current_time_ok
+
+    # Check that the head has few enough votes to be overpowered by our proposer boost.
+    assert store.proposer_boost_root != head_node.root  # ensure boost has worn off
+    head_weak = is_head_weak(store, head_node.root)
+
+    # Check that the missing votes are assigned to the parent and not being hoarded.
+    parent_strong = is_parent_strong(store, head_node.root)
+
+    # Re-org more aggressively if there is a proposer equivocation in the previous slot.
+    proposer_equivocation = is_proposer_equivocation(store, head_node.root)
+
+    if all([
+        head_late,
+        ffg_competitive,
+        finalization_ok,
+        proposing_on_time,
+        single_slot_reorg,
+        head_weak,
+        parent_strong,
+    ]):
+        # We can re-org the current head by building upon its parent node.
+        return parent_node
+    elif all([head_weak, current_time_ok, proposer_equivocation]):
+        return parent_node
+    else:
+        return head_node
+```
 
 ### Modified `is_data_available`
 

--- a/specs/fulu/fork-choice.md
+++ b/specs/fulu/fork-choice.md
@@ -35,7 +35,7 @@ def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> Fo
     head_late = is_head_late(store, head_node.root)
 
     # [Modified in Fulu:EIP7917]
-    # Proposer re-orgs are allowed at epoch boundaries.
+    # Removed `shuffling_stable = is_shuffling_stable(slot)`
 
     # Ensure that the FFG information of the new head will be competitive with the current head.
     ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
@@ -63,6 +63,8 @@ def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> Fo
 
     if all([
         head_late,
+        # [Modified in Fulu:EIP7917]
+        # Removed `shuffling_stable`
         ffg_competitive,
         finalization_ok,
         proposing_on_time,

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -774,9 +774,6 @@ def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> Fo
     # Only re-org the head block if it arrived later than the attestation deadline.
     head_late = is_head_late(store, head_node.root)
 
-    # Do not re-org on an epoch boundary.
-    not_epoch_boundary = is_not_epoch_boundary(slot)
-
     # Ensure that the FFG information of the new head will be competitive with the current head.
     ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
 
@@ -803,7 +800,6 @@ def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> Fo
 
     if all([
         head_late,
-        not_epoch_boundary,
         ffg_competitive,
         finalization_ok,
         proposing_on_time,

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -40,7 +40,7 @@
     - [`get_aggregate_due_ms`](#get_aggregate_due_ms)
     - [Proposer head and reorg helpers](#proposer-head-and-reorg-helpers)
       - [`is_head_late`](#is_head_late)
-      - [`is_not_epoch_boundary`](#is_not_epoch_boundary)
+      - [`is_shuffling_stable`](#is_shuffling_stable)
       - [`is_ffg_competitive`](#is_ffg_competitive)
       - [`is_finalization_ok`](#is_finalization_ok)
       - [`is_proposing_on_time`](#is_proposing_on_time)
@@ -590,10 +590,10 @@ def is_head_late(store: Store, head_root: Root) -> bool:
     return not store.block_timeliness[head_root]
 ```
 
-##### `is_not_epoch_boundary`
+##### `is_shuffling_stable`
 
 ```python
-def is_not_epoch_boundary(slot: Slot) -> bool:
+def is_shuffling_stable(slot: Slot) -> bool:
     return slot % SLOTS_PER_EPOCH != 0
 ```
 
@@ -697,8 +697,8 @@ def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> Fo
     # Only re-org the head block if it arrived later than the attestation deadline.
     head_late = is_head_late(store, head_node.root)
 
-    # Do not re-org on an epoch boundary.
-    not_epoch_boundary = is_not_epoch_boundary(slot)
+    # Do not re-org on an epoch boundary where the proposer shuffling could change.
+    shuffling_stable = is_shuffling_stable(slot)
 
     # Ensure that the FFG information of the new head will be competitive with the current head.
     ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
@@ -726,7 +726,7 @@ def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> Fo
 
     if all([
         head_late,
-        not_epoch_boundary,
+        shuffling_stable,
         ffg_competitive,
         finalization_ok,
         proposing_on_time,

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_get_proposer_head.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_get_proposer_head.py
@@ -23,6 +23,7 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     tick_and_add_block,
     tick_and_run_on_attestation,
 )
+from eth_consensus_specs.test.helpers.forks import is_post_fulu
 from eth_consensus_specs.test.helpers.state import (
     next_epoch,
     next_slot,
@@ -70,9 +71,7 @@ def test_basic_is_head_root(spec, state):
     yield "steps", test_steps
 
 
-@with_all_phases_from_to(ALTAIR, GLOAS)
-@spec_state_test
-def test_basic_is_parent_root(spec, state):
+def _run_is_parent_root(spec, state, at_epoch_boundary):
     test_steps = []
     # Initialization
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
@@ -100,17 +99,43 @@ def test_basic_is_parent_root(spec, state):
     assert state.current_justified_checkpoint.epoch == store.justified_checkpoint.epoch == 3
     assert state.finalized_checkpoint.epoch == store.finalized_checkpoint.epoch == 2
 
-    # Make an empty block
-    block = build_empty_block_for_next_slot(spec, state)
-    signed_block = state_transition_and_sign_block(spec, state, block)
-    yield from tick_and_add_block(spec, store, signed_block, test_steps)
+    if at_epoch_boundary:
+        # Align the proposal slot with the next epoch boundary. Four slots are
+        # consumed below: one initial block, the parent, the late head, and the proposal.
+        state, store, _ = yield from apply_next_slots_with_attestations(
+            spec,
+            state,
+            store,
+            spec.SLOTS_PER_EPOCH - 4,
+            fill_cur_epoch=True,
+            fill_prev_epoch=True,
+            test_steps=test_steps,
+        )
+
+    if at_epoch_boundary:
+        # Include enough attestations before the parent to keep finalization healthy
+        # without changing FFG information in the late head.
+        state, store, _ = yield from apply_next_slots_with_attestations(
+            spec,
+            state,
+            store,
+            1,
+            fill_cur_epoch=True,
+            fill_prev_epoch=True,
+            test_steps=test_steps,
+        )
+    else:
+        # Make an empty block.
+        block = build_empty_block_for_next_slot(spec, state)
+        signed_block = state_transition_and_sign_block(spec, state, block)
+        yield from tick_and_add_block(spec, store, signed_block, test_steps)
 
     # Fill a slot (parent)
     state, store, signed_parent_block = yield from apply_next_slots_with_attestations(
         spec, state, store, 1, fill_cur_epoch=True, fill_prev_epoch=True, test_steps=test_steps
     )
 
-    # Fill a slot with attestations to its parent
+    # Fill a slot with attestations to its parent.
     block = build_empty_block_for_next_slot(spec, state)
     parent_block_slot = block.slot - 1
     block.body.attestations = get_valid_attestations_at_slot(
@@ -155,7 +180,14 @@ def test_basic_is_parent_root(spec, state):
 
     # The conditions in `get_proposer_head`
     assert spec.is_head_late(store, head.root)
-    assert spec.is_not_epoch_boundary(slot)
+    if at_epoch_boundary:
+        assert slot % spec.SLOTS_PER_EPOCH == 0
+    else:
+        assert slot % spec.SLOTS_PER_EPOCH != 0
+    if is_post_fulu(spec):
+        assert not hasattr(spec, "is_shuffling_stable")
+    else:
+        assert spec.is_shuffling_stable(slot) == (not at_epoch_boundary)
     assert spec.is_ffg_competitive(store, head.root, parent_root)
     assert spec.is_finalization_ok(store, slot)
     assert spec.is_proposing_on_time(store)
@@ -169,7 +201,9 @@ def test_basic_is_parent_root(spec, state):
     assert spec.is_parent_strong(store, head.root)
 
     proposer_head = spec.get_proposer_head(store, head, state.slot)
-    assert proposer_head.root == parent_root
+    expect_reorg = not at_epoch_boundary or is_post_fulu(spec)
+    expected_root = parent_root if expect_reorg else head.root
+    assert proposer_head.root == expected_root
 
     output_store_checks(spec, store, test_steps)
     test_steps.append(
@@ -181,3 +215,15 @@ def test_basic_is_parent_root(spec, state):
     )
 
     yield "steps", test_steps
+
+
+@with_all_phases_from_to(ALTAIR, GLOAS)
+@spec_state_test
+def test_basic_is_parent_root(spec, state):
+    yield from _run_is_parent_root(spec, state, at_epoch_boundary=False)
+
+
+@with_all_phases_from_to(ALTAIR, GLOAS)
+@spec_state_test
+def test_epoch_boundary(spec, state):
+    yield from _run_is_parent_root(spec, state, at_epoch_boundary=True)

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_get_proposer_head.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/fork_choice/test_get_proposer_head.py
@@ -125,7 +125,7 @@ def _run_is_parent_root(spec, state, at_epoch_boundary):
             test_steps=test_steps,
         )
     else:
-        # Make an empty block.
+        # Make an empty block
         block = build_empty_block_for_next_slot(spec, state)
         signed_block = state_transition_and_sign_block(spec, state, block)
         yield from tick_and_add_block(spec, store, signed_block, test_steps)
@@ -135,7 +135,7 @@ def _run_is_parent_root(spec, state, at_epoch_boundary):
         spec, state, store, 1, fill_cur_epoch=True, fill_prev_epoch=True, test_steps=test_steps
     )
 
-    # Fill a slot with attestations to its parent.
+    # Fill a slot with attestations to its parent
     block = build_empty_block_for_next_slot(spec, state)
     parent_block_slot = block.slot - 1
     block.body.attestations = get_valid_attestations_at_slot(


### PR DESCRIPTION
The proposer lookahead introduced in Fulu fixes proposer assignments before the epoch boundary, so a re-org of a late block at the end of the previous epoch cannot change the current slot's proposer.

Alternative to https://github.com/ethereum/consensus-specs/pull/5492