### PR TITLE
Rename sections for presets/configs

### DIFF
--- a/specs/_features/eip6914/beacon-chain.md
+++ b/specs/_features/eip6914/beacon-chain.md
@@ -5,7 +5,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Time parameters](#time-parameters)
 - [Helpers](#helpers)
   - [Predicates](#predicates)
@@ -25,7 +25,7 @@ validator records. Refers to
 *Note*: This specification is built upon
 [Capella](../../capella/beacon-chain.md).
 
-## Preset
+## Presets
 
 ### Time parameters
 

--- a/specs/_features/eip8148/beacon-chain.md
+++ b/specs/_features/eip8148/beacon-chain.md
@@ -11,7 +11,7 @@
 - [Constants](#constants)
   - [New execution layer triggered request type](#new-execution-layer-triggered-request-type)
   - [Sweep threshold validation](#sweep-threshold-validation)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Execution](#execution)
 - [Containers](#containers)
   - [Modified containers](#modified-containers)
@@ -87,7 +87,7 @@ class SweepThresholds(ProgressiveList[Gwei]):
 | --------------------- | --------------------------------------------- |
 | `MIN_SWEEP_THRESHOLD` | `MIN_ACTIVATION_BALANCE + Gwei(2**0 * 10**9)` |
 
-## Preset
+## Presets
 
 ### Execution
 

--- a/specs/_features/eip8148/fork.md
+++ b/specs/_features/eip8148/fork.md
@@ -5,7 +5,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Fork to EIP-8148](#fork-to-eip-8148)
 
 <!-- mdformat-toc end -->
@@ -14,7 +14,7 @@
 
 This document describes the process of the EIP-8148 upgrade.
 
-## Configuration
+## Configs
 
 Warning: this configuration is not definitive.
 

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -14,10 +14,10 @@
   - [Incentivization weights](#incentivization-weights)
   - [Domains](#domains)
   - [Misc](#misc)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Rewards and penalties](#rewards-and-penalties)
   - [Sync committee](#sync-committee)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Inactivity penalties](#inactivity-penalties)
 - [Containers](#containers)
   - [Modified containers](#modified-containers)
@@ -151,7 +151,7 @@ class SyncCommitteePubkeys(Vector[BLSPubkey, SYNC_COMMITTEE_SIZE]):
 | ---------------------------- | ------------------------------------------------------------------ |
 | `PARTICIPATION_FLAG_WEIGHTS` | `[TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_WEIGHT]` |
 
-## Preset
+## Presets
 
 ### Rewards and penalties
 
@@ -171,7 +171,7 @@ to their final, maximum security values.
 | `SYNC_COMMITTEE_SIZE`              | `Uint64(2**9)` (= 512) |
 | `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `Epoch(2**8)` (= 256)  |
 
-## Configuration
+## Configs
 
 ### Inactivity penalties
 

--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -3,7 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Fork to Altair](#fork-to-altair)
   - [Fork trigger](#fork-trigger)
   - [Upgrading the state](#upgrading-the-state)
@@ -15,7 +15,7 @@
 This document describes the process of the first upgrade of the beacon chain:
 the Altair upgrade, introducing light client support and other improvements.
 
-## Configuration
+## Configs
 
 | Name                  | Value                                         |
 | --------------------- | --------------------------------------------- |

--- a/specs/altair/light-client/p2p-interface.md
+++ b/specs/altair/light-client/p2p-interface.md
@@ -5,7 +5,7 @@
 - [Networking](#networking)
   - [Types](#types)
     - [`LightClientUpdates`](#lightclientupdates)
-  - [Configuration](#configuration)
+  - [Configs](#configs)
   - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
     - [Topics and messages](#topics-and-messages)
       - [Global topics](#global-topics)
@@ -41,7 +41,7 @@ class LightClientUpdates(List[LightClientUpdate, MAX_REQUEST_LIGHT_CLIENT_UPDATE
     """
 ```
 
-### Configuration
+### Configs
 
 | Name                               | Value                  | Description                                                         |
 | ---------------------------------- | ---------------------- | ------------------------------------------------------------------- |

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -8,7 +8,7 @@
   - [`FinalityBranch`](#finalitybranch)
   - [`NextSyncCommitteeBranch`](#nextsynccommitteebranch)
 - [Constants](#constants)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Misc](#misc)
 - [Containers](#containers)
   - [`LightClientHeader`](#lightclientheader)
@@ -98,7 +98,7 @@ class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GIND
 | `CURRENT_SYNC_COMMITTEE_GINDEX` | `get_generalized_index(BeaconState, 'current_sync_committee')` (= 54)        |
 | `NEXT_SYNC_COMMITTEE_GINDEX`    | `get_generalized_index(BeaconState, 'next_sync_committee')` (= 55)           |
 
-## Preset
+## Presets
 
 ### Misc
 

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -12,7 +12,7 @@ actions of a "validator" participating in the Ethereum proof-of-stake protocol.
   - [`SyncSubcommitteeBits`](#syncsubcommitteebits)
 - [Constants](#constants)
   - [Misc](#misc)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Time parameters](#time-parameters)
 - [Containers](#containers)
   - [`SyncCommitteeMessage`](#synccommitteemessage)
@@ -93,7 +93,7 @@ class SyncSubcommitteeBits(BitVector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNE
 | `TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE` | `Uint64(2**4)` (= 16) |
 | `SYNC_COMMITTEE_SUBNET_COUNT`              | `Uint64(2**2)` (= 4)  |
 
-## Configuration
+## Configs
 
 ### Time parameters
 

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -9,10 +9,10 @@
   - [New `Transaction`](#new-transaction)
   - [New `Transactions`](#new-transactions)
 - [Constants](#constants)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Rewards and penalties](#rewards-and-penalties)
   - [Execution](#execution)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Transition settings](#transition-settings)
 - [Containers](#containers)
   - [Modified containers](#modified-containers)
@@ -105,7 +105,7 @@ class Transactions(List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]):
 | ------------------ | ---------- |
 | `EMPTY_BLOCK_HASH` | `Hash32()` |
 
-## Preset
+## Presets
 
 ### Rewards and penalties
 
@@ -127,7 +127,7 @@ final, maximum security values.
 | `BYTES_PER_LOGS_BLOOM`         | `Uint64(2**8)` (= 256)            |
 | `MAX_EXTRA_DATA_BYTES`         | `Uint64(2**5)` (= 32)             |
 
-## Configuration
+## Configs
 
 ### Transition settings
 

--- a/specs/bellatrix/fork.md
+++ b/specs/bellatrix/fork.md
@@ -3,7 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Fork to Bellatrix](#fork-to-bellatrix)
   - [Fork trigger](#fork-trigger)
   - [Upgrading the state](#upgrading-the-state)
@@ -14,7 +14,7 @@
 
 This document describes the process of Bellatrix upgrade.
 
-## Configuration
+## Configs
 
 | Name                     | Value                                          |
 | ------------------------ | ---------------------------------------------- |

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -10,7 +10,7 @@
   - [New `Withdrawals`](#new-withdrawals)
 - [Constants](#constants)
   - [Domains](#domains)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Max operations per block](#max-operations-per-block)
   - [Execution](#execution)
   - [Withdrawals processing](#withdrawals-processing)
@@ -117,7 +117,7 @@ class Withdrawals(List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]):
 | -------------------------------- | -------------------------- |
 | `DOMAIN_BLS_TO_EXECUTION_CHANGE` | `DomainType('0x0A000000')` |
 
-## Preset
+## Presets
 
 ### Max operations per block
 

--- a/specs/capella/fork.md
+++ b/specs/capella/fork.md
@@ -3,7 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Fork to Capella](#fork-to-capella)
   - [Fork trigger](#fork-trigger)
   - [Upgrading the state](#upgrading-the-state)
@@ -14,7 +14,7 @@
 
 This document describes the process of the Capella upgrade.
 
-## Configuration
+## Configs
 
 | Name                   | Value                                            |
 | ---------------------- | ------------------------------------------------ |

--- a/specs/deneb/beacon-chain.md
+++ b/specs/deneb/beacon-chain.md
@@ -12,10 +12,10 @@
   - [New `VersionedHash`](#new-versionedhash)
 - [Constants](#constants)
   - [Blob](#blob)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Blob](#blob-1)
   - [Execution](#execution)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Execution](#execution-1)
   - [Validator cycle](#validator-cycle)
 - [Containers](#containers)
@@ -129,7 +129,7 @@ class VersionedHash(Bytes32):
 | `VERSIONED_HASH_VERSION_KZG` | `Bytes1('0x01')` | Version byte of a blob's versioned hash         |
 | `BYTES_PER_FIELD_ELEMENT`    | `Uint64(32)`     | Bytes used to encode a BLS scalar field element |
 
-## Preset
+## Presets
 
 ### Blob
 
@@ -143,7 +143,7 @@ class VersionedHash(Bytes32):
 | -------------------------------- | ------------------------- | ------------------------------------------------------------------------------- |
 | `MAX_BLOB_COMMITMENTS_PER_BLOCK` | `Uint64(2**12)` (= 4,096) | Upgrade independent fixed theoretical limit same as `TARGET_BLOB_GAS_PER_BLOCK` |
 
-## Configuration
+## Configs
 
 ### Execution
 

--- a/specs/deneb/fork.md
+++ b/specs/deneb/fork.md
@@ -3,7 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Fork to Deneb](#fork-to-deneb)
   - [Fork trigger](#fork-trigger)
   - [Upgrading the state](#upgrading-the-state)
@@ -14,7 +14,7 @@
 
 This document describes the process of Deneb upgrade.
 
-## Configuration
+## Configs
 
 Warning: this configuration is not definitive.
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -3,8 +3,8 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Preset](#preset)
-- [Configuration](#configuration)
+- [Presets](#presets)
+- [Configs](#configs)
 - [Types](#types)
   - [Modified `BeaconBlockRoots`](#modified-beaconblockroots)
   - [Modified `SignedBeaconBlocks`](#modified-signedbeaconblocks)
@@ -51,7 +51,7 @@ This document contains the consensus-layer networking specifications for Deneb.
 The specification of these changes continues in the same format as the network
 specifications of previous upgrades, and assumes them as pre-requisite.
 
-## Preset
+## Presets
 
 *[New in Deneb:EIP4844]*
 
@@ -59,7 +59,7 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `KZG_COMMITMENT_INCLUSION_PROOF_DEPTH` | `Uint64(floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK))` (= 17) | <!-- predefined --> Merkle proof depth for `blob_kzg_commitments` list item |
 
-## Configuration
+## Configs
 
 *[New in Deneb:EIP4844]*
 

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -19,7 +19,7 @@
   - [Misc](#misc)
   - [Withdrawal prefixes](#withdrawal-prefixes)
   - [Execution-layer triggered requests](#execution-layer-triggered-requests)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Gwei values](#gwei-values)
   - [Rewards and penalties](#rewards-and-penalties)
   - [State list lengths](#state-list-lengths)
@@ -27,7 +27,7 @@
   - [Execution](#execution)
   - [Withdrawals processing](#withdrawals-processing)
   - [Pending deposits processing](#pending-deposits-processing)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Execution](#execution-1)
   - [Validator cycle](#validator-cycle)
 - [Containers](#containers)
@@ -272,7 +272,7 @@ specification.
 | `WITHDRAWAL_REQUEST_TYPE`    | `Bytes1('0x01')` |
 | `CONSOLIDATION_REQUEST_TYPE` | `Bytes1('0x02')` |
 
-## Preset
+## Presets
 
 ### Gwei values
 
@@ -323,7 +323,7 @@ specification.
 | -------------------------------- | --------------------- | ------------------------------------------------------- |
 | `MAX_PENDING_DEPOSITS_PER_EPOCH` | `Uint64(2**4)` (= 16) | Maximum number of pending deposits to process per epoch |
 
-## Configuration
+## Configs
 
 ### Execution
 

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -3,7 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Fork to Electra](#fork-to-electra)
   - [Fork trigger](#fork-trigger)
   - [Upgrading the state](#upgrading-the-state)
@@ -14,7 +14,7 @@
 
 This document describes the process of the Electra upgrade.
 
-## Configuration
+## Configs
 
 Warning: this configuration is not definitive.
 

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -3,7 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Helpers](#helpers)
   - [Modified `Seen`](#modified-seen)
   - [Modified `compute_fork_version`](#modified-compute_fork_version)
@@ -35,7 +35,7 @@ Electra.
 The specification of these changes continues in the same format as the network
 specifications of previous upgrades, and assumes them as pre-requisite.
 
-## Configuration
+## Configs
 
 *[New in Electra:EIP7691]*
 

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -6,7 +6,7 @@
 - [Types](#types)
   - [New `ProposerIndices`](#new-proposerindices)
   - [New `ProposerLookahead`](#new-proposerlookahead)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Blob schedule](#blob-schedule)
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
   - [Block processing](#block-processing)
@@ -67,7 +67,7 @@ class ProposerLookahead(Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_
     """
 ```
 
-## Configuration
+## Configs
 
 ### Blob schedule
 

--- a/specs/fulu/das-core.md
+++ b/specs/fulu/das-core.md
@@ -14,10 +14,10 @@
   - [`RowIndex`](#rowindex)
 - [Constants](#constants)
   - [Misc](#misc)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Blob](#blob)
   - [Size parameters](#size-parameters)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Custody setting](#custody-setting)
 - [Containers](#containers)
   - [`DataColumnSidecar`](#datacolumnsidecar)
@@ -137,7 +137,7 @@ specification.
 | ------------- | --------------------- |
 | `UINT256_MAX` | `Uint256(2**256 - 1)` |
 
-## Preset
+## Presets
 
 ### Blob
 
@@ -153,7 +153,7 @@ specification.
 | ------------------- | ------------------------------------ | --------------------------------------------- |
 | `NUMBER_OF_COLUMNS` | `Uint64(CELLS_PER_EXT_BLOB)` (= 128) | Number of columns in the extended data matrix |
 
-## Configuration
+## Configs
 
 ### Custody setting
 

--- a/specs/fulu/fork.md
+++ b/specs/fulu/fork.md
@@ -3,7 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Helpers](#helpers)
   - [New `initialize_proposer_lookahead`](#new-initialize_proposer_lookahead)
 - [Fork to Fulu](#fork-to-fulu)
@@ -16,7 +16,7 @@
 
 This document describes the process of the Fulu upgrade.
 
-## Configuration
+## Configs
 
 Warning: this configuration is not definitive.
 

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -3,8 +3,8 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Preset](#preset)
-- [Configuration](#configuration)
+- [Presets](#presets)
+- [Configs](#configs)
 - [Types](#types)
   - [New `DataColumnIndices`](#new-datacolumnindices)
   - [New `DataColumnsByRootIdentifiers`](#new-datacolumnsbyrootidentifiers)
@@ -54,13 +54,13 @@ This document contains the consensus-layer networking specifications for Fulu.
 The specification of these changes continues in the same format as the network
 specifications of previous upgrades, and assumes them as pre-requisite.
 
-## Preset
+## Presets
 
 | Name                                    | Value                                                                                     | Description                                                       |
 | --------------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | `KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH` | `Uint64(floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')))` (= 4) | <!-- predefined --> Merkle proof index for `blob_kzg_commitments` |
 
-## Configuration
+## Configs
 
 *[New in Fulu:EIP7594]*
 

--- a/specs/fulu/validator.md
+++ b/specs/fulu/validator.md
@@ -4,7 +4,7 @@
 
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Custody setting](#custody-setting)
 - [Types](#types)
   - [`CellKZGProofs`](#cellkzgproofs)
@@ -43,7 +43,7 @@ All terminology, constants, functions, and protocol mechanics defined in
 [Fulu -- Data Availability Sampling Core](./das-core.md) are requisite for this
 document and used throughout.
 
-## Configuration
+## Configs
 
 ### Custody setting
 

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -48,12 +48,12 @@
   - [Withdrawal prefixes](#withdrawal-prefixes)
   - [Builder versions](#builder-versions)
   - [Execution-layer triggered requests](#execution-layer-triggered-requests)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Misc](#misc-1)
   - [Max operations per block](#max-operations-per-block)
   - [Execution](#execution)
   - [Withdrawals processing](#withdrawals-processing)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Validator cycle](#validator-cycle)
   - [Time parameters](#time-parameters)
   - [Gas limit schedule](#gas-limit-schedule)
@@ -575,7 +575,7 @@ same `Withdrawal` container can be used for validators and builders.
 | `BUILDER_DEPOSIT_REQUEST_TYPE` | `Bytes1('0x03')` |
 | `BUILDER_EXIT_REQUEST_TYPE`    | `Bytes1('0x04')` |
 
-## Preset
+## Presets
 
 ### Misc
 
@@ -602,7 +602,7 @@ same `Withdrawal` container can be used for validators and builders.
 | ------------------------------------ | -------------------------- |
 | `MAX_BUILDERS_PER_WITHDRAWALS_SWEEP` | `Uint64(2**14)` (= 16,384) |
 
-## Configuration
+## Configs
 
 ### Validator cycle
 

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -5,7 +5,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Helpers](#helpers)
   - [New `initialize_ptc_window`](#new-initialize_ptc_window)
   - [New `onboard_builders_from_pending_deposits`](#new-onboard_builders_from_pending_deposits)
@@ -20,7 +20,7 @@
 
 This document describes the process of the Gloas upgrade.
 
-## Configuration
+## Configs
 
 Warning: this configuration is not definitive.
 

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -5,9 +5,9 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Type-specific SSZ bounds](#type-specific-ssz-bounds)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Types](#types)
   - [Modified `DataColumn`](#modified-datacolumn)
   - [Modified `KZGProofs`](#modified-kzgproofs)
@@ -59,7 +59,7 @@ This document contains the consensus-layer networking specifications for Gloas.
 The specification of these changes continues in the same format as the network
 specifications of previous upgrades, and assumes them as pre-requisite.
 
-## Preset
+## Presets
 
 ### Type-specific SSZ bounds
 
@@ -76,7 +76,7 @@ for the corresponding variable-size libp2p messages.
 | `MAX_DATA_COLUMN_SIDECAR_SIZE`          | `Uint64(8585272)` (= ~8 MiB)  |
 | `MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE` | `Uint64(196932)` (= ~192 KiB) |
 
-## Configuration
+## Configs
 
 | Name                   | Value                  |
 | ---------------------- | ---------------------- |

--- a/specs/gloas/partial-columns/p2p-interface.md
+++ b/specs/gloas/partial-columns/p2p-interface.md
@@ -5,7 +5,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Type-specific SSZ bounds](#type-specific-ssz-bounds)
 - [Types](#types)
   - [Modified `CellsBitList`](#modified-cellsbitlist)
@@ -30,7 +30,7 @@ particular, this document builds on the
 [Fulu partial columns networking specification](../../fulu/partial-columns/p2p-interface.md)
 and the [Gloas networking specification](../p2p-interface.md).
 
-## Preset
+## Presets
 
 ### Type-specific SSZ bounds
 

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -5,7 +5,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Time parameters](#time-parameters)
 - [Validator assignment](#validator-assignment)
   - [Payload timeliness committee](#payload-timeliness-committee)
@@ -34,7 +34,7 @@
 This document represents the changes to be made in the code of an "honest
 validator" to implement Gloas.
 
-## Configuration
+## Configs
 
 ### Time parameters
 

--- a/specs/heze/beacon-chain.md
+++ b/specs/heze/beacon-chain.md
@@ -10,7 +10,7 @@
   - [New `InclusionListCommittee`](#new-inclusionlistcommittee)
 - [Constants](#constants)
   - [Domains](#domains)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Inclusion list committee](#inclusion-list-committee)
 - [Containers](#containers)
   - [New containers](#new-containers)
@@ -68,7 +68,7 @@ class InclusionListCommittee(Vector[ValidatorIndex, INCLUSION_LIST_COMMITTEE_SIZ
 | --------------------------------- | -------------------------- |
 | `DOMAIN_INCLUSION_LIST_COMMITTEE` | `DomainType('0x10000000')` |
 
-## Preset
+## Presets
 
 ### Inclusion list committee
 

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -5,7 +5,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Time parameters](#time-parameters)
 - [Protocols](#protocols)
   - [`ExecutionEngine`](#executionengine)
@@ -29,7 +29,7 @@
 
 This is the modification of the fork choice accompanying the Heze upgrade.
 
-## Configuration
+## Configs
 
 ### Time parameters
 

--- a/specs/heze/fork.md
+++ b/specs/heze/fork.md
@@ -5,7 +5,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Fork to Heze](#fork-to-heze)
   - [Upgrading the state](#upgrading-the-state)
 
@@ -15,7 +15,7 @@
 
 This document describes the process of the Heze upgrade.
 
-## Configuration
+## Configs
 
 Warning: this configuration is not definitive.
 

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -5,9 +5,9 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Type-specific SSZ bounds](#type-specific-ssz-bounds)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Types](#types)
   - [New `SignedInclusionLists`](#new-signedinclusionlists)
 - [Helpers](#helpers)
@@ -32,7 +32,7 @@ This document contains the consensus-layer networking specifications for Heze.
 The specification of these changes continues in the same format as the network
 specifications of previous upgrades, and assumes them as pre-requisite.
 
-## Preset
+## Presets
 
 ### Type-specific SSZ bounds
 
@@ -41,7 +41,7 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 | `MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE` | `Uint64(196934)` (= ~192 KiB) |
 | `MAX_SIGNED_INCLUSION_LIST_SIZE`             | `Uint64(8348)` (= ~8 KiB)     |
 
-## Configuration
+## Configs
 
 | Name                                        | Value                     | Description                                                     |
 | ------------------------------------------- | ------------------------- | --------------------------------------------------------------- |

--- a/specs/heze/validator.md
+++ b/specs/heze/validator.md
@@ -5,7 +5,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Helpers](#helpers)
   - [New `GetInclusionListResponse`](#new-getinclusionlistresponse)
 - [Protocols](#protocols)
@@ -29,7 +29,7 @@
 This document represents the changes to be made in the code of an "honest
 validator" to implement Heze.
 
-## Configuration
+## Configs
 
 ## Helpers
 

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -41,14 +41,14 @@
   - [Misc](#misc)
   - [Withdrawal prefixes](#withdrawal-prefixes)
   - [Domains](#domains)
-- [Preset](#preset)
+- [Presets](#presets)
   - [Misc](#misc-1)
   - [Gwei values](#gwei-values)
   - [Time parameters](#time-parameters)
   - [State list lengths](#state-list-lengths)
   - [Rewards and penalties](#rewards-and-penalties)
   - [Max operations per block](#max-operations-per-block)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Genesis settings](#genesis-settings)
   - [Time parameters](#time-parameters-1)
   - [Validator cycle](#validator-cycle)
@@ -533,7 +533,7 @@ specification.
 **MUST** be non-zero. This expression for any other `DomainType` in the
 consensus-layer specifications **MUST** be zero.
 
-## Preset
+## Presets
 
 *Note*: The below configuration is bundled as a preset: a bundle of
 configuration variables which are expected to differ between different modes of
@@ -624,7 +624,7 @@ operation, e.g. testing, but not generally between different networks.
 | `MAX_DEPOSITS`           | `Uint64(2**4)` (= 16)  |
 | `MAX_VOLUNTARY_EXITS`    | `Uint64(2**4)` (= 16)  |
 
-## Configuration
+## Configs
 
 *Note*: The default mainnet configuration values are included here for
 illustrative purposes. Defaults for this more dynamic type of configuration are

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -6,7 +6,7 @@
 - [Types](#types)
   - [`ExecutionAddress`](#executionaddress)
 - [Constants](#constants)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Staking deposit contract](#staking-deposit-contract)
   - [`deposit` function](#deposit-function)
     - [Deposit amount](#deposit-amount)
@@ -41,7 +41,7 @@ specification.
 | ----------------------------- | --------------------- |
 | `DEPOSIT_CONTRACT_TREE_DEPTH` | `Uint64(2**5)` (= 32) |
 
-## Configuration
+## Configs
 
 *Note*: The default mainnet configuration values are included here for
 specification-design purposes.

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -5,7 +5,7 @@
 - [Introduction](#introduction)
 - [Fast Confirmation Rule](#fast-confirmation-rule)
   - [Constants](#constants)
-  - [Configuration](#configuration)
+  - [Configs](#configs)
   - [Helpers](#helpers)
     - [`FastConfirmationStore`](#fastconfirmationstore)
     - [`get_fast_confirmation_store`](#get_fast_confirmation_store)
@@ -73,7 +73,7 @@ blocks can be reorged without any adversarial behavior and without slashing.
 | ----------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR` | `Uint64(5)` | Per mille value to add to the estimation of the committee weight across a range of slots not covering a full epoch in order to ensure the safety of the confirmation rule with high probability. See [here](https://gist.github.com/saltiniroberto/9ee53d29c33878d79417abb2b4468c20) for an explanation about the value chosen. |
 
-### Configuration
+### Configs
 
 | Name                               | Value        | Max. Value   | Description                                                                |
 | ---------------------------------- | ------------ | ------------ | -------------------------------------------------------------------------- |

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -4,8 +4,8 @@
 
 - [Introduction](#introduction)
 - [Fork choice](#fork-choice)
-  - [Constant](#constant)
-  - [Configuration](#configuration)
+  - [Constants](#constants)
+  - [Configs](#configs)
     - [Time parameters](#time-parameters)
   - [Helpers](#helpers)
     - [`ForkChoiceNode`](#forkchoicenode)
@@ -116,13 +116,13 @@ handlers must not modify `store`.
    computation, space, or any other resource. A number of optimized alternatives
    can be found [here](https://github.com/protolambda/lmd-ghost).
 
-### Constant
+### Constants
 
 | Name           | Value           |
 | -------------- | --------------- |
 | `BASIS_POINTS` | `Uint64(10000)` |
 
-### Configuration
+### Configs
 
 | Name                                  | Value         |
 | ------------------------------------- | ------------- |

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -17,7 +17,7 @@
     - [`SignedBeaconBlocks`](#signedbeaconblocks)
     - [`SubnetID`](#subnetid)
   - [Constants](#constants)
-  - [Configuration](#configuration)
+  - [Configs](#configs)
   - [Helpers](#helpers)
     - [`Seen`](#seen)
     - [`compute_fork_version`](#compute_fork_version)
@@ -282,7 +282,7 @@ class SubnetID(Uint64):
 | -------------- | ------------- |
 | `NODE_ID_BITS` | `Uint64(256)` |
 
-### Configuration
+### Configs
 
 This section outlines configurations that are used in this specification.
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -10,7 +10,7 @@ actions of a "validator" participating in the Ethereum proof-of-stake protocol.
 - [Prerequisites](#prerequisites)
 - [Constants](#constants)
   - [Misc](#misc)
-- [Configuration](#configuration)
+- [Configs](#configs)
   - [Time parameters](#time-parameters)
 - [Containers](#containers)
   - [`Eth1Block`](#eth1block)
@@ -104,7 +104,7 @@ specifications before continuing and use as a reference throughout.
 | ---------------------------------- | --------------------- |
 | `TARGET_AGGREGATORS_PER_COMMITTEE` | `Uint64(2**4)` (= 16) |
 
-## Configuration
+## Configs
 
 ### Time parameters
 

--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -7,7 +7,7 @@
 - [Types](#types)
   - [`Ether`](#ether)
 - [Constants](#constants)
-- [Configuration](#configuration)
+- [Configs](#configs)
 - [Weak Subjectivity Checkpoint](#weak-subjectivity-checkpoint)
 - [Weak Subjectivity Period](#weak-subjectivity-period)
   - [Calculating the Weak Subjectivity Period](#calculating-the-weak-subjectivity-period)
@@ -53,7 +53,7 @@ class Ether(Uint64):
 | ------------- | --------------- |
 | `ETH_TO_GWEI` | `Uint64(10**9)` |
 
-## Configuration
+## Configs
 
 | Name           | Value        |
 | -------------- | ------------ |


### PR DESCRIPTION
To match `Types` and `Constants`, rename `Preset` -> `Presets` and `Configuration` -> `Configs`.

Also rename one instance of `Constant` -> `Constants`.
