### PR TITLE
Check the voluntary exit epoch against the wall clock

### DIFF
--- a/specs/deneb/p2p-interface.md
+++ b/specs/deneb/p2p-interface.md
@@ -530,6 +530,7 @@ def validate_voluntary_exit_gossip(
     seen: Seen,
     store: Store,
     signed_voluntary_exit: SignedVoluntaryExit,
+    current_time_ms: Uint64,
 ) -> None:
     """
     Validate a SignedVoluntaryExit for gossip propagation.
@@ -542,6 +543,10 @@ def validate_voluntary_exit_gossip(
     if validator_index in seen.voluntary_exit_indices:
         raise GossipIgnore("already seen voluntary exit for this validator")
 
+    # [IGNORE] The voluntary exit epoch is not in the future
+    if is_future_epoch(store, voluntary_exit.epoch, current_time_ms):
+        raise GossipIgnore("voluntary exit epoch is in the future")
+
     state = store.block_states[get_head(store).root]
 
     # [REJECT] The validator index is valid
@@ -551,17 +556,13 @@ def validate_voluntary_exit_gossip(
     validator = state.validators[validator_index]
     current_epoch = get_current_epoch(state)
 
+    # [IGNORE] The validator has not already initiated exit
+    if validator.exit_epoch != FAR_FUTURE_EPOCH:
+        raise GossipIgnore("validator has already initiated exit")
+
     # [REJECT] The validator is active
     if not is_active_validator(validator, current_epoch):
         raise GossipReject("validator is not active")
-
-    # [REJECT] The validator has not already initiated exit
-    if validator.exit_epoch != FAR_FUTURE_EPOCH:
-        raise GossipReject("validator has already initiated exit")
-
-    # [REJECT] The voluntary exit epoch is not in the future
-    if current_epoch < voluntary_exit.epoch:
-        raise GossipReject("voluntary exit epoch is in the future")
 
     # [REJECT] The validator has been active long enough
     if current_epoch < validator.activation_epoch + SHARD_COMMITTEE_PERIOD:

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -24,6 +24,7 @@
     - [`compute_fork_digest`](#compute_fork_digest)
     - [`compute_time_at_slot_ms`](#compute_time_at_slot_ms)
     - [`is_future_slot`](#is_future_slot)
+    - [`is_future_epoch`](#is_future_epoch)
     - [`is_within_slot_range`](#is_within_slot_range)
     - [`compute_attestation_subnet_prefix_bits`](#compute_attestation_subnet_prefix_bits)
     - [`compute_min_epochs_for_block_requests`](#compute_min_epochs_for_block_requests)
@@ -381,6 +382,24 @@ def is_future_slot(
     """
     slot_time_ms = compute_time_at_slot_ms(store, slot)
     return current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < slot_time_ms
