### PR TITLE
Reject bids from builders exited by the parent's payload

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -1030,7 +1030,7 @@ def validate_execution_payload_bid_gossip(
     if not can_builder_cover_bid(state, bid.builder_index, bid.value):
         raise GossipIgnore("builder cannot cover bid value")
 
-    # [IGNORE] The parent's payload does try not to exit the builder
+    # [IGNORE] The parent's payload does not try to exit the builder
     if bid.parent_block_hash == state.latest_execution_payload_bid.block_hash:
         envelope = store.payloads[bid.parent_block_root]
         for request in envelope.execution_requests.builder_exits:

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -1016,11 +1016,11 @@ def validate_execution_payload_bid_gossip(
     if bid.builder_index >= len(state.builders):
         raise GossipReject("builder index out of range")
 
-    if bid.parent_block_hash == state.latest_execution_payload_bid.block_hash:
-        envelope = store.payloads[bid.parent_block_root]
-        for exit_request in envelope.execution_requests.builder_exits:
-            if exit_request.pubkey == state.builders[bid.builder_index].pubkey:
-                process_builder_exit_request(state, exit_request)
+    builder = state.builders[bid.builder_index]
+
+    # [REJECT] The builder is a payload builder
+    if builder.version != PAYLOAD_BUILDER_VERSION:
+        raise GossipReject("builder is not a payload builder")
 
     # [REJECT] The builder is active
     if not is_active_builder(state, bid.builder_index):
@@ -1030,9 +1030,13 @@ def validate_execution_payload_bid_gossip(
     if not can_builder_cover_bid(state, bid.builder_index, bid.value):
         raise GossipIgnore("builder cannot cover bid value")
 
-    # [REJECT] The builder is a payload builder
-    if state.builders[bid.builder_index].version != PAYLOAD_BUILDER_VERSION:
-        raise GossipReject("builder is not a payload builder")
+    # [IGNORE] The parent's payload does try not to exit the builder
+    if bid.parent_block_hash == state.latest_execution_payload_bid.block_hash:
+        envelope = store.payloads[bid.parent_block_root]
+        for request in envelope.execution_requests.builder_exits:
+            if request.pubkey == builder.pubkey:
+                if request.source_address == builder.execution_address:
+                    raise GossipIgnore("builder may exit")
 
     # [REJECT] The bid signature is valid
     if not verify_execution_payload_bid_signature(state, signed_execution_payload_bid):

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -1009,7 +1009,6 @@ def validate_execution_payload_bid_gossip(
     if bid.prev_randao != get_randao_mix(state, get_current_epoch(state)):
         raise GossipReject("bid's previous randao is incorrect")
 
-    # Advance state
     state = state.copy()
     process_slots(state, bid.slot)
 
@@ -1017,13 +1016,19 @@ def validate_execution_payload_bid_gossip(
     if bid.builder_index >= len(state.builders):
         raise GossipReject("builder index out of range")
 
-    # [IGNORE] The builder can cover the bid
-    if not can_builder_cover_bid(state, bid.builder_index, bid.value):
-        raise GossipIgnore("builder cannot cover bid value")
+    if bid.parent_block_hash == state.latest_execution_payload_bid.block_hash:
+        envelope = store.payloads[bid.parent_block_root]
+        for exit_request in envelope.execution_requests.builder_exits:
+            if exit_request.pubkey == state.builders[bid.builder_index].pubkey:
+                process_builder_exit_request(state, exit_request)
 
     # [REJECT] The builder is active
     if not is_active_builder(state, bid.builder_index):
         raise GossipReject("builder is not active")
+
+    # [IGNORE] The builder can cover the bid
+    if not can_builder_cover_bid(state, bid.builder_index, bid.value):
+        raise GossipIgnore("builder cannot cover bid value")
 
     # [REJECT] The builder is a payload builder
     if state.builders[bid.builder_index].version != PAYLOAD_BUILDER_VERSION:

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_execution_payload_bid.py
@@ -8,11 +8,13 @@ from eth_consensus_specs.test.helpers.execution_payload import (
 )
 from eth_consensus_specs.test.helpers.gloas.bid import (
     activate_builders,
+    append_head_with_requests,
     build_signed_bid,
     get_blocks_meta,
     record_block_in_store,
     record_head_payload,
     setup_store_advanced_for_bid,
+    setup_store_finalized_with_head_payment,
     setup_store_finalized_with_pending_payment,
 )
 from eth_consensus_specs.test.helpers.gloas.proposer_preferences import (
@@ -1317,6 +1319,313 @@ def test_gossip_execution_payload_bid__reject_builder_not_payload_version(spec, 
             "message": get_filename(signed_bid),
             "expected": result,
             "reason": reason,
+        }
+    )
+
+    yield "messages", "meta", messages
+
+
+@with_gloas_and_later
+@spec_state_test_with_matching_config
+def test_gossip_execution_payload_bid__reject_builder_exited_by_parent_payload(spec, state):
+    """A bid from a builder that the full parent's payload exits is rejected.
+
+    The parent's execution requests are applied by its descendant block, so the
+    parent block's post-state still shows the builder as active. Block
+    processing applies the exit before validating the bid, so validation must
+    apply it too or the bid is accepted and then sinks the proposal.
+    """
+    anchor_state = state.copy()
+    yield "topic", "meta", "execution_payload_bid"
+
+    builder_index = spec.BuilderIndex(0)
+    store, blocks, _ = setup_store_advanced_for_bid(spec, state)
+    builder = state.builders[builder_index]
+    requests = spec.ExecutionRequests(
+        builder_exits=spec.BuilderExitRequests.of(
+            spec.BuilderExitRequest(
+                source_address=builder.execution_address,
+                pubkey=builder.pubkey,
+            )
+        ),
+    )
+    parent_root = append_head_with_requests(spec, state, store, blocks, requests)
+    finalized_checkpoint_meta = activate_builders(spec, state, store, blocks)
+    assert spec.is_active_builder(state, builder_index)
+    head_payload = record_head_payload(spec, state, store, blocks, execution_requests=requests)
+    yield "state", anchor_state
+    for signed in blocks:
+        yield get_filename(signed), signed
+    yield "blocks", "meta", get_blocks_meta(blocks, head_payload)
+    yield "finalized_checkpoint", "meta", finalized_checkpoint_meta
+
+    time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(time_ms)
+    messages = []
+    seen, common_fee, parent_gas_limit, proposal_slot, parent_block_hash, time_ms = yield from (
+        _seed_bid_context(spec, state, store, head_payload, messages, time_ms)
+    )
+
+    signed_bid = build_signed_bid(
+        spec,
+        state,
+        builder_index=builder_index,
+        slot=proposal_slot,
+        parent_block_hash=parent_block_hash,
+        parent_block_root=parent_root,
+        fee_recipient=common_fee,
+        gas_limit=parent_gas_limit,
+        value=spec.Gwei(1),
+    )
+    yield get_filename(signed_bid), signed_bid
+
+    time_ms += 40
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_execution_payload_bid=signed_bid,
+        current_time_ms=time_ms,
+    )
+    assert result == "reject"
+    assert reason == "builder is not active"
+    messages.append(
+        {
+            "current_time_ms": int(time_ms),
+            "message": get_filename(signed_bid),
+            "expected": result,
+            "reason": reason,
+        }
+    )
+
+    yield "messages", "meta", messages
+
+
+@with_gloas_and_later
+@spec_state_test_with_matching_config
+def test_gossip_execution_payload_bid__valid_parent_exit_unknown_pubkey(spec, state):
+    """A bid is valid when the full parent's exit request names no known builder.
+
+    The request cannot exit any builder, so the bid's builder stays active.
+    """
+    anchor_state = state.copy()
+    yield "topic", "meta", "execution_payload_bid"
+
+    builder_index = spec.BuilderIndex(0)
+    store, blocks, _ = setup_store_advanced_for_bid(spec, state)
+    builder = state.builders[builder_index]
+    unknown_pubkey = spec.BLSPubkey(b"\xab" * 48)
+    assert unknown_pubkey not in [b.pubkey for b in state.builders]
+    requests = spec.ExecutionRequests(
+        builder_exits=spec.BuilderExitRequests.of(
+            spec.BuilderExitRequest(
+                source_address=builder.execution_address,
+                pubkey=unknown_pubkey,
+            )
+        ),
+    )
+    parent_root = append_head_with_requests(spec, state, store, blocks, requests)
+    finalized_checkpoint_meta = activate_builders(spec, state, store, blocks)
+    assert spec.is_active_builder(state, builder_index)
+    head_payload = record_head_payload(spec, state, store, blocks, execution_requests=requests)
+    yield "state", anchor_state
+    for signed in blocks:
+        yield get_filename(signed), signed
+    yield "blocks", "meta", get_blocks_meta(blocks, head_payload)
+    yield "finalized_checkpoint", "meta", finalized_checkpoint_meta
+
+    time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(time_ms)
+    messages = []
+    seen, common_fee, parent_gas_limit, proposal_slot, parent_block_hash, time_ms = yield from (
+        _seed_bid_context(spec, state, store, head_payload, messages, time_ms)
+    )
+
+    signed_bid = build_signed_bid(
+        spec,
+        state,
+        builder_index=builder_index,
+        slot=proposal_slot,
+        parent_block_hash=parent_block_hash,
+        parent_block_root=parent_root,
+        fee_recipient=common_fee,
+        gas_limit=parent_gas_limit,
+        value=spec.Gwei(1),
+    )
+    yield get_filename(signed_bid), signed_bid
+
+    time_ms += 40
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_execution_payload_bid=signed_bid,
+        current_time_ms=time_ms,
+    )
+    assert result == "valid"
+    assert reason is None
+    messages.append(
+        {
+            "current_time_ms": int(time_ms),
+            "message": get_filename(signed_bid),
+            "expected": result,
+        }
+    )
+
+    yield "messages", "meta", messages
+
+
+@with_gloas_and_later
+@spec_state_test_with_matching_config
+def test_gossip_execution_payload_bid__valid_parent_exit_wrong_source_address(spec, state):
+    """A bid is valid when the full parent's exit request is not authorized.
+
+    The request's source address is not the builder's execution address, so the
+    exit is not initiated and the bid's builder stays active.
+    """
+    anchor_state = state.copy()
+    yield "topic", "meta", "execution_payload_bid"
+
+    builder_index = spec.BuilderIndex(0)
+    store, blocks, _ = setup_store_advanced_for_bid(spec, state)
+    builder = state.builders[builder_index]
+    wrong_address = spec.ExecutionAddress(b"\xff" * 20)
+    assert builder.execution_address != wrong_address
+    requests = spec.ExecutionRequests(
+        builder_exits=spec.BuilderExitRequests.of(
+            spec.BuilderExitRequest(
+                source_address=wrong_address,
+                pubkey=builder.pubkey,
+            )
+        ),
+    )
+    parent_root = append_head_with_requests(spec, state, store, blocks, requests)
+    finalized_checkpoint_meta = activate_builders(spec, state, store, blocks)
+    assert spec.is_active_builder(state, builder_index)
+    head_payload = record_head_payload(spec, state, store, blocks, execution_requests=requests)
+    yield "state", anchor_state
+    for signed in blocks:
+        yield get_filename(signed), signed
+    yield "blocks", "meta", get_blocks_meta(blocks, head_payload)
+    yield "finalized_checkpoint", "meta", finalized_checkpoint_meta
+
+    time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(time_ms)
+    messages = []
+    seen, common_fee, parent_gas_limit, proposal_slot, parent_block_hash, time_ms = yield from (
+        _seed_bid_context(spec, state, store, head_payload, messages, time_ms)
+    )
+
+    signed_bid = build_signed_bid(
+        spec,
+        state,
+        builder_index=builder_index,
+        slot=proposal_slot,
+        parent_block_hash=parent_block_hash,
+        parent_block_root=parent_root,
+        fee_recipient=common_fee,
+        gas_limit=parent_gas_limit,
+        value=spec.Gwei(1),
+    )
+    yield get_filename(signed_bid), signed_bid
+
+    time_ms += 40
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_execution_payload_bid=signed_bid,
+        current_time_ms=time_ms,
+    )
+    assert result == "valid"
+    assert reason is None
+    messages.append(
+        {
+            "current_time_ms": int(time_ms),
+            "message": get_filename(signed_bid),
+            "expected": result,
+        }
+    )
+
+    yield "messages", "meta", messages
+
+
+@with_gloas_and_later
+@spec_state_test_with_matching_config
+def test_gossip_execution_payload_bid__valid_parent_exit_with_pending_balance(spec, state):
+    """A bid is valid when the exiting builder still has a pending balance.
+
+    The full parent's bid pays builder 0, and only a descendant block settles a
+    payment, so the builder has a pending balance when the parent's authorized
+    exit request is applied. That blocks the exit, so the builder stays active.
+    """
+    anchor_state = state.copy()
+    yield "topic", "meta", "execution_payload_bid"
+
+    builder_index = spec.BuilderIndex(0)
+    builder = state.builders[builder_index]
+    requests = spec.ExecutionRequests(
+        builder_exits=spec.BuilderExitRequests.of(
+            spec.BuilderExitRequest(
+                source_address=builder.execution_address,
+                pubkey=builder.pubkey,
+            )
+        ),
+    )
+    store, blocks, parent_root, builder_index, pending_value = (
+        setup_store_finalized_with_head_payment(spec, state, requests)
+    )
+    assert pending_value > 0
+    assert spec.is_active_builder(state, builder_index)
+    head_payload = record_head_payload(spec, state, store, blocks, execution_requests=requests)
+    yield "state", anchor_state
+    for signed in blocks:
+        yield get_filename(signed), signed
+    yield "blocks", "meta", get_blocks_meta(blocks, head_payload)
+
+    time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(time_ms)
+    messages = []
+    seen, common_fee, parent_gas_limit, proposal_slot, parent_block_hash, time_ms = yield from (
+        _seed_bid_context(spec, state, store, head_payload, messages, time_ms)
+    )
+    # The pending payment survives the advance to the bid's slot, which is what
+    # blocks the exit.
+    advanced_state = store.block_states[parent_root].copy()
+    spec.process_slots(advanced_state, proposal_slot)
+    assert (
+        spec.get_pending_balance_to_withdraw_for_builder(advanced_state, builder_index)
+        == pending_value
+    )
+
+    signed_bid = build_signed_bid(
+        spec,
+        state,
+        builder_index=builder_index,
+        slot=proposal_slot,
+        parent_block_hash=parent_block_hash,
+        parent_block_root=parent_root,
+        fee_recipient=common_fee,
+        gas_limit=parent_gas_limit,
+        value=spec.Gwei(1),
+    )
+    yield get_filename(signed_bid), signed_bid
+
+    time_ms += 40
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_execution_payload_bid=signed_bid,
+        current_time_ms=time_ms,
+    )
+    assert result == "valid"
+    assert reason is None
+    messages.append(
+        {
+            "current_time_ms": int(time_ms),
+            "message": get_filename(signed_bid),
+            "expected": result,
         }
     )
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_execution_payload_bid.py
@@ -1327,13 +1327,13 @@ def test_gossip_execution_payload_bid__reject_builder_not_payload_version(spec, 
 
 @with_gloas_and_later
 @spec_state_test_with_matching_config
-def test_gossip_execution_payload_bid__reject_builder_exited_by_parent_payload(spec, state):
-    """A bid from a builder that the full parent's payload exits is rejected.
+def test_gossip_execution_payload_bid__ignore_builder_exit_in_parent_payload(spec, state):
+    """A bid from a builder that the full parent's payload exits is ignored.
 
     The parent's execution requests are applied by its descendant block, so the
     parent block's post-state still shows the builder as active. Block
-    processing applies the exit before validating the bid, so validation must
-    apply it too or the bid is accepted and then sinks the proposal.
+    processing applies the exit before validating the bid, so a bid that
+    validation accepts here sinks the proposal that includes it.
     """
     anchor_state = state.copy()
     yield "topic", "meta", "execution_payload_bid"
@@ -1387,8 +1387,8 @@ def test_gossip_execution_payload_bid__reject_builder_exited_by_parent_payload(s
         signed_execution_payload_bid=signed_bid,
         current_time_ms=time_ms,
     )
-    assert result == "reject"
-    assert reason == "builder is not active"
+    assert result == "ignore"
+    assert reason == "builder may exit"
     messages.append(
         {
             "current_time_ms": int(time_ms),
@@ -1406,7 +1406,7 @@ def test_gossip_execution_payload_bid__reject_builder_exited_by_parent_payload(s
 def test_gossip_execution_payload_bid__valid_parent_exit_unknown_pubkey(spec, state):
     """A bid is valid when the full parent's exit request names no known builder.
 
-    The request cannot exit any builder, so the bid's builder stays active.
+    The request's pubkey does not match the bid's builder, so it cannot exit it.
     """
     anchor_state = state.copy()
     yield "topic", "meta", "execution_payload_bid"
@@ -1480,8 +1480,8 @@ def test_gossip_execution_payload_bid__valid_parent_exit_unknown_pubkey(spec, st
 def test_gossip_execution_payload_bid__valid_parent_exit_wrong_source_address(spec, state):
     """A bid is valid when the full parent's exit request is not authorized.
 
-    The request's source address is not the builder's execution address, so the
-    exit is not initiated and the bid's builder stays active.
+    The request's source address is not the builder's execution address, so it
+    cannot exit the builder.
     """
     anchor_state = state.copy()
     yield "topic", "meta", "execution_payload_bid"
@@ -1552,12 +1552,14 @@ def test_gossip_execution_payload_bid__valid_parent_exit_wrong_source_address(sp
 
 @with_gloas_and_later
 @spec_state_test_with_matching_config
-def test_gossip_execution_payload_bid__valid_parent_exit_with_pending_balance(spec, state):
-    """A bid is valid when the exiting builder still has a pending balance.
+def test_gossip_execution_payload_bid__ignore_builder_exit_with_pending_balance(spec, state):
+    """A bid is ignored when a pending balance would block the requested exit.
 
     The full parent's bid pays builder 0, and only a descendant block settles a
     payment, so the builder has a pending balance when the parent's authorized
-    exit request is applied. That blocks the exit, so the builder stays active.
+    exit request is applied. That blocks the exit, so block processing keeps the
+    builder active and accepts the bid. Validation does not model the pending
+    balance, so it ignores the bid regardless.
     """
     anchor_state = state.copy()
     yield "topic", "meta", "execution_payload_bid"
@@ -1590,7 +1592,7 @@ def test_gossip_execution_payload_bid__valid_parent_exit_with_pending_balance(sp
         _seed_bid_context(spec, state, store, head_payload, messages, time_ms)
     )
     # The pending payment survives the advance to the bid's slot, which is what
-    # blocks the exit.
+    # blocks the exit that validation assumes.
     advanced_state = store.block_states[parent_root].copy()
     spec.process_slots(advanced_state, proposal_slot)
     assert (
@@ -1619,13 +1621,14 @@ def test_gossip_execution_payload_bid__valid_parent_exit_with_pending_balance(sp
         signed_execution_payload_bid=signed_bid,
         current_time_ms=time_ms,
     )
-    assert result == "valid"
-    assert reason is None
+    assert result == "ignore"
+    assert reason == "builder may exit"
     messages.append(
         {
             "current_time_ms": int(time_ms),
             "message": get_filename(signed_bid),
             "expected": result,
+            "reason": reason,
         }
     )
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_execution_payload_bid.py
@@ -1406,7 +1406,8 @@ def test_gossip_execution_payload_bid__ignore_builder_exit_in_parent_payload(spe
 def test_gossip_execution_payload_bid__valid_parent_exit_unknown_pubkey(spec, state):
     """A bid is valid when the full parent's exit request names no known builder.
 
-    The request's pubkey does not match the bid's builder, so it cannot exit it.
+    The request's pubkey does not match the bid's builder, so the exit check
+    does not flag the bid.
     """
     anchor_state = state.copy()
     yield "topic", "meta", "execution_payload_bid"
@@ -1480,8 +1481,8 @@ def test_gossip_execution_payload_bid__valid_parent_exit_unknown_pubkey(spec, st
 def test_gossip_execution_payload_bid__valid_parent_exit_wrong_source_address(spec, state):
     """A bid is valid when the full parent's exit request is not authorized.
 
-    The request's source address is not the builder's execution address, so it
-    cannot exit the builder.
+    The request's source address is not the builder's execution address, so the
+    exit check does not flag the bid.
     """
     anchor_state = state.copy()
     yield "topic", "meta", "execution_payload_bid"

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload_bid.py
@@ -38,6 +38,7 @@ def prepare_signed_execution_payload_bid(
     blob_kzg_commitments=None,
     prev_randao=None,
     inclusion_list_bits=None,
+    execution_requests_root=None,
     valid_signature=True,
     valid_amount=True,
 ):
@@ -95,6 +96,8 @@ def prepare_signed_execution_payload_bid(
         "value": value,
         "blob_kzg_commitments": blob_kzg_commitments,
     }
+    if execution_requests_root is not None:
+        bid_kwargs["execution_requests_root"] = execution_requests_root
     if is_post_heze(spec) and inclusion_list_bits is not None:
         bid_kwargs["inclusion_list_bits"] = inclusion_list_bits
 

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/gloas/bid.py
@@ -51,7 +51,7 @@ def record_block_in_store(spec, store, signed_block, post_state):
     return block_root
 
 
-def record_head_payload(spec, state, store, blocks):
+def record_head_payload(spec, state, store, blocks, execution_requests=None):
     """
     Build the head block's payload envelope and record it in ``store`` as
     ``on_execution_payload_envelope`` does, so that fork choice sees the head as
@@ -64,7 +64,7 @@ def record_head_payload(spec, state, store, blocks):
     head_signed_block = blocks[-1]
     head_root = head_signed_block.message.hash_tree_root()
     signed_envelope = build_signed_execution_payload_envelope(
-        spec, state, head_root, head_signed_block
+        spec, state, head_root, head_signed_block, execution_requests=execution_requests
     )
     store.payloads[head_root] = signed_envelope.message
     return signed_envelope
@@ -193,6 +193,87 @@ def setup_store_finalized_with_pending_payment(spec, state):
     store.finalized_checkpoint = state.finalized_checkpoint
 
     return store, blocks, blocks[-1].message.hash_tree_root(), builder_index, pending_value
+
+
+def append_head_with_requests(spec, state, store, blocks, execution_requests, signed_bid=None):
+    """
+    Append a block whose bid commits to ``execution_requests`` and record it in
+    ``store``, so that a bid for the next slot builds on a full parent whose
+    payload carries those requests. ``signed_bid`` replaces the block's default
+    self-build bid, in which case it must already commit to the same requests.
+
+    Returns the new parent block root.
+    """
+    block = build_empty_block_for_next_slot(spec, state)
+    if signed_bid is None:
+        # A self-build bid is signed with the infinity signature, so the
+        # commitment can be set after the fact.
+        bid = block.body.signed_execution_payload_bid.message
+        bid.execution_requests_root = spec.hash_tree_root(execution_requests)
+    else:
+        assert signed_bid.message.execution_requests_root == spec.hash_tree_root(execution_requests)
+        block.body.signed_execution_payload_bid = signed_bid
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    record_block_in_store(spec, store, signed_block, state.copy())
+    blocks.append(signed_block)
+    return signed_block.message.hash_tree_root()
+
+
+def setup_store_finalized_with_head_payment(spec, state, execution_requests):
+    """
+    Build a chain in which epoch 1 finalizes organically (so builders are active
+    without a finalized checkpoint override), then append a head block whose bid
+    pays builder 0 and commits to ``execution_requests``.
+
+    Only a descendant block settles a payment, so the head block's own payment
+    is still queued at the head. The head is kept away from the end of an epoch
+    so that advancing to the next slot does not cross the epoch transition that
+    would drop the payment.
+
+    Returns (store, blocks, parent_block_root, builder_index, pending_value).
+    """
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    signed_anchor = wrap_genesis_block(spec, anchor_block)
+    blocks = [signed_anchor]
+
+    def record(signed_block):
+        record_block_in_store(spec, store, signed_block, state.copy())
+        blocks.append(signed_block)
+
+    # Finalize organically: builders activate once their deposit epoch (0)
+    # is strictly before the finalized epoch.
+    while state.finalized_checkpoint.epoch < 1:
+        record(
+            state_transition_with_full_block(spec, state, fill_cur_epoch=True, fill_prev_epoch=True)
+        )
+    builder_index = spec.BuilderIndex(0)
+    assert spec.is_active_builder(state, builder_index)
+
+    while (state.slot + 1) % spec.SLOTS_PER_EPOCH == spec.SLOTS_PER_EPOCH - 1:
+        record(
+            state_transition_and_sign_block(
+                spec, state, build_empty_block_for_next_slot(spec, state)
+            )
+        )
+
+    pending_value = spec.Gwei(1)
+    signed_bid = prepare_signed_execution_payload_bid(
+        spec,
+        state.copy(),
+        builder_index=builder_index,
+        value=pending_value,
+        slot=spec.Slot(state.slot + 1),
+        execution_requests_root=spec.hash_tree_root(execution_requests),
+    )
+    parent_root = append_head_with_requests(
+        spec, state, store, blocks, execution_requests, signed_bid=signed_bid
+    )
+
+    assert spec.get_pending_balance_to_withdraw_for_builder(state, builder_index) == pending_value
+    # Mirror what importing the blocks does to the store's finalized checkpoint.
+    store.finalized_checkpoint = state.finalized_checkpoint
+
+    return store, blocks, parent_root, builder_index, pending_value
 
 
 def build_signed_bid(


### PR DESCRIPTION
Bid gossip validation accepts a bid that block processing rejects, which risks a missed proposal. It validates against the parent block's post-state, which does not reflect the parent payload's execution requests, so a builder that the full parent's payload exits still looks active. Block processing applies that exit before it validates the bid.

The fix is to ignore bids from builders which *might* exit; ie there exists a builder exit request in which `pubkey` and `source_address` match the builder. Note, builder exits where the builder still has a pending withdrawal are also ignored, even though they wouldn't actually be exited.

Thanks to @bshastry for pointing this out!