### PR TITLE
Increase `MAX_SIGNED_INCLUSION_LIST_SIZE` to the worst-case size

### DIFF
--- a/presets/mainnet/heze.yaml
+++ b/presets/mainnet/heze.yaml
@@ -9,7 +9,5 @@ INCLUSION_LIST_COMMITTEE_SIZE: 16
 # ---------------------------------------------------------------
 # 196,934 bytes, ~192 KiB
 MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE: 196934
-# 152 + 5 * MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST = 41,112 bytes, ~40 KiB:
-# a list of MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST one-byte transactions,
-# each costing its byte plus a 4-byte SSZ offset
+# 41,112 bytes, ~40 KiB
 MAX_SIGNED_INCLUSION_LIST_SIZE: 41112

--- a/presets/mainnet/heze.yaml
+++ b/presets/mainnet/heze.yaml
@@ -9,5 +9,7 @@ INCLUSION_LIST_COMMITTEE_SIZE: 16
 # ---------------------------------------------------------------
 # 196,934 bytes, ~192 KiB
 MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE: 196934
-# 8,348 bytes, ~8 KiB
-MAX_SIGNED_INCLUSION_LIST_SIZE: 8348
+# 152 + 5 * MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST = 41,112 bytes, ~40 KiB:
+# a list of MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST one-byte transactions,
+# each costing its byte plus a 4-byte SSZ offset
+MAX_SIGNED_INCLUSION_LIST_SIZE: 41112

--- a/presets/minimal/heze.yaml
+++ b/presets/minimal/heze.yaml
@@ -9,7 +9,5 @@ INCLUSION_LIST_COMMITTEE_SIZE: 16
 # ---------------------------------------------------------------
 # 196,934 bytes, ~192 KiB
 MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE: 196934
-# 152 + 5 * MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST = 41,112 bytes, ~40 KiB:
-# a list of MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST one-byte transactions,
-# each costing its byte plus a 4-byte SSZ offset
+# 41,112 bytes, ~40 KiB
 MAX_SIGNED_INCLUSION_LIST_SIZE: 41112

--- a/presets/minimal/heze.yaml
+++ b/presets/minimal/heze.yaml
@@ -9,5 +9,7 @@ INCLUSION_LIST_COMMITTEE_SIZE: 16
 # ---------------------------------------------------------------
 # 196,934 bytes, ~192 KiB
 MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE: 196934
-# 8,348 bytes, ~8 KiB
-MAX_SIGNED_INCLUSION_LIST_SIZE: 8348
+# 152 + 5 * MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST = 41,112 bytes, ~40 KiB:
+# a list of MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST one-byte transactions,
+# each costing its byte plus a 4-byte SSZ offset
+MAX_SIGNED_INCLUSION_LIST_SIZE: 41112

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -272,6 +272,9 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     transactions_size = sum(len(transaction) for transaction in inclusion_list.transactions)
     assert transactions_size <= MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST
 
+    # Every transaction must be non-empty
+    assert all(len(transaction) > 0 for transaction in inclusion_list.transactions)
+
     # The slot must be within the retention window
     assert inclusion_list.slot <= current_slot
     assert inclusion_list.slot + MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS >= current_slot

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -268,8 +268,9 @@ def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) 
     inclusion_list = signed_inclusion_list.message
     current_slot = get_current_slot(store)
 
-    # The transactions must not exceed the maximum size
+    # The transactions must be non-empty and not exceed the maximum size
     transactions_size = sum(len(transaction) for transaction in inclusion_list.transactions)
+    assert transactions_size > 0
     assert transactions_size <= MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST
 
     # Every transaction must be non-empty

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -126,6 +126,7 @@ This topic is used to propagate signed inclusion list as `SignedInclusionList`.
 The following validations MUST pass before forwarding the `inclusion_list` on
 the network, assuming the alias `message = signed_inclusion_list.message`:
 
+- _[IGNORE]_ The size of `message.transactions` is greater than 0.
 - _[REJECT]_ The size of `message.transactions` is within upperbound
   `MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST`.
 - _[REJECT]_ Every transaction in `message.transactions` is non-empty.

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -39,7 +39,7 @@ specifications of previous upgrades, and assumes them as pre-requisite.
 | Name                                         | Value                         |
 | -------------------------------------------- | ----------------------------- |
 | `MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE` | `Uint64(196934)` (= ~192 KiB) |
-| `MAX_SIGNED_INCLUSION_LIST_SIZE`             | `Uint64(8348)` (= ~8 KiB)     |
+| `MAX_SIGNED_INCLUSION_LIST_SIZE`             | `Uint64(41112)` (= ~40 KiB)   |
 
 ## Configs
 
@@ -128,6 +128,7 @@ the network, assuming the alias `message = signed_inclusion_list.message`:
 
 - _[REJECT]_ The size of `message.transactions` is within upperbound
   `MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST`.
