### PR TITLE
Move seen checks to the top of gossip validation functions

### DIFF
--- a/specs/_features/eip8025/p2p-interface.md
+++ b/specs/_features/eip8025/p2p-interface.md
@@ -95,6 +95,14 @@ def validate_execution_proof_gossip(
     if proof_root in seen.execution_proof_roots.get(beacon_block_root, set()):
         raise GossipIgnore("execution proof has already been processed")
 
+    # [IGNORE] This is the prover's first valid or invalid proof for this key
+    validator_index = signed_proof_envelope.validator_index
+    prover_key = (beacon_block_root, proof_envelope.proof_type, validator_index)
+    if prover_key in seen.execution_proof_provers:
+        raise GossipIgnore(
+            "proof already seen from this prover for this beacon block and proof type"
+        )
+
     # [IGNORE] The proof's beacon block has been seen
     if beacon_block_root not in store.blocks:
         raise GossipIgnore("execution proof's beacon block has not been seen")
@@ -114,14 +122,6 @@ def validate_execution_proof_gossip(
     # [IGNORE] No valid proof is known for this beacon block and proof type
     if proof_envelope.proof_type in store.execution_proofs.get(beacon_block_root, {}):
         raise GossipIgnore("verified proof already known for this beacon block and proof type")
-
-    # [IGNORE] This is the prover's first valid or invalid proof for this key
-    validator_index = signed_proof_envelope.validator_index
-    prover_key = (beacon_block_root, proof_envelope.proof_type, validator_index)
-    if prover_key in seen.execution_proof_provers:
-        raise GossipIgnore(
-            "proof already seen from this prover for this beacon block and proof type"
-        )
 
     # [REJECT] The execution proof envelope passes validation
     try:

--- a/specs/_features/eip8321/p2p-interface.md
+++ b/specs/_features/eip8321/p2p-interface.md
@@ -130,6 +130,11 @@ def validate_randao_commitment_registration_gossip(
     """
     registration = signed_registration.message
     index = registration.validator_index
+
+    # [IGNORE] This is the first valid registration received for the validator
+    if index in seen.randao_commitment_registration_indices:
+        raise GossipIgnore("already seen RANDAO commitment registration for this validator")
+
     state = store.block_states[get_head(store).root]
 
     # [IGNORE] The head state has upgraded to EIP-8321
@@ -139,10 +144,6 @@ def validate_randao_commitment_registration_gossip(
     # [REJECT] The validator index is valid
     if index >= len(state.validators):
         raise GossipReject("validator index out of range")
-
-    # [IGNORE] This is the first valid registration received for the validator
-    if index in seen.randao_commitment_registration_indices:
-        raise GossipIgnore("already seen RANDAO commitment registration for this validator")
 
     # [REJECT] The commitment is non-zero
     if registration.commitment == UNSET_RANDAO_COMMITMENT:

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -240,6 +240,30 @@ def validate_sync_committee_contribution_and_proof_gossip(
     contribution_and_proof = signed_contribution_and_proof.message
     contribution = contribution_and_proof.contribution
 
+    # [IGNORE] A valid sync committee contribution with equal slot, beacon_block_root
+    # and subcommittee_index whose aggregation_bits is non-strict superset
+    # has not already been seen
+    contribution_key = (
+        contribution.slot,
+        contribution.beacon_block_root,
+        contribution.subcommittee_index,
+    )
+    contribution_bits = tuple(bool(bit) for bit in contribution.aggregation_bits)
+    seen_bits = seen.sync_contribution_data.get(contribution_key, set())
+    if is_non_strict_superset(seen_bits, contribution_bits):
+        raise GossipIgnore("already seen contribution for this data")
+
+    # [IGNORE] The sync committee contribution is the first valid contribution received
+    # for the slot contribution.slot, aggregator with index contribution_and_proof.aggregator_index,
+    # and subcommittee index contribution.subcommittee_index
+    aggregator_key = (
+        contribution.slot,
+        contribution_and_proof.aggregator_index,
+        contribution.subcommittee_index,
+    )
+    if aggregator_key in seen.sync_contribution_aggregator_slots:
+        raise GossipIgnore("already seen contribution from this aggregator")
+
     # [IGNORE] The contribution's slot is for the current slot
     if not is_current_slot(store, contribution.slot, current_time_ms):
         raise GossipIgnore("contribution is not for the current slot")
@@ -268,30 +292,6 @@ def validate_sync_committee_contribution_and_proof_gossip(
     subcommittee_pubkeys = get_sync_subcommittee_pubkeys(state, contribution.subcommittee_index)
     if aggregator_pubkey not in subcommittee_pubkeys:
         raise GossipReject("aggregator not in subcommittee")
-
-    # [IGNORE] A valid sync committee contribution with equal slot, beacon_block_root
-    # and subcommittee_index whose aggregation_bits is non-strict superset
-    # has not already been seen
-    contribution_key = (
-        contribution.slot,
-        contribution.beacon_block_root,
-        contribution.subcommittee_index,
-    )
-    contribution_bits = tuple(bool(bit) for bit in contribution.aggregation_bits)
-    seen_bits = seen.sync_contribution_data.get(contribution_key, set())
-    if is_non_strict_superset(seen_bits, contribution_bits):
-        raise GossipIgnore("already seen contribution for this data")
-
-    # [IGNORE] The sync committee contribution is the first valid contribution received
-    # for the slot contribution.slot, aggregator with index contribution_and_proof.aggregator_index,
-    # and subcommittee index contribution.subcommittee_index
-    aggregator_key = (
-        contribution.slot,
-        contribution_and_proof.aggregator_index,
-        contribution.subcommittee_index,
-    )
-    if aggregator_key in seen.sync_contribution_aggregator_slots:
-        raise GossipIgnore("already seen contribution from this aggregator")
 
     # [REJECT] The contribution_and_proof.selection_proof is a valid signature
     # of the SyncAggregatorSelectionData derived from the contribution
@@ -356,6 +356,14 @@ def validate_sync_committee_message_gossip(
     Validate a SyncCommitteeMessage for gossip propagation on a subnet.
     Raises GossipIgnore or GossipReject on validation failure.
     """
+    # [IGNORE] There has been no other valid sync committee message for the declared slot
+    # for the validator referenced by sync_committee_message.validator_index
+    # (this validation is per topic so that for a given slot, multiple messages could be
+    # forwarded with the same validator_index as long as the subnet_ids are distinct)
+    message_key = (sync_committee_message.slot, sync_committee_message.validator_index, subnet_id)
+    if message_key in seen.sync_message_validator_slots:
+        raise GossipIgnore("already seen message from this validator for this slot and subnet")
+
     # [IGNORE] The message's slot is for the current slot
     if not is_current_slot(store, sync_committee_message.slot, current_time_ms):
         raise GossipIgnore("message is not for the current slot")
@@ -374,14 +382,6 @@ def validate_sync_committee_message_gossip(
     )
     if subnet_id not in valid_subnets:
         raise GossipReject("subnet_id is not valid for the validator")
-
-    # [IGNORE] There has been no other valid sync committee message for the declared slot
-    # for the validator referenced by sync_committee_message.validator_index
-    # (this validation is per topic so that for a given slot, multiple messages could be
-    # forwarded with the same validator_index as long as the subnet_ids are distinct)
-    message_key = (sync_committee_message.slot, sync_committee_message.validator_index, subnet_id)
-    if message_key in seen.sync_message_validator_slots:
-        raise GossipIgnore("already seen message from this validator for this slot and subnet")
 
     # [REJECT] The signature is valid
     validator = state.validators[sync_committee_message.validator_index]

--- a/specs/bellatrix/p2p-interface.md
+++ b/specs/bellatrix/p2p-interface.md
@@ -127,6 +127,11 @@ def validate_beacon_block_gossip(
     block = signed_beacon_block.message
     execution_payload = block.body.execution_payload
 
+    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+    proposer_slot_key = (block.slot, block.proposer_index)
+    if proposer_slot_key in seen.proposer_slots:
+        raise GossipIgnore("block is not the first valid block for this slot and proposer")
+
     # [IGNORE] The block is not from a future slot
     # (MAY be queued for processing at the appropriate slot)
     if is_future_slot(store, block.slot, current_time_ms):
@@ -138,11 +143,6 @@ def validate_beacon_block_gossip(
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     if block.slot <= finalized_slot:
         raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
-
-    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-    proposer_slot_key = (block.slot, block.proposer_index)
-    if proposer_slot_key in seen.proposer_slots:
-        raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
     # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
     # (MAY be queued until parent is retrieved)

--- a/specs/capella/p2p-interface.md
+++ b/specs/capella/p2p-interface.md
@@ -118,6 +118,11 @@ def validate_beacon_block_gossip(
     block = signed_beacon_block.message
     execution_payload = block.body.execution_payload
 
+    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+    proposer_slot_key = (block.slot, block.proposer_index)
+    if proposer_slot_key in seen.proposer_slots:
+        raise GossipIgnore("block is not the first valid block for this slot and proposer")
+
     # [IGNORE] The block is not from a future slot
     # (MAY be queued for processing at the appropriate slot)
     if is_future_slot(store, block.slot, current_time_ms):
@@ -129,11 +134,6 @@ def validate_beacon_block_gossip(
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     if block.slot <= finalized_slot:
         raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
-
-    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-    proposer_slot_key = (block.slot, block.proposer_index)
-    if proposer_slot_key in seen.proposer_slots:
-        raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
     # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
     # (MAY be queued until parent is retrieved)
@@ -215,6 +215,10 @@ def validate_bls_to_execution_change_gossip(
     bls_to_execution_change = signed_bls_to_execution_change.message
     validator_index = bls_to_execution_change.validator_index
 
+    # [IGNORE] This is the first valid bls_to_execution_change received for the validator
+    if validator_index in seen.bls_to_execution_change_indices:
+        raise GossipIgnore("already seen BLS to execution change for this validator")
+
     # [IGNORE] The current epoch is at or after the Capella fork epoch
     # (where current_epoch is defined by the current wall-clock time)
     time_since_genesis_ms = current_time_ms - store.genesis_time * 1000
@@ -222,10 +226,6 @@ def validate_bls_to_execution_change_gossip(
     current_epoch = compute_epoch_at_slot(current_slot)
     if current_epoch < CAPELLA_FORK_EPOCH:
         raise GossipIgnore("current epoch is pre-capella")
-
-    # [IGNORE] This is the first valid bls_to_execution_change received for the validator
-    if validator_index in seen.bls_to_execution_change_indices:
-        raise GossipIgnore("already seen BLS to execution change for this validator")
 
     state = store.block_states[get_head(store).root]
 

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -316,6 +316,11 @@ def validate_beacon_block_gossip(
     block = signed_beacon_block.message
     execution_payload = block.body.execution_payload
 
+    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+    proposer_slot_key = (block.slot, block.proposer_index)
+    if proposer_slot_key in seen.proposer_slots:
+        raise GossipIgnore("block is not the first valid block for this slot and proposer")
+
     # [IGNORE] The block is not from a future slot
     # (MAY be queued for processing at the appropriate slot)
     if is_future_slot(store, block.slot, current_time_ms):
@@ -327,11 +332,6 @@ def validate_beacon_block_gossip(
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     if block.slot <= finalized_slot:
         raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
-
-    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-    proposer_slot_key = (block.slot, block.proposer_index)
-    if proposer_slot_key in seen.proposer_slots:
-        raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
     # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
     # (MAY be queued until parent is retrieved)
@@ -708,6 +708,12 @@ def validate_blob_sidecar_gossip(
     """
     block_header = blob_sidecar.signed_block_header.message
 
+    # [IGNORE] The sidecar is the first sidecar for the tuple
+    # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+    sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+    if sidecar_tuple in seen.blob_sidecar_tuples:
+        raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
+
     # [REJECT] The sidecar's index is consistent with MAX_BLOBS_PER_BLOCK
     if blob_sidecar.index >= MAX_BLOBS_PER_BLOCK:
         raise GossipReject("blob index out of range")
@@ -768,12 +774,6 @@ def validate_blob_sidecar_gossip(
         blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof
     ):
         raise GossipReject("invalid blob kzg proof")
-
-    # [IGNORE] The sidecar is the first sidecar for the tuple
-    # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-    sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-    if sidecar_tuple in seen.blob_sidecar_tuples:
-        raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
 
     # [REJECT] The sidecar is proposed by the expected proposer_index
     # (if shuffling is not available, IGNORE instead and MAY be queued for later)

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -139,6 +139,11 @@ def validate_beacon_block_gossip(
     block = signed_beacon_block.message
     execution_payload = block.body.execution_payload
 
+    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+    proposer_slot_key = (block.slot, block.proposer_index)
+    if proposer_slot_key in seen.proposer_slots:
+        raise GossipIgnore("block is not the first valid block for this slot and proposer")
+
     # [IGNORE] The block is not from a future slot
     # (MAY be queued for processing at the appropriate slot)
     if is_future_slot(store, block.slot, current_time_ms):
@@ -150,11 +155,6 @@ def validate_beacon_block_gossip(
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     if block.slot <= finalized_slot:
         raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
-
-    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-    proposer_slot_key = (block.slot, block.proposer_index)
-    if proposer_slot_key in seen.proposer_slots:
-        raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
     # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
     # (MAY be queued until parent is retrieved)
@@ -390,6 +390,12 @@ def validate_beacon_attestation_gossip(
     attester_index = attestation.attester_index
     target_epoch = data.target.epoch
 
+    # [Modified in Electra:EIP7549]
+    # [IGNORE] No other valid attestation seen for this target epoch and validator
+    attestation_epoch_key = (target_epoch, attester_index)
+    if attestation_epoch_key in seen.attestation_validator_epochs:
+        raise GossipIgnore("already seen attestation for this epoch and validator")
+
     # [New in Electra:EIP7549]
     # [REJECT] The attestation's data index is zero
     if data.index != 0:
@@ -440,12 +446,6 @@ def validate_beacon_attestation_gossip(
         raise GossipReject("attester is not a member of the committee")
 
     # [Modified in Electra:EIP7549]
-    # [IGNORE] No other valid attestation seen for this target epoch and validator
-    attestation_epoch_key = (target_epoch, attester_index)
-    if attestation_epoch_key in seen.attestation_validator_epochs:
-        raise GossipIgnore("already seen attestation for this epoch and validator")
-
-    # [Modified in Electra:EIP7549]
     # [REJECT] The attestation signature is valid
     attester = state.validators[attester_index]
     domain = get_domain(state, DOMAIN_BEACON_ATTESTER, target_epoch)
@@ -488,6 +488,12 @@ def validate_blob_sidecar_gossip(
     Raises GossipIgnore or GossipReject on validation failure.
     """
     block_header = blob_sidecar.signed_block_header.message
+
+    # [IGNORE] The sidecar is the first sidecar for the tuple
+    # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+    sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
+    if sidecar_tuple in seen.blob_sidecar_tuples:
+        raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
 
     # [Modified in Electra:EIP7691]
     # [REJECT] The sidecar's index is consistent with MAX_BLOBS_PER_BLOCK_ELECTRA
@@ -550,12 +556,6 @@ def validate_blob_sidecar_gossip(
         blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof
     ):
         raise GossipReject("invalid blob kzg proof")
-
-    # [IGNORE] The sidecar is the first sidecar for the tuple
-    # (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-    sidecar_tuple = (block_header.slot, block_header.proposer_index, blob_sidecar.index)
-    if sidecar_tuple in seen.blob_sidecar_tuples:
-        raise GossipIgnore("already seen blob sidecar from this proposer for this slot and index")
 
     # [REJECT] The sidecar is proposed by the expected proposer_index
     # (if shuffling is not available, IGNORE instead and MAY be queued for later)

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -316,6 +316,11 @@ def validate_beacon_block_gossip(
     block = signed_beacon_block.message
     execution_payload = block.body.execution_payload
 
+    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+    proposer_slot_key = (block.slot, block.proposer_index)
+    if proposer_slot_key in seen.proposer_slots:
+        raise GossipIgnore("block is not the first valid block for this slot and proposer")
+
     # [IGNORE] The block is not from a future slot
     # (MAY be queued for processing at the appropriate slot)
     if is_future_slot(store, block.slot, current_time_ms):
@@ -327,11 +332,6 @@ def validate_beacon_block_gossip(
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     if block.slot <= finalized_slot:
         raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
-
-    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-    proposer_slot_key = (block.slot, block.proposer_index)
-    if proposer_slot_key in seen.proposer_slots:
-        raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
     # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
     # (MAY be queued until parent is retrieved)

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -567,6 +567,11 @@ def validate_beacon_block_gossip(
     block = signed_beacon_block.message
     bid = block.body.signed_execution_payload_bid.message
 
+    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+    proposer_slot_key = (block.slot, block.proposer_index)
+    if proposer_slot_key in seen.proposer_slots:
+        raise GossipIgnore("block is not the first valid block for this slot and proposer")
+
     # [IGNORE] The block is not from a future slot
     # (MAY be queued for processing at the appropriate slot)
     if is_future_slot(store, block.slot, current_time_ms):
@@ -578,11 +583,6 @@ def validate_beacon_block_gossip(
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     if block.slot <= finalized_slot:
         raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
-
-    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-    proposer_slot_key = (block.slot, block.proposer_index)
-    if proposer_slot_key in seen.proposer_slots:
-        raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
     # [New in Gloas:EIP7688]
     # [REJECT] The block body operation counts are within their limits
@@ -817,6 +817,11 @@ def validate_execution_payload_envelope_gossip(
     payload = envelope.payload
     block_root = envelope.beacon_block_root
 
+    # [IGNORE] The node has not seen another valid envelope for this block root from this builder
+    envelope_key = (block_root, envelope.builder_index)
+    if envelope_key in seen.execution_payload_envelopes:
+        raise GossipIgnore("already seen envelope for this block root from this builder")
+
     # [IGNORE] The envelope's block root has been seen (via gossip or non-gossip sources)
     # (MAY be queued until block is retrieved)
     if block_root not in store.blocks:
@@ -827,11 +832,6 @@ def validate_execution_payload_envelope_gossip(
         raise GossipReject("envelope's block failed validation")
 
     state = store.block_states[block_root]
-
-    # [IGNORE] The node has not seen another valid envelope for this block root from this builder
-    envelope_key = (block_root, envelope.builder_index)
-    if envelope_key in seen.execution_payload_envelopes:
-        raise GossipIgnore("already seen envelope for this block root from this builder")
 
     # [IGNORE] The envelope is from a slot greater than or equal to the latest finalized slot
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
@@ -891,14 +891,14 @@ def validate_payload_attestation_message_gossip(
     data = payload_attestation_message.data
     validator_index = payload_attestation_message.validator_index
 
-    # [IGNORE] The payload attestation's slot is for the current slot
-    if not is_current_slot(store, data.slot, current_time_ms):
-        raise GossipIgnore("payload attestation is not for the current slot")
-
     # [IGNORE] This is the first valid payload attestation from this validator index
     payload_attestation_key = (data.slot, validator_index)
     if payload_attestation_key in seen.payload_attestation_validators:
         raise GossipIgnore("already seen payload attestation from this validator")
+
+    # [IGNORE] The payload attestation's slot is for the current slot
+    if not is_current_slot(store, data.slot, current_time_ms):
+        raise GossipIgnore("payload attestation is not for the current slot")
 
     # [IGNORE] The payload attestation's block has been seen (via gossip or non-gossip sources)
     # (MAY be queued until block is retrieved)
@@ -951,10 +951,6 @@ def validate_execution_payload_bid_gossip(
     """
     bid = signed_execution_payload_bid.message
 
-    # [IGNORE] The bid's slot is the current slot or the next slot
-    if not is_current_or_next_slot(store, bid.slot, current_time_ms):
-        raise GossipIgnore("bid's slot is not the current or next slot")
-
     # [IGNORE] This is the first bid for this slot, parent, and builder
     bid_key = (bid.slot, bid.parent_block_hash, bid.parent_block_root, bid.builder_index)
     if bid_key in seen.execution_payload_bids:
@@ -965,6 +961,10 @@ def validate_execution_payload_bid_gossip(
     if best_bid_key in seen.best_execution_payload_bid:
         if bid.value <= seen.best_execution_payload_bid[best_bid_key]:
             raise GossipIgnore("bid is not the highest value bid seen for this slot and parent")
+
+    # [IGNORE] The bid's slot is the current slot or the next slot
+    if not is_current_or_next_slot(store, bid.slot, current_time_ms):
+        raise GossipIgnore("bid's slot is not the current or next slot")
 
     # [REJECT] The bid's execution payment is zero
     if bid.execution_payment != 0:
@@ -1093,9 +1093,14 @@ def validate_proposer_preferences_gossip(
     Raises GossipIgnore or GossipReject on validation failure.
     """
     preferences = signed_proposer_preferences.message
-    proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
+
+    # [IGNORE] These are the first valid preferences seen for this dependent root and slot
+    prefs_key = (preferences.proposal_slot, preferences.dependent_root)
+    if prefs_key in seen.proposer_preferences:
+        raise GossipIgnore("already seen preferences for this dependent root and proposal slot")
 
     # [IGNORE] The proposal epoch is after the Gloas upgrade
+    proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
     if proposal_epoch < GLOAS_FORK_EPOCH:
         raise GossipIgnore("proposal epoch is pre-gloas")
 
@@ -1113,11 +1118,6 @@ def validate_proposer_preferences_gossip(
     # (MAY be queued until block is retrieved)
     if preferences.dependent_root not in store.blocks:
         raise GossipIgnore("dependent block has not been seen")
-
-    # [IGNORE] These are the first valid preferences seen for this dependent root and slot
-    prefs_key = (preferences.proposal_slot, preferences.dependent_root)
-    if prefs_key in seen.proposer_preferences:
-        raise GossipIgnore("already seen preferences for this dependent root and proposal slot")
 
     # [IGNORE] The dependent block passes validation
     if preferences.dependent_root not in store.block_states:
@@ -1180,6 +1180,11 @@ def validate_beacon_attestation_gossip(
     attester_index = attestation.attester_index
     target_epoch = data.target.epoch
 
+    # [IGNORE] No other valid attestation seen for this target epoch and validator
+    attestation_epoch_key = (target_epoch, attester_index)
+    if attestation_epoch_key in seen.attestation_validator_epochs:
+        raise GossipIgnore("already seen attestation for this epoch and validator")
+
     # [New in Gloas:EIP7732]
     # [REJECT] The attestation's data index is 0 or 1
     if data.index > 1:
@@ -1227,11 +1232,6 @@ def validate_beacon_attestation_gossip(
     committee = get_beacon_committee(state, data.slot, committee_index)
     if attester_index not in committee:
         raise GossipReject("attester is not a member of the committee")
-
-    # [IGNORE] No other valid attestation seen for this target epoch and validator
-    attestation_epoch_key = (target_epoch, attester_index)
-    if attestation_epoch_key in seen.attestation_validator_epochs:
-        raise GossipIgnore("already seen attestation for this epoch and validator")
 
     # [REJECT] The attestation signature is valid
     attester = state.validators[attester_index]

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -630,6 +630,11 @@ def validate_beacon_block_gossip(
     """
     block = signed_beacon_block.message
 
+    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+    proposer_slot_key = (block.slot, block.proposer_index)
+    if proposer_slot_key in seen.proposer_slots:
+        raise GossipIgnore("block is not the first valid block for this slot and proposer")
+
     # [IGNORE] The block is not from a future slot
     # (MAY be queued for processing at the appropriate slot)
     if is_future_slot(store, block.slot, current_time_ms):
@@ -641,11 +646,6 @@ def validate_beacon_block_gossip(
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     if block.slot <= finalized_slot:
         raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
-
-    # [IGNORE] The block is the first block with valid signature received for the slot and proposer
-    proposer_slot_key = (block.slot, block.proposer_index)
-    if proposer_slot_key in seen.proposer_slots:
-        raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
     # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
     # (MAY be queued until parent is retrieved)


### PR DESCRIPTION
Move checks for "has this been seen already" to the top of gossip validation functions. Prior to this, these checks were performed after the inputs were validated, so that invalid lookups were not performed. I thought a client stated that these lookups were expensive, so I took that into consideration when converting these to executable functions. I'm no longer sure this is the case, but even if it is, I no longer believe it should influence the specifications.

Alternative to #5579.