### PR TITLE
Expand `PTC` to `PayloadTimelinessCommittee` in type names

### DIFF
--- a/specs/_features/eip8148/beacon-chain.md
+++ b/specs/_features/eip8148/beacon-chain.md
@@ -148,7 +148,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 47)):
     builder_pending_withdrawals: BuilderPendingWithdrawals
     latest_execution_payload_bid: ExecutionPayloadBid
     payload_expected_withdrawals: Withdrawals
-    ptc_window: PTCWindow
+    ptc_window: PayloadTimelinessCommitteeWindow
     # [New in EIP8148]
     validator_sweep_thresholds: SweepThresholds
 ```

--- a/specs/_features/eip8321/beacon-chain.md
+++ b/specs/_features/eip8321/beacon-chain.md
@@ -248,7 +248,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 48)):
     builder_pending_withdrawals: BuilderPendingWithdrawals
     latest_execution_payload_bid: ExecutionPayloadBid
     payload_expected_withdrawals: Withdrawals
-    ptc_window: PTCWindow
+    ptc_window: PayloadTimelinessCommitteeWindow
     # [New in EIP8321]
     randao_commitments: RandaoCommitments
     # [New in EIP8321]

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -37,10 +37,10 @@
   - [New `Builders`](#new-builders)
   - [New `ExecutionPayloadAvailability`](#new-executionpayloadavailability)
   - [New `PayloadAttestations`](#new-payloadattestations)
-  - [New `PTC`](#new-ptc)
-  - [New `PTCAttestingIndices`](#new-ptcattestingindices)
-  - [New `PTCBits`](#new-ptcbits)
-  - [New `PTCWindow`](#new-ptcwindow)
+  - [New `PayloadTimelinessCommittee`](#new-payloadtimelinesscommittee)
+  - [New `PayloadTimelinessCommitteeIndices`](#new-payloadtimelinesscommitteeindices)
+  - [New `PayloadTimelinessCommitteeBits`](#new-payloadtimelinesscommitteebits)
+  - [New `PayloadTimelinessCommitteeWindow`](#new-payloadtimelinesscommitteewindow)
 - [Constants](#constants)
   - [Index flags](#index-flags)
   - [Domains](#domains)
@@ -491,38 +491,41 @@ class PayloadAttestations(ProgressiveList[PayloadAttestation]):
     """
 ```
 
-### New `PTC`
+### New `PayloadTimelinessCommittee`
 
 ```python
-class PTC(Vector[ValidatorIndex, PTC_SIZE]):
+class PayloadTimelinessCommittee(Vector[ValidatorIndex, PTC_SIZE]):
     """
     The payload timeliness committee of a slot.
     """
 ```
 
-### New `PTCAttestingIndices`
+### New `PayloadTimelinessCommitteeIndices`
 
 ```python
-class PTCAttestingIndices(List[ValidatorIndex, PTC_SIZE]):
+class PayloadTimelinessCommitteeIndices(List[ValidatorIndex, PTC_SIZE]):
     """
-    The indices of the PTC members participating in a payload attestation.
+    The indices of payload timeliness committee members, as a list limited
+    by the size of the committee.
     """
 ```
 
-### New `PTCBits`
+### New `PayloadTimelinessCommitteeBits`
 
 ```python
-class PTCBits(BitVector[PTC_SIZE]):
+class PayloadTimelinessCommitteeBits(BitVector[PTC_SIZE]):
     """
     The participation bits of the payload timeliness committee, one bit per
     member in committee order.
     """
 ```
 
-### New `PTCWindow`
+### New `PayloadTimelinessCommitteeWindow`
 
 ```python
-class PTCWindow(Vector[PTC, (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]):
+class PayloadTimelinessCommitteeWindow(
+    Vector[PayloadTimelinessCommittee, (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
+):
     """
     A rolling window of payload timeliness committees for the previous,
     current, and lookahead epochs.
@@ -702,7 +705,7 @@ class PayloadAttestationData(Container):
 
 ```python
 class PayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):
-    aggregation_bits: PTCBits
+    aggregation_bits: PayloadTimelinessCommitteeBits
     data: PayloadAttestationData
     signature: BLSSignature
 ```
@@ -720,7 +723,7 @@ class PayloadAttestationMessage(Container):
 
 ```python
 class IndexedPayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):
-    attesting_indices: PTCAttestingIndices
+    attesting_indices: PayloadTimelinessCommitteeIndices
     data: PayloadAttestationData
     signature: BLSSignature
 ```
@@ -900,7 +903,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):
     # [New in Gloas:EIP7732]
     payload_expected_withdrawals: Withdrawals
     # [New in Gloas:EIP7732]
-    ptc_window: PTCWindow
+    ptc_window: PayloadTimelinessCommitteeWindow
 ```
 
 #### `ExecutionPayload`