+- _[REJECT]_ Every transaction in `message.transactions` is non-empty.
 - _[IGNORE]_ The slot `message.slot` is equal to the current slot (with a
   `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e.
   `message.slot == current_slot`.

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/inclusion_list.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/inclusion_list.py
@@ -34,22 +34,6 @@ def get_empty_inclusion_list(spec, store, state, slot=None, validator_index=None
     return empty_inclusion_list
 
 
-def get_empty_signed_inclusion_list(
-    spec,
-    store,
-    state,
-    slot=None,
-    validator_index=None,
-):
-    """
-    Build an empty signed inclusion list for ``slot``. Slot must be greater than or equal to the current slot in ``state``.
-    """
-    empty_inclusion_list = get_empty_inclusion_list(spec, store, state, slot, validator_index)
-    signed_inclusion_list = sign_inclusion_list(spec, state, empty_inclusion_list)
-
-    return signed_inclusion_list
-
-
 def get_sample_inclusion_list(
     spec,
     store,

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/inclusion_list.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/inclusion_list.py
@@ -107,14 +107,13 @@ def get_sample_transactions(spec, max_transaction_size=200, max_transaction_coun
     """
     Build a list of sample transactions.
     """
-    transaction_size = min(
-        max_transaction_size, spec.config.MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST
+    # Transactions must be non-empty and their total size within the bound
+    transaction_size = max(
+        1, min(max_transaction_size, spec.config.MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST)
     )
     transaction_count = min(
         max_transaction_count,
-        spec.config.MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST // transaction_size
-        if transaction_size
-        else spec.config.MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST,
+        spec.config.MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST // transaction_size,
     )
 
     assert transaction_size >= 0

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/p2p_size_bounds.py
@@ -86,8 +86,12 @@ def build_max_size_partial_data_column_sidecar(spec):
 
 
 def build_max_size_signed_inclusion_list(spec):
-    transactions_size = spec.config.MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST
-    transactions = spec.Transactions.of(spec.Transaction(data=list(b"\x00" * transactions_size)))
+    # The largest valid list: MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST one-byte transactions,
+    # each costing its byte plus a 4-byte SSZ offset
+    transaction_count = spec.config.MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST
+    transactions = spec.Transactions.of(
+        *[spec.Transaction(data=[0]) for _ in range(transaction_count)]
+    )
     inclusion_list = spec.InclusionList(
         slot=spec.Slot(0),
         validator_index=spec.ValidatorIndex(0),

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
@@ -12,7 +12,6 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     run_on_block,
 )
 from eth_consensus_specs.test.helpers.inclusion_list import (
-    get_empty_signed_inclusion_list,
     get_sample_inclusion_list,
     get_sample_signed_inclusion_list,
     get_sample_transactions,
@@ -44,13 +43,6 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
         inclusion_list_committee = spec.get_inclusion_list_committee(state, state.slot)
 
         signed_inclusion_lists = []
-
-        # An empty IL.
-        signed_inclusion_lists.append(
-            get_empty_signed_inclusion_list(
-                spec, forkchoice_store, state, validator_index=inclusion_list_committee[0]
-            )
-        )
 
         # An IL with minimal (one-byte) transactions.
         signed_inclusion_lists.append(

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/inclusion_list/test_inclusion_list_store.py
@@ -52,14 +52,14 @@ def test_inclusion_list_store_transaction_uniqueness(spec, state):
             )
         )
 
-        # An IL with empty transactions.
+        # An IL with minimal (one-byte) transactions.
         signed_inclusion_lists.append(
             get_sample_signed_inclusion_list(
                 spec,
                 forkchoice_store,
                 state,
                 validator_index=inclusion_list_committee[1],
-                max_transaction_size=0,
+                max_transaction_size=1,
                 max_transaction_count=5,
             )
         )

--- a/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/heze/unittests/validator/test_validator.py
@@ -10,7 +10,10 @@ from eth_consensus_specs.test.context import (
     with_heze_and_later,
 )
 from eth_consensus_specs.test.helpers.fork_choice import get_genesis_forkchoice_store
-from eth_consensus_specs.test.helpers.inclusion_list import get_empty_inclusion_list
+from eth_consensus_specs.test.helpers.inclusion_list import (
+    get_sample_inclusion_list,
+    get_sample_transactions,
+)
 from eth_consensus_specs.test.helpers.keys import privkeys, pubkeys
 from eth_consensus_specs.test.phase0.unittests.validator.test_validator_unittest import (
     run_get_signature_test,
@@ -87,7 +90,12 @@ def test_get_inclusion_committee_assignment_out_bound_epoch(spec, state):
 @always_bls
 def test_get_inclusion_list_signature(spec, state):
     forkchoice_store = get_genesis_forkchoice_store(spec, state)
-    inclusion_list = get_empty_inclusion_list(spec, forkchoice_store, state)
+    inclusion_list = get_sample_inclusion_list(
+        spec,
+        forkchoice_store,
+        state,
+        transactions=get_sample_transactions(spec, max_transaction_count=3),
+    )
     domain = spec.get_domain(
         state, spec.DOMAIN_INCLUSION_LIST_COMMITTEE, spec.compute_epoch_at_slot(inclusion_list.slot)
     )


### PR DESCRIPTION
`MAX_SIGNED_INCLUSION_LIST_SIZE` is the maximum (serialized) message size for the `inclusion_list` gossip topic. It is currently 8348 bytes, which is the size of a list holding one large transaction. That is too small, because SSZ adds a four-byte offset per transaction, so a list of many smaller transactions is valid under the byte limit but still too large to publish. This changes it to 41112 bytes, which is the theoretical worst case, a list of `MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST` (8192) one-byte transactions and their offset.

Closes #5575.