### PR TITLE
Preserve packaged tests for release upload retries

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -1,12 +1,16 @@
 name: Package tests
 description: >-
-  Download intermediate test artifacts, archive them into a tarball, and delete
-  the intermediates. The caller is responsible for uploading the tarball.
+  Download intermediate test artifacts, archive them into a tarball, persist
+  the tarball as a workflow artifact, and delete the intermediates.
 
 inputs:
   name:
-    description: Tarball name (without .tar.gz) and key used in artifact filtering.
+    description: Key used in artifact filtering.
     required: true
+  tarball:
+    description: Tarball name without .tar.gz. Defaults to name.
+    required: false
+    default: ''
   artifact-prefix:
     description: Prefix for intermediate artifact names.
     required: true
@@ -41,8 +45,14 @@ runs:
             --format=gnu \
             --use-compress-program='gzip --no-name' \
             --create \
-            --file=${{ inputs.name }}.tar.gz \
+            --file=${{ inputs.tarball || inputs.name }}.tar.gz \
             ${{ inputs.source-path }}
+
+    - name: Upload packaged tarball
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        path: ${{ inputs.tarball || inputs.name }}.tar.gz
+        archive: false
 
     - name: Delete intermediate artifacts
       shell: bash

--- a/.github/workflows/comptests.yml
+++ b/.github/workflows/comptests.yml
@@ -272,43 +272,31 @@ jobs:
     strategy:
       matrix:
         config: ${{ fromJson(needs.config.outputs.configs) }}
+    env:
+      TARBALL: ${{ needs.config.outputs.release != '' && 'comptests' || matrix.config }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Download previously packaged tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: ${{ env.TARBALL }}.tar.gz
+          merge-multiple: true
+
       - name: Package compliance tests
+        if: ${{ hashFiles(format('{0}.tar.gz', env.TARBALL)) == '' }}
         uses: ./.github/actions/package
         with:
           name: ${{ matrix.config }}
+          tarball: ${{ env.TARBALL }}
           artifact-prefix: comptests
           source-path: tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Name packaged archive
-        id: archive
-        run: |
-          archive="${{ matrix.config }}.tar.gz"
-
-          # Release archives are named comptests.tar.gz
-          release="${{ needs.config.outputs.release }}"
-          if [[ -n "$release" ]]; then
-            renamed="comptests.tar.gz"
-            mv "$archive" "$renamed"
-            archive="$renamed"
-          fi
-
-          echo "archive=$archive" >> "$GITHUB_OUTPUT"
-
-      - name: Upload ${{ steps.archive.outputs.archive }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ steps.archive.outputs.archive }}
-          path: ${{ steps.archive.outputs.archive }}
-          archive: false
-
       - name: Upload to release
         if: ${{ needs.config.outputs.release != '' }}
-        run: gh release upload "${{ needs.config.outputs.release }}" "${{ steps.archive.outputs.archive }}"
+        run: gh release upload "${{ needs.config.outputs.release }}" ${{ env.TARBALL }}.tar.gz
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
       actions: write
       contents: write
     strategy:
+      fail-fast: false
       matrix:
         preset:
           - general
@@ -99,7 +100,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Download previously packaged tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: ${{ matrix.preset }}.tar.gz
+          merge-multiple: true
+
       - name: Package reference tests
+        if: ${{ hashFiles(format('{0}.tar.gz', matrix.preset)) == '' }}
         uses: ./.github/actions/package
         with:
           name: ${{ matrix.preset }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -226,9 +226,3 @@ jobs:
           artifact-prefix: reftests
           source-path: tests/${{ matrix.preset }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload ${{ matrix.preset }}.tar.gz
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          path: ${{ matrix.preset }}.tar.gz
-          archive: false


### PR DESCRIPTION
Save test tarballs as workflow artifacts before deleting per-fork artifacts, and reuse them when retrying release uploads. This prevents failed uploads from leaving retries with no tests to package. If a release upload fails, you'll be able to re-run the package step to fix it. This happened during the v1.7.0-beta.0 release which was a pain to deal with.

<img width="872" height="789" alt="image" src="https://github.com/user-attachments/assets/d281285c-e175-42a0-9461-4bda4cefbcb7" />