@@ -1209,7 +1212,7 @@ def compute_proposer_indices(
 #### New `compute_ptc`
 
 ```python
-def compute_ptc(state: BeaconState, slot: Slot) -> PTC:
+def compute_ptc(state: BeaconState, slot: Slot) -> PayloadTimelinessCommittee:
     """
     Get the payload timeliness committee, with possible duplicates, for the given ``slot``.
     """
@@ -1221,7 +1224,7 @@ def compute_ptc(state: BeaconState, slot: Slot) -> PTC:
     for i in range(committees_per_slot):
         committee = get_beacon_committee(state, slot, CommitteeIndex(i))
         indices.extend(committee)
-    return PTC(
+    return PayloadTimelinessCommittee(
         compute_balance_weighted_selection(
             state, indices, seed, size=PTC_SIZE, shuffle_indices=False
         )
@@ -1335,7 +1338,7 @@ def get_attestation_participation_flag_indices(
 #### New `get_ptc`
 
 ```python
-def get_ptc(state: BeaconState, slot: Slot) -> PTC:
+def get_ptc(state: BeaconState, slot: Slot) -> PayloadTimelinessCommittee:
     """
     Get the payload timeliness committee for the given ``slot``.
     """
@@ -1364,7 +1367,7 @@ def get_indexed_payload_attestation(
     attesting_indices = [index for i, index in enumerate(ptc) if bits[i]]
 
     return IndexedPayloadAttestation(
-        attesting_indices=PTCAttestingIndices(sorted(attesting_indices)),
+        attesting_indices=PayloadTimelinessCommitteeIndices(sorted(attesting_indices)),
         data=payload_attestation.data,
         signature=payload_attestation.signature,
     )

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -36,13 +36,14 @@ Warning: this configuration is not definitive.
 ```python
 def initialize_ptc_window(
     state: BeaconState,
-) -> PTCWindow:
+) -> PayloadTimelinessCommitteeWindow:
     """
     Return the cached PTC window starting from the current epoch.
     Used to initialize the ``ptc_window`` field in the beacon state at genesis and after forks.
     """
     empty_previous_epoch = [
-        PTC([ValidatorIndex(0) for _ in range(PTC_SIZE)]) for _ in range(SLOTS_PER_EPOCH)
+        PayloadTimelinessCommittee([ValidatorIndex(0) for _ in range(PTC_SIZE)])
+        for _ in range(SLOTS_PER_EPOCH)
     ]
 
     ptcs = []
@@ -52,7 +53,7 @@ def initialize_ptc_window(
         start_slot = compute_start_slot_at_epoch(epoch)
         ptcs += [compute_ptc(state, Slot(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
 
-    return PTCWindow(empty_previous_epoch + ptcs)
+    return PayloadTimelinessCommitteeWindow(empty_previous_epoch + ptcs)
 ```
 
 ### New `onboard_builders_from_pending_deposits`

--- a/specs/heze/beacon-chain.md
+++ b/specs/heze/beacon-chain.md
@@ -179,7 +179,7 @@ class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):
     # [Modified in Heze:EIP7805]
     latest_execution_payload_bid: ExecutionPayloadBid
     payload_expected_withdrawals: Withdrawals
-    ptc_window: PTCWindow
+    ptc_window: PayloadTimelinessCommitteeWindow
 ```
 
 ## Helpers

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/genesis.py
@@ -220,7 +220,7 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
             [spec.BuilderPendingPayment() for _ in range(2 * spec.SLOTS_PER_EPOCH)]
         )
         state.builder_pending_withdrawals = spec.BuilderPendingWithdrawals()
-        state.ptc_window = spec.PTCWindow(initialize_ptc_window(spec, state))
+        state.ptc_window = spec.PayloadTimelinessCommitteeWindow(initialize_ptc_window(spec, state))
 
     if is_post_eip8148(spec):
         state.validator_sweep_thresholds = spec.SweepThresholds(

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/state.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/state.py
@@ -1,6 +1,6 @@
 def initialize_ptc_window(spec, state):
     empty_previous_epoch = [
-        spec.PTC([spec.ValidatorIndex(0) for _ in range(spec.PTC_SIZE)])
+        spec.PayloadTimelinessCommittee([spec.ValidatorIndex(0) for _ in range(spec.PTC_SIZE)])
         for _ in range(spec.SLOTS_PER_EPOCH)
     ]
     ptcs = []

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
@@ -27,7 +27,7 @@ def build_max_size_indexed_attestation(spec):
 
 def build_max_size_payload_attestation(spec):
     return spec.PayloadAttestation(
-        aggregation_bits=spec.PTCBits([True] * spec.PTC_SIZE),
+        aggregation_bits=spec.PayloadTimelinessCommitteeBits([True] * spec.PTC_SIZE),
         data=spec.PayloadAttestationData(),
         signature=spec.BLSSignature(),
     )


### PR DESCRIPTION
With the exception of BLS, we typically do not use acronyms in the specifications, because first time readers might not know what a PTC is. Expanding this in type names should be helpful & it's not going to break anything in clients.