### PR TITLE
Fix attestation step order in FCR test vectors

### DIFF
--- a/tests/core/pyspec/eth_consensus_specs/test/helpers/fast_confirmation.py
+++ b/tests/core/pyspec/eth_consensus_specs/test/helpers/fast_confirmation.py
@@ -401,9 +401,9 @@ class FCRTest:
 
             # Yield test data
             for attestation in attestations:
-                att_tuple = (get_attestation_file_name(attestation), attestation)
-                self.blockchain_artefacts.append(att_tuple)
-                self.test_steps.append({"attestation": att_tuple[0]})
+                self.blockchain_artefacts.append(
+                    (get_attestation_file_name(attestation), attestation)
+                )
 
         return attestations
 
@@ -411,6 +411,7 @@ class FCRTest:
         # Apply attestations to the fork choice
         for attestation in attestations:
             self.spec.on_attestation(self.store, attestation, is_from_block=False)
+            self.test_steps.append({"attestation": get_attestation_file_name(attestation)})
 
     def run_fast_confirmation(self):
         on_fast_confirmation_and_append_step(self.spec, self.fcr_store, self.test_steps)
@@ -733,6 +734,9 @@ class Attesting(PhaseRun):
         # Instantly apply past slot attestations
         past_slot_attestations = [att for att in attestations if att.data.slot < fcr.current_slot()]
         fcr.apply_attestations(past_slot_attestations)
+        fcr.recent_attestations = [
+            att for att in fcr.recent_attestations if att not in past_slot_attestations
+        ]
 
         return attestations
 


### PR DESCRIPTION
The FCR test vectors list each slot's attestation steps before the tick that moves the test to the next slot. The test generator applies them after that tick. When lighthouse replays the steps as written, we reject the attestation as a future-slot attestation.

- `FCRTest.attest` records the attestation step when it creates the attestation
- `FCRTest.next_slot` ticks first then applies the attestation

This PR fixes this issue by recording the attestation step in `apply_attestations`, right after `on_attestation` runs (instead of when its created). This allows for the attestation step to land after the tick. Also had to tweak some things to make sure duplicate attestation steps werent created.

AI disclosure: Fable helped me debug, find the issue and write a fix. I've done a self review and understand the issue.