### PR TITLE
Set the slot of the upgraded execution payload bid

### DIFF
--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -205,6 +205,7 @@ def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         builder_pending_withdrawals=BuilderPendingWithdrawals(),
         # [New in Gloas:EIP7732]
         latest_execution_payload_bid=ExecutionPayloadBid(
+            slot=pre.latest_block_header.slot,
             block_hash=pre.latest_execution_payload_header.block_hash,
             gas_limit=pre.latest_execution_payload_header.gas_limit,
             execution_requests_root=hash_tree_root(ExecutionRequests()),

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_basic.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/fork/test_gloas_fork_basic.py
@@ -20,6 +20,7 @@ from eth_consensus_specs.test.helpers.gloas.fork import (
 from eth_consensus_specs.test.helpers.state import (
     next_epoch,
     next_epoch_via_block,
+    next_slots,
 )
 from eth_consensus_specs.test.utils import with_meta_tags
 
@@ -57,6 +58,20 @@ def test_fork_next_epoch_with_block(spec, phases, state):
 def test_fork_many_next_epoch(spec, phases, state):
     for _ in range(3):
         next_epoch(spec, state)
+    yield from run_fork_test(phases[GLOAS], state)
+
+
+@with_phases(phases=[FULU], other_phases=[GLOAS])
+@spec_test
+@with_state
+@with_meta_tags(GLOAS_FORK_TEST_META_TAGS)
+def test_fork_missed_slots_before_fork(spec, phases, state):
+    # Leave a gap between the last pre-fork block and the fork slot, so that the
+    # upgraded payload bid cannot inherit its slot from the slot before the fork
+    next_epoch_via_block(spec, state)
+    next_slots(spec, state, 3)
+    assert state.latest_block_header.slot > 0
+    assert state.slot > state.latest_block_header.slot + 1
     yield from run_fork_test(phases[GLOAS], state)
 
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/fork.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/fork.py
@@ -85,6 +85,11 @@ def run_fork_test(post_spec, pre_state):
     assert post_state.fork.current_version == post_spec.config.GLOAS_FORK_VERSION
     assert post_state.fork.epoch == post_spec.get_current_epoch(post_state)
 
+    # `process_execution_payload_bid` returns this slot as the `parent_slot` of
+    # the first Gloas block, which is where `process_attestation` looks up the
+    # availability of the attested payload.
+    assert post_state.latest_execution_payload_bid.slot == pre_state.latest_block_header.slot
+
     yield "post", post_state
 
     return post_state


### PR DESCRIPTION
`process_execution_payload_bid` returns
`state.latest_execution_payload_bid.slot` as the `parent_slot` that `process_block` hands to `process_attestation`, where it selects the `execution_payload_availability` bit of the attested payload. The upgraded bid leaves that field at zero, so the first Gloas block looks up a bit belonging to slot 0 rather than to its own parent, and `apply_parent_execution_payload` writes the availability of slot 0 instead of the parent's.