### PR TITLE
Only serve canonical payload envelopes by range

### DIFF
--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -1368,15 +1368,14 @@ being the response content type.
 
 Clients MUST respond with execution payload envelopes from their view of the
 current fork choice -- that is, envelopes of payloads that are part of the
-single chain defined by the current head. For slots before the finalization,
-that chain leads to the finalized block reported in the `Status` handshake. A
-payload is part of that chain if the next block in the chain builds on it, i.e.
-the `parent_block_hash` of that block's execution payload bid equals the
-`block_hash` of the payload. For the head block, the payload is part of the
-chain if the head `ForkChoiceNode` has `payload_status` equal to
-`PAYLOAD_STATUS_FULL`. Clients MUST NOT include envelopes for blocks whose
-`ForkChoiceNode` in that chain has `payload_status` equal to
-`PAYLOAD_STATUS_EMPTY`.
+single chain defined by the current head. A payload is part of that chain if the
+next block in the chain builds on it, i.e. the `parent_block_hash` of that
+block's execution payload bid equals the `block_hash` of the payload. For the
+head block, the payload is part of the chain if the head `ForkChoiceNode` has
+`payload_status` equal to `PAYLOAD_STATUS_FULL`. Clients MUST NOT include
+envelopes for blocks whose `ForkChoiceNode` in that chain has `payload_status`
+equal to `PAYLOAD_STATUS_EMPTY`. For slots before the finalization, that chain
+leads to the finalized block reported in the `Status` handshake.
 
 For each successful `response_chunk`, the `ForkDigest` context epoch is
 determined by `compute_epoch_at_slot(beacon_block.slot)` based on the

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -1368,15 +1368,15 @@ being the response content type.
 
 Clients MUST respond with execution payload envelopes from their view of the
 current fork choice -- that is, envelopes of payloads that are part of the
-single chain defined by the current head. A payload is part of that chain if the
-next block in the chain builds on it, i.e. the `parent_block_hash` of that
-block's execution payload bid equals the `block_hash` of the payload. For the
-head block, the payload is part of the chain if the head `ForkChoiceNode` has
-`payload_status` equal to `PAYLOAD_STATUS_FULL`. Of note, for slots before the
-finalization, the next block is determined by the chain leading to the finalized
-block reported in the `Status` handshake. Clients MUST NOT include envelopes of
-payloads that the chain did not build on (`PAYLOAD_STATUS_EMPTY`), even though
-their block is part of the chain.
+single chain defined by the current head. For slots before the finalization,
+that chain leads to the finalized block reported in the `Status` handshake. A
+payload is part of that chain if the next block in the chain builds on it, i.e.
+the `parent_block_hash` of that block's execution payload bid equals the
+`block_hash` of the payload. For the head block, the payload is part of the
+chain if the head `ForkChoiceNode` has `payload_status` equal to
+`PAYLOAD_STATUS_FULL`. Clients MUST NOT include envelopes for blocks whose
+`ForkChoiceNode` in that chain has `payload_status` equal to
+`PAYLOAD_STATUS_EMPTY`.
 
 For each successful `response_chunk`, the `ForkDigest` context epoch is
 determined by `compute_epoch_at_slot(beacon_block.slot)` based on the

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -1366,6 +1366,18 @@ Specifications of request/response methods are equivalent to
 [BeaconBlocksByRange v2](#beaconblocksbyrange-v2), with the only difference
 being the response content type.
 
+Clients MUST respond with execution payload envelopes from their view of the
+current fork choice -- that is, envelopes of payloads that are part of the
+single chain defined by the current head. A payload is part of that chain if the
+next block in the chain builds on it, i.e. the `parent_block_hash` of that
+block's execution payload bid equals the `block_hash` of the payload. For the
+head block, the payload is part of the chain if the head `ForkChoiceNode` has
+`payload_status` equal to `PAYLOAD_STATUS_FULL`. Of note, for slots before the
+finalization, the next block is determined by the chain leading to the finalized
+block reported in the `Status` handshake. Clients MUST NOT include envelopes of
+payloads that the chain did not build on (`PAYLOAD_STATUS_EMPTY`), even though
+their block is part of the chain.
+
 For each successful `response_chunk`, the `ForkDigest` context epoch is
 determined by `compute_epoch_at_slot(beacon_block.slot)` based on the
 `beacon_block` referred to by


### PR DESCRIPTION
I pointed this out in March [on discord](https://discord.com/channels/595666850260713488/874767108809031740/1485985060753506456) already and [clients still don't follow it](https://discord.com/channels/595666850260713488/1546418299263258634), so I think it's worth to add a note to the spec

<img width="1048" height="329" alt="image" src="https://github.com/user-attachments/assets/dcbff81b-d37c-47a8-bad9-17b1ba1422a3" />
