### PR TITLE
Hex-encode only literal `ProgressiveList[Byte]` in reference tests

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/debug/decode.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/decode.py
@@ -15,7 +15,7 @@ def decode(data: Any, typ):
     if issubclass(typ, Uint | Boolean):
         return typ(data)
     elif issubclass(typ, BitList | ProgressiveBitList | BitVector) or (
-        issubclass(typ, ProgressiveList) and issubclass(typ.ELEMENT_TYPE, Byte)
+        issubclass(typ, ProgressiveList) and typ.ELEMENT_TYPE is Byte
     ):
         return deserialize(typ, bytes.fromhex(data[2:]))
     elif issubclass(typ, List | ProgressiveList | Vector):

--- a/tests/core/pyspec/eth_consensus_specs/debug/encode.py
+++ b/tests/core/pyspec/eth_consensus_specs/debug/encode.py
@@ -18,7 +18,7 @@ def encode(value, include_hash_tree_roots=False):
     elif isinstance(value, Boolean):
         return bool(value)
     elif isinstance(value, BitList | ProgressiveBitList | BitVector) or (
-        isinstance(value, ProgressiveList) and issubclass(type(value).ELEMENT_TYPE, Byte)
+        isinstance(value, ProgressiveList) and type(value).ELEMENT_TYPE is Byte
     ):
         return "0x" + serialize(value).hex()
     elif isinstance(value, (list, List | ProgressiveList | Vector)):  # normal python lists


### PR DESCRIPTION
Since #5520, `Byte` is an alias of `Uint8`, so the hex-encoding branch in `debug/encode.py` now matches `ProgressiveList` of any `Uint8` subclass. This changed the encoding of the Gloas participation fields in ssz_static vectors, and is inconsistent with pre-Gloas forks which still encode them as a list of numbers.

```yaml
# electra
previous_epoch_participation: [173]
# gloas
previous_epoch_participation: '0xad'
```

Require the element type to be exactly `Byte`, matching the previous remerkleable behavior where `byte` was a distinct subclass of `uint8`. Literal byte lists such as `Transaction` remain hex-encoded. Same change applied to `debug/decode.py` for symmetry.