### PR TITLE
Cache `compute_balance_weighted_selection`

### DIFF
--- a/pysetup/spec_builders/gloas.py
+++ b/pysetup/spec_builders/gloas.py
@@ -118,4 +118,11 @@ _get_parent_payload_status = get_parent_payload_status
 get_parent_payload_status = cache_this(
     lambda store, block: block.hash_tree_root(),
     _get_parent_payload_status, lru_size=1024)
+
+_compute_balance_weighted_selection = compute_balance_weighted_selection
+compute_balance_weighted_selection = cache_this(
+    lambda state, indices, seed, size, shuffle_indices: (
+        state.validators.hash_tree_root(), tuple(indices), seed, size, shuffle_indices
+    ),
+    _compute_balance_weighted_selection, lru_size=SLOTS_PER_EPOCH * 6)
 """


### PR DESCRIPTION
Caching `compute_balance_weighted_selection` in Gloas makes the mainnet tests notably faster; the PTC window computations are really expensive. This is important now because we've added more tests and now the runners are timing out at 6 hours. This is a simple optimization to get them under the threshold again.

Gloas, before:
<img width="359" height="102" alt="image" src="https://github.com/user-attachments/assets/be2484a0-6379-4ff2-9a0a-f27174256b85" />

Gloas, after:
<img width="359" height="102" alt="image" src="https://github.com/user-attachments/assets/3e009836-134f-40e8-8ac4-86f9608af3df" />

Heze, before:

<img width="359" height="100" alt="image" src="https://github.com/user-attachments/assets/314672dd-01e4-4bf1-b97e-39b0c9c58398" />

Heze, after:
<img width="359" height="102" alt="image" src="https://github.com/user-attachments/assets/2b5b39a9-480e-4555-8d09-b447d0329acd" />
