### PR TITLE
Remove unnecessary casts

### DIFF
--- a/specs/_features/eip8148/beacon-chain.md
+++ b/specs/_features/eip8148/beacon-chain.md
@@ -436,7 +436,7 @@ def get_validators_sweep_withdrawals(
             )
             withdrawal_index += WithdrawalIndex(1)
 
-        validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+        validator_index = (validator_index + 1) % len(state.validators)
         processed_count += 1
 
     return withdrawals, withdrawal_index, processed_count

--- a/specs/_features/eip8148/beacon-chain.md
+++ b/specs/_features/eip8148/beacon-chain.md
@@ -422,7 +422,7 @@ def get_validators_sweep_withdrawals(
                     amount=balance,
                 )
             )
-            withdrawal_index += WithdrawalIndex(1)
+            withdrawal_index += 1
         # [Modified in EIP8148]
         elif is_partially_withdrawable_validator(validator, balance, sweep_threshold):
             withdrawals.append(
@@ -434,7 +434,7 @@ def get_validators_sweep_withdrawals(
                     amount=balance - get_effective_sweep_threshold(validator, sweep_threshold),
                 )
             )
-            withdrawal_index += WithdrawalIndex(1)
+            withdrawal_index += 1
 
         validator_index = (validator_index + 1) % len(state.validators)
         processed_count += 1

--- a/specs/_features/eip8205/beacon-chain.md
+++ b/specs/_features/eip8205/beacon-chain.md
@@ -416,7 +416,7 @@ def process_preregistration_request(state: BeaconState, request: Preregistration
     preregistration = StoredPreregistration(
         pubkey=pubkey,
         withdrawal_credentials=request.withdrawal_credentials,
-        expiry_slot=Slot(state.slot + PREREGISTRATION_EXPIRY_SLOTS),
+        expiry_slot=state.slot + PREREGISTRATION_EXPIRY_SLOTS,
     )
     index = get_stored_preregistration_index(state, pubkey)
     if index is not None:

--- a/specs/_features/eip8321/beacon-chain.md
+++ b/specs/_features/eip8321/beacon-chain.md
@@ -369,7 +369,7 @@ from the front.
 
 ```python
 def process_pending_randao_commitments(state: BeaconState) -> None:
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     next_pending_commitment = 0
     for pending_commitment in state.pending_randao_commitments:
         if pending_commitment.activation_epoch > next_epoch:
@@ -503,7 +503,7 @@ def process_randao_commitment_registration(
         PendingRandaoCommitment(
             validator_index=index,
             commitment=registration.commitment,
-            activation_epoch=Epoch(get_current_epoch(state) + COMMITMENT_REGISTRATION_DELAY),
+            activation_epoch=get_current_epoch(state) + COMMITMENT_REGISTRATION_DELAY,
         )
     )
 ```

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -661,7 +661,7 @@ def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) ->
             )
             if bit
         ]
-    previous_slot = max(state.slot, Slot(1)) - Slot(1)
+    previous_slot = max(state.slot, Slot(1)) - 1
     domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
     signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
     # Note: eth_fast_aggregate_verify works with a singleton list containing an aggregated key
@@ -834,7 +834,7 @@ def process_participation_flag_updates(state: BeaconState) -> None:
 
 ```python
 def process_sync_committee_updates(state: BeaconState) -> None:
-    next_epoch = get_current_epoch(state) + Epoch(1)
+    next_epoch = get_current_epoch(state) + 1
     if next_epoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0:
         state.current_sync_committee = state.next_sync_committee
         state.next_sync_committee = get_next_sync_committee(state)

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -325,7 +325,7 @@ def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorInd
     """
     Return the sync committee indices, with possible duplicates, for the next sync committee.
     """
-    epoch = Epoch(get_current_epoch(state) + 1)
+    epoch = get_current_epoch(state) + 1
 
     MAX_RANDOM_BYTE = 2**8 - 1
     active_validator_indices = get_active_validator_indices(state, epoch)
@@ -388,7 +388,7 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
     Return the base reward for the validator defined by ``index`` with respect to the current ``state``.
     """
     increments = state.validators[index].effective_balance // EFFECTIVE_BALANCE_INCREMENT
-    return Gwei(increments * get_base_reward_per_increment(state))
+    return increments * get_base_reward_per_increment(state)
 ```
 
 #### `get_unslashed_participating_indices`
