### PR TITLE
Ignore proposer preferences for pre-Gloas slots

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -1066,6 +1066,10 @@ def validate_proposer_preferences_gossip(
     preferences = signed_proposer_preferences.message
     proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
 
+    # [IGNORE] The proposal epoch is after the Gloas upgrade
+    if proposal_epoch < GLOAS_FORK_EPOCH:
+        raise GossipIgnore("proposal epoch is pre-gloas")
+
     # [IGNORE] The proposal slot has not started yet
     if is_past_slot(store, preferences.proposal_slot, current_time_ms):
         raise GossipIgnore("proposal slot has already started")

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_execution_payload_bid.py
@@ -1,5 +1,5 @@
 from eth_consensus_specs.test.context import (
-    spec_state_test,
+    spec_state_test_with_matching_config,
     with_gloas_and_later,
 )
 from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
@@ -106,7 +106,7 @@ def _seed_bid_context(
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid(spec, state):
     """A bid for the next slot from an active builder with matching preferences is valid."""
     anchor_state = state.copy()
@@ -164,7 +164,7 @@ def test_gossip_execution_payload_bid__valid(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_zero_value_first_bid(spec, state):
     """The first bid for a slot and parent is valid even with a zero value.
 
@@ -227,7 +227,7 @@ def test_gossip_execution_payload_bid__valid_zero_value_first_bid(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_slot_too_far_future(spec, state):
     """A bid whose slot is far in the future is ignored."""
     anchor_state = state.copy()
@@ -287,7 +287,7 @@ def test_gossip_execution_payload_bid__ignore_slot_too_far_future(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_slot_outside_lower_disparity(spec, state):
     """A bid whose slot is 1ms before the lower clock-disparity edge is ignored."""
     anchor_state = state.copy()
@@ -356,7 +356,7 @@ def test_gossip_execution_payload_bid__ignore_slot_outside_lower_disparity(spec,
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_slot_at_lower_disparity(spec, state):
     """A bid whose slot lands exactly on the lower clock-disparity edge is valid."""
     anchor_state = state.copy()
@@ -465,7 +465,7 @@ def test_gossip_execution_payload_bid__valid_slot_at_lower_disparity(spec, state
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_slot_at_upper_disparity(spec, state):
     """A bid whose slot lands exactly on the upper clock-disparity edge is valid."""
     anchor_state = state.copy()
@@ -569,7 +569,7 @@ def test_gossip_execution_payload_bid__valid_slot_at_upper_disparity(spec, state
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_slot_outside_upper_disparity(spec, state):
     """A bid whose slot is 1ms past the upper clock-disparity edge is ignored."""
     anchor_state = state.copy()
@@ -634,7 +634,7 @@ def test_gossip_execution_payload_bid__ignore_slot_outside_upper_disparity(spec,
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_duplicate_from_builder(spec, state):
     """A second bid from the same builder for the same slot and parent is ignored.
 
@@ -732,7 +732,7 @@ def test_gossip_execution_payload_bid__ignore_duplicate_from_builder(spec, state
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_not_highest_value(spec, state):
     """A bid whose value does not exceed the best bid for this slot/parent is ignored.
 
@@ -829,7 +829,7 @@ def test_gossip_execution_payload_bid__ignore_not_highest_value(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_equal_value(spec, state):
     """A bid whose value merely equals (does not exceed) the best bid is ignored.
 
@@ -927,7 +927,7 @@ def test_gossip_execution_payload_bid__ignore_equal_value(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_higher_value(spec, state):
     """A bid whose value strictly exceeds the best bid for this slot/parent is valid.
 
@@ -1023,7 +1023,7 @@ def test_gossip_execution_payload_bid__valid_higher_value(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__reject_builder_index_out_of_range(spec, state):
     """A bid whose builder_index is past the builder registry is rejected.
 
@@ -1089,7 +1089,7 @@ def test_gossip_execution_payload_bid__reject_builder_index_out_of_range(spec, s
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_builder_cannot_cover(spec, state):
     """A bid whose value exceeds what the builder can cover is ignored."""
     # Zero out the builder's balance so it cannot cover even a tiny bid. This
@@ -1154,7 +1154,7 @@ def test_gossip_execution_payload_bid__ignore_builder_cannot_cover(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__reject_execution_payment_nonzero(spec, state):
     """A bid whose execution_payment is non-zero is rejected."""
     anchor_state = state.copy()
@@ -1214,7 +1214,7 @@ def test_gossip_execution_payload_bid__reject_execution_payment_nonzero(spec, st
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__reject_builder_not_active(spec, state):
     """A bid from an inactive builder is rejected."""
     anchor_state = state.copy()
@@ -1276,7 +1276,7 @@ def test_gossip_execution_payload_bid__reject_builder_not_active(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__reject_builder_not_payload_version(spec, state):
     """A bid from a builder whose version is not PAYLOAD_BUILDER_VERSION is rejected.
 
@@ -1344,7 +1344,7 @@ def test_gossip_execution_payload_bid__reject_builder_not_payload_version(spec, 
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__reject_too_many_blobs(spec, state):
     """A bid whose blob KZG commitment count exceeds the per-epoch limit is rejected."""
     anchor_state = state.copy()
@@ -1410,7 +1410,7 @@ def test_gossip_execution_payload_bid__reject_too_many_blobs(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_max_blobs(spec, state):
     """A bid with exactly the per-epoch blob KZG commitment limit is valid.
 
@@ -1477,7 +1477,7 @@ def test_gossip_execution_payload_bid__valid_max_blobs(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_parent_block_unknown(spec, state):
     """A bid whose parent_block_root is not in store.blocks is ignored.
 
@@ -1541,7 +1541,7 @@ def test_gossip_execution_payload_bid__ignore_parent_block_unknown(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__reject_slot_not_higher_than_parent(spec, state):
     """A bid whose slot is not greater than its parent block's slot is rejected.
 
@@ -1638,7 +1638,7 @@ def test_gossip_execution_payload_bid__reject_slot_not_higher_than_parent(spec, 
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_parent_block_hash_unknown(spec, state):
     """A bid whose parent_block_hash is not in seen.execution_payloads is ignored.
 
@@ -1702,7 +1702,7 @@ def test_gossip_execution_payload_bid__ignore_parent_block_hash_unknown(spec, st
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_parent_state_unavailable(spec, state):
     """A bid whose parent block's state is missing is ignored."""
     anchor_state = state.copy()
@@ -1791,7 +1791,7 @@ def test_gossip_execution_payload_bid__ignore_parent_state_unavailable(spec, sta
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_slot_past_parent_lookahead(spec, state):
     """
     A bid whose slot is more than MIN_SEED_LOOKAHEAD epochs ahead of its parent
@@ -1880,7 +1880,7 @@ def test_gossip_execution_payload_bid__ignore_slot_past_parent_lookahead(spec, s
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_preferences_not_seen(spec, state):
     """A bid whose matching proposer preferences have not been seen is ignored."""
     anchor_state = state.copy()
@@ -1958,7 +1958,7 @@ def test_gossip_execution_payload_bid__ignore_preferences_not_seen(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_fee_recipient_mismatch(spec, state):
     """A bid whose fee_recipient does not match the proposer's preference is ignored."""
     anchor_state = state.copy()
@@ -2061,7 +2061,7 @@ def test_gossip_execution_payload_bid__ignore_fee_recipient_mismatch(spec, state
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_gas_limit_incompatible(spec, state):
     """A bid whose gas_limit is incompatible with the proposer's target is ignored."""
     anchor_state = state.copy()
@@ -2165,7 +2165,7 @@ def test_gossip_execution_payload_bid__ignore_gas_limit_incompatible(spec, state
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__reject_incorrect_prev_randao(spec, state):
     """A bid whose prev_randao does not match the parent state's RANDAO mix is rejected."""
     anchor_state = state.copy()
@@ -2273,7 +2273,7 @@ def test_gossip_execution_payload_bid__reject_incorrect_prev_randao(spec, state)
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__reject_invalid_signature(spec, state):
     """A bid with an invalid signature is rejected once all other checks pass."""
     anchor_state = state.copy()
@@ -2492,7 +2492,7 @@ def _run_bid_gas_limit_scenario(
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_gas_limit_increase_within_limit(spec, state):
     """A bid with gas_limit raised within the EIP-1559 step toward target is valid."""
     yield from _run_bid_gas_limit_scenario(
@@ -2507,7 +2507,7 @@ def test_gossip_execution_payload_bid__valid_gas_limit_increase_within_limit(spe
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_gas_limit_increase_exceeding_limit(spec, state):
     """When target is above the EIP-1559 max, a bid pinned to the max value is valid."""
     # max_gas_limit_difference = 60_000_000 // 1024 - 1 = 58_592
@@ -2523,7 +2523,7 @@ def test_gossip_execution_payload_bid__valid_gas_limit_increase_exceeding_limit(
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_gas_limit_increase_exceeding_limit_off_by_one(
     spec, state
 ):
@@ -2540,7 +2540,7 @@ def test_gossip_execution_payload_bid__ignore_gas_limit_increase_exceeding_limit
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_gas_limit_decrease_within_limit(spec, state):
     """A bid with gas_limit lowered within the EIP-1559 step toward target is valid."""
     yield from _run_bid_gas_limit_scenario(
@@ -2555,7 +2555,7 @@ def test_gossip_execution_payload_bid__valid_gas_limit_decrease_within_limit(spe
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_gas_limit_decrease_exceeding_limit(spec, state):
     """When target is below the EIP-1559 min, a bid pinned to the min value is valid."""
     yield from _run_bid_gas_limit_scenario(
@@ -2570,7 +2570,7 @@ def test_gossip_execution_payload_bid__valid_gas_limit_decrease_exceeding_limit(
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__ignore_gas_limit_decrease_exceeding_limit_off_by_one(
     spec, state
 ):
@@ -2587,7 +2587,7 @@ def test_gossip_execution_payload_bid__ignore_gas_limit_decrease_exceeding_limit
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_gas_limit_target_equals_parent(spec, state):
     """A bid whose gas_limit equals both target and parent gas_limit is valid."""
     yield from _run_bid_gas_limit_scenario(
@@ -2602,7 +2602,7 @@ def test_gossip_execution_payload_bid__valid_gas_limit_target_equals_parent(spec
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_gas_limit_parent_under_step(spec, state):
     """A bid is valid when parent gas_limit is below the 1024 step (step floors to 1)."""
     yield from _run_bid_gas_limit_scenario(
@@ -2617,7 +2617,7 @@ def test_gossip_execution_payload_bid__valid_gas_limit_parent_under_step(spec, s
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_execution_payload_bid__valid_requires_state_advanced_across_epoch(spec, state):
     """
     A bid that is only coverable because validation advances the state across

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_proposer_preferences.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_proposer_preferences.py
@@ -1,11 +1,14 @@
 from eth_consensus_specs.test.context import (
-    spec_state_test,
+    spec_configured_state_test,
+    spec_state_test_with_matching_config,
     with_gloas_and_later,
+    with_phases,
 )
 from eth_consensus_specs.test.helpers.block import (
     build_empty_block,
     build_empty_block_for_next_slot,
 )
+from eth_consensus_specs.test.helpers.constants import GLOAS
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
 )
@@ -56,7 +59,7 @@ def setup_store_with_advanced_state(spec, state, target_slot):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__valid(spec, state):
     """A well-formed SignedProposerPreferences for an upcoming proposal passes gossip."""
     anchor_state = state.copy()
@@ -72,6 +75,105 @@ def test_gossip_proposer_preferences__valid(spec, state):
     yield "blocks", "meta", [{"block": get_filename(b)} for b in blocks]
 
     signed_prefs = build_signed_proposer_preferences(spec, state)
+    yield get_filename(signed_prefs), signed_prefs
+
+    time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(time_ms)
+    messages = []
+
+    time_ms += 100
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_proposer_preferences=signed_prefs,
+        current_time_ms=time_ms,
+    )
+    assert result == "valid"
+    assert reason is None
+    messages.append(
+        {
+            "current_time_ms": int(time_ms),
+            "message": get_filename(signed_prefs),
+            "expected": result,
+        }
+    )
+
+    yield "messages", "meta", messages
+
+
+@with_phases([GLOAS])
+@spec_configured_state_test({"GLOAS_FORK_EPOCH": 1})
+def test_gossip_proposer_preferences__ignore_pre_gloas_epoch(spec, state):
+    """Preferences for a proposal slot before the Gloas fork are ignored."""
+    anchor_state = state.copy()
+    yield "topic", "meta", "proposer_preferences"
+
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    signed_anchor = wrap_genesis_block(spec, anchor_block)
+
+    yield "state", anchor_state
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    # Epoch 0 is before GLOAS_FORK_EPOCH. The dependent root is a placeholder;
+    # this check fires before any dependent_root lookup.
+    proposal_slot = spec.Slot(1)
+    assert spec.compute_epoch_at_slot(proposal_slot) < spec.config.GLOAS_FORK_EPOCH
+    signed_prefs = build_signed_proposer_preferences(
+        spec,
+        state,
+        proposal_slot=proposal_slot,
+        validator_index=spec.ValidatorIndex(0),
+        dependent_root=spec.Root(),
+    )
+    yield get_filename(signed_prefs), signed_prefs
+
+    time_ms = spec.compute_time_at_slot_ms(store, spec.Slot(0))
+    yield "current_time_ms", "meta", int(time_ms)
+    messages = []
+
+    result, reason = run_validate_gossip(
+        spec,
+        seen=get_seen(spec),
+        store=store,
+        signed_proposer_preferences=signed_prefs,
+        current_time_ms=time_ms,
+    )
+    assert result == "ignore"
+    assert reason == "proposal epoch is pre-gloas"
+    messages.append(
+        {
+            "current_time_ms": int(time_ms),
+            "message": get_filename(signed_prefs),
+            "expected": result,
+            "reason": reason,
+        }
+    )
+
+    yield "messages", "meta", messages
+
+
+@with_phases([GLOAS])
+@spec_configured_state_test({"GLOAS_FORK_EPOCH": 2})
+def test_gossip_proposer_preferences__valid_at_gloas_fork_epoch(spec, state):
+    """Preferences for a proposal slot in the Gloas fork epoch are valid."""
+    anchor_state = state.copy()
+    yield "topic", "meta", "proposer_preferences"
+
+    fork_epoch = spec.config.GLOAS_FORK_EPOCH
+    target_slot = spec.compute_start_slot_at_epoch(fork_epoch)
+    store, blocks = setup_store_with_advanced_state(spec, state, target_slot)
+
+    yield "state", anchor_state
+    seen = get_seen(spec)
+    for signed in blocks:
+        yield get_filename(signed), signed
+    yield "blocks", "meta", [{"block": get_filename(b)} for b in blocks]
+
+    signed_prefs = build_signed_proposer_preferences(spec, state)
+    proposal_epoch = spec.compute_epoch_at_slot(signed_prefs.message.proposal_slot)
+    assert proposal_epoch == fork_epoch
     yield get_filename(signed_prefs), signed_prefs
 
     time_ms = spec.compute_time_at_slot_ms(store, state.slot)
@@ -116,7 +218,7 @@ def setup_lookahead_window(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__ignore_slot_before_lookahead(spec, state):
     """Preferences for the slot just below the lookahead window are ignored.
 
@@ -171,7 +273,7 @@ def test_gossip_proposer_preferences__ignore_slot_before_lookahead(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__valid_at_first_lookahead_slot(spec, state):
     """Preferences for the first slot of the lookahead window are valid.
 
@@ -225,7 +327,7 @@ def test_gossip_proposer_preferences__valid_at_first_lookahead_slot(spec, state)
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__valid_at_last_lookahead_slot(spec, state):
     """Preferences for the last slot of the lookahead window are valid.
 
@@ -279,7 +381,7 @@ def test_gossip_proposer_preferences__valid_at_last_lookahead_slot(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__ignore_slot_after_lookahead(spec, state):
     """Preferences for the slot just past the lookahead window are ignored.
 
@@ -366,7 +468,7 @@ def setup_lookahead_boundary_preferences(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__ignore_outside_lookahead_disparity(spec, state):
     """Preferences validated 1ms before the lookahead lower bound are ignored.
 
@@ -416,7 +518,7 @@ def test_gossip_proposer_preferences__ignore_outside_lookahead_disparity(spec, s
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__valid_at_lookahead_disparity_edge(spec, state):
     """Preferences validated exactly at the lookahead lower bound are valid.
 
@@ -465,7 +567,7 @@ def test_gossip_proposer_preferences__valid_at_lookahead_disparity_edge(spec, st
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__valid_at_slot_start_disparity_edge(spec, state):
     """Preferences validated exactly at the clock-disparity edge are still valid.
 
@@ -516,7 +618,7 @@ def test_gossip_proposer_preferences__valid_at_slot_start_disparity_edge(spec, s
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__ignore_outside_slot_start_disparity(spec, state):
     """Preferences validated 1ms past the clock-disparity window are ignored as started."""
     anchor_state = state.copy()
@@ -567,7 +669,7 @@ def test_gossip_proposer_preferences__ignore_outside_slot_start_disparity(spec, 
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__ignore_dependent_root_unseen(spec, state):
     """Preferences whose dependent_root has no corresponding block in the store are ignored."""
     anchor_state = state.copy()
@@ -615,7 +717,7 @@ def test_gossip_proposer_preferences__ignore_dependent_root_unseen(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__ignore_duplicate(spec, state):
     """The second valid preferences for the same dependent_root and proposal slot is ignored."""
     anchor_state = state.copy()
@@ -680,7 +782,7 @@ def test_gossip_proposer_preferences__ignore_duplicate(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__reject_wrong_proposer(spec, state):
     """Preferences signed by a validator that is not the slot's proposer are rejected."""
     anchor_state = state.copy()
@@ -732,7 +834,7 @@ def test_gossip_proposer_preferences__reject_wrong_proposer(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__reject_invalid_signature(spec, state):
     """Preferences with an invalid signature are rejected."""
     anchor_state = state.copy()
@@ -777,7 +879,7 @@ def test_gossip_proposer_preferences__reject_invalid_signature(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__ignore_slot_from_past_epoch(spec, state):
     """Preferences whose proposal slot is in a past epoch are ignored as started.
 
@@ -835,7 +937,7 @@ def test_gossip_proposer_preferences__ignore_slot_from_past_epoch(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__ignore_dependent_root_state_unavailable(spec, state):
     """Preferences whose dependent_root has no corresponding state are ignored."""
     anchor_state = state.copy()
@@ -896,7 +998,7 @@ def test_gossip_proposer_preferences__ignore_dependent_root_state_unavailable(sp
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__reject_dependent_root_at_lookahead_epoch_start(spec, state):
     """
     Preferences whose dependent_root points to a block at the proposal slot's
@@ -968,7 +1070,7 @@ def test_gossip_proposer_preferences__reject_dependent_root_at_lookahead_epoch_s
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__ignore_dependent_root_not_possible(spec, state):
     """Preferences whose dependent_root is superseded on every branch are ignored.
 
@@ -1032,7 +1134,7 @@ def test_gossip_proposer_preferences__ignore_dependent_root_not_possible(spec, s
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__valid_dependent_root_on_fork(spec, state):
     """Preferences whose dependent_root is a non-canonical fork block are valid.
 
@@ -1110,7 +1212,7 @@ def test_gossip_proposer_preferences__valid_dependent_root_on_fork(spec, state):
 
 
 @with_gloas_and_later
-@spec_state_test
+@spec_state_test_with_matching_config
 def test_gossip_proposer_preferences__valid_dependent_root_across_empty_epochs(spec, state):
     """
     Preferences remain valid when two empty epochs reuse the same dependent


### PR DESCRIPTION
As mentioned by @nflaig at ACDC today, we should ignore proposer preferences for proposal slots which are before the Glamsterdam upgrade. I'm pretty sure the only reason I didn't want to do this before was that comparing anything against a fork epoch value in the testing framework is a pain in the butt. This is a worthwhile condition to have though.