### PR TITLE
Fix proposer preferences gossip for genesis dependent block

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -1071,7 +1071,11 @@ def validate_proposer_preferences_gossip(
         raise GossipIgnore("proposal slot has already started")
 
     # [IGNORE] The proposer for the proposal slot is known
-    lookahead_epoch = Epoch(proposal_epoch - MIN_SEED_LOOKAHEAD)
+    # The genesis block is the dependent block for the first MIN_SEED_LOOKAHEAD + 1 epochs
+    if proposal_epoch <= MIN_SEED_LOOKAHEAD:
+        lookahead_epoch = GENESIS_EPOCH
+    else:
+        lookahead_epoch = Epoch(proposal_epoch - MIN_SEED_LOOKAHEAD)
     lookahead_epoch_start_slot = compute_start_slot_at_epoch(lookahead_epoch)
     if is_future_slot(store, lookahead_epoch_start_slot, current_time_ms):
         raise GossipIgnore("proposer for the proposal slot is not yet known")
@@ -1091,7 +1095,8 @@ def validate_proposer_preferences_gossip(
         raise GossipIgnore("dependent block failed validation")
 
     # [REJECT] The dependent root is a valid dependent block for the proposal slot
-    if store.blocks[preferences.dependent_root].slot >= lookahead_epoch_start_slot:
+    dependent_slot = compute_shuffling_dependent_slot(proposal_epoch)
+    if store.blocks[preferences.dependent_root].slot > dependent_slot:
         raise GossipReject("dependent root is not before the proposer lookahead epoch")
 
     # [IGNORE] The dependent root is a possible dependent block for the lookahead epoch
@@ -1100,7 +1105,8 @@ def validate_proposer_preferences_gossip(
 
     # [REJECT] The validator is the proposer for the given slot in the proposer lookahead
     lookahead_state = store.block_states[preferences.dependent_root].copy()
-    process_slots(lookahead_state, lookahead_epoch_start_slot)
+    if lookahead_state.slot < lookahead_epoch_start_slot:
+        process_slots(lookahead_state, lookahead_epoch_start_slot)
     lookahead_index = preferences.proposal_slot - lookahead_epoch_start_slot
     if lookahead_state.proposer_lookahead[lookahead_index] != preferences.validator_index:
         raise GossipReject("validator is not the proposer for the given slot")

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_proposer_preferences.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_proposer_preferences.py
@@ -1193,3 +1193,78 @@ def test_gossip_proposer_preferences__valid_dependent_root_across_empty_epochs(s
             }
         ],
     )
+
+
+def run_genesis_dependent_root_test(spec, state, proposal_epoch):
+    """
+    Validate preferences for a proposal in ``proposal_epoch`` whose dependent
+    root is the genesis block, with no other block imported yet.
+    """
+    anchor_state = state.copy()
+    yield "topic", "meta", "proposer_preferences"
+
+    store, blocks = setup_store_with_advanced_state(spec, state, state.slot)
+    dependent_root = blocks[0].message.hash_tree_root()
+    assert store.blocks[dependent_root].slot == spec.GENESIS_SLOT
+    assert spec.compute_shuffling_dependent_slot(proposal_epoch) == spec.GENESIS_SLOT
+
+    proposal_slot, validator_index = find_upcoming_proposal_slot(spec, state, epoch=proposal_epoch)
+    signed_prefs = build_signed_proposer_preferences(
+        spec,
+        state,
+        proposal_slot=proposal_slot,
+        validator_index=validator_index,
+        dependent_root=dependent_root,
+    )
+
+    yield "state", anchor_state
+    for signed in blocks:
+        yield get_filename(signed), signed
+    yield "blocks", "meta", [{"block": get_filename(block)} for block in blocks]
+    yield get_filename(signed_prefs), signed_prefs
+
+    time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(time_ms)
+    time_ms += 100
+    result, reason = run_validate_gossip(
+        spec,
+        seen=get_seen(spec),
+        store=store,
+        signed_proposer_preferences=signed_prefs,
+        current_time_ms=time_ms,
+    )
+    assert result == "valid"
+    assert reason is None
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "current_time_ms": int(time_ms),
+                "message": get_filename(signed_prefs),
+                "expected": result,
+            }
+        ],
+    )
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_gossip_proposer_preferences__valid_genesis_dependent_root_in_first_epoch(spec, state):
+    """
+    Preferences for a proposal in the first epoch are valid with the genesis
+    block as dependent_root. ``compute_shuffling_dependent_slot`` returns
+    ``GENESIS_SLOT`` for every epoch up to ``MIN_SEED_LOOKAHEAD``, so the
+    genesis block is the only possible dependent block there.
+    """
+    yield from run_genesis_dependent_root_test(spec, state, spec.GENESIS_EPOCH)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_gossip_proposer_preferences__valid_genesis_dependent_root_in_lookahead_epoch(spec, state):
+    """
+    The same holds at ``MIN_SEED_LOOKAHEAD``, the last epoch whose shuffling
+    dependent slot is ``GENESIS_SLOT``.
+    """
+    yield from run_genesis_dependent_root_test(spec, state, spec.Epoch(spec.MIN_SEED_LOOKAHEAD))

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/proposer_preferences.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/proposer_preferences.py
@@ -1,15 +1,18 @@
 from eth_consensus_specs.test.helpers.keys import privkeys
 
 
-def find_upcoming_proposal_slot(spec, state):
+def find_upcoming_proposal_slot(spec, state, epoch=None):
     """
     Return the next future slot in the proposer lookahead, with the validator
-    that is proposing it.
+    that is proposing it. If ``epoch`` is given, only slots in that epoch are
+    considered.
     """
     current_epoch_start = spec.compute_start_slot_at_epoch(spec.get_current_epoch(state))
     for offset, validator_index in enumerate(state.proposer_lookahead):
         slot = spec.Slot(current_epoch_start + offset)
         if slot <= state.slot:
+            continue
+        if epoch is not None and spec.compute_epoch_at_slot(slot) != epoch:
             continue
         return slot, validator_index
     raise AssertionError("no upcoming proposal slot found in lookahead")


### PR DESCRIPTION
For proposals in the first `MIN_SEED_LOOKAHEAD + 1` epochs the genesis block is the dependent block, but `validate_proposer_preferences_gossip` did not account for this: the lookahead epoch underflowed in `GENESIS_EPOCH`, the dependent root check always rejected the genesis block, and `process_slots` was called with a slot the lookahead state had already reached. The dependent slot now comes from `compute_shuffling_dependent_slot`, so gossip validation agrees with `get_shuffling_dependent_root` in fork choice

<!-- Relations
Link any related PRs or issues:
* Use "Fixes #123" to auto-close issues
* Use "Related to #456" for related work
-->