@@ -477,9 +477,9 @@ def get_flag_index_deltas(
         if index in unslashed_participating_indices:
             if not is_in_inactivity_leak(state):
                 reward_numerator = base_reward * weight * unslashed_participating_increments
-                rewards[index] += Gwei(reward_numerator // (active_increments * WEIGHT_DENOMINATOR))
+                rewards[index] += reward_numerator // active_increments * WEIGHT_DENOMINATOR
         elif flag_index != TIMELY_HEAD_FLAG_INDEX:
-            penalties[index] += Gwei(base_reward * weight // WEIGHT_DENOMINATOR)
+            penalties[index] += base_reward * weight // WEIGHT_DENOMINATOR
     return rewards, penalties
 ```
 
@@ -502,7 +502,7 @@ def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], S
                 state.validators[index].effective_balance * state.inactivity_scores[index]
             )
             penalty_denominator = INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_ALTAIR
-            penalties[index] += Gwei(penalty_numerator // penalty_denominator)
+            penalties[index] += penalty_numerator // penalty_denominator
     return rewards, penalties
 ```
 
@@ -528,7 +528,7 @@ def slash_validator(
     validator = state.validators[slashed_index]
     validator.slashed = Boolean(True)
     validator.withdrawable_epoch = max(
-        validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR)
+        validator.withdrawable_epoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR
     )
     state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
     decrease_balance(
@@ -539,10 +539,10 @@ def slash_validator(
     proposer_index = get_beacon_proposer_index(state)
     if whistleblower_index is None:
         whistleblower_index = proposer_index
-    whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
-    proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
+    whistleblower_reward = validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT
+    proposer_reward = whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR
     increase_balance(state, proposer_index, proposer_reward)
-    increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+    increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
 ```
 
 ### Block processing
@@ -671,14 +671,12 @@ def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) ->
 
     # Compute participant and proposer rewards
     total_active_increments = get_total_active_balance(state) // EFFECTIVE_BALANCE_INCREMENT
-    total_base_rewards = Gwei(get_base_reward_per_increment(state) * total_active_increments)
-    max_participant_rewards = Gwei(
+    total_base_rewards = get_base_reward_per_increment(state) * total_active_increments
+    max_participant_rewards = (
         total_base_rewards * SYNC_REWARD_WEIGHT // WEIGHT_DENOMINATOR // Uint64(SLOTS_PER_EPOCH)
     )
-    participant_reward = Gwei(max_participant_rewards // SYNC_COMMITTEE_SIZE)
-    proposer_reward = Gwei(
-        participant_reward * PROPOSER_WEIGHT // (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)
-    )
+    participant_reward = max_participant_rewards // SYNC_COMMITTEE_SIZE
+    proposer_reward = participant_reward * PROPOSER_WEIGHT // (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)
 
     # Apply participant and proposer rewards
     all_pubkeys = [v.pubkey for v in state.validators]

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -477,7 +477,7 @@ def get_flag_index_deltas(
         if index in unslashed_participating_indices:
             if not is_in_inactivity_leak(state):
                 reward_numerator = base_reward * weight * unslashed_participating_increments
-                rewards[index] += reward_numerator // active_increments * WEIGHT_DENOMINATOR
+                rewards[index] += reward_numerator // (active_increments * WEIGHT_DENOMINATOR)
         elif flag_index != TIMELY_HEAD_FLAG_INDEX:
             penalties[index] += base_reward * weight // WEIGHT_DENOMINATOR
     return rewards, penalties

--- a/specs/altair/light-client/sync-protocol.md
+++ b/specs/altair/light-client/sync-protocol.md
@@ -479,7 +479,7 @@ def validate_light_client_update(
         )
         if bit
     ]
-    fork_version_slot = max(update.signature_slot, Slot(1)) - Slot(1)
+    fork_version_slot = max(update.signature_slot, Slot(1)) - 1
     fork_version = compute_fork_version(compute_epoch_at_slot(fork_version_slot))
     domain = compute_domain(DOMAIN_SYNC_COMMITTEE, fork_version, genesis_validators_root)
     signing_root = compute_signing_root(update.attested_header.beacon, domain)

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -115,7 +115,7 @@ def get_sync_subcommittee_pubkeys(
 ) -> Sequence[BLSPubkey]:
     # Committees assigned to `slot` sign for `slot - 1`
     # This creates the exceptional logic below when transitioning between sync committee periods
-    next_slot_epoch = compute_epoch_at_slot(Slot(state.slot + 1))
+    next_slot_epoch = compute_epoch_at_slot(state.slot + 1)
     if compute_sync_committee_period(get_current_epoch(state)) == compute_sync_committee_period(
         next_slot_epoch
     ):

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -394,7 +394,7 @@ subcommittees.
 def compute_subnets_for_sync_committee(
     state: BeaconState, validator_index: ValidatorIndex
 ) -> Set[SubnetID]:
-    next_slot_epoch = compute_epoch_at_slot(Slot(state.slot + 1))
+    next_slot_epoch = compute_epoch_at_slot(state.slot + 1)
     if compute_sync_committee_period(get_current_epoch(state)) == compute_sync_committee_period(
         next_slot_epoch
     ):

--- a/specs/bellatrix/beacon-chain.md
+++ b/specs/bellatrix/beacon-chain.md
@@ -300,7 +300,7 @@ def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], S
             )
             # [Modified in Bellatrix]
             penalty_denominator = INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_BELLATRIX
-            penalties[index] += Gwei(penalty_numerator // penalty_denominator)
+            penalties[index] += penalty_numerator // penalty_denominator
     return rewards, penalties
 ```
 
@@ -325,7 +325,7 @@ def slash_validator(
     validator = state.validators[slashed_index]
     validator.slashed = Boolean(True)
     validator.withdrawable_epoch = max(
-        validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR)
+        validator.withdrawable_epoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR
     )
     state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
     # [Modified in Bellatrix]
@@ -336,10 +336,10 @@ def slash_validator(
     proposer_index = get_beacon_proposer_index(state)
     if whistleblower_index is None:
         whistleblower_index = proposer_index
-    whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
-    proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
+    whistleblower_reward = validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT
+    proposer_reward = whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR
     increase_balance(state, proposer_index, proposer_reward)
-    increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+    increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
 ```
 
 ## Beacon chain state transition function

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -455,7 +455,7 @@ def get_validators_sweep_withdrawals(
                     amount=balance,
                 )
             )
-            withdrawal_index += WithdrawalIndex(1)
+            withdrawal_index += 1
         elif is_partially_withdrawable_validator(validator, balance):
             withdrawals.append(
                 Withdrawal(
@@ -465,7 +465,7 @@ def get_validators_sweep_withdrawals(
                     amount=balance - MAX_EFFECTIVE_BALANCE,
                 )
             )
-            withdrawal_index += WithdrawalIndex(1)
+            withdrawal_index += 1
 
         validator_index = (validator_index + 1) % len(state.validators)
         processed_count += 1

--- a/specs/capella/beacon-chain.md
+++ b/specs/capella/beacon-chain.md
@@ -378,7 +378,7 @@ def process_epoch(state: BeaconState) -> None:
 ```python
 def process_historical_summaries_update(state: BeaconState) -> None:
     # Set historical block root accumulator.
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     if next_epoch % Uint64(SLOTS_PER_HISTORICAL_ROOT // SLOTS_PER_EPOCH) == 0:
         historical_summary = HistoricalSummary(
             block_summary_root=hash_tree_root(state.block_roots),
@@ -467,7 +467,7 @@ def get_validators_sweep_withdrawals(
             )
             withdrawal_index += WithdrawalIndex(1)
 
-        validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+        validator_index = (validator_index + 1) % len(state.validators)
         processed_count += 1
 
     return withdrawals, withdrawal_index, processed_count
@@ -507,7 +507,7 @@ def update_next_withdrawal_index(state: BeaconState, withdrawals: Sequence[Withd
     # Update the next withdrawal index if this block contained withdrawals
     if len(withdrawals) != 0:
         latest_withdrawal = withdrawals[-1]
-        state.next_withdrawal_index = WithdrawalIndex(latest_withdrawal.index + 1)
+        state.next_withdrawal_index = latest_withdrawal.index + 1
 ```
 
 #### New `update_next_withdrawal_validator_index`
@@ -519,14 +519,12 @@ def update_next_withdrawal_validator_index(
     # Update the next validator index to start the next withdrawal sweep
     if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
         # Next sweep starts after the latest withdrawal's validator index
-        next_validator_index = ValidatorIndex(
-            (withdrawals[-1].validator_index + 1) % len(state.validators)
-        )
+        next_validator_index = (withdrawals[-1].validator_index + 1) % len(state.validators)
         state.next_withdrawal_validator_index = next_validator_index
     else:
         # Advance sweep by the max length of the sweep if there was not a full set of withdrawals
         next_index = state.next_withdrawal_validator_index + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
-        next_validator_index = ValidatorIndex(next_index % len(state.validators))
+        next_validator_index = next_index % len(state.validators)
         state.next_withdrawal_validator_index = next_validator_index
 ```
 

--- a/specs/deneb/light-client/sync-protocol.md
+++ b/specs/deneb/light-client/sync-protocol.md
@@ -66,9 +66,9 @@ def is_valid_light_client_header(header: LightClientHeader) -> bool:
 
     # [New in Deneb:EIP4844]
     if epoch < DENEB_FORK_EPOCH:
-        if header.execution.blob_gas_used != Uint64(0):
+        if header.execution.blob_gas_used != 0:
             return False
-        if header.execution.excess_blob_gas != Uint64(0):
+        if header.execution.excess_blob_gas != 0:
             return False
 
     if epoch < CAPELLA_FORK_EPOCH:

--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -233,7 +233,7 @@ def is_current_or_previous_epoch(
     (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
     """
     is_current = is_within_epoch(store, epoch, current_time_ms)
-    is_previous = is_within_epoch(store, Epoch(epoch + 1), current_time_ms)
+    is_previous = is_within_epoch(store, epoch + 1, current_time_ms)
     return is_current or is_previous
 ```
 
@@ -244,7 +244,7 @@ def compute_max_request_blob_sidecars() -> Uint64:
     """
     Return the maximum number of blob sidecars in a single request.
     """
-    return Uint64(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK)
+    return MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
 ```
 
 ### New `verify_blob_sidecar_inclusion_proof`

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -820,7 +820,7 @@ def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorInd
     """
     Return the sync committee indices, with possible duplicates, for the next sync committee.
     """
-    epoch = Epoch(get_current_epoch(state) + 1)
+    epoch = get_current_epoch(state) + 1
 
     # [Modified in Electra]
     MAX_RANDOM_VALUE = 2**16 - 1
@@ -868,7 +868,7 @@ def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
 
     # Set validator exit epoch and withdrawable epoch
     validator.exit_epoch = exit_queue_epoch
-    validator.withdrawable_epoch = Epoch(validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
+    validator.withdrawable_epoch = validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
 ```
 
 #### New `switch_to_compounding_validator`
@@ -984,7 +984,7 @@ def slash_validator(
     validator = state.validators[slashed_index]
     validator.slashed = Boolean(True)
     validator.withdrawable_epoch = max(
-        validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR)
+        validator.withdrawable_epoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR
     )
     state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
     # [Modified in Electra:EIP7251]
@@ -996,12 +996,10 @@ def slash_validator(
     if whistleblower_index is None:
         whistleblower_index = proposer_index
     # [Modified in Electra:EIP7251]
-    whistleblower_reward = Gwei(
-        validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA
-    )
-    proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
+    whistleblower_reward = validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA
+    proposer_reward = whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR
     increase_balance(state, proposer_index, proposer_reward)
-    increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+    increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
 ```
 
 ## Beacon chain state transition function
@@ -1128,7 +1126,7 @@ before applying pending deposit:
 
 ```python
 def process_pending_deposits(state: BeaconState) -> None:
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     available_for_processing = state.deposit_balance_to_consume + get_activation_exit_churn_limit(
         state
     )
@@ -1198,7 +1196,7 @@ def process_pending_deposits(state: BeaconState) -> None:
 
 ```python
 def process_pending_consolidations(state: BeaconState) -> None:
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     next_pending_consolidation = 0
     for pending_consolidation in state.pending_consolidations:
         source_validator = state.validators[pending_consolidation.source_index]
@@ -1450,7 +1448,7 @@ def get_validators_sweep_withdrawals(
             )
             withdrawal_index += WithdrawalIndex(1)
 
-        validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+        validator_index = (validator_index + 1) % len(state.validators)
         processed_count += 1
 
     return withdrawals, withdrawal_index, processed_count
@@ -1929,7 +1927,7 @@ def process_withdrawal_request(state: BeaconState, withdrawal_request: Withdrawa
             state.balances[index] - MIN_ACTIVATION_BALANCE - pending_balance_to_withdraw, amount
         )
         exit_queue_epoch = compute_exit_epoch_and_update_churn(state, to_withdraw)
-        withdrawable_epoch = Epoch(exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
+        withdrawable_epoch = exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
         state.pending_partial_withdrawals.append(
             PendingPartialWithdrawal(
                 validator_index=index,
@@ -2070,7 +2068,7 @@ def process_consolidation_request(
     source_validator.exit_epoch = compute_consolidation_epoch_and_update_churn(
         state, source_validator.effective_balance
     )
-    source_validator.withdrawable_epoch = Epoch(
+    source_validator.withdrawable_epoch = (
         source_validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
     )
     state.pending_consolidations.append(

--- a/specs/electra/beacon-chain.md
+++ b/specs/electra/beacon-chain.md
@@ -1391,7 +1391,7 @@ def get_pending_partial_withdrawals(
                     amount=withdrawal_amount,
                 )
             )
-            withdrawal_index += WithdrawalIndex(1)
+            withdrawal_index += 1
 
         processed_count += 1
 
@@ -1435,7 +1435,7 @@ def get_validators_sweep_withdrawals(
                     amount=balance,
                 )
             )
-            withdrawal_index += WithdrawalIndex(1)
+            withdrawal_index += 1
         elif is_partially_withdrawable_validator(validator, balance):
             withdrawals.append(
                 Withdrawal(
@@ -1446,7 +1446,7 @@ def get_validators_sweep_withdrawals(
                     amount=balance - get_max_effective_balance(validator),
                 )
             )
-            withdrawal_index += WithdrawalIndex(1)
+            withdrawal_index += 1
 
         validator_index = (validator_index + 1) % len(state.validators)
         processed_count += 1

--- a/specs/electra/fork.md
+++ b/specs/electra/fork.md
@@ -46,7 +46,7 @@ def upgrade_to_electra(pre: deneb.BeaconState) -> BeaconState:
     for validator in pre.validators:
         if validator.exit_epoch != FAR_FUTURE_EPOCH:
             earliest_exit_epoch = max(earliest_exit_epoch, validator.exit_epoch)
-    earliest_exit_epoch += Epoch(1)
+    earliest_exit_epoch += 1
 
     post = BeaconState(
         genesis_time=pre.genesis_time,

--- a/specs/electra/p2p-interface.md
+++ b/specs/electra/p2p-interface.md
@@ -93,7 +93,7 @@ def compute_max_request_blob_sidecars() -> Uint64:
     Return the maximum number of blob sidecars in a single request.
     """
     # [Modified in Electra:EIP7691]
-    return Uint64(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK_ELECTRA)
+    return MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK_ELECTRA
 ```
 
 ## The gossip domain: gossipsub

--- a/specs/fulu/beacon-chain.md
+++ b/specs/fulu/beacon-chain.md
@@ -327,14 +327,12 @@ def compute_fork_digest(
     # Bitmask digest with hash of blob parameters
     blob_parameters = get_blob_parameters(epoch)
     return ForkDigest(
-        bytes(
-            xor(
-                base_digest,
-                sha256(
-                    uint_to_bytes(Uint64(blob_parameters.epoch))
-                    + uint_to_bytes(Uint64(blob_parameters.max_blobs_per_block))
-                ),
-            )
+        xor(
+            base_digest,
+            sha256(
+                uint_to_bytes(Uint64(blob_parameters.epoch))
+                + uint_to_bytes(Uint64(blob_parameters.max_blobs_per_block))
+            ),
         )[:4]
     )
 ```
@@ -349,7 +347,7 @@ def compute_proposer_indices(
     Return the proposer indices for the given ``epoch``.
     """
     start_slot = compute_start_slot_at_epoch(epoch)
-    seeds = [sha256(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
+    seeds = [sha256(seed + uint_to_bytes(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
     return ProposerIndices(data=[compute_proposer_index(state, indices, seed) for seed in seeds])
 ```
 
@@ -415,7 +413,7 @@ for the former deposit mechanism.
 
 ```python
 def process_pending_deposits(state: BeaconState) -> None:
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     available_for_processing = state.deposit_balance_to_consume + get_activation_exit_churn_limit(
         state
     )
@@ -486,7 +484,7 @@ def process_proposer_lookahead(state: BeaconState) -> None:
     state.proposer_lookahead[:last_epoch_start] = state.proposer_lookahead[SLOTS_PER_EPOCH:]
     # Fill in the last epoch with new proposer indices
     last_epoch_proposers = get_beacon_proposer_indices(
-        state, Epoch(get_current_epoch(state) + MIN_SEED_LOOKAHEAD + 1)
+        state, get_current_epoch(state) + MIN_SEED_LOOKAHEAD + 1
     )
     state.proposer_lookahead[last_epoch_start:] = last_epoch_proposers
 ```

--- a/specs/fulu/fork.md
+++ b/specs/fulu/fork.md
@@ -40,7 +40,7 @@ def initialize_proposer_lookahead(
     current_epoch = get_current_epoch(state)
     lookahead: list[ValidatorIndex] = []
     for i in range(MIN_SEED_LOOKAHEAD + 1):
-        lookahead.extend(get_beacon_proposer_indices(state, Epoch(current_epoch + i)))
+        lookahead.extend(get_beacon_proposer_indices(state, current_epoch + i))
     return ProposerLookahead(data=lookahead)
 ```
 

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -171,7 +171,7 @@ def compute_max_request_data_column_sidecars() -> Uint64:
     """
     Return the maximum number of data column sidecars in a single request.
     """
-    return Uint64(MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS)
+    return MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS
 ```
 
 ### New `verify_data_column_sidecar`

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -1827,7 +1827,7 @@ def get_builder_withdrawals(
                 amount=withdrawal.amount,
             )
         )
-        withdrawal_index += WithdrawalIndex(1)
+        withdrawal_index += 1
         processed_count += 1
 
     return withdrawals, withdrawal_index, processed_count
@@ -1865,7 +1865,7 @@ def get_builders_sweep_withdrawals(
                     amount=builder.balance,
                 )
             )
-            withdrawal_index += WithdrawalIndex(1)
+            withdrawal_index += 1
 
         builder_index = (builder_index + 1) % len(state.builders)
         processed_count += 1
@@ -2365,7 +2365,7 @@ def process_attestation(
     proposer_reward_numerator = 0
     for index in get_attesting_indices(state, attestation):
         # [New in Gloas:EIP7732]
-        had_no_participation = epoch_participation[index] == ParticipationFlags(0b0000_0000)
+        had_no_participation = epoch_participation[index] == 0b0000_0000
         will_set_new_flag = False
 
         for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):

--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -1069,7 +1069,7 @@ def is_attestation_same_slot(state: BeaconState, data: AttestationData) -> bool:
 
     blockroot = data.beacon_block_root
     slot_blockroot = get_block_root_at_slot(state, data.slot)
-    prev_blockroot = get_block_root_at_slot(state, Slot(data.slot - 1))
+    prev_blockroot = get_block_root_at_slot(state, data.slot - 1)
 
     return blockroot == slot_blockroot and blockroot != prev_blockroot
 ```
@@ -1230,7 +1230,7 @@ def compute_proposer_indices(
     Return the proposer indices for the given ``epoch``.
     """
     start_slot = compute_start_slot_at_epoch(epoch)
-    seeds = [sha256(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
+    seeds = [sha256(seed + uint_to_bytes(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
     # [Modified in Gloas:EIP7732]
     return ProposerIndices(
         data=[
@@ -1302,7 +1302,7 @@ def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorInd
     """
     Return the sync committee indices, with possible duplicates, for the next sync committee.
     """
-    epoch = Epoch(get_current_epoch(state) + 1)
+    epoch = get_current_epoch(state) + 1
     seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
     indices = get_active_validator_indices(state, epoch)
     return compute_balance_weighted_selection(
@@ -1602,7 +1602,7 @@ def process_epoch(state: BeaconState) -> None:
 
 ```python
 def process_pending_deposits(state: BeaconState) -> None:
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     # [Modified in Gloas:EIP8061]
     # Deposits still consume the activation-only churn budget in Gloas.
     available_for_processing = state.deposit_balance_to_consume + get_activation_churn_limit(state)
@@ -1686,7 +1686,7 @@ def process_ptc_window(state: BeaconState) -> None:
     # Shift all epochs forward by one
     state.ptc_window[: len(state.ptc_window) - SLOTS_PER_EPOCH] = state.ptc_window[SLOTS_PER_EPOCH:]
     # Fill in the last epoch
-    next_epoch = Epoch(get_current_epoch(state) + MIN_SEED_LOOKAHEAD + 1)
+    next_epoch = get_current_epoch(state) + MIN_SEED_LOOKAHEAD + 1
     start_slot = compute_start_slot_at_epoch(next_epoch)
     state.ptc_window[len(state.ptc_window) - SLOTS_PER_EPOCH :] = [
         compute_ptc(state, Slot(slot)) for slot in range(start_slot, start_slot + SLOTS_PER_EPOCH)
@@ -1867,7 +1867,7 @@ def get_builders_sweep_withdrawals(
             )
             withdrawal_index += WithdrawalIndex(1)
 
-        builder_index = BuilderIndex((builder_index + 1) % len(state.builders))
+        builder_index = (builder_index + 1) % len(state.builders)
         processed_count += 1
 
     return withdrawals, withdrawal_index, processed_count
@@ -1960,7 +1960,7 @@ def update_next_withdrawal_builder_index(
     if len(state.builders) > 0:
         # Update the next builder index to start the next withdrawal sweep
         next_index = state.next_withdrawal_builder_index + processed_builders_sweep_count
-        next_builder_index = BuilderIndex(next_index % len(state.builders))
+        next_builder_index = next_index % len(state.builders)
         state.next_withdrawal_builder_index = next_builder_index
 ```
 
@@ -2116,7 +2116,7 @@ def process_execution_payload_bid(
     assert state.slot > GENESIS_SLOT
     # Verify that the bid is for the right parent block
     assert bid.parent_block_hash == state.latest_block_hash
-    assert bid.parent_block_root == get_block_root_at_slot(state, Slot(state.slot - 1))
+    assert bid.parent_block_root == get_block_root_at_slot(state, state.slot - 1)
     assert bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
 
     # Record the pending payment if there is some payment

--- a/specs/gloas/fork.md
+++ b/specs/gloas/fork.md
@@ -49,9 +49,9 @@ def initialize_ptc_window(
     ptcs = []
     current_epoch = get_current_epoch(state)
     for e in range(1 + MIN_SEED_LOOKAHEAD):
-        epoch = Epoch(current_epoch + e)
+        epoch = current_epoch + e
         start_slot = compute_start_slot_at_epoch(epoch)
-        ptcs += [compute_ptc(state, Slot(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
+        ptcs += [compute_ptc(state, start_slot + i) for i in range(SLOTS_PER_EPOCH)]
 
     return PayloadTimelinessCommitteeWindow(data=empty_previous_epoch + ptcs)
 ```

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -312,7 +312,7 @@ def is_current_or_next_slot(
     (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
     """
     is_current = is_current_slot(store, slot, current_time_ms)
-    is_next = is_current_slot(store, Slot(slot - 1), current_time_ms)
+    is_next = is_current_slot(store, slot - 1, current_time_ms)
     return is_current or is_next
 ```
 
@@ -410,7 +410,7 @@ def compute_shuffling_dependent_epoch(epoch: Epoch) -> Epoch:
     """
     if epoch <= MIN_SEED_LOOKAHEAD:
         return GENESIS_EPOCH
-    return Epoch(epoch - MIN_SEED_LOOKAHEAD)
+    return epoch - MIN_SEED_LOOKAHEAD
 ```
 
 ### New `verify_attestation_payload_status`
@@ -993,7 +993,7 @@ def validate_execution_payload_bid_gossip(
     state = store.block_states[bid.parent_block_root]
 
     # [IGNORE] The bid's slot is within the parent's proposer lookahead
-    if proposal_epoch > get_current_epoch(state) + Epoch(MIN_SEED_LOOKAHEAD):
+    if proposal_epoch > get_current_epoch(state) + MIN_SEED_LOOKAHEAD:
         raise GossipIgnore("bid's slot is past the parent's proposer lookahead")
 
     # [IGNORE] The matching proposer preferences have been seen

--- a/specs/gloas/validator.md
+++ b/specs/gloas/validator.md
@@ -67,7 +67,7 @@ def get_ptc_assignment(
     index ``validator_index`` is a member of the PTC. Returns None if no
     assignment is found.
     """
-    max_epoch = Epoch(get_current_epoch(state) + MIN_SEED_LOOKAHEAD)
+    max_epoch = get_current_epoch(state) + MIN_SEED_LOOKAHEAD
     assert epoch <= max_epoch
 
     start_slot = compute_start_slot_at_epoch(epoch)
@@ -144,7 +144,7 @@ def get_upcoming_proposal_slots(
     current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
     upcoming_proposal_slots = []
     for offset, proposer_index in enumerate(state.proposer_lookahead):
-        slot = Slot(current_epoch_start_slot + offset)
+        slot = current_epoch_start_slot + offset
         if slot <= state.slot:
             continue
         if validator_index == proposer_index:

--- a/specs/heze/builder.md
+++ b/specs/heze/builder.md
@@ -26,7 +26,7 @@ comprises all valid and non-equivocating inclusion lists they have observed.
 1. Set `bid.inclusion_list_bits` to
    `get_inclusion_list_bits(get_inclusion_list_store(), inclusion_list_committee, slot, dependent_root, only_timely=False)`,
    where `inclusion_list_committee` is
-   `get_inclusion_list_committee(state, slot)`, `slot` is `bid.slot - Slot(1)`,
+   `get_inclusion_list_committee(state, slot)`, `slot` is `bid.slot - 1`,
    `dependent_root` is
    `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`,
    and `store` is the fork choice store.

--- a/specs/heze/fork-choice.md
+++ b/specs/heze/fork-choice.md
@@ -190,7 +190,7 @@ def record_payload_inclusion_list_satisfaction(
     payload: ExecutionPayload,
     execution_engine: ExecutionEngine,
 ) -> None:
-    slot = store.blocks[root].slot - Slot(1)
+    slot = store.blocks[root].slot - 1
     dependent_root = get_shuffling_dependent_root(store, root, compute_epoch_at_slot(slot))
     inclusion_list_transactions = get_inclusion_list_transactions(
         get_inclusion_list_store(), slot, dependent_root, only_timely=True

--- a/specs/heze/p2p-interface.md
+++ b/specs/heze/p2p-interface.md
@@ -115,7 +115,7 @@ The following validations are added, assuming the alias
   inclusion lists for the slot preceding the bid's slot -- i.e.
   `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), inclusion_list_committee, slot, dependent_root, bid.inclusion_list_bits, only_timely=True)`
   returns `True`, where `inclusion_list_committee` is
-  `get_inclusion_list_committee(state, slot)`, `slot` is `bid.slot - Slot(1)`,
+  `get_inclusion_list_committee(state, slot)`, `slot` is `bid.slot - 1`,
   `dependent_root` is
   `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`,
   and `store` is the fork choice store.

--- a/specs/heze/validator.md
+++ b/specs/heze/validator.md
@@ -87,7 +87,7 @@ def get_inclusion_list_committee_assignment(
     index ``validator_index`` is a member of the inclusion list committee.
     Returns None if no assignment is found.
     """
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     assert epoch <= next_epoch
 
     start_slot = compute_start_slot_at_epoch(epoch)

--- a/specs/heze/validator.md
+++ b/specs/heze/validator.md
@@ -118,7 +118,7 @@ and non-equivocating inclusion lists they have observed.
 - The `bid.inclusion_list_bits` must satisfy
   `is_inclusion_list_bits_inclusive(get_inclusion_list_store(), inclusion_list_committee, slot, dependent_root, bid.inclusion_list_bits, only_timely=False)`,
   where `inclusion_list_committee` is
-  `get_inclusion_list_committee(state, slot)`, `slot` is `bid.slot - Slot(1)`,
+  `get_inclusion_list_committee(state, slot)`, `slot` is `bid.slot - 1`,
   `dependent_root` is
   `get_shuffling_dependent_root(store, bid.parent_block_root, compute_epoch_at_slot(slot))`,
   and `store` is the fork choice store.
@@ -174,10 +174,8 @@ def prepare_execution_payload(
         # [New in Heze:EIP7805]
         inclusion_list_transactions=get_inclusion_list_transactions(
             get_inclusion_list_store(),
-            state.slot - Slot(1),
-            get_shuffling_dependent_root(
-                store, head.root, compute_epoch_at_slot(state.slot - Slot(1))
-            ),
+            state.slot - 1,
+            get_shuffling_dependent_root(store, head.root, compute_epoch_at_slot(state.slot - 1)),
             only_timely=False,
         ),
     )

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1215,7 +1215,7 @@ def compute_shuffled_permutation(index_count: Uint64, seed: Bytes32) -> Sequence
                 )
             source = source_by_bucket[position_bucket]
             byte_val = source[(position % 256) // 8]
-            bit = (byte_val >> int(position % 8)) % 2
+            bit = (byte_val >> (position % 8)) % 2
             indices[i] = flip if bit else indices[i]
     return indices
 ```
@@ -1307,7 +1307,7 @@ def compute_activation_exit_epoch(epoch: Epoch) -> Epoch:
     """
     Return the epoch during which validator activations and exits initiated in ``epoch`` take effect.
     """
-    return Epoch(epoch + 1 + MAX_SEED_LOOKAHEAD)
+    return epoch + 1 + MAX_SEED_LOOKAHEAD
 ```
 
 #### `compute_fork_data_root`
@@ -1380,7 +1380,7 @@ def get_previous_epoch(state: BeaconState) -> Epoch:
     Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
     """
     current_epoch = get_current_epoch(state)
-    return GENESIS_EPOCH if current_epoch == GENESIS_EPOCH else Epoch(current_epoch - 1)
+    return GENESIS_EPOCH if current_epoch == GENESIS_EPOCH else current_epoch - 1
 ```
 
 #### `get_block_root`
@@ -1447,7 +1447,7 @@ def get_seed(state: BeaconState, epoch: Epoch, domain_type: DomainType) -> Bytes
     Return the seed at ``epoch``.
     """
     mix = get_randao_mix(
-        state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1)
+        state, epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1
     )  # Avoid underflow
     return sha256(domain_type + uint_to_bytes(epoch) + mix)
 ```
@@ -1634,7 +1634,7 @@ def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
 
     # Set validator exit epoch and withdrawable epoch
     validator.exit_epoch = exit_queue_epoch
-    validator.withdrawable_epoch = Epoch(validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
+    validator.withdrawable_epoch = validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
 ```
 
 #### `slash_validator`
@@ -1653,7 +1653,7 @@ def slash_validator(
     validator = state.validators[slashed_index]
     validator.slashed = Boolean(True)
     validator.withdrawable_epoch = max(
-        validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR)
+        validator.withdrawable_epoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR
     )
     state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
     decrease_balance(
@@ -1664,10 +1664,10 @@ def slash_validator(
     proposer_index = get_beacon_proposer_index(state)
     if whistleblower_index is None:
         whistleblower_index = proposer_index
-    whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
-    proposer_reward = Gwei(whistleblower_reward // PROPOSER_REWARD_QUOTIENT)
+    whistleblower_reward = validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT
+    proposer_reward = whistleblower_reward // PROPOSER_REWARD_QUOTIENT
     increase_balance(state, proposer_index, proposer_reward)
-    increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+    increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
 ```
 
 ## Genesis
@@ -1792,7 +1792,7 @@ def process_slots(state: BeaconState, slot: Slot) -> None:
         # Process epoch on the start slot of the next epoch
         if (state.slot + 1) % SLOTS_PER_EPOCH == 0:
             process_epoch(state)
-        state.slot = Slot(state.slot + 1)
+        state.slot = state.slot + 1
 ```
 
 ```python
@@ -1959,7 +1959,7 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
 
 ```python
 def get_proposer_reward(state: BeaconState, attesting_index: ValidatorIndex) -> Gwei:
-    return Gwei(get_base_reward(state, attesting_index) // PROPOSER_REWARD_QUOTIENT)
+    return get_base_reward(state, attesting_index) // PROPOSER_REWARD_QUOTIENT
 ```
 
 ```python
@@ -2062,10 +2062,8 @@ def get_inclusion_delay_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequ
             key=lambda a: a.inclusion_delay,
         )
         rewards[attestation.proposer_index] += get_proposer_reward(state, index)
-        max_attester_reward = Gwei(
-            get_base_reward(state, index) - get_proposer_reward(state, index)
-        )
-        rewards[index] += Gwei(max_attester_reward // Uint64(attestation.inclusion_delay))
+        max_attester_reward = get_base_reward(state, index) - get_proposer_reward(state, index)
+        rewards[index] += max_attester_reward // Uint64(attestation.inclusion_delay)
 
     # No penalties associated with inclusion delay
     penalties = [Gwei(0)] * len(state.validators)
@@ -2088,12 +2086,12 @@ def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], S
         for index in get_eligible_validator_indices(state):
             # If validator is performing optimally this cancels all rewards for a neutral balance
             base_reward = get_base_reward(state, index)
-            penalties[index] += Gwei(
-                BASE_REWARDS_PER_EPOCH * base_reward - get_proposer_reward(state, index)
+            penalties[index] += BASE_REWARDS_PER_EPOCH * base_reward - get_proposer_reward(
+                state, index
             )
             if index not in matching_target_attesting_indices:
                 effective_balance = state.validators[index].effective_balance
-                penalties[index] += Gwei(
+                penalties[index] += (
                     effective_balance * get_finality_delay(state) // INACTIVITY_PENALTY_QUOTIENT
                 )
 
@@ -2199,7 +2197,7 @@ def process_slashings(state: BeaconState) -> None:
 
 ```python
 def process_eth1_data_reset(state: BeaconState) -> None:
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     # Reset eth1 data votes
     if next_epoch % EPOCHS_PER_ETH1_VOTING_PERIOD == 0:
         state.eth1_data_votes = Eth1DataVotes()
@@ -2228,7 +2226,7 @@ def process_effective_balance_updates(state: BeaconState) -> None:
 
 ```python
 def process_slashings_reset(state: BeaconState) -> None:
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     # Reset slashings
     state.slashings[next_epoch % EPOCHS_PER_SLASHINGS_VECTOR] = Gwei(0)
 ```
@@ -2238,7 +2236,7 @@ def process_slashings_reset(state: BeaconState) -> None:
 ```python
 def process_randao_mixes_reset(state: BeaconState) -> None:
     current_epoch = get_current_epoch(state)
-    next_epoch = Epoch(current_epoch + 1)
+    next_epoch = current_epoch + 1
     # Set randao mix
     state.randao_mixes[next_epoch % EPOCHS_PER_HISTORICAL_VECTOR] = get_randao_mix(
         state, current_epoch
@@ -2250,7 +2248,7 @@ def process_randao_mixes_reset(state: BeaconState) -> None:
 ```python
 def process_historical_roots_update(state: BeaconState) -> None:
     # Set historical root accumulator
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     if next_epoch % Uint64(SLOTS_PER_HISTORICAL_ROOT // SLOTS_PER_EPOCH) == 0:
         historical_batch = HistoricalBatch(
             block_roots=state.block_roots, state_roots=state.state_roots
@@ -2323,7 +2321,7 @@ def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
 def process_eth1_data(state: BeaconState, body: BeaconBlockBody) -> None:
     state.eth1_data_votes.append(body.eth1_data)
     if (
-        list(state.eth1_data_votes).count(body.eth1_data) * 2
+        state.eth1_data_votes.count(body.eth1_data) * 2
         > Uint64(EPOCHS_PER_ETH1_VOTING_PERIOD) * SLOTS_PER_EPOCH
     ):
         state.eth1_data = body.eth1_data

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1630,7 +1630,7 @@ def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
     exit_queue_epoch = max(exit_epochs + [compute_activation_exit_epoch(get_current_epoch(state))])
     exit_queue_churn = len([v for v in state.validators if v.exit_epoch == exit_queue_epoch])
     if exit_queue_churn >= get_validator_churn_limit(state):
-        exit_queue_epoch += Epoch(1)
+        exit_queue_epoch += 1
 
     # Set validator exit epoch and withdrawable epoch
     validator.exit_epoch = exit_queue_epoch

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -356,8 +356,8 @@ def is_full_validator_set_covered(start_slot: Slot, end_slot: Slot) -> bool:
     """
     Return ``True`` if the range between ``start_slot`` and ``end_slot`` (inclusive of both) includes an entire epoch.
     """
-    start_full_epoch = compute_epoch_at_slot(start_slot + SLOTS_PER_EPOCH - Slot(1))
-    end_full_epoch = compute_epoch_at_slot(end_slot + Slot(1))
+    start_full_epoch = compute_epoch_at_slot(start_slot + SLOTS_PER_EPOCH - 1)
+    end_full_epoch = compute_epoch_at_slot(end_slot + 1)
     return start_full_epoch < end_full_epoch
 ```
 

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -377,7 +377,7 @@ def adjust_committee_weight_estimate_to_ensure_safety(estimate: Gwei) -> Gwei:
     spanning an epoch boundary that does not cover any full epoch.
     """
     ceil = (estimate + 999) // 1000
-    return Gwei(ceil * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR))
+    return ceil * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR)
 ```
 
 ##### `estimate_committee_weight_between_slots`
@@ -425,7 +425,7 @@ def estimate_committee_weight_between_slots(
         )
 
         return adjust_committee_weight_estimate_to_ensure_safety(
-            Gwei(start_epoch_weight_pro_rated + end_epoch_weight)
+            start_epoch_weight_pro_rated + end_epoch_weight
         )
 ```
 
@@ -497,7 +497,7 @@ def compute_adversarial_weight(
     # Discount total weight of equivocating validators
     equivocation_score = get_equivocation_score(store, balance_source, start_slot, end_slot)
     if max_adversarial_weight > equivocation_score:
-        return Gwei(max_adversarial_weight - equivocation_score)
+        return max_adversarial_weight - equivocation_score
     else:
         return Gwei(0)
 ```
@@ -514,9 +514,9 @@ def get_adversarial_weight(store: Store, balance_source: BeaconState, block_root
     if get_block_epoch(store, block_root) > get_block_epoch(store, block.parent_root):
         # Use the first epoch slot as the start slot when crossing epoch boundary
         start_slot = compute_start_slot_at_epoch(get_block_epoch(store, block_root))
-        return compute_adversarial_weight(store, balance_source, start_slot, Slot(current_slot - 1))
+        return compute_adversarial_weight(store, balance_source, start_slot, current_slot - 1)
     else:
-        return compute_adversarial_weight(store, balance_source, block.slot, Slot(current_slot - 1))
+        return compute_adversarial_weight(store, balance_source, block.slot, current_slot - 1)
 ```
 
 ##### `compute_empty_slot_support_discount`
@@ -545,12 +545,12 @@ def compute_empty_slot_support_discount(
         store,
         balance_source,
         block.parent_root,
-        Slot(parent_block.slot + 1),
-        Slot(block.slot - 1),
+        parent_block.slot + 1,
+        block.slot - 1,
     )
     # Adversarial weight is not discounted
     adversarial_weight = compute_adversarial_weight(
-        store, balance_source, Slot(parent_block.slot + 1), Slot(block.slot - 1)
+        store, balance_source, parent_block.slot + 1, block.slot - 1
     )
     if parent_support_in_empty_slots > adversarial_weight:
         return parent_support_in_empty_slots - adversarial_weight
@@ -582,7 +582,7 @@ def compute_safety_threshold(store: Store, block_root: Root, balance_source: Bea
     total_active_balance = get_total_active_balance(balance_source)
     proposer_score = compute_proposer_score(balance_source)
     maximum_support = estimate_committee_weight_between_slots(
-        total_active_balance, Slot(parent_block.slot + 1), Slot(current_slot - 1)
+        total_active_balance, parent_block.slot + 1, current_slot - 1
     )
     support_discount = get_support_discount(store, balance_source, block_root)
     adversarial_weight = get_adversarial_weight(store, balance_source, block_root)
@@ -665,7 +665,7 @@ def is_confirmed_chain_safe(fcr_store: FastConfirmationStore, confirmed_root: Ro
         ancestor_at_previous_epoch_start = get_ancestor(
             store,
             get_node_for_root(confirmed_root),
-            compute_start_slot_at_epoch(Epoch(current_epoch - 1)),
+            compute_start_slot_at_epoch(current_epoch - 1),
         ).root
         if get_block_epoch(store, ancestor_at_previous_epoch_start) + 1 == current_epoch:
             # The parent of the first block of the previous epoch
@@ -741,18 +741,18 @@ def compute_honest_ffg_support_for_current_target(store: Store) -> Gwei:
 
     # Compute the total FFG weight up to, but excluding, the current slot
     ffg_weight_till_now = estimate_committee_weight_between_slots(
-        total_active_balance, compute_start_slot_at_epoch(current_epoch), Slot(current_slot - 1)
+        total_active_balance, compute_start_slot_at_epoch(current_epoch), current_slot - 1
     )
 
     # Compute remaining honest FFG weight
     remaining_ffg_weight = total_active_balance - ffg_weight_till_now
-    remaining_honest_ffg_weight = Gwei(
+    remaining_honest_ffg_weight = (
         remaining_ffg_weight // 100 * (100 - CONFIRMATION_BYZANTINE_THRESHOLD)
     )
 
     # Compute potential adversarial weight
     adversarial_weight = compute_adversarial_weight(
-        store, balance_source, compute_start_slot_at_epoch(current_epoch), Slot(current_slot - 1)
+        store, balance_source, compute_start_slot_at_epoch(current_epoch), current_slot - 1
     )
 
     # Compute min honest FFG support
@@ -760,7 +760,7 @@ def compute_honest_ffg_support_for_current_target(store: Store) -> Gwei:
         adversarial_weight, ffg_support_for_checkpoint
     )
 
-    return Gwei(min_honest_ffg_support + remaining_honest_ffg_weight)
+    return min_honest_ffg_support + remaining_honest_ffg_weight
 ```
 
 ##### `will_no_conflicting_checkpoint_be_justified`
@@ -812,7 +812,7 @@ def update_fast_confirmation_variables(fcr_store: FastConfirmationStore) -> None
     fcr_store.current_slot_head = get_head(store).root
 
     # Update greatest unrealized justified checkpoint at the last slot of an epoch
-    if is_start_slot_at_epoch(Slot(get_current_slot(store) + 1)):
+    if is_start_slot_at_epoch(get_current_slot(store) + 1):
         fcr_store.previous_epoch_greatest_unrealized_checkpoint = (
             store.unrealized_justified_checkpoint
         )

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -888,7 +888,7 @@ def record_block_timeliness(store: Store, root: Root) -> None:
 def compute_shuffling_dependent_slot(epoch: Epoch) -> Slot:
     if epoch <= MIN_SEED_LOOKAHEAD:
         return GENESIS_SLOT
-    return compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - Slot(1)
+    return compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1
 ```
 
 ##### `get_shuffling_dependent_root`

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -249,7 +249,7 @@ def get_slots_since_genesis(store: Store) -> int:
 
 ```python
 def get_current_slot(store: Store) -> Slot:
-    return Slot(GENESIS_SLOT + get_slots_since_genesis(store))
+    return GENESIS_SLOT + get_slots_since_genesis(store)
 ```
 
 #### `get_current_store_epoch`
@@ -289,7 +289,7 @@ def is_ancestor(store: Store, node: ForkChoiceNode, ancestor: ForkChoiceNode) ->
 ```python
 def calculate_committee_fraction(state: BeaconState, committee_percent: Uint64) -> Gwei:
     committee_weight = get_total_active_balance(state) // Uint64(SLOTS_PER_EPOCH)
-    return Gwei((committee_weight * committee_percent) // 100)
+    return (committee_weight * committee_percent) // 100
 ```
 
 #### `get_checkpoint_block`

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -399,7 +399,7 @@ def is_within_slot_range(
     start_time_ms = compute_time_at_slot_ms(store, slot)
     if current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < start_time_ms:
         return False
-    end_time_ms = compute_time_at_slot_ms(store, Slot(slot + slot_range + 1))
+    end_time_ms = compute_time_at_slot_ms(store, slot + slot_range + 1)
     if end_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < current_time_ms:
         return False
     return True
@@ -412,7 +412,7 @@ def compute_attestation_subnet_prefix_bits() -> Uint64:
     """
     Return the number of NodeId bits to use when mapping to a subscribed subnet.
     """
-    return Uint64(ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS)
+    return ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS
 ```
 
 #### `compute_min_epochs_for_block_requests`
@@ -481,7 +481,7 @@ can carry according to the following functions:
 def max_compressed_len(n: Uint64) -> Uint64:
     # Worst-case compressed length for a given payload of size n when using snappy:
     # https://github.com/google/snappy/blob/32ded457c0b1fe78ceb8397632c416568d6714a0/snappy.cc#L218C1-L218C47
-    return Uint64(32 + n + n / 6)
+    return 32 + n + n // 6
 ```
 
 #### `max_message_size`

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -291,7 +291,7 @@ def get_committee_assignment(
         * ``assignment[2]`` is the slot at which the committee is assigned
     Return None if no assignment.
     """
-    next_epoch = Epoch(get_current_epoch(state) + 1)
+    next_epoch = get_current_epoch(state) + 1
     assert epoch <= next_epoch
 
     start_slot = compute_start_slot_at_epoch(epoch)
@@ -460,8 +460,8 @@ An honest block proposer sets
 
 ```python
 def voting_period_start_time(state: BeaconState) -> Uint64:
-    eth1_voting_period_start_slot = Slot(
-        state.slot - state.slot % (Uint64(EPOCHS_PER_ETH1_VOTING_PERIOD) * SLOTS_PER_EPOCH)
+    eth1_voting_period_start_slot = state.slot - state.slot % (
+        Uint64(EPOCHS_PER_ETH1_VOTING_PERIOD) * SLOTS_PER_EPOCH
     )
     return compute_time_at_slot(state, eth1_voting_period_start_slot)
 ```


### PR DESCRIPTION
Now that we're using `eth-ssz-specs` and `ty`, we can remove a lot of these unnecessary type casts. This is because in `eth-ssz-specs`, operations return the expected type. I believe this helps readability a lot, because it's simpler.