### PR TITLE
Use block's slot to validate max blobs in gossip

### DIFF
--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -286,12 +286,11 @@ def validate_sync_committee_contribution_and_proof_gossip(
     if contribution_and_proof.aggregator_index >= len(state.validators):
         raise GossipReject("aggregator index out of range")
 
-    # [REJECT] The aggregator's validator index is in the declared subcommittee
-    # of the current sync committee
+    # [REJECT] The aggregator is a member of the committee
     aggregator_pubkey = state.validators[contribution_and_proof.aggregator_index].pubkey
     subcommittee_pubkeys = get_sync_subcommittee_pubkeys(state, contribution.subcommittee_index)
     if aggregator_pubkey not in subcommittee_pubkeys:
-        raise GossipReject("aggregator not in subcommittee")
+        raise GossipReject("aggregator is not a member of the committee")
 
     # [REJECT] The contribution_and_proof.selection_proof is a valid signature
     # of the SyncAggregatorSelectionData derived from the contribution

--- a/specs/fulu/p2p-interface.md
+++ b/specs/fulu/p2p-interface.md
@@ -299,7 +299,7 @@ Some gossip meshes are upgraded in Fulu to support upgraded types.
 
 *Note*: This function is modified per EIP-7892. The block's KZG commitment count
 is bounded by
-`get_blob_parameters(get_current_epoch(state)).max_blobs_per_block`.
+`get_blob_parameters(compute_epoch_at_slot(block.slot)).max_blobs_per_block`.
 
 ```python
 def validate_beacon_block_gossip(
@@ -383,7 +383,7 @@ def validate_beacon_block_gossip(
 
     # [Modified in Fulu:EIP7892]
     # [REJECT] The length of KZG commitments is less than or equal to the limit
-    max_blobs = get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
+    max_blobs = get_blob_parameters(compute_epoch_at_slot(block.slot)).max_blobs_per_block
     if len(block.body.blob_kzg_commitments) > max_blobs:
         raise GossipReject("too many blob kzg commitments")
 

--- a/specs/gloas/p2p-interface.md
+++ b/specs/gloas/p2p-interface.md
@@ -599,7 +599,7 @@ def validate_beacon_block_gossip(
 
     # [Modified in Gloas:EIP7732]
     # [REJECT] The bid's blob KZG commitment count is within the per-epoch limit
-    max_blobs = get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
+    max_blobs = get_blob_parameters(compute_epoch_at_slot(block.slot)).max_blobs_per_block
     if len(bid.blob_kzg_commitments) > max_blobs:
         raise GossipReject("too many blob kzg commitments")
 

--- a/tests/core/pyspec/eth_consensus_specs/test/altair/networking/test_gossip_sync_committee_contribution_and_proof.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/altair/networking/test_gossip_sync_committee_contribution_and_proof.py
@@ -588,7 +588,7 @@ def test_gossip_sync_committee_contribution_and_proof__reject_aggregator_not_in_
         current_time_ms=current_time_ms + 500,
     )
     assert result == "reject"
-    assert reason == "aggregator not in subcommittee"
+    assert reason == "aggregator is not a member of the committee"
 
     yield (
         "messages",

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/fork_choice/test_on_block.py
@@ -4,7 +4,7 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_all_phases_from_to,
 )
-from eth_consensus_specs.test.helpers.blob import get_block_with_blob
+from eth_consensus_specs.test.helpers.blob import build_block_with_blobs_for_next_slot
 from eth_consensus_specs.test.helpers.constants import (
     DENEB,
     FULU,
@@ -34,8 +34,8 @@ def test_simple_blob_data(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    # On receiving a block of `GENESIS_SLOT + 1` slot
-    block, blobs, _, blob_kzg_proofs = get_block_with_blob(spec, state, rng=rng)
+    # On receiving a block for `GENESIS_SLOT + 1` slot
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state, rng=rng)
     signed_block = state_transition_and_sign_block(spec, state, block)
     blob_data = BlobData(blobs, blob_kzg_proofs)
 
@@ -43,8 +43,8 @@ def test_simple_blob_data(spec, state):
 
     assert spec.get_head(store).root == signed_block.message.hash_tree_root()
 
-    # On receiving a block of next epoch
-    block, blobs, _, blob_kzg_proofs = get_block_with_blob(spec, state, rng=rng)
+    # On receiving a block that extends the block for `GENESIS_SLOT + 1`
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state, rng=rng)
     signed_block = state_transition_and_sign_block(spec, state, block)
     blob_data = BlobData(blobs, blob_kzg_proofs)
 
@@ -69,8 +69,8 @@ def test_invalid_incorrect_proof(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    # On receiving a block of `GENESIS_SLOT + 1` slot
-    block, blobs, _, _ = get_block_with_blob(spec, state, rng=rng)
+    # On receiving a block for `GENESIS_SLOT + 1` slot
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state, rng=rng)
     signed_block = state_transition_and_sign_block(spec, state, block)
     # Insert incorrect proof
     blob_kzg_proofs = [b"\xc0" + b"\x00" * 47]
@@ -99,8 +99,8 @@ def test_invalid_data_unavailable(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    # On receiving a block of `GENESIS_SLOT + 1` slot
-    block, _, _, _ = get_block_with_blob(spec, state, rng=rng)
+    # On receiving a block for `GENESIS_SLOT + 1` slot
+    block, _, _, _ = build_block_with_blobs_for_next_slot(spec, state, rng=rng)
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     # data unavailable
@@ -129,8 +129,8 @@ def test_invalid_wrong_proofs_length(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    # On receiving a block of `GENESIS_SLOT + 1` slot
-    block, blobs, _, _ = get_block_with_blob(spec, state, rng=rng)
+    # On receiving a block for `GENESIS_SLOT + 1` slot
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state, rng=rng)
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     # unavailable proofs
@@ -159,8 +159,8 @@ def test_invalid_wrong_blobs_length(spec, state):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    # On receiving a block of `GENESIS_SLOT + 1` slot
-    block, _, _, blob_kzg_proofs = get_block_with_blob(spec, state, rng=rng)
+    # On receiving a block for `GENESIS_SLOT + 1` slot
+    block, _, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state, rng=rng)
     signed_block = state_transition_and_sign_block(spec, state, block)
 
     # unavailable blobs

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_beacon_block.py
@@ -4,7 +4,10 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_deneb_and_later,
 )
-from eth_consensus_specs.test.helpers.blob import get_block_with_blob, get_max_blob_count
+from eth_consensus_specs.test.helpers.blob import (
+    build_block_with_blobs_for_next_slot,
+    get_max_blob_count,
+)
 from eth_consensus_specs.test.helpers.block import sign_block
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_state_with_complete_transition,
@@ -18,9 +21,6 @@ from eth_consensus_specs.test.helpers.gossip import (
     get_seen,
     run_validate_gossip,
     wrap_genesis_block,
-)
-from eth_consensus_specs.test.helpers.state import (
-    state_transition_and_sign_block,
 )
 
 
@@ -44,8 +44,8 @@ def test_gossip_beacon_block__valid_with_blob_kzg_commitments(spec, state):
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
     rng = random.Random(1234)
-    block, _, _, _ = get_block_with_blob(spec, state, rng=rng, blob_count=1)
-    signed_block = state_transition_and_sign_block(spec, state, block)
+    block, _, _, _ = build_block_with_blobs_for_next_slot(spec, state, rng=rng)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
 
     yield get_filename(signed_block), signed_block
 
@@ -93,8 +93,9 @@ def test_gossip_beacon_block__reject_too_many_kzg_commitments(spec, state):
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
     rng = random.Random(1234)
-    block, _, _, _ = get_block_with_blob(
-        spec, state, rng=rng, blob_count=get_max_blob_count(spec, state) + 1
+    max_blobs = get_max_blob_count(spec, state.slot + 1)
+    block, _, _, _ = build_block_with_blobs_for_next_slot(
+        spec, state, rng=rng, blob_count=max_blobs + 1
     )
     signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
 

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_blob_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/networking/test_gossip_blob_sidecar.py
@@ -1,12 +1,14 @@
-import random
-
 from eth_consensus_specs.test.context import (
     always_bls,
     spec_state_test,
     with_all_phases_from_to,
 )
-from eth_consensus_specs.test.helpers.blob import get_block_with_blob, get_max_blob_count
-from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
+from eth_consensus_specs.test.helpers.blob import (
+    build_block_with_blobs,
+    build_block_with_blobs_for_next_slot,
+    get_max_blob_count,
+)
+from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot, sign_block
 from eth_consensus_specs.test.helpers.constants import DENEB, FULU
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_state_with_complete_transition,
@@ -23,22 +25,7 @@ from eth_consensus_specs.test.helpers.gossip import (
 from eth_consensus_specs.test.helpers.keys import privkeys
 from eth_consensus_specs.test.helpers.state import (
     state_transition_and_sign_block,
-    transition_to,
 )
-
-
-def build_signed_block_and_sidecars(spec, state, rng=None, blob_count=1):
-    """
-    Build a signed block carrying ``blob_count`` blobs, applying the state
-    transition. Returns (signed_block, blob_sidecars).
-    """
-    rng = rng or random.Random(1234)
-    block, blobs, _, blob_kzg_proofs = get_block_with_blob(
-        spec, state, rng=rng, blob_count=blob_count
-    )
-    signed_block = state_transition_and_sign_block(spec, state, block)
-    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
-    return signed_block, list(sidecars)
 
 
 def setup_store_with_anchor(spec, state):
@@ -80,7 +67,9 @@ def test_gossip_blob_sidecar__valid(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     yield get_filename(blob_sidecar), blob_sidecar
@@ -132,15 +121,16 @@ def test_gossip_blob_sidecar__reject_index_out_of_range(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
-    blob_sidecar.index = spec.BlobIndex(get_max_blob_count(spec, state))
+    blob_sidecar_slot = blob_sidecar.signed_block_header.message.slot
+    blob_sidecar.index = spec.BlobIndex(get_max_blob_count(spec, blob_sidecar_slot))
 
     yield get_filename(blob_sidecar), blob_sidecar
 
-    block_time_ms = spec.compute_time_at_slot_ms(
-        store, blob_sidecar.signed_block_header.message.slot
-    )
+    block_time_ms = spec.compute_time_at_slot_ms(store, blob_sidecar_slot)
     yield "current_time_ms", "meta", int(block_time_ms)
 
     subnet_id = spec.SubnetID(0)
@@ -186,7 +176,9 @@ def test_gossip_blob_sidecar__reject_wrong_subnet(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     yield get_filename(blob_sidecar), blob_sidecar
@@ -241,7 +233,9 @@ def test_gossip_blob_sidecar__reject_invalid_proposer_signature(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
     # Corrupt the signature
     blob_sidecar.signed_block_header.signature = spec.BLSSignature(b"\x00" * 96)
@@ -296,7 +290,9 @@ def test_gossip_blob_sidecar__reject_invalid_inclusion_proof(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
     # Corrupt the inclusion proof
     blob_sidecar.kzg_commitment_inclusion_proof = spec.KZGCommitmentInclusionProof()
@@ -351,7 +347,9 @@ def test_gossip_blob_sidecar__reject_invalid_kzg_proof(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
     # Corrupt the KZG proof to a zero point (invalid relative to the real commitment)
     blob_sidecar.kzg_proof = spec.KZGProof(b"\xc0" + b"\x00" * 47)
@@ -406,7 +404,9 @@ def test_gossip_blob_sidecar__ignore_future_slot(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     yield get_filename(blob_sidecar), blob_sidecar
@@ -460,7 +460,9 @@ def test_gossip_blob_sidecar__valid_slot_within_clock_disparity(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     yield get_filename(blob_sidecar), blob_sidecar
@@ -511,10 +513,13 @@ def test_gossip_blob_sidecar__ignore_not_later_than_finalized_slot(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    transition_to(spec, state, spec.Slot(spec.SLOTS_PER_EPOCH - 1))
     yield "state", anchor_state
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs(
+        spec, state, slot=spec.SLOTS_PER_EPOCH
+    )
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     block_header = blob_sidecar.signed_block_header.message
@@ -580,7 +585,9 @@ def test_gossip_blob_sidecar__reject_proposer_index_out_of_range(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
     blob_sidecar.signed_block_header.message.proposer_index = spec.ValidatorIndex(
         len(state.validators)
@@ -636,7 +643,9 @@ def test_gossip_blob_sidecar__ignore_parent_not_seen(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     # Modify parent_root to something unknown to the store
@@ -714,7 +723,9 @@ def test_gossip_blob_sidecar__reject_parent_failed_validation(spec, state):
         ],
     )
 
-    _, sidecars = build_signed_block_and_sidecars(spec, parent_state.copy(), blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, parent_state)
+    signed_block = sign_block(spec, parent_state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     yield get_filename(blob_sidecar), blob_sidecar
@@ -771,7 +782,9 @@ def test_gossip_blob_sidecar__ignore_already_seen(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     yield get_filename(blob_sidecar), blob_sidecar
@@ -863,7 +876,9 @@ def test_gossip_blob_sidecar__reject_slot_not_higher_than_parent(spec, state):
         ],
     )
 
-    _, sidecars = build_signed_block_and_sidecars(spec, parent_state.copy(), blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, parent_state)
+    signed_block = sign_block(spec, parent_state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
     blob_sidecar.signed_block_header.message.slot = signed_parent.message.slot
     resign_blob_sidecar_header(spec, parent_state, blob_sidecar)
@@ -918,7 +933,9 @@ def test_gossip_blob_sidecar__reject_non_ancestor_finalized_checkpoint(spec, sta
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     fake_finalized_root = spec.Root(b"\xab" * 32)
@@ -978,7 +995,9 @@ def test_gossip_blob_sidecar__reject_wrong_proposer_index(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, blob_kzg_proofs = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = spec.get_blob_sidecars(signed_block, blobs, blob_kzg_proofs)
     blob_sidecar = sidecars[0]
 
     correct_proposer = blob_sidecar.signed_block_header.message.proposer_index

--- a/tests/core/pyspec/eth_consensus_specs/test/deneb/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/deneb/sanity/test_blocks.py
@@ -27,6 +27,7 @@ from eth_consensus_specs.test.helpers.state import (
 def run_block_with_blobs(
     spec,
     state,
+    block,
     blob_count,
     tx_count=1,
     blob_gas_used=1,
@@ -39,7 +40,6 @@ def run_block_with_blobs(
         rng = random.Random(7777)
     yield "pre", state
 
-    block = build_empty_block_for_next_slot(spec, state)
     txs = spec.Transactions()
     blob_kzg_commitments = spec.BlobKZGCommitments()
     for _ in range(tx_count):
@@ -72,60 +72,72 @@ def run_block_with_blobs(
 @with_all_phases_from_to(DENEB, GLOAS)
 @spec_state_test
 def test_zero_blob(spec, state):
-    yield from run_block_with_blobs(spec, state, blob_count=0)
+    block = build_empty_block_for_next_slot(spec, state)
+    yield from run_block_with_blobs(spec, state, block, blob_count=0)
 
 
 @with_all_phases_from_to(DENEB, GLOAS)
 @spec_state_test
 def test_one_blob(spec, state):
-    yield from run_block_with_blobs(spec, state, blob_count=1)
+    block = build_empty_block_for_next_slot(spec, state)
+    yield from run_block_with_blobs(spec, state, block, blob_count=1)
 
 
 @with_all_phases_from_to(DENEB, GLOAS)
 @spec_state_test
 def test_one_blob_two_txs(spec, state):
-    yield from run_block_with_blobs(spec, state, blob_count=1, tx_count=2)
+    block = build_empty_block_for_next_slot(spec, state)
+    yield from run_block_with_blobs(spec, state, block, blob_count=1, tx_count=2)
 
 
 @with_all_phases_from_to(DENEB, GLOAS)
 @spec_state_test
 def test_one_blob_max_txs(spec, state):
-    yield from run_block_with_blobs(
-        spec, state, blob_count=1, tx_count=get_max_blob_count(spec, state)
-    )
+    block = build_empty_block_for_next_slot(spec, state)
+    max_blobs = get_max_blob_count(spec, block.slot)
+    yield from run_block_with_blobs(spec, state, block, blob_count=1, tx_count=max_blobs)
 
 
 @with_all_phases_from_to(DENEB, GLOAS)
 @spec_state_test
 def test_invalid_one_blob_max_plus_one_txs(spec, state):
+    block = build_empty_block_for_next_slot(spec, state)
+    max_blobs = get_max_blob_count(spec, block.slot)
     yield from run_block_with_blobs(
-        spec, state, blob_count=1, tx_count=get_max_blob_count(spec, state) + 1, valid=False
+        spec, state, block, blob_count=1, tx_count=max_blobs + 1, valid=False
     )
 
 
 @with_all_phases_from_to(DENEB, GLOAS)
 @spec_state_test
 def test_max_blobs_per_block(spec, state):
-    yield from run_block_with_blobs(spec, state, blob_count=get_max_blob_count(spec, state))
+    block = build_empty_block_for_next_slot(spec, state)
+    max_blobs = get_max_blob_count(spec, block.slot)
+    yield from run_block_with_blobs(spec, state, block, blob_count=max_blobs)
 
 
 @with_all_phases_from_to(DENEB, GLOAS)
 @spec_state_test
 def test_invalid_max_blobs_per_block_two_txs(spec, state):
+    block = build_empty_block_for_next_slot(spec, state)
+    max_blobs = get_max_blob_count(spec, block.slot)
     yield from run_block_with_blobs(
-        spec, state, blob_count=get_max_blob_count(spec, state), tx_count=2, valid=False
+        spec, state, block, blob_count=max_blobs, tx_count=2, valid=False
     )
 
 
 @with_all_phases_from_to(DENEB, GLOAS)
 @spec_state_test
 def test_invalid_exceed_max_blobs_per_block(spec, state):
-    yield from run_block_with_blobs(
-        spec, state, blob_count=get_max_blob_count(spec, state) + 1, valid=False
-    )
+    block = build_empty_block_for_next_slot(spec, state)
+    max_blobs = get_max_blob_count(spec, block.slot)
+    yield from run_block_with_blobs(spec, state, block, blob_count=max_blobs + 1, valid=False)
 
 
 @with_all_phases_from_to(DENEB, GLOAS)
 @spec_state_test
 def test_mix_blob_tx_and_non_blob_tx(spec, state):
-    yield from run_block_with_blobs(spec, state, blob_count=1, tx_count=1, non_blob_tx_count=1)
+    block = build_empty_block_for_next_slot(spec, state)
+    yield from run_block_with_blobs(
+        spec, state, block, blob_count=1, tx_count=1, non_blob_tx_count=1
+    )

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/fork_choice/test_on_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/fork_choice/test_on_block.py
@@ -6,7 +6,12 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_all_phases_from_to,
 )
-from eth_consensus_specs.test.helpers.blob import get_block_with_blob_and_sidecars
+from eth_consensus_specs.test.helpers.blob import (
+    build_block_with_blobs,
+    build_block_with_blobs_for_next_slot,
+    get_data_column_sidecars,
+)
+from eth_consensus_specs.test.helpers.block import sign_block
 from eth_consensus_specs.test.helpers.constants import (
     FULU,
     GLOAS,
@@ -17,6 +22,7 @@ from eth_consensus_specs.test.helpers.fork_choice import (
     on_tick_and_append_step,
     tick_and_add_block_with_data,
 )
+from eth_consensus_specs.test.helpers.state import state_transition_and_sign_block
 
 
 def flip_one_bit_in_bytes(data: bytes, index: int = 0) -> bytes:
@@ -37,11 +43,9 @@ def get_alt_sidecars(spec, state):
     Get alternative sidecars for negative test cases.
     """
     rng = Random(4321)
-    state_copy = state.copy()
-    _, _, _, _, alt_sidecars, _ = get_block_with_blob_and_sidecars(
-        spec, state_copy, rng=rng, blob_count=2
-    )
-    return alt_sidecars
+    block, blobs, _, _ = build_block_with_blobs(spec, state, rng=rng, blob_count=2)
+    signed_block = sign_block(spec, state, block)
+    return get_data_column_sidecars(spec, signed_block, blobs)
 
 
 @with_all_phases_from_to(FULU, GLOAS)
@@ -64,19 +68,23 @@ def test_on_block_peerdas__ok(spec, state):
     assert store.time == current_time
 
     # On receiving a block of `GENESIS_SLOT + 1` slot
-    _, _, _, signed_block, sidecars, kzg_commitments = get_block_with_blob_and_sidecars(
+    block, blobs, kzg_commitments, _ = build_block_with_blobs_for_next_slot(
         spec, state, rng=rng, blob_count=2
     )
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     blob_data = BlobData(sidecars=sidecars, kzg_commitments=kzg_commitments)
 
     yield from tick_and_add_block_with_data(spec, store, signed_block, test_steps, blob_data)
 
     assert spec.get_head(store).root == signed_block.message.hash_tree_root()
 
-    # On receiving a block of next epoch
-    _, _, _, signed_block, sidecars, kzg_commitments = get_block_with_blob_and_sidecars(
+    # On receiving a block that extends the block for `GENESIS_SLOT + 1`
+    block, blobs, kzg_commitments, _ = build_block_with_blobs_for_next_slot(
         spec, state, rng=rng, blob_count=2
     )
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     blob_data = BlobData(sidecars=sidecars, kzg_commitments=kzg_commitments)
 
     yield from tick_and_add_block_with_data(spec, store, signed_block, test_steps, blob_data)
@@ -102,9 +110,11 @@ def run_on_block_peerdas_invalid_test(spec, state, fn):
     on_tick_and_append_step(spec, store, current_time, test_steps)
     assert store.time == current_time
 
-    _, _, _, signed_block, sidecars, kzg_commitments = get_block_with_blob_and_sidecars(
+    block, blobs, kzg_commitments, _ = build_block_with_blobs_for_next_slot(
         spec, state, rng=rng, blob_count=2
     )
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecars = fn(sidecars)
     blob_data = BlobData(sidecars=sidecars, kzg_commitments=kzg_commitments)
 

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_beacon_block.py
@@ -6,7 +6,12 @@ from eth_consensus_specs.test.context import (
     spec_configured_state_test,
     with_fulu_and_later,
 )
-from eth_consensus_specs.test.helpers.blob import get_block_with_blob, get_max_blob_count
+from eth_consensus_specs.test.helpers.blob import (
+    build_block_with_blobs,
+    build_block_with_blobs_for_next_slot,
+    get_max_blob_count,
+)
+from eth_consensus_specs.test.helpers.block import sign_block
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_state_with_complete_transition,
 )
@@ -22,15 +27,12 @@ from eth_consensus_specs.test.helpers.gossip import (
     run_validate_gossip,
     wrap_genesis_block,
 )
-from eth_consensus_specs.test.helpers.state import (
-    state_transition_and_sign_block,
-)
 
 
 @with_fulu_and_later
 @spec_configured_state_test(
     {
-        "BLOB_SCHEDULE": (frozendict({"EPOCH": 0, "MAX_BLOBS_PER_BLOCK": 12}),),
+        "BLOB_SCHEDULE": (frozendict({"EPOCH": 0, "MAX_BLOBS_PER_BLOCK": 15}),),
     },
     activate_at_genesis=True,
 )
@@ -53,13 +55,47 @@ def test_gossip_beacon_block__valid_at_blob_parameters_limit(spec, state):
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
     rng = random.Random(1234)
-    max_blobs = get_max_blob_count(spec, state)
+    max_blobs = get_max_blob_count(spec, state.slot + 1)
     # Sanity check: the BLOB_SCHEDULE override should be exercising the Fulu
     # code path (`get_blob_parameters`), not the Electra fallback. A client that
     # forgets EIP-7892 and uses MAX_BLOBS_PER_BLOCK_ELECTRA would reject this block.
     assert max_blobs > spec.config.MAX_BLOBS_PER_BLOCK_ELECTRA
-    block, _, _, _ = get_block_with_blob(spec, state, rng=rng, blob_count=max_blobs)
-    signed_block = state_transition_and_sign_block(spec, state, block)
+    block, _, _, _ = build_block_with_blobs_for_next_slot(
+        spec, state, rng=rng, blob_count=max_blobs
+    )
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+
+    yield get_filename(signed_block), signed_block
+
+    block_time_ms = spec.compute_time_at_slot_ms(store, signed_block.message.slot)
+    yield "current_time_ms", "meta", int(block_time_ms)
+
+    kwargs = {}
+    if not is_post_gloas(spec):
+        kwargs["block_payload_statuses"] = {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
+    )
+    assert result == "valid"
+    assert reason is None
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "offset_ms": 500,
+                "message": get_filename(signed_block),
+                "expected": "valid",
+            }
+        ],
+    )
+
 
     yield get_filename(signed_block), signed_block
 

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_beacon_block.py
@@ -97,6 +97,108 @@ def test_gossip_beacon_block__valid_at_blob_parameters_limit(spec, state):
     )
 
 
+@with_fulu_and_later
+@spec_configured_state_test(
+    {
+        "BLOB_SCHEDULE": (
+            frozendict({"EPOCH": 0, "MAX_BLOBS_PER_BLOCK": 15}),
+            frozendict({"EPOCH": 1, "MAX_BLOBS_PER_BLOCK": 21}),
+        ),
+    },
+    activate_at_genesis=True,
+)
+def test_gossip_beacon_block__reject_next_epoch_blob_limit_at_epoch_end(spec, state):
+    """A block at epoch 0's last slot carrying epoch 1's blob limit is rejected."""
+    yield "topic", "meta", "beacon_block"
+
+    state = build_state_with_complete_transition(spec, state)
+    anchor_state = state.copy()
+    yield "state", anchor_state
+
+    seen = get_seen(spec)
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    signed_anchor = wrap_genesis_block(spec, anchor_block)
+
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    rng = random.Random(1234)
+    slot = spec.Slot(spec.SLOTS_PER_EPOCH - 1)
+    current_max_blobs = get_max_blob_count(spec, slot)
+    next_max_blobs = get_max_blob_count(spec, slot + 1)
+    assert next_max_blobs > current_max_blobs
+    block, _, _, _ = build_block_with_blobs(
+        spec, state, rng=rng, blob_count=next_max_blobs, slot=slot
+    )
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+
+    yield get_filename(signed_block), signed_block
+
+    block_time_ms = spec.compute_time_at_slot_ms(store, signed_block.message.slot)
+    yield "current_time_ms", "meta", int(block_time_ms)
+
+    kwargs = {}
+    if not is_post_gloas(spec):
+        kwargs["block_payload_statuses"] = {}
+    result, reason = run_validate_gossip(
+        spec,
+        seen=seen,
+        store=store,
+        signed_beacon_block=signed_block,
+        current_time_ms=block_time_ms + 500,
+        **kwargs,
+    )
+    assert result == "reject"
+    assert reason == "too many blob kzg commitments"
+
+    yield (
+        "messages",
+        "meta",
+        [
+            {
+                "offset_ms": 500,
+                "message": get_filename(signed_block),
+                "expected": "reject",
+                "reason": reason,
+            }
+        ],
+    )
+
+
+@with_fulu_and_later
+@spec_configured_state_test(
+    {
+        "BLOB_SCHEDULE": (
+            frozendict({"EPOCH": 0, "MAX_BLOBS_PER_BLOCK": 15}),
+            frozendict({"EPOCH": 1, "MAX_BLOBS_PER_BLOCK": 21}),
+        ),
+    },
+    activate_at_genesis=True,
+)
+def test_gossip_beacon_block__valid_previous_epoch_blob_limit_plus_one_at_epoch_start(spec, state):
+    """A block at epoch 1's first slot carrying epoch 0's blob limit plus one is valid."""
+    yield "topic", "meta", "beacon_block"
+
+    state = build_state_with_complete_transition(spec, state)
+    anchor_state = state.copy()
+    yield "state", anchor_state
+
+    seen = get_seen(spec)
+    store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
+    signed_anchor = wrap_genesis_block(spec, anchor_block)
+
+    yield get_filename(signed_anchor), signed_anchor
+    yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
+
+    rng = random.Random(1234)
+    slot = spec.Slot(spec.SLOTS_PER_EPOCH)
+    previous_max_blobs = get_max_blob_count(spec, slot - 1)
+    current_max_blobs = get_max_blob_count(spec, slot)
+    blob_count = previous_max_blobs + 1
+    assert blob_count < current_max_blobs
+    block, _, _, _ = build_block_with_blobs(spec, state, rng=rng, blob_count=blob_count, slot=slot)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+
     yield get_filename(signed_block), signed_block
 
     block_time_ms = spec.compute_time_at_slot_ms(store, signed_block.message.slot)
@@ -119,5 +221,11 @@ def test_gossip_beacon_block__valid_at_blob_parameters_limit(spec, state):
     yield (
         "messages",
         "meta",
-        [{"offset_ms": 500, "message": get_filename(signed_block), "expected": "valid"}],
+        [
+            {
+                "offset_ms": 500,
+                "message": get_filename(signed_block),
+                "expected": "valid",
+            }
+        ],
     )

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_data_column_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_data_column_sidecar.py
@@ -8,10 +8,12 @@ from eth_consensus_specs.test.context import (
     with_fulu_and_later,
 )
 from eth_consensus_specs.test.helpers.blob import (
-    get_block_with_blob_and_sidecars,
+    build_block_with_blobs,
+    build_block_with_blobs_for_next_slot,
+    get_data_column_sidecars,
     get_max_blob_count,
 )
-from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
+from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot, sign_block
 from eth_consensus_specs.test.helpers.constants import FULU, GLOAS
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_state_with_complete_transition,
@@ -27,21 +29,7 @@ from eth_consensus_specs.test.helpers.gossip import (
     wrap_genesis_block,
 )
 from eth_consensus_specs.test.helpers.keys import privkeys
-from eth_consensus_specs.test.helpers.state import (
-    state_transition_and_sign_block,
-    transition_to,
-)
-
-
-def build_signed_block_and_sidecars(spec, state, blob_count=1):
-    """
-    Build a signed block carrying ``blob_count`` blobs (applying the state
-    transition) and return its (signed_block, data_column_sidecars).
-    """
-    _, _, _, signed_block, sidecars, _ = get_block_with_blob_and_sidecars(
-        spec, state, blob_count=blob_count
-    )
-    return signed_block, list(sidecars)
+from eth_consensus_specs.test.helpers.state import state_transition_and_sign_block
 
 
 def setup_store_with_anchor(spec, state):
@@ -68,7 +56,7 @@ def resign_sidecar_header(spec, state, sidecar):
 @with_fulu_and_later
 @spec_configured_state_test(
     {
-        "BLOB_SCHEDULE": (frozendict({"EPOCH": 0, "MAX_BLOBS_PER_BLOCK": 12}),),
+        "BLOB_SCHEDULE": (frozendict({"EPOCH": 0, "MAX_BLOBS_PER_BLOCK": 15}),),
     },
     activate_at_genesis=True,
 )
@@ -86,24 +74,28 @@ def test_gossip_data_column_sidecar__valid(spec, state):
     signed_anchor = wrap_genesis_block(spec, anchor_block)
     yield get_filename(signed_anchor), signed_anchor
 
-    max_blobs = get_max_blob_count(spec, state)
+    max_blobs = get_max_blob_count(spec, state.slot + 1)
     # Sanity check: the BLOB_SCHEDULE override should be exercising the Fulu
     # code path (`get_blob_parameters`), not the Electra fallback. A client that
     # forgets EIP-7892 and uses MAX_BLOBS_PER_BLOCK_ELECTRA would reject this sidecar.
     assert max_blobs > spec.config.MAX_BLOBS_PER_BLOCK_ELECTRA
-    signed_block, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=max_blobs)
-    sidecar = sidecars[0]
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state, blob_count=max_blobs)
 
     blocks_meta = [{"block": get_filename(signed_anchor)}]
     if is_post_gloas(spec):
+        signed_block = state_transition_and_sign_block(spec, state, block)
         # gloas's validator requires the sidecar's referenced block to be in store.
         block_root = signed_block.message.hash_tree_root()
         store.blocks[block_root] = signed_block.message
         store.block_states[block_root] = state.copy()
         yield get_filename(signed_block), signed_block
         blocks_meta.append({"block": get_filename(signed_block)})
+    else:
+        signed_block = sign_block(spec, state, block)
     yield "blocks", "meta", blocks_meta
 
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
+    sidecar = sidecars[0]
     yield get_filename(sidecar), sidecar
 
     sidecar_slot = sidecar.slot if is_post_gloas(spec) else sidecar.signed_block_header.message.slot
@@ -152,7 +144,9 @@ def test_gossip_data_column_sidecar__reject_index_out_of_range(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     sidecar.index = spec.ColumnIndex(spec.NUMBER_OF_COLUMNS)
 
@@ -204,14 +198,17 @@ def test_gossip_data_column_sidecar__reject_too_many_commitments(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     # Pad commitments past the blob limit. The verify_data_column_sidecar
     # check is independent of the inclusion proof, so we don't need a
     # consistent block here.
-    extra = get_max_blob_count(spec, state) + 1 - len(sidecar.kzg_commitments)
+    max_blobs = get_max_blob_count(spec, sidecar.signed_block_header.message.slot)
+    extra_blobs = max_blobs + 1 - len(sidecar.kzg_commitments)
     sidecar.kzg_commitments = spec.BlobKZGCommitments(
-        data=list(sidecar.kzg_commitments) + [spec.KZGCommitment()] * extra
+        data=list(sidecar.kzg_commitments) + [spec.KZGCommitment()] * extra_blobs
     )
 
     yield get_filename(sidecar), sidecar
@@ -262,18 +259,23 @@ def test_gossip_data_column_sidecar__reject_wrong_subnet(spec, state):
     signed_anchor = wrap_genesis_block(spec, anchor_block)
     yield get_filename(signed_anchor), signed_anchor
 
-    signed_block, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
-    sidecar = sidecars[0]
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
 
     blocks_meta = [{"block": get_filename(signed_anchor)}]
     if is_post_gloas(spec):
+        signed_block = state_transition_and_sign_block(spec, state, block)
+        # gloas's validator requires the sidecar's referenced block to be in store.
         block_root = signed_block.message.hash_tree_root()
         store.blocks[block_root] = signed_block.message
         store.block_states[block_root] = state.copy()
         yield get_filename(signed_block), signed_block
         blocks_meta.append({"block": get_filename(signed_block)})
+    else:
+        signed_block = sign_block(spec, state, block)
     yield "blocks", "meta", blocks_meta
 
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
+    sidecar = sidecars[0]
     yield get_filename(sidecar), sidecar
 
     sidecar_slot = sidecar.slot if is_post_gloas(spec) else sidecar.signed_block_header.message.slot
@@ -327,7 +329,9 @@ def test_gossip_data_column_sidecar__ignore_future_slot(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
 
     yield get_filename(sidecar), sidecar
@@ -380,19 +384,23 @@ def test_gossip_data_column_sidecar__valid_slot_within_clock_disparity(spec, sta
     signed_anchor = wrap_genesis_block(spec, anchor_block)
     yield get_filename(signed_anchor), signed_anchor
 
-    signed_block, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
-    sidecar = sidecars[0]
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
 
     blocks_meta = [{"block": get_filename(signed_anchor)}]
     if is_post_gloas(spec):
+        signed_block = state_transition_and_sign_block(spec, state, block)
         # gloas's validator requires the sidecar's referenced block to be in store.
         block_root = signed_block.message.hash_tree_root()
         store.blocks[block_root] = signed_block.message
         store.block_states[block_root] = state.copy()
         yield get_filename(signed_block), signed_block
         blocks_meta.append({"block": get_filename(signed_block)})
+    else:
+        signed_block = sign_block(spec, state, block)
     yield "blocks", "meta", blocks_meta
 
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
+    sidecar = sidecars[0]
     yield get_filename(sidecar), sidecar
 
     sidecar_slot = sidecar.slot if is_post_gloas(spec) else sidecar.signed_block_header.message.slot
@@ -440,10 +448,11 @@ def test_gossip_data_column_sidecar__ignore_not_later_than_finalized_slot(spec, 
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    transition_to(spec, state, spec.Slot(spec.SLOTS_PER_EPOCH - 1))
     yield "state", anchor_state
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs(spec, state, slot=spec.SLOTS_PER_EPOCH)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
 
     block_header = sidecar.signed_block_header.message
@@ -509,7 +518,9 @@ def test_gossip_data_column_sidecar__reject_proposer_index_out_of_range(spec, st
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     sidecar.signed_block_header.message.proposer_index = spec.ValidatorIndex(len(state.validators))
 
@@ -562,7 +573,9 @@ def test_gossip_data_column_sidecar__reject_invalid_proposer_signature(spec, sta
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     sidecar.signed_block_header.signature = spec.BLSSignature(b"\x00" * 96)
 
@@ -614,7 +627,9 @@ def test_gossip_data_column_sidecar__ignore_parent_not_seen(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
 
     # Modify parent_root to something unknown to the store
@@ -690,7 +705,9 @@ def test_gossip_data_column_sidecar__reject_parent_failed_validation(spec, state
         ],
     )
 
-    _, sidecars = build_signed_block_and_sidecars(spec, parent_state.copy(), blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, parent_state)
+    signed_block = sign_block(spec, parent_state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
 
     yield get_filename(sidecar), sidecar
@@ -760,7 +777,9 @@ def test_gossip_data_column_sidecar__reject_slot_not_higher_than_parent(spec, st
         ],
     )
 
-    _, sidecars = build_signed_block_and_sidecars(spec, parent_state.copy(), blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, parent_state)
+    signed_block = sign_block(spec, parent_state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     sidecar.signed_block_header.message.slot = signed_parent.message.slot
     resign_sidecar_header(spec, parent_state, sidecar)
@@ -813,7 +832,9 @@ def test_gossip_data_column_sidecar__reject_non_ancestor_finalized_checkpoint(sp
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
 
     fake_finalized_root = spec.Root(b"\xab" * 32)
@@ -871,7 +892,9 @@ def test_gossip_data_column_sidecar__reject_invalid_inclusion_proof(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     # Corrupt the inclusion proof.
     sidecar.kzg_commitments_inclusion_proof = spec.KZGCommitmentsInclusionProof()
@@ -924,22 +947,27 @@ def test_gossip_data_column_sidecar__reject_invalid_kzg_proofs(spec, state):
     signed_anchor = wrap_genesis_block(spec, anchor_block)
     yield get_filename(signed_anchor), signed_anchor
 
-    signed_block, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
-    sidecar = sidecars[0]
-    # Corrupt every KZG proof to the point at infinity, which won't verify
-    # against the real commitments.
-    bad_proof = spec.KZGProof(b"\xc0" + b"\x00" * 47)
-    sidecar.kzg_proofs = spec.KZGProofs(data=[bad_proof for _ in sidecar.kzg_proofs])
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
 
     blocks_meta = [{"block": get_filename(signed_anchor)}]
     if is_post_gloas(spec):
+        signed_block = state_transition_and_sign_block(spec, state, block)
         # gloas's validator requires the sidecar's referenced block to be in store.
         block_root = signed_block.message.hash_tree_root()
         store.blocks[block_root] = signed_block.message
         store.block_states[block_root] = state.copy()
         yield get_filename(signed_block), signed_block
         blocks_meta.append({"block": get_filename(signed_block)})
+    else:
+        signed_block = sign_block(spec, state, block)
     yield "blocks", "meta", blocks_meta
+
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
+    sidecar = sidecars[0]
+    # Corrupt every KZG proof to the point at infinity, which won't verify
+    # against the real commitments.
+    bad_proof = spec.KZGProof(b"\xc0" + b"\x00" * 47)
+    sidecar.kzg_proofs = spec.KZGProofs(data=[bad_proof for _ in sidecar.kzg_proofs])
 
     yield get_filename(sidecar), sidecar
 
@@ -994,7 +1022,9 @@ def test_gossip_data_column_sidecar__ignore_already_seen(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
 
     yield get_filename(sidecar), sidecar
@@ -1063,7 +1093,9 @@ def test_gossip_data_column_sidecar__reject_wrong_proposer_index(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
 
     correct_proposer = sidecar.signed_block_header.message.proposer_index

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_partial_data_column_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/networking/test_gossip_partial_data_column_sidecar.py
@@ -8,13 +8,15 @@ from eth_consensus_specs.test.context import (
     with_fulu_and_later,
 )
 from eth_consensus_specs.test.helpers.blob import (
-    get_block_with_blob_and_sidecars,
+    build_block_with_blobs,
+    build_block_with_blobs_for_next_slot,
+    get_data_column_sidecars,
     get_max_blob_count,
     make_partial_data_column_group_id,
     make_partial_header,
     make_partial_sidecar,
 )
-from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
+from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot, sign_block
 from eth_consensus_specs.test.helpers.constants import FULU, GLOAS
 from eth_consensus_specs.test.helpers.execution_payload import (
     build_state_with_complete_transition,
@@ -30,21 +32,7 @@ from eth_consensus_specs.test.helpers.gossip import (
     wrap_genesis_block,
 )
 from eth_consensus_specs.test.helpers.keys import privkeys
-from eth_consensus_specs.test.helpers.state import (
-    state_transition_and_sign_block,
-    transition_to,
-)
-
-
-def build_signed_block_and_sidecars(spec, state, blob_count=1):
-    """
-    Build a signed block carrying ``blob_count`` blobs (applying the state
-    transition) and return its (signed_block, data_column_sidecars).
-    """
-    _, _, _, signed_block, sidecars, _ = get_block_with_blob_and_sidecars(
-        spec, state, blob_count=blob_count
-    )
-    return signed_block, list(sidecars)
+from eth_consensus_specs.test.helpers.state import state_transition_and_sign_block
 
 
 def setup_store_with_anchor(spec, state):
@@ -79,7 +67,9 @@ def test_gossip_partial_data_column_sidecar__valid_header_only(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     group_id = make_partial_data_column_group_id(spec, sidecar)
@@ -121,7 +111,7 @@ def test_gossip_partial_data_column_sidecar__valid_header_only(spec, state):
 @with_all_phases_from_to(FULU, GLOAS)
 @spec_configured_state_test(
     {
-        "BLOB_SCHEDULE": (frozendict({"EPOCH": 0, "MAX_BLOBS_PER_BLOCK": 12}),),
+        "BLOB_SCHEDULE": (frozendict({"EPOCH": 0, "MAX_BLOBS_PER_BLOCK": 15}),),
     },
     activate_at_genesis=True,
 )
@@ -139,12 +129,14 @@ def test_gossip_partial_data_column_sidecar__valid_header_and_cells(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    max_blobs = get_max_blob_count(spec, state)
+    max_blobs = get_max_blob_count(spec, state.slot + 1)
     # Sanity check: the BLOB_SCHEDULE override should be exercising the Fulu
     # code path (`get_blob_parameters`), not the Electra fallback. A client that
     # forgets EIP-7892 and uses MAX_BLOBS_PER_BLOCK_ELECTRA would reject this sidecar.
     assert max_blobs > spec.config.MAX_BLOBS_PER_BLOCK_ELECTRA
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=max_blobs)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state, blob_count=max_blobs)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, include_header=True)
     group_id = make_partial_data_column_group_id(spec, sidecar)
@@ -199,7 +191,9 @@ def test_gossip_partial_data_column_sidecar__valid_cells_only_with_cached_header
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=2)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state, blob_count=2)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     group_id = make_partial_data_column_group_id(spec, sidecar)
     yield get_filename(group_id), group_id
@@ -275,7 +269,23 @@ def test_gossip_partial_data_column_sidecar__reject_empty(spec, state):
 
     store, anchor_block = setup_store_with_anchor(spec, state)
     signed_anchor = wrap_genesis_block(spec, anchor_block)
-    signed_block, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    yield get_filename(signed_anchor), signed_anchor
+
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+
+    blocks_meta = [{"block": get_filename(signed_anchor)}]
+    if is_post_gloas(spec):
+        signed_block = state_transition_and_sign_block(spec, state, block)
+        block_root = signed_block.message.hash_tree_root()
+        store.blocks[block_root] = signed_block.message
+        store.block_states[block_root] = state.copy()
+        yield get_filename(signed_block), signed_block
+        blocks_meta.append({"block": get_filename(signed_block)})
+    else:
+        signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    yield "blocks", "meta", blocks_meta
+
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     column_index = sidecar.index
 
@@ -284,15 +294,6 @@ def test_gossip_partial_data_column_sidecar__reject_empty(spec, state):
 
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=False)
     yield get_filename(partial), partial
-
-    yield get_filename(signed_anchor), signed_anchor
-    blocks_meta = [{"block": get_filename(signed_anchor)}]
-    if is_post_gloas(spec):
-        store.blocks[sidecar.beacon_block_root] = signed_block.message
-        store.block_states[sidecar.beacon_block_root] = state.copy()
-        yield get_filename(signed_block), signed_block
-        blocks_meta.append({"block": get_filename(signed_block)})
-    yield "blocks", "meta", blocks_meta
 
     block_time_ms = spec.compute_time_at_slot_ms(store, signed_block.message.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
@@ -341,7 +342,23 @@ def test_gossip_partial_data_column_sidecar__reject_cell_count_mismatch(spec, st
 
     store, anchor_block = setup_store_with_anchor(spec, state)
     signed_anchor = wrap_genesis_block(spec, anchor_block)
-    signed_block, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    yield get_filename(signed_anchor), signed_anchor
+
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+
+    blocks_meta = [{"block": get_filename(signed_anchor)}]
+    if is_post_gloas(spec):
+        signed_block = state_transition_and_sign_block(spec, state, block)
+        block_root = signed_block.message.hash_tree_root()
+        store.blocks[block_root] = signed_block.message
+        store.block_states[block_root] = state.copy()
+        yield get_filename(signed_block), signed_block
+        blocks_meta.append({"block": get_filename(signed_block)})
+    else:
+        signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    yield "blocks", "meta", blocks_meta
+
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     column_index = sidecar.index
 
@@ -353,15 +370,6 @@ def test_gossip_partial_data_column_sidecar__reject_cell_count_mismatch(spec, st
     cells_type = type(partial.partial_column)
     partial.partial_column = cells_type(data=list(partial.partial_column) + [spec.Cell()])
     yield get_filename(partial), partial
-
-    yield get_filename(signed_anchor), signed_anchor
-    blocks_meta = [{"block": get_filename(signed_anchor)}]
-    if is_post_gloas(spec):
-        store.blocks[sidecar.beacon_block_root] = signed_block.message
-        store.block_states[sidecar.beacon_block_root] = state.copy()
-        yield get_filename(signed_block), signed_block
-        blocks_meta.append({"block": get_filename(signed_block)})
-    yield "blocks", "meta", blocks_meta
 
     block_time_ms = spec.compute_time_at_slot_ms(store, signed_block.message.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
@@ -410,7 +418,23 @@ def test_gossip_partial_data_column_sidecar__reject_proof_count_mismatch(spec, s
 
     store, anchor_block = setup_store_with_anchor(spec, state)
     signed_anchor = wrap_genesis_block(spec, anchor_block)
-    signed_block, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    yield get_filename(signed_anchor), signed_anchor
+
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+
+    blocks_meta = [{"block": get_filename(signed_anchor)}]
+    if is_post_gloas(spec):
+        signed_block = state_transition_and_sign_block(spec, state, block)
+        block_root = signed_block.message.hash_tree_root()
+        store.blocks[block_root] = signed_block.message
+        store.block_states[block_root] = state.copy()
+        yield get_filename(signed_block), signed_block
+        blocks_meta.append({"block": get_filename(signed_block)})
+    else:
+        signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    yield "blocks", "meta", blocks_meta
+
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     column_index = sidecar.index
 
@@ -422,15 +446,6 @@ def test_gossip_partial_data_column_sidecar__reject_proof_count_mismatch(spec, s
     proofs_type = type(partial.kzg_proofs)
     partial.kzg_proofs = proofs_type(data=list(partial.kzg_proofs) + [spec.KZGProof()])
     yield get_filename(partial), partial
-
-    yield get_filename(signed_anchor), signed_anchor
-    blocks_meta = [{"block": get_filename(signed_anchor)}]
-    if is_post_gloas(spec):
-        store.blocks[sidecar.beacon_block_root] = signed_block.message
-        store.block_states[sidecar.beacon_block_root] = state.copy()
-        yield get_filename(signed_block), signed_block
-        blocks_meta.append({"block": get_filename(signed_block)})
-    yield "blocks", "meta", blocks_meta
 
     block_time_ms = spec.compute_time_at_slot_ms(store, signed_block.message.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
@@ -482,7 +497,9 @@ def test_gossip_partial_data_column_sidecar__reject_prior_header_differs(spec, s
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     group_id = make_partial_data_column_group_id(spec, sidecar)
     yield get_filename(group_id), group_id
@@ -564,7 +581,9 @@ def test_gossip_partial_data_column_sidecar__reject_block_root_mismatch(spec, st
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     block_root = spec.Root(b"\xab" * 32)
@@ -621,7 +640,9 @@ def test_gossip_partial_data_column_sidecar__reject_empty_commitments(spec, stat
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     partial.header[0].kzg_commitments = spec.BlobKZGCommitments()
@@ -678,7 +699,9 @@ def test_gossip_partial_data_column_sidecar__ignore_future_slot(spec, state):
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     group_id = make_partial_data_column_group_id(spec, sidecar)
@@ -733,10 +756,11 @@ def test_gossip_partial_data_column_sidecar__ignore_not_later_than_finalized_slo
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    transition_to(spec, state, spec.Slot(spec.SLOTS_PER_EPOCH - 1))
     yield "state", anchor_state
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs(spec, state, slot=spec.SLOTS_PER_EPOCH)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     group_id = make_partial_data_column_group_id(spec, sidecar)
@@ -804,7 +828,9 @@ def test_gossip_partial_data_column_sidecar__reject_proposer_index_out_of_range(
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     partial.header[0].signed_block_header.message.proposer_index = spec.ValidatorIndex(
@@ -865,7 +891,9 @@ def test_gossip_partial_data_column_sidecar__reject_invalid_proposer_signature(s
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     partial.header[0].signed_block_header.signature = spec.BLSSignature(b"\x00" * 96)
@@ -922,7 +950,9 @@ def test_gossip_partial_data_column_sidecar__ignore_parent_not_seen(spec, state)
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     partial.header[0].signed_block_header.message.parent_root = b"\x12" * 32
@@ -997,7 +1027,9 @@ def test_gossip_partial_data_column_sidecar__reject_parent_failed_validation(spe
         ],
     )
 
-    _, sidecars = build_signed_block_and_sidecars(spec, parent_state.copy(), blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, parent_state)
+    signed_block = sign_block(spec, parent_state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     group_id = make_partial_data_column_group_id(spec, sidecar)
@@ -1069,7 +1101,9 @@ def test_gossip_partial_data_column_sidecar__reject_slot_not_higher_than_parent(
         ],
     )
 
-    _, sidecars = build_signed_block_and_sidecars(spec, parent_state.copy(), blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, parent_state)
+    signed_block = sign_block(spec, parent_state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     partial.header[0].signed_block_header.message.slot = signed_parent.message.slot
@@ -1130,7 +1164,9 @@ def test_gossip_partial_data_column_sidecar__reject_non_ancestor_finalized_check
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     group_id = make_partial_data_column_group_id(spec, sidecar)
@@ -1193,7 +1229,9 @@ def test_gossip_partial_data_column_sidecar__reject_invalid_inclusion_proof(spec
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
     partial.header[0].kzg_commitments_inclusion_proof = spec.KZGCommitmentsInclusionProof()
@@ -1250,7 +1288,9 @@ def test_gossip_partial_data_column_sidecar__reject_wrong_proposer_index(spec, s
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, blob_indices=[], include_header=True)
 
@@ -1312,7 +1352,9 @@ def test_gossip_partial_data_column_sidecar__ignore_cells_without_cached_header(
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     partial = make_partial_sidecar(spec, sidecar, include_header=False)
     group_id = make_partial_data_column_group_id(spec, sidecar)
@@ -1370,7 +1412,9 @@ def test_gossip_partial_data_column_sidecar__ignore_cells_with_cached_header_fut
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     group_id = make_partial_data_column_group_id(spec, sidecar)
     yield get_filename(group_id), group_id
@@ -1450,10 +1494,11 @@ def test_gossip_partial_data_column_sidecar__ignore_cells_with_cached_header_not
     yield get_filename(signed_anchor), signed_anchor
     yield "blocks", "meta", [{"block": get_filename(signed_anchor)}]
 
-    transition_to(spec, state, spec.Slot(spec.SLOTS_PER_EPOCH - 1))
     yield "state", anchor_state
 
-    _, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs(spec, state, slot=spec.SLOTS_PER_EPOCH)
+    signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     group_id = make_partial_data_column_group_id(spec, sidecar)
     yield get_filename(group_id), group_id
@@ -1538,7 +1583,23 @@ def test_gossip_partial_data_column_sidecar__reject_bitmap_length_mismatch(spec,
 
     store, anchor_block = setup_store_with_anchor(spec, state)
     signed_anchor = wrap_genesis_block(spec, anchor_block)
-    signed_block, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=1)
+    yield get_filename(signed_anchor), signed_anchor
+
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+
+    blocks_meta = [{"block": get_filename(signed_anchor)}]
+    if is_post_gloas(spec):
+        signed_block = state_transition_and_sign_block(spec, state, block)
+        block_root = signed_block.message.hash_tree_root()
+        store.blocks[block_root] = signed_block.message
+        store.block_states[block_root] = state.copy()
+        yield get_filename(signed_block), signed_block
+        blocks_meta.append({"block": get_filename(signed_block)})
+    else:
+        signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    yield "blocks", "meta", blocks_meta
+
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     column_index = sidecar.index
 
@@ -1555,15 +1616,6 @@ def test_gossip_partial_data_column_sidecar__reject_bitmap_length_mismatch(spec,
     partial.partial_column = cells_type(data=list(partial.partial_column) + [spec.Cell()])
     partial.kzg_proofs = proofs_type(data=list(partial.kzg_proofs) + [spec.KZGProof()])
     yield get_filename(partial), partial
-
-    yield get_filename(signed_anchor), signed_anchor
-    blocks_meta = [{"block": get_filename(signed_anchor)}]
-    if is_post_gloas(spec):
-        store.blocks[sidecar.beacon_block_root] = signed_block.message
-        store.block_states[sidecar.beacon_block_root] = state.copy()
-        yield get_filename(signed_block), signed_block
-        blocks_meta.append({"block": get_filename(signed_block)})
-    yield "blocks", "meta", blocks_meta
 
     block_time_ms = spec.compute_time_at_slot_ms(store, signed_block.message.slot)
     yield "current_time_ms", "meta", int(block_time_ms)
@@ -1612,7 +1664,23 @@ def test_gossip_partial_data_column_sidecar__reject_invalid_kzg_proofs(spec, sta
 
     store, anchor_block = setup_store_with_anchor(spec, state)
     signed_anchor = wrap_genesis_block(spec, anchor_block)
-    signed_block, sidecars = build_signed_block_and_sidecars(spec, state, blob_count=2)
+    yield get_filename(signed_anchor), signed_anchor
+
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state, blob_count=2)
+
+    blocks_meta = [{"block": get_filename(signed_anchor)}]
+    if is_post_gloas(spec):
+        signed_block = state_transition_and_sign_block(spec, state, block)
+        block_root = signed_block.message.hash_tree_root()
+        store.blocks[block_root] = signed_block.message
+        store.block_states[block_root] = state.copy()
+        yield get_filename(signed_block), signed_block
+        blocks_meta.append({"block": get_filename(signed_block)})
+    else:
+        signed_block = sign_block(spec, state, block, proposer_index=block.proposer_index)
+    yield "blocks", "meta", blocks_meta
+
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     sidecar = sidecars[0]
     column_index = sidecar.index
 
@@ -1626,15 +1694,6 @@ def test_gossip_partial_data_column_sidecar__reject_invalid_kzg_proofs(spec, sta
     first, second = partial.kzg_proofs[0], partial.kzg_proofs[1]
     partial.kzg_proofs = proofs_type(data=[second, first])
     yield get_filename(partial), partial
-
-    yield get_filename(signed_anchor), signed_anchor
-    blocks_meta = [{"block": get_filename(signed_anchor)}]
-    if is_post_gloas(spec):
-        store.blocks[sidecar.beacon_block_root] = signed_block.message
-        store.block_states[sidecar.beacon_block_root] = state.copy()
-        yield get_filename(signed_block), signed_block
-        blocks_meta.append({"block": get_filename(signed_block)})
-    yield "blocks", "meta", blocks_meta
 
     block_time_ms = spec.compute_time_at_slot_ms(store, signed_block.message.slot)
     yield "current_time_ms", "meta", int(block_time_ms)

--- a/tests/core/pyspec/eth_consensus_specs/test/fulu/unittests/das/test_das.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/fulu/unittests/das/test_das.py
@@ -9,9 +9,11 @@ from eth_consensus_specs.test.context import (
     with_fulu_and_later,
 )
 from eth_consensus_specs.test.helpers.blob import (
-    get_block_with_blob_and_sidecars,
+    build_block_with_blobs,
+    get_data_column_sidecars,
     get_sample_blob,
 )
+from eth_consensus_specs.test.helpers.block import sign_block
 from eth_consensus_specs.test.helpers.fork_choice import BlobData, with_blob_data
 from eth_consensus_specs.test.helpers.forks import (
     is_post_gloas,
@@ -85,9 +87,11 @@ def run_is_data_available_peerdas_test(spec, blob_data):
 @spec_state_test
 def test_is_data_available_peerdas(spec, state):
     rng = random.Random(1234)
-    _, blobs, blob_kzg_proofs, _, sidecars, kzg_commitments = get_block_with_blob_and_sidecars(
+    block, blobs, kzg_commitments, blob_kzg_proofs = build_block_with_blobs(
         spec, state, rng=rng, blob_count=2
     )
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     blob_data = BlobData(blobs, blob_kzg_proofs, sidecars, kzg_commitments)
 
     result = run_is_data_available_peerdas_test(spec, blob_data)
@@ -99,9 +103,9 @@ def test_is_data_available_peerdas(spec, state):
 @spec_state_test
 def test_get_data_column_sidecars(spec, state):
     rng = random.Random(1234)
-    _, blobs, _, signed_block, sidecars, _kzg_commitments = get_block_with_blob_and_sidecars(
-        spec, state, rng=rng, blob_count=2
-    )
+    block, blobs, _, _ = build_block_with_blobs(spec, state, rng=rng, blob_count=2)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
 
     if is_post_gloas(spec):
         sidecars_result = spec.get_data_column_sidecars_from_block(
@@ -126,9 +130,9 @@ def test_get_data_column_sidecars(spec, state):
 @spec_state_test
 def test_get_data_column_sidecars_from_column_sidecar(spec, state):
     rng = random.Random(1234)
-    _, blobs, _, _, sidecars, _ = get_block_with_blob_and_sidecars(
-        spec, state, rng=rng, blob_count=2
-    )
+    block, blobs, _, _ = build_block_with_blobs(spec, state, rng=rng, blob_count=2)
+    signed_block = sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
 
     sidecars_result = spec.get_data_column_sidecars_from_column_sidecar(
         sidecar=sidecars[0],

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_beacon_block.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_beacon_block.py
@@ -258,7 +258,7 @@ def test_gossip_beacon_block__reject_too_many_blob_commitments(spec, state):
 
     seen = get_seen(spec)
     block = build_empty_block_for_next_slot(spec, state)
-    max_blobs = spec.get_blob_parameters(spec.get_current_epoch(state)).max_blobs_per_block
+    max_blobs = spec.get_blob_parameters(spec.compute_epoch_at_slot(block.slot)).max_blobs_per_block
     over_limit = int(max_blobs) + 1
     block.body.signed_execution_payload_bid.message.blob_kzg_commitments = spec.BlobKZGCommitments(
         data=[spec.KZGCommitment()] * over_limit

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_data_column_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/networking/test_gossip_data_column_sidecar.py
@@ -3,7 +3,10 @@ from eth_consensus_specs.test.context import (
     spec_state_test,
     with_gloas_and_later,
 )
-from eth_consensus_specs.test.helpers.blob import get_block_with_blob_and_sidecars
+from eth_consensus_specs.test.helpers.blob import (
+    build_block_with_blobs_for_next_slot,
+    get_data_column_sidecars,
+)
 from eth_consensus_specs.test.helpers.block import sign_block
 from eth_consensus_specs.test.helpers.fork_choice import (
     get_genesis_forkchoice_store_and_block,
@@ -14,6 +17,7 @@ from eth_consensus_specs.test.helpers.gossip import (
     run_validate_gossip,
     wrap_genesis_block,
 )
+from eth_consensus_specs.test.helpers.state import state_transition_and_sign_block
 
 
 def setup_gloas_sidecar(spec, state, block_in_store=True):
@@ -24,7 +28,9 @@ def setup_gloas_sidecar(spec, state, block_in_store=True):
     """
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     signed_anchor = wrap_genesis_block(spec, anchor_block)
-    _, _, _, signed_block, sidecars, _ = get_block_with_blob_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     if block_in_store:
         block_root = signed_block.message.hash_tree_root()
         store.blocks[block_root] = signed_block.message
@@ -43,7 +49,9 @@ def setup_gloas_failed_block_sidecar(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     signed_anchor = wrap_genesis_block(spec, anchor_block)
     pre_state = state.copy()
-    _, _, _, signed_block, sidecars, _ = get_block_with_blob_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
 
     # Corrupt the block so it genuinely fails state transition, mirroring
     # setup_store_with_failed_block but for a blob-carrying block.

--- a/tests/core/pyspec/eth_consensus_specs/test/gloas/partial-columns/test_gossip_partial_data_column_sidecar.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/gloas/partial-columns/test_gossip_partial_data_column_sidecar.py
@@ -4,7 +4,8 @@ from eth_consensus_specs.test.context import (
     with_gloas_and_later,
 )
 from eth_consensus_specs.test.helpers.blob import (
-    get_block_with_blob_and_sidecars,
+    build_block_with_blobs_for_next_slot,
+    get_data_column_sidecars,
     make_partial_data_column_group_id,
     make_partial_sidecar,
 )
@@ -17,6 +18,7 @@ from eth_consensus_specs.test.helpers.gossip import (
     run_validate_gossip,
     wrap_genesis_block,
 )
+from eth_consensus_specs.test.helpers.state import state_transition_and_sign_block
 
 
 def setup_gloas_partial_sidecar(spec, state, blob_indices=None):
@@ -27,7 +29,9 @@ def setup_gloas_partial_sidecar(spec, state, blob_indices=None):
     """
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     signed_anchor = wrap_genesis_block(spec, anchor_block)
-    _, _, _, signed_block, sidecars, _ = get_block_with_blob_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
     block_root = signed_block.message.hash_tree_root()
     store.blocks[block_root] = signed_block.message
     store.block_states[block_root] = state.copy()
@@ -49,7 +53,9 @@ def setup_gloas_partial_failed_block_sidecar(spec, state):
     store, anchor_block = get_genesis_forkchoice_store_and_block(spec, state)
     signed_anchor = wrap_genesis_block(spec, anchor_block)
     pre_state = state.copy()
-    _, _, _, signed_block, sidecars, _ = get_block_with_blob_and_sidecars(spec, state, blob_count=1)
+    block, blobs, _, _ = build_block_with_blobs_for_next_slot(spec, state)
+    signed_block = state_transition_and_sign_block(spec, state, block)
+    sidecars = get_data_column_sidecars(spec, signed_block, blobs)
 
     # Corrupt the block so it genuinely fails state transition.
     failed_block = signed_block.message.copy()

--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/blob.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/blob.py
@@ -5,7 +5,10 @@ from random import Random
 from rlp import encode, Serializable
 from rlp.sedes import big_endian_int, Binary, binary, CountableList, List as RLPList
 
-from eth_consensus_specs.test.helpers.block import build_empty_block_for_next_slot
+from eth_consensus_specs.test.helpers.block import (
+    build_empty_block,
+    build_empty_block_for_next_slot,
+)
 from eth_consensus_specs.test.helpers.execution_payload import compute_el_block_hash
 from eth_consensus_specs.test.helpers.forks import (
     is_post_electra,
@@ -13,7 +16,6 @@ from eth_consensus_specs.test.helpers.forks import (
     is_post_gloas,
 )
 from eth_consensus_specs.test.helpers.keys import builder_privkeys
-from eth_consensus_specs.test.helpers.state import state_transition_and_sign_block
 from eth_consensus_specs.utils import kzg
 
 # Scalar field modulus of BLS12-381; a canonical field element is in [0, BLS_MODULUS).
@@ -105,17 +107,17 @@ def get_sample_blob_tx(spec, blob_count=1, rng=None, is_valid_blob=True):
     return opaque_tx, blobs, blob_kzg_commitments, blob_kzg_proofs
 
 
-def get_max_blob_count(spec, state):
+def get_max_blob_count(spec, slot):
     if is_post_fulu(spec):
-        return spec.get_blob_parameters(spec.get_current_epoch(state)).max_blobs_per_block
+        return spec.get_blob_parameters(spec.compute_epoch_at_slot(slot)).max_blobs_per_block
     elif is_post_electra(spec):
         return spec.config.MAX_BLOBS_PER_BLOCK_ELECTRA
     else:
         return spec.config.MAX_BLOBS_PER_BLOCK
 
 
-def get_block_with_blob(spec, state, rng: Random | None = None, blob_count=1):
-    block = build_empty_block_for_next_slot(spec, state)
+def add_blobs_to_block(spec, state, block, rng: Random | None = None, blob_count=1):
+    """Populate a block with blob data."""
     opaque_tx, blobs, blob_kzg_commitments, blob_kzg_proofs = get_sample_blob_tx(
         spec, blob_count=blob_count, rng=rng or random.Random(5566)
     )
@@ -145,24 +147,31 @@ def get_block_with_blob(spec, state, rng: Random | None = None, blob_count=1):
             spec, block.body.execution_payload, state
         )
         block.body.blob_kzg_commitments = spec.BlobKZGCommitments(data=blob_kzg_commitments)
+    return blobs, blob_kzg_commitments, blob_kzg_proofs
+
+
+def build_block_with_blobs(spec, state, rng: Random | None = None, blob_count=1, slot=None):
+    """Build an unsigned block with blobs for ``slot``."""
+    block = build_empty_block(spec, state, slot=slot)
+    blobs, blob_kzg_commitments, blob_kzg_proofs = add_blobs_to_block(
+        spec, state, block, rng=rng, blob_count=blob_count
+    )
     return block, blobs, blob_kzg_commitments, blob_kzg_proofs
 
 
-def get_block_with_blob_and_sidecars(spec, state, rng=None, blob_count=1):
-    block, blobs, blob_kzg_commitments, blob_kzg_proofs = get_block_with_blob(
-        spec, state, rng=rng, blob_count=blob_count
+def build_block_with_blobs_for_next_slot(spec, state, rng: Random | None = None, blob_count=1):
+    """Build an unsigned block with blobs for the next slot."""
+    block = build_empty_block_for_next_slot(spec, state)
+    blobs, blob_kzg_commitments, blob_kzg_proofs = add_blobs_to_block(
+        spec, state, block, rng=rng, blob_count=blob_count
     )
+    return block, blobs, blob_kzg_commitments, blob_kzg_proofs
+
+
+def get_data_column_sidecars(spec, signed_block, blobs):
+    """Build data column sidecars from a signed block and its blobs."""
     cells_and_kzg_proofs = [_cached_compute_cells_and_kzg_proofs(spec, blob) for blob in blobs]
-
-    # We need a signed block to call `get_data_column_sidecars_from_block`
-    signed_block = state_transition_and_sign_block(spec, state, block)
-
-    if is_post_gloas(spec):
-        sidecars = spec.get_data_column_sidecars_from_block(signed_block, cells_and_kzg_proofs)
-    else:
-        # For Fulu and earlier, use 2-parameter version
-        sidecars = spec.get_data_column_sidecars_from_block(signed_block, cells_and_kzg_proofs)
-    return block, blobs, blob_kzg_proofs, signed_block, sidecars, blob_kzg_commitments
+    return spec.get_data_column_sidecars_from_block(signed_block, cells_and_kzg_proofs)
 
 
 def make_partial_data_column_group_id(spec, sidecar):


### PR DESCRIPTION
In block gossip validation, the state used for the checks may have an earlier slot than the block. Deriving the max blobs limit from the state's slot can therefore incorrectly reject a block at a BPO fork boundary that carries blobs up to the increased limit.

Additionally, this PR improves testing helpers:
- `build_block_*` helpers return a block with the requested conditions, and don't do any state transition or signing.
- `build_block_*` helpers builds a block for `state.slot` unless a specific slot is requested.
