### PR TITLE
Bound the bid's gas limit against the parent execution payload

### DIFF
--- a/specs/gloas/beacon-chain.md
+++ b/specs/gloas/beacon-chain.md
@@ -2116,6 +2116,16 @@ def process_execution_payload_bid(
     assert state.slot > GENESIS_SLOT
     # Verify that the bid is for the right parent block
     assert bid.parent_block_hash == state.latest_block_hash
+    # Verify that the bid's gas limit is within the EIP-1559 adjustment bound of the
+    # parent execution payload's gas limit. This is only checkable when the state knows
+    # that gas limit, i.e. when the parent payload was revealed and
+    # `latest_execution_payload_bid` therefore describes the payload at
+    # `latest_block_hash`.
+    if state.latest_block_hash == state.latest_execution_payload_bid.block_hash:
+        parent_gas_limit = state.latest_execution_payload_bid.gas_limit
+        max_gas_limit_difference = max(parent_gas_limit // 1024, 1) - 1
+        assert bid.gas_limit >= parent_gas_limit - max_gas_limit_difference
+        assert bid.gas_limit <= parent_gas_limit + max_gas_limit_difference
     assert bid.parent_block_root == get_block_root_at_slot(state, state.slot - 1)
     assert bid.prev_randao == get_randao_mix(state, get_current_epoch(state))
 

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/block_processing/test_process_execution_payload_bid.py
@@ -749,3 +749,116 @@ def test_process_execution_payload_bid_blob_kzg_commitments_over_limit(spec, sta
     block.body.signed_execution_payload_bid = signed_bid
 
     yield from run_execution_payload_bid_processing(spec, state, block, valid=False)
+
+
+def set_parent_payload_revealed(spec, state, parent_gas_limit=30000000):
+    """
+    Make the state describe a *revealed* parent payload, so that
+    ``latest_execution_payload_bid`` refers to the payload at ``latest_block_hash``.
+    This is the condition under which the gas limit bound is checkable.
+    Returns ``(parent_gas_limit, max_gas_limit_difference)``.
+    """
+    state.latest_execution_payload_bid.block_hash = state.latest_block_hash
+    state.latest_execution_payload_bid.gas_limit = spec.Uint64(parent_gas_limit)
+    max_gas_limit_difference = max(parent_gas_limit // 1024, 1) - 1
+    return parent_gas_limit, max_gas_limit_difference
+
+
+def run_gas_limit_test(spec, state, gas_limit, valid):
+    block = build_empty_block_for_next_slot(spec, state)
+    signed_bid = prepare_signed_execution_payload_bid(
+        spec,
+        state,
+        builder_index=spec.BUILDER_INDEX_SELF_BUILD,
+        slot=block.slot,
+        parent_block_root=block.parent_root,
+        gas_limit=spec.Uint64(gas_limit),
+    )
+    block.body.signed_execution_payload_bid = signed_bid
+    yield from run_execution_payload_bid_processing(spec, state, block, valid=valid)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_execution_payload_bid_gas_limit_equal_to_parent(spec, state):
+    """
+    Test a gas limit equal to the revealed parent payload's is accepted
+    """
+    parent_gas_limit, _ = set_parent_payload_revealed(spec, state)
+
+    yield from run_gas_limit_test(spec, state, parent_gas_limit, valid=True)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_execution_payload_bid_gas_limit_at_upper_bound(spec, state):
+    """
+    Test a gas limit at the maximum permitted increase is accepted
+    """
+    parent_gas_limit, max_difference = set_parent_payload_revealed(spec, state)
+
+    yield from run_gas_limit_test(spec, state, parent_gas_limit + max_difference, valid=True)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_execution_payload_bid_gas_limit_at_lower_bound(spec, state):
+    """
+    Test a gas limit at the maximum permitted decrease is accepted
+    """
+    parent_gas_limit, max_difference = set_parent_payload_revealed(spec, state)
+
+    yield from run_gas_limit_test(spec, state, parent_gas_limit - max_difference, valid=True)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_execution_payload_bid_gas_limit_above_upper_bound(spec, state):
+    """
+    Test a gas limit one above the maximum permitted increase fails
+    """
+    parent_gas_limit, max_difference = set_parent_payload_revealed(spec, state)
+
+    yield from run_gas_limit_test(spec, state, parent_gas_limit + max_difference + 1, valid=False)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_execution_payload_bid_gas_limit_below_lower_bound(spec, state):
+    """
+    Test a gas limit one below the maximum permitted decrease fails
+    """
+    parent_gas_limit, max_difference = set_parent_payload_revealed(spec, state)
+
+    yield from run_gas_limit_test(spec, state, parent_gas_limit - max_difference - 1, valid=False)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_execution_payload_bid_gas_limit_max_uint64(spec, state):
+    """
+    Test the maximum uint64 gas limit fails
+
+    Such a bid is unfulfillable: the envelope must carry the same gas limit, which the
+    execution layer rejects, so the slot is forced empty while the proposer has already
+    committed to the bid.
+    """
+    set_parent_payload_revealed(spec, state)
+
+    yield from run_gas_limit_test(spec, state, 2**64 - 1, valid=False)
+
+
+@with_gloas_and_later
+@spec_state_test
+def test_process_execution_payload_bid_gas_limit_unchecked_when_parent_empty(spec, state):
+    """
+    Test the gas limit is not bounded when the parent payload was not revealed
+
+    When the parent payload is empty, ``latest_execution_payload_bid`` describes a payload
+    that never executed, so the state does not know the gas limit of the payload at
+    ``latest_block_hash`` and no bound can be applied.
+    """
+    # Leave `latest_execution_payload_bid.block_hash` differing from `latest_block_hash`
+    assert state.latest_execution_payload_bid.block_hash != state.latest_block_hash
+
+    yield from run_gas_limit_test(spec, state, 2**64 - 1, valid=True)

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/execution_payload.py
@@ -310,7 +310,9 @@ def build_empty_post_gloas_execution_payload_bid(spec, state):
         block_hash=empty_payload_hash,
         prev_randao=prev_randao,
         fee_recipient=spec.ExecutionAddress(),
-        gas_limit=spec.Uint64(0),
+        # Keep the parent payload's gas limit: an unchanged gas limit is always within the
+        # EIP-1559 adjustment bound that `process_execution_payload_bid` enforces.
+        gas_limit=state.latest_execution_payload_bid.gas_limit,
         builder_index=builder_index,
         slot=state.slot,
         value=spec.Gwei(0),


### PR DESCRIPTION
## Problem

`process_execution_payload_bid` never reads `bid.gas_limit`. The only rule on the field is the
**IGNORE**-level `is_gas_limit_target_compatible` check on the `execution_payload_bid` gossip topic
(`p2p-interface.md:995-1000`), and a bid obtained by the off-protocol means that
`validator.md:200-203` explicitly permits never passes that topic. A bid may therefore declare any
gas limit and still be block-valid.

Such a bid is **unfulfillable**, not merely odd. `verify_execution_payload_envelope` requires
`payload.gas_limit == bid.gas_limit`, and the execution layer rejects a payload that violates the
EIP-1559 adjustment bound. The envelope can never be revealed, so the slot is forced empty — while
the proposer has already committed to the bid and cannot discover the problem until after the fact.

Reproduced on a three-client devnet (Lighthouse, Teku, Lodestar, each on geth). A bid declaring
`gas_limit = 2**64-1` against a 150,000,000 gas-limit network was accepted into a block by **all
three clients**; the builder then failed three reveal attempts and the slot went empty, with the next
block building on the previous payload. The builder is still charged, so the cost matches plain
withholding — what differs is that it leaves no bid-topic trace and defeats "the builder never
revealed" monitoring.

## Why only the parent-relative half

The full predicate needs `target_gas_limit`, which lives in `ProposerPreferences`
(`p2p-interface.md:163-169`) — a networking container with no representation in `BeaconState`. It is
structurally unavailable to the state transition.

The parent-relative half *is* available: `state.latest_execution_payload_bid` is overwritten only at
the end of this function, so while the checks run it still describes the parent. And the bound is not
a weakening — `is_gas_limit_target_compatible` returns a value inside
`[parent - max_difference, parent + max_difference]` in all three of its branches, so every gas limit
an honest builder can legitimately choose already satisfies it.

## Why it is conditional

The bound applies only when `latest_execution_payload_bid` actually describes the payload at
`latest_block_hash`, i.e. when the parent payload was revealed. When the parent was **empty**, that
bid describes a payload that never executed, and the state does not hold the gas limit of the payload
actually being built on — so no bound is expressible there. A bid immediately following an empty slot
is therefore still unconstrained.

Closing that case too would need the executed head's gas limit in the state, for example recorded
next to `latest_block_hash` in `apply_parent_execution_payload`. That changes the state container, so
it is deliberately left out here. Happy to follow up with it if reviewers prefer the complete rule.

## Test fixture change

`build_empty_post_gloas_execution_payload_bid` hardcoded `gas_limit=0`, which is not a legal
adjustment from the 30,000,000 genesis gas limit. It produced bids no honest builder could send and
passed only because nothing checked the field. It now inherits the parent's gas limit, which is
always within the bound.

## Tests

Seven new cases: equal to parent, at both bounds, one outside each bound, the `2**64-1`
reproduction, and one documenting that the bound is *not* applied after an empty parent.

- `make test fork=gloas` — **1466 passed**, 0 failed (33 transition tests failed before the fixture
  fix; that failure was the hardcoded zero, not the rule).
- Reverting only `specs/` makes exactly the three negative tests fail, confirming they are
  meaningful.
- `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NC2FCd8hhcfw5CZKL7QMH