+```
+
+#### `is_future_epoch`
+
+```python
+def is_future_epoch(
+    store: Store,
+    epoch: Epoch,
+    current_time_ms: Uint64,
+) -> bool:
+    """
+    Check if the given epoch is in the future
+    (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+    """
+    time_since_genesis_ms = current_time_ms - store.genesis_time * 1000
+    time_since_genesis_ms += MAXIMUM_GOSSIP_CLOCK_DISPARITY
+    current_slot = Slot(time_since_genesis_ms // SLOT_DURATION_MS)
+    return compute_epoch_at_slot(current_slot) < epoch
 ```
 
 #### `is_within_slot_range`
@@ -819,6 +838,7 @@ def validate_voluntary_exit_gossip(
     seen: Seen,
     store: Store,
     signed_voluntary_exit: SignedVoluntaryExit,
+    current_time_ms: Uint64,
 ) -> None:
     """
     Validate a SignedVoluntaryExit for gossip propagation.
@@ -831,6 +851,10 @@ def validate_voluntary_exit_gossip(
     if validator_index in seen.voluntary_exit_indices:
         raise GossipIgnore("already seen voluntary exit for this validator")
 
+    # [IGNORE] The voluntary exit epoch is not in the future
+    if is_future_epoch(store, voluntary_exit.epoch, current_time_ms):
+        raise GossipIgnore("voluntary exit epoch is in the future")
+
     state = store.block_states[get_head(store).root]
 
     # [REJECT] The validator index is valid
@@ -840,17 +864,13 @@ def validate_voluntary_exit_gossip(
     validator = state.validators[validator_index]
     current_epoch = get_current_epoch(state)
 
+    # [IGNORE] The validator has not already initiated exit
+    if validator.exit_epoch != FAR_FUTURE_EPOCH:
+        raise GossipIgnore("validator has already initiated exit")
+
     # [REJECT] The validator is active
     if not is_active_validator(validator, current_epoch):
         raise GossipReject("validator is not active")
-
-    # [REJECT] The validator has not already initiated exit
-    if validator.exit_epoch != FAR_FUTURE_EPOCH:
-        raise GossipReject("validator has already initiated exit")
-
-    # [REJECT] The voluntary exit epoch is not in the future
-    if current_epoch < voluntary_exit.epoch:
-        raise GossipReject("voluntary exit epoch is in the future")
 
     # [REJECT] The validator has been active long enough
     if current_epoch < validator.activation_epoch + SHARD_COMMITTEE_PERIOD:

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_voluntary_exit.py
@@ -40,17 +40,27 @@ def test_gossip_voluntary_exit__valid_capella_signature(spec, state):
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     signed_exit = create_signed_voluntary_exit(spec, state, validator_index=0)
     yield get_filename(signed_exit), signed_exit
 
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
 
-    yield "messages", "meta", [{"message": get_filename(signed_exit), "expected": "valid"}]
+    yield (
+        "messages",
+        "meta",
+        [{"offset_ms": 0, "message": get_filename(signed_exit), "expected": "valid"}],
+    )
 
 
 @with_deneb_and_later
@@ -70,6 +80,8 @@ def test_gossip_voluntary_exit__reject_deneb_signature(spec, state):
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     # Sign with DENEB fork version (the wrong domain under EIP-7044).
     signed_exit = create_signed_voluntary_exit(
@@ -78,7 +90,11 @@ def test_gossip_voluntary_exit__reject_deneb_signature(spec, state):
     yield get_filename(signed_exit), signed_exit
 
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
     assert result == "reject"
     assert reason == "invalid voluntary exit signature"
@@ -86,5 +102,12 @@ def test_gossip_voluntary_exit__reject_deneb_signature(spec, state):
     yield (
         "messages",
         "meta",
-        [{"message": get_filename(signed_exit), "expected": "reject", "reason": reason}],
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_voluntary_exit.py
@@ -59,7 +59,13 @@ def test_gossip_voluntary_exit__valid_capella_signature(spec, state):
     yield (
         "messages",
         "meta",
-        [{"offset_ms": 0, "message": get_filename(signed_exit), "expected": "valid"}],
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "valid",
+            }
+        ],
     )
 
 

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
@@ -521,6 +521,53 @@ def test_gossip_voluntary_exit__valid_at_clock_disparity(spec, state):
 
 @with_all_phases
 @spec_state_test
+def test_gossip_voluntary_exit__valid_previous_epoch(spec, state):
+    """
+    Test that a voluntary exit with an epoch in the past is valid.
+    """
+    yield "topic", "meta", "voluntary_exit"
+
+    seen = get_seen(spec)
+
+    # Advance state past SHARD_COMMITTEE_PERIOD
+    state.slot += spec.Uint64(spec.config.SHARD_COMMITTEE_PERIOD) * spec.SLOTS_PER_EPOCH
+    yield "state", state
+
+    store, signed_anchor = get_store_from_state(spec, state)
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
+
+    exit_epoch = spec.get_current_epoch(state) - 1
+    signed_exit = create_signed_voluntary_exit(spec, state, validator_index=0, epoch=exit_epoch)
+    yield get_filename(signed_exit), signed_exit
+
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
+    )
+    assert result == "valid"
+    assert reason is None
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "valid",
+            }
+        ],
+    )
+
+
+@with_all_phases
+@spec_state_test
 def test_gossip_voluntary_exit__reject_not_active_long_enough(spec, state):
     """
     Test that a voluntary exit for a validator not active long enough is rejected.

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
@@ -49,6 +49,8 @@ def test_gossip_voluntary_exit__valid(spec, state):
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     # Pick a validator to exit
     validator_index = 0
@@ -59,12 +61,20 @@ def test_gossip_voluntary_exit__valid(spec, state):
     yield get_filename(signed_exit), signed_exit
 
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
 
-    yield "messages", "meta", [{"message": get_filename(signed_exit), "expected": "valid"}]
+    yield (
+        "messages",
+        "meta",
+        [{"offset_ms": 0, "message": get_filename(signed_exit), "expected": "valid"}],
+    )
 
 
 @with_all_phases
@@ -85,6 +95,8 @@ def test_gossip_voluntary_exit__ignore_already_seen(spec, state):
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     # Pick a validator to exit
     validator_index = 0
@@ -96,19 +108,35 @@ def test_gossip_voluntary_exit__ignore_already_seen(spec, state):
 
     # First validation should pass
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
     assert result == "valid"
     assert reason is None
-    messages.append({"message": get_filename(signed_exit), "expected": "valid"})
+    messages.append({"offset_ms": 0, "message": get_filename(signed_exit), "expected": "valid"})
 
     # Second validation should be ignored
+    current_time_ms += 50
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
     assert result == "ignore"
     assert reason == "already seen voluntary exit for this validator"
-    messages.append({"message": get_filename(signed_exit), "expected": "ignore", "reason": reason})
+    messages.append(
+        {
+            "offset_ms": 50,
+            "message": get_filename(signed_exit),
+            "expected": "ignore",
+            "reason": reason,
+        }
+    )
 
     yield "messages", "meta", messages
 
@@ -130,6 +158,8 @@ def test_gossip_voluntary_exit__reject_validator_index_out_of_range(spec, state)
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     # Create voluntary exit with invalid validator index
     invalid_index = len(state.validators) + 100
@@ -143,7 +173,11 @@ def test_gossip_voluntary_exit__reject_validator_index_out_of_range(spec, state)
     yield get_filename(signed_exit), signed_exit
 
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
     assert result == "reject"
     assert reason == "validator index out of range"
@@ -151,7 +185,14 @@ def test_gossip_voluntary_exit__reject_validator_index_out_of_range(spec, state)
     yield (
         "messages",
         "meta",
-        [{"message": get_filename(signed_exit), "expected": "reject", "reason": reason}],
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
     )
 
 
@@ -176,6 +217,8 @@ def test_gossip_voluntary_exit__reject_validator_not_active(spec, state):
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     # Create voluntary exit
     signed_exit = create_signed_voluntary_exit(spec, state, validator_index)
@@ -183,7 +226,11 @@ def test_gossip_voluntary_exit__reject_validator_not_active(spec, state):
     yield get_filename(signed_exit), signed_exit
 
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
     assert result == "reject"
     assert reason == "validator is not active"
@@ -191,15 +238,22 @@ def test_gossip_voluntary_exit__reject_validator_not_active(spec, state):
     yield (
         "messages",
         "meta",
-        [{"message": get_filename(signed_exit), "expected": "reject", "reason": reason}],
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
     )
 
 
 @with_all_phases
 @spec_state_test
-def test_gossip_voluntary_exit__reject_already_initiated_exit(spec, state):
+def test_gossip_voluntary_exit__ignore_already_initiated_exit(spec, state):
     """
-    Test that a voluntary exit for a validator that has already initiated exit is rejected.
+    Test that a voluntary exit for a validator that has already initiated exit is ignored.
     """
     yield "topic", "meta", "voluntary_exit"
 
@@ -216,6 +270,8 @@ def test_gossip_voluntary_exit__reject_already_initiated_exit(spec, state):
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     # Create voluntary exit
     signed_exit = create_signed_voluntary_exit(spec, state, validator_index)
@@ -223,23 +279,34 @@ def test_gossip_voluntary_exit__reject_already_initiated_exit(spec, state):
     yield get_filename(signed_exit), signed_exit
 
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
-    assert result == "reject"
+    assert result == "ignore"
     assert reason == "validator has already initiated exit"
 
     yield (
         "messages",
         "meta",
-        [{"message": get_filename(signed_exit), "expected": "reject", "reason": reason}],
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "ignore",
+                "reason": reason,
+            }
+        ],
     )
 
 
 @with_all_phases
 @spec_state_test
-def test_gossip_voluntary_exit__reject_epoch_in_future(spec, state):
+def test_gossip_voluntary_exit__ignore_epoch_in_future(spec, state):
     """
-    Test that a voluntary exit with epoch in the future is rejected.
+    Test that a voluntary exit with epoch in the future is ignored.
     """
     yield "topic", "meta", "voluntary_exit"
 
@@ -252,6 +319,8 @@ def test_gossip_voluntary_exit__reject_epoch_in_future(spec, state):
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     # Pick a validator
     validator_index = 0
@@ -263,15 +332,178 @@ def test_gossip_voluntary_exit__reject_epoch_in_future(spec, state):
     yield get_filename(signed_exit), signed_exit
 
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
-    assert result == "reject"
+    assert result == "ignore"
     assert reason == "voluntary exit epoch is in the future"
 
     yield (
         "messages",
         "meta",
-        [{"message": get_filename(signed_exit), "expected": "reject", "reason": reason}],
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "ignore",
+                "reason": reason,
+            }
+        ],
+    )
+
+
+@with_all_phases
+@spec_state_test
+def test_gossip_voluntary_exit__ignore_far_future_epoch(spec, state):
+    """
+    Test that a voluntary exit with the maximum Epoch is ignored without overflowing.
+    """
+    yield "topic", "meta", "voluntary_exit"
+
+    seen = get_seen(spec)
+
+    # Advance state past SHARD_COMMITTEE_PERIOD
+    state.slot += spec.Uint64(spec.config.SHARD_COMMITTEE_PERIOD) * spec.SLOTS_PER_EPOCH
+    yield "state", state
+
+    store, signed_anchor = get_store_from_state(spec, state)
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
+
+    signed_exit = create_signed_voluntary_exit(
+        spec, state, validator_index=0, epoch=spec.FAR_FUTURE_EPOCH
+    )
+    yield get_filename(signed_exit), signed_exit
+
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
+    )
+    assert result == "ignore"
+    assert reason == "voluntary exit epoch is in the future"
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "ignore",
+                "reason": reason,
+            }
+        ],
+    )
+
+
+@with_all_phases
+@spec_state_test
+def test_gossip_voluntary_exit__ignore_before_clock_disparity(spec, state):
+    """
+    Test that a voluntary exit is ignored immediately before its epoch's
+    clock-disparity window opens.
+    """
+    yield "topic", "meta", "voluntary_exit"
+
+    seen = get_seen(spec)
+
+    # Keep the head state in the prior epoch while the next epoch's acceptance window opens.
+    state.slot = spec.compute_start_slot_at_epoch(spec.Epoch(spec.config.SHARD_COMMITTEE_PERIOD))
+    yield "state", state
+
+    store, signed_anchor = get_store_from_state(spec, state)
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    exit_epoch = spec.get_current_epoch(state) + 1
+    signed_exit = create_signed_voluntary_exit(spec, state, validator_index=0, epoch=exit_epoch)
+    yield get_filename(signed_exit), signed_exit
+
+    epoch_start_slot = spec.compute_start_slot_at_epoch(exit_epoch)
+    epoch_start_time_ms = spec.compute_time_at_slot_ms(store, epoch_start_slot)
+    current_time_ms = epoch_start_time_ms - spec.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY - 1
+    yield "current_time_ms", "meta", int(current_time_ms)
+
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
+    )
+    assert result == "ignore"
+    assert reason == "voluntary exit epoch is in the future"
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "ignore",
+                "reason": reason,
+            }
+        ],
+    )
+
+
+@with_all_phases
+@spec_state_test
+def test_gossip_voluntary_exit__valid_at_clock_disparity(spec, state):
+    """
+    Test that a voluntary exit is valid when its epoch's clock-disparity window
+    opens while the head state is still in the previous epoch.
+    """
+    yield "topic", "meta", "voluntary_exit"
+
+    seen = get_seen(spec)
+
+    # Keep the head state in the prior epoch while the next epoch's acceptance window opens.
+    state.slot = spec.compute_start_slot_at_epoch(spec.Epoch(spec.config.SHARD_COMMITTEE_PERIOD))
+    yield "state", state
+
+    store, signed_anchor = get_store_from_state(spec, state)
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    exit_epoch = spec.get_current_epoch(state) + 1
+    signed_exit = create_signed_voluntary_exit(spec, state, validator_index=0, epoch=exit_epoch)
+    yield get_filename(signed_exit), signed_exit
+
+    epoch_start_slot = spec.compute_start_slot_at_epoch(exit_epoch)
+    epoch_start_time_ms = spec.compute_time_at_slot_ms(store, epoch_start_slot)
+    current_time_ms = epoch_start_time_ms - spec.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY
+    yield "current_time_ms", "meta", int(current_time_ms)
+
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
+    )
+    assert result == "valid"
+    assert reason is None
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "valid",
+            }
+        ],
     )
 
 
@@ -294,6 +526,8 @@ def test_gossip_voluntary_exit__reject_not_active_long_enough(spec, state):
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     # Pick a validator
     validator_index = 0
@@ -304,7 +538,11 @@ def test_gossip_voluntary_exit__reject_not_active_long_enough(spec, state):
     yield get_filename(signed_exit), signed_exit
 
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
     assert result == "reject"
     assert reason == "validator has not been active long enough"
@@ -312,7 +550,14 @@ def test_gossip_voluntary_exit__reject_not_active_long_enough(spec, state):
     yield (
         "messages",
         "meta",
-        [{"message": get_filename(signed_exit), "expected": "reject", "reason": reason}],
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
     )
 
 
@@ -334,6 +579,8 @@ def test_gossip_voluntary_exit__reject_invalid_signature(spec, state):
     store, signed_anchor = get_store_from_state(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+    current_time_ms = spec.compute_time_at_slot_ms(store, state.slot)
+    yield "current_time_ms", "meta", int(current_time_ms)
 
     # Pick a validator
     validator_index = 0
@@ -350,7 +597,11 @@ def test_gossip_voluntary_exit__reject_invalid_signature(spec, state):
     yield get_filename(signed_exit), signed_exit
 
     result, reason = run_validate_gossip(
-        spec, seen=seen, store=store, signed_voluntary_exit=signed_exit
+        spec,
+        seen=seen,
+        store=store,
+        signed_voluntary_exit=signed_exit,
+        current_time_ms=current_time_ms,
     )
     assert result == "reject"
     assert reason == "invalid voluntary exit signature"
@@ -358,5 +609,12 @@ def test_gossip_voluntary_exit__reject_invalid_signature(spec, state):
     yield (
         "messages",
         "meta",
-        [{"message": get_filename(signed_exit), "expected": "reject", "reason": reason}],
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/phase0/networking/test_gossip_voluntary_exit.py
@@ -73,7 +73,13 @@ def test_gossip_voluntary_exit__valid(spec, state):
     yield (
         "messages",
         "meta",
-        [{"offset_ms": 0, "message": get_filename(signed_exit), "expected": "valid"}],
+        [
+            {
+                "offset_ms": 0,
+                "message": get_filename(signed_exit),
+                "expected": "valid",
+            }
+        ],
     )
 
 
@@ -116,7 +122,13 @@ def test_gossip_voluntary_exit__ignore_already_seen(spec, state):
     )
     assert result == "valid"
     assert reason is None
-    messages.append({"offset_ms": 0, "message": get_filename(signed_exit), "expected": "valid"})
+    messages.append(
+        {
+            "offset_ms": 0,
+            "message": get_filename(signed_exit),
+            "expected": "valid",
+        }
+    )
 
     # Second validation should be ignored
     current_time_ms += 50


### PR DESCRIPTION
In `validate_voluntary_exit_gossip`, the voluntary exit epoch was compared against the head state's current epoch, which lags the wall clock and ignores clock disparity, so an exit published at the start of its epoch could be dropped by peers whose head has not advanced yet. This PR adds `is_future_epoch`, which derives the current epoch from the wall clock with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance, and use it in place of that comparison. The check no longer needs the state, so it moves ahead of the head lookup where it is much cheaper.