### PR TITLE
Set sweep threshold when switching to 0x02 and cap effective balance

### DIFF
--- a/specs/_features/eip8148/beacon-chain.md
+++ b/specs/_features/eip8148/beacon-chain.md
@@ -26,6 +26,8 @@
     - [New `get_effective_sweep_threshold`](#new-get_effective_sweep_threshold)
   - [Validator registry](#validator-registry)
     - [Modified `add_validator_to_registry`](#modified-add_validator_to_registry)
+  - [Beacon state mutators](#beacon-state-mutators)
+    - [Modified `switch_to_compounding_validator`](#modified-switch_to_compounding_validator)
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
   - [Block processing](#block-processing)
     - [Execution payload](#execution-payload)
@@ -245,6 +247,21 @@ def add_validator_to_registry(
         if has_compounding_withdrawal_credential(validator)
         else Gwei(0),
     )
+```
+
+### Beacon state mutators
+
+#### Modified `switch_to_compounding_validator`
+
+```python
+def switch_to_compounding_validator(state: BeaconState, index: ValidatorIndex) -> None:
+    validator = state.validators[index]
+    validator.withdrawal_credentials = (
+        COMPOUNDING_WITHDRAWAL_PREFIX + validator.withdrawal_credentials[1:]
+    )
+    queue_excess_active_balance(state, index)
+    # [New in EIP8148]
+    state.validator_sweep_thresholds[index] = MAX_EFFECTIVE_BALANCE_ELECTRA
 ```
 
 ## Beacon chain state transition function

--- a/specs/_features/eip8148/beacon-chain.md
+++ b/specs/_features/eip8148/beacon-chain.md
@@ -29,6 +29,8 @@
   - [Beacon state mutators](#beacon-state-mutators)
     - [Modified `switch_to_compounding_validator`](#modified-switch_to_compounding_validator)
 - [Beacon chain state transition function](#beacon-chain-state-transition-function)
+  - [Epoch processing](#epoch-processing)
+    - [Modified `process_effective_balance_updates`](#modified-process_effective_balance_updates)
   - [Block processing](#block-processing)
     - [Execution payload](#execution-payload)
       - [Modified `get_execution_requests_list`](#modified-get_execution_requests_list)
@@ -265,6 +267,35 @@ def switch_to_compounding_validator(state: BeaconState, index: ValidatorIndex) -
 ```
 
 ## Beacon chain state transition function
+
+### Epoch processing
+
+#### Modified `process_effective_balance_updates`
+
+*Note*: The function `process_effective_balance_updates` is modified to use
+custom sweep thresholds.
+
+```python
+def process_effective_balance_updates(state: BeaconState) -> None:
+    # Update effective balances with hysteresis
+    for index, validator in enumerate(state.validators):
+        balance = state.balances[index]
+        HYSTERESIS_INCREMENT = Uint64(EFFECTIVE_BALANCE_INCREMENT // HYSTERESIS_QUOTIENT)
+        DOWNWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_DOWNWARD_MULTIPLIER
+        UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_UPWARD_MULTIPLIER
+        # [Modified in EIP8148]
+        sweep_threshold = state.validator_sweep_thresholds[index]
+        effective_sweep_threshold = get_effective_sweep_threshold(validator, sweep_threshold)
+
+        if (
+            balance + DOWNWARD_THRESHOLD < validator.effective_balance
+            or validator.effective_balance + UPWARD_THRESHOLD < balance
+        ):
+            # [Modified in EIP8148]
+            validator.effective_balance = min(
+                balance - balance % EFFECTIVE_BALANCE_INCREMENT, effective_sweep_threshold
+            )
+```
 
 ### Block processing
 

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/epoch_processing/test_process_registry_updates.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/epoch_processing/test_process_registry_updates.py
@@ -10,7 +10,7 @@ from eth_consensus_specs.test.context import (
 )
 from eth_consensus_specs.test.helpers.constants import MINIMAL
 from eth_consensus_specs.test.helpers.epoch_processing import run_epoch_processing_with
-from eth_consensus_specs.test.helpers.forks import is_post_electra
+from eth_consensus_specs.test.helpers.forks import is_post_eip8148, is_post_electra
 from eth_consensus_specs.test.helpers.keys import pubkeys
 from tests.core.pyspec.eth_consensus_specs.test.helpers.churn import get_activation_churn_limit
 
@@ -50,6 +50,8 @@ def run_test_activation_churn_limit(spec, state):
         state.current_epoch_participation.append(spec.ParticipationFlags(0b0000_0000))
         state.inactivity_scores.append(0)
         state.validators[index].activation_epoch = spec.FAR_FUTURE_EPOCH
+        if is_post_eip8148(spec):
+            state.validator_sweep_thresholds.append(spec.Gwei(0))
 
     if is_post_electra(spec):
         churn_limit_0 = get_activation_churn_limit(spec, state) // spec.MIN_ACTIVATION_BALANCE


### PR DESCRIPTION
Since the sweep threshold is set to `MAX_EFFECTIVE_BALANCE_ELECTRA` on fork for all existing 0x02 validators and when creating new 0x02 validators, it makes sense to also set it to `MAX_EFFECTIVE_BALANCE_ELECTRA` during rotation to 0x02.

Another change is to limit the value of the effective balance with sweep threshold to avoid cases when a validator with sweep threshold set below `MAX_EFFECTIVE_BALANCE_ELECTRA` has an effective balance higher than sweep threshold.